### PR TITLE
remove Matrix URL notation

### DIFF
--- a/src/app/shared/pagination/pagination.component.spec.ts
+++ b/src/app/shared/pagination/pagination.component.spec.ts
@@ -247,12 +247,12 @@ describe('Pagination component', () => {
 
     changePage(testFixture, 3);
     tick();
-    expect(routerStub.navigate).toHaveBeenCalledWith([{pageId: 'test', page: 3, pageSize: 10}]);
+    expect(routerStub.navigate).toHaveBeenCalledWith([], { queryParams: { pageId: 'test', page: 3, pageSize: 10 } });
     expect(paginationComponent.currentPage).toEqual(3);
 
     changePageSize(testFixture, '20');
     tick();
-    expect(routerStub.navigate).toHaveBeenCalledWith([{pageId: 'test', page: 3, pageSize: 20}]);
+    expect(routerStub.navigate).toHaveBeenCalledWith([], { queryParams: { pageId: 'test', page: 3, pageSize: 20 } });
     expect(paginationComponent.pageSize).toEqual(20);
   }));
 

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -57,6 +57,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    * Current page.
    */
   public currentPage = 1;
+  public currentQueryParams = {};
 
   /**
    * An observable of HostWindowState type
@@ -121,14 +122,15 @@ export class PaginationComponent implements OnDestroy, OnInit {
     this.pageSize = this.paginationOptions.pageSize;
     this.pageSizeOptions = this.paginationOptions.pageSizeOptions;
 
-    this.routeSubscription = this.route.params
-      .map(params => params)
-      .subscribe(params => {
-        if(this.id == params['pageId']
-           && (this.paginationOptions.currentPage != params['page']
-           || this.paginationOptions.pageSize != params['pageSize'])
+    this.routeSubscription = this.route.queryParams
+      .map(queryParams => queryParams)
+      .subscribe(queryParams => {
+        this.currentQueryParams = queryParams;
+        if(this.id == queryParams['pageId']
+           && (this.paginationOptions.currentPage != queryParams['page']
+           || this.paginationOptions.pageSize != queryParams['pageSize'])
           ) {
-          this.validateParams(params['page'], params['pageSize']);
+          this.validateParams(queryParams['page'], queryParams['pageSize']);
         }
       });
     this.setShowingDetail();
@@ -162,7 +164,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The page being navigated to.
    */
   public doPageChange(page: number) {
-    this.router.navigate([{ pageId: this.id, page: page, pageSize: this.pageSize }]);
+    this.router.navigate([], { queryParams: Object.assign({}, this.currentQueryParams, { pageId: this.id, page: page, pageSize: this.pageSize }) });
     this.currentPage = page;
     this.setShowingDetail();
     this.pageChange.emit(page);
@@ -175,7 +177,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The new page size.
    */
   public setPageSize(pageSize: number) {
-    this.router.navigate([{ pageId: this.id, page: this.currentPage, pageSize: pageSize }]);
+    this.router.navigate([], { queryParams: Object.assign({}, this.currentQueryParams, { pageId: this.id, page: this.currentPage, pageSize: pageSize }) });
     this.pageSize = pageSize;
     this.setShowingDetail();
     this.pageSizeChange.emit(pageSize);

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -57,6 +57,10 @@ export class PaginationComponent implements OnDestroy, OnInit {
    * Current page.
    */
   public currentPage = 1;
+  
+  /**
+   * Current URL query parameters
+   */
   public currentQueryParams = {};
 
   /**

--- a/src/app/shared/testing/router-stubs.ts
+++ b/src/app/shared/testing/router-stubs.ts
@@ -4,7 +4,6 @@ import { BehaviorSubject } from "rxjs";
 export class RouterStub {
   //noinspection TypeScriptUnresolvedFunction
   navigate = jasmine.createSpy('navigate');
-  //navigate1: jasmine.createSpy('navigate');
 }
 
 export class ActivatedRouteStub {
@@ -12,6 +11,7 @@ export class ActivatedRouteStub {
   // ActivatedRoute.params is Observable
   private subject = new BehaviorSubject(this.testParams);
   params = this.subject.asObservable();
+  queryParams = this.subject.asObservable();
 
   constructor(params?: Params) {
     if (params) {


### PR DESCRIPTION
This PR connects to #109 

Remove matrix URL notation and add the possibility to keep any other parameters, in the URL, which do not belong to PaginationComponent