### PR TITLE
fixed an issue where if there is only one bitstream it would be retur…

### DIFF
--- a/src/app/core/cache/builders/remote-data-build.service.ts
+++ b/src/app/core/cache/builders/remote-data-build.service.ts
@@ -186,10 +186,10 @@ export class RemoteDataBuildService {
             rdArr.push(this.buildSingle(href, resourceConstructor));
           });
 
-          if (rdArr.length === 1) {
-            links[relationship] = rdArr[0];
-          } else {
+          if (isList) {
             links[relationship] = this.aggregate(rdArr);
+          } else if (rdArr.length === 1) {
+            links[relationship] = rdArr[0];
           }
         } else {
           // without the setTimeout, the actions inside requestService.configure


### PR DESCRIPTION
…ned as a single object and not an array in the item.bitstreams property.

This bug would throw an exception and as a consequence the router wouldn't remove the previous view:

This PR connects to #128