### PR TITLE
Travis build timeout: this connects to #101

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,17 @@ cache:
     - node_modules
 
 before_install:
-  - yarn run global
+  - travis_wait 15 yarn run global
 
 install:
-  - yarn install
+  - travis_wait 15 yarn install
 
 before_script:
-  - yarn run build
+  - travis_wait 20 yarn run build
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
 
 script:
-  - yarn run ci
+  - travis_wait 20 yarn run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,20 @@ cache:
   directories:
     - node_modules
 
+bundler_args: --retry 5
+
 before_install:
-  - travis_wait 15 yarn run global
+  - travis_retry yarn run global
 
 install:
-  - travis_wait 15 yarn install
+  - travis_retry yarn install
 
 before_script:
-  - travis_wait 20 yarn run build
+  - travis_wait yarn run build
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
 
 script:
-  - travis_wait 20 yarn run ci
+  - yarn run ci


### PR DESCRIPTION
Here are some details on preventing timeouts: https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out

I implemented a conservative approach. I simply added retries to installs and a wait to the build. The default is 3 retries if the install times out. This can be increased by adding `bundler_args: --retry 5` to the .travis.yml file. The wait is done using travis_wait wrapper that will wait greater then 10 minutes for output before timing out. The documentation says to be cautious using this. If we need we can have it wait longer by adding a minute value after the wrapper command, i.e. `travis_wait 30 yarn build`.

