### PR TITLE
switch rest demo to https in the default config

### DIFF
--- a/config/environment.default.js
+++ b/config/environment.default.js
@@ -9,9 +9,9 @@ module.exports = {
   },
   // The REST API server settings.
   rest: {
-    ssl: false,
+    ssl: true,
     host: 'dspace7.4science.it',
-    port: 80,
+    port: 443,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
     nameSpace: '/dspace-spring-rest/api'
   },

--- a/src/app/shared/empty.util.spec.ts
+++ b/src/app/shared/empty.util.spec.ts
@@ -1,7 +1,6 @@
 import {
   isEmpty, hasNoValue, hasValue, isNotEmpty, isNull, isNotNull,
-  isUndefined
-  isNotUndefined,
+  isUndefined, isNotUndefined
 } from './empty.util';
 
 describe('Empty Utils', () => {


### PR DESCRIPTION
Since the REST API enabled https I've noticed CORS issues in some cases when using http. 
This PR enables https by default.