### PR TITLE
Added facet/filter methods to the mock search service 

### DIFF
--- a/src/app/+search-page/search-page.component.spec.ts
+++ b/src/app/+search-page/search-page.component.spec.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { CommunityDataService } from '../core/data/community-data.service';
 import { SearchPageComponent } from './search-page.component';
-import { SearchService } from './search.service';
+import { SearchService } from './search-service/search.service';
 import { Community } from '../core/shared/community.model';
 import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
 import { SortDirection, SortOptions } from '../core/cache/models/sort-options.model';

--- a/src/app/+search-page/search-page.component.ts
+++ b/src/app/+search-page/search-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { SearchService } from './search.service';
+import { SearchService } from './search-service/search.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RemoteData } from '../core/data/remote-data';
 import { SearchResult } from './search-result.model';
@@ -10,6 +10,8 @@ import { SearchOptions } from './search-options.model';
 import { CommunityDataService } from '../core/data/community-data.service';
 import { isNotEmpty } from '../shared/empty.util';
 import { Community } from '../core/shared/community.model';
+import { SearchFilterConfig } from './search-service/search-filter-config.model';
+import { FacetValue } from './search-service/facet-value.model';
 
 /**
  * This component renders a simple item page.
@@ -47,6 +49,13 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     pagination.pageSize = 10;
     const sort: SortOptions = new SortOptions();
     this.searchOptions = { pagination: pagination, sort: sort };
+    this.service.getConfig().payload.subscribe((filters: SearchFilterConfig[]) => {
+      console.log(filters)
+    });
+    this.service.getFacetValuesFor('scope').payload.subscribe((values: FacetValue[]) => console.log(values));
+    this.service.getFacetValuesFor('author').payload.subscribe((values: FacetValue[]) => console.log(values));
+    this.service.getFacetValuesFor('date').payload.subscribe((values: FacetValue[]) => console.log(values));
+    this.service.getFacetValuesFor('subject').payload.subscribe((values: FacetValue[]) => console.log(values));
   }
 
   ngOnInit(): void {
@@ -57,8 +66,8 @@ export class SearchPageComponent implements OnInit, OnDestroy {
           this.currentParams = params;
           this.query = params.query || '';
           this.scope = params.scope;
-          const page = +params.page  || this.searchOptions.pagination.currentPage;
-          const pageSize = +params.pageSize  || this.searchOptions.pagination.pageSize;
+          const page = +params.page || this.searchOptions.pagination.currentPage;
+          const pageSize = +params.pageSize || this.searchOptions.pagination.pageSize;
           const sortDirection = +params.sortDirection || this.searchOptions.sort.direction;
           const pagination = Object.assign({},
             this.searchOptions.pagination,

--- a/src/app/+search-page/search-page.component.ts
+++ b/src/app/+search-page/search-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { SearchService } from './search-service/search.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { RemoteData } from '../core/data/remote-data';
 import { SearchResult } from './search-result.model';
 import { DSpaceObject } from '../core/shared/dspace-object.model';
@@ -10,8 +10,6 @@ import { SearchOptions } from './search-options.model';
 import { CommunityDataService } from '../core/data/community-data.service';
 import { isNotEmpty } from '../shared/empty.util';
 import { Community } from '../core/shared/community.model';
-import { SearchFilterConfig } from './search-service/search-filter-config.model';
-import { FacetValue } from './search-service/facet-value.model';
 
 /**
  * This component renders a simple item page.

--- a/src/app/+search-page/search-page.component.ts
+++ b/src/app/+search-page/search-page.component.ts
@@ -49,13 +49,6 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     pagination.pageSize = 10;
     const sort: SortOptions = new SortOptions();
     this.searchOptions = { pagination: pagination, sort: sort };
-    this.service.getConfig().payload.subscribe((filters: SearchFilterConfig[]) => {
-      console.log(filters)
-    });
-    this.service.getFacetValuesFor('scope').payload.subscribe((values: FacetValue[]) => console.log(values));
-    this.service.getFacetValuesFor('author').payload.subscribe((values: FacetValue[]) => console.log(values));
-    this.service.getFacetValuesFor('date').payload.subscribe((values: FacetValue[]) => console.log(values));
-    this.service.getFacetValuesFor('subject').payload.subscribe((values: FacetValue[]) => console.log(values));
   }
 
   ngOnInit(): void {

--- a/src/app/+search-page/search-page.module.ts
+++ b/src/app/+search-page/search-page.module.ts
@@ -11,7 +11,7 @@ import { SearchResultsComponent } from './search-results/search-results.componen
 import { ItemSearchResultListElementComponent } from '../object-list/search-result-list-element/item-search-result/item-search-result-list-element.component';
 import { CollectionSearchResultListElementComponent } from '../object-list/search-result-list-element/collection-search-result/collection-search-result-list-element.component';
 import { CommunitySearchResultListElementComponent } from '../object-list/search-result-list-element/community-search-result/community-search-result-list-element.component';
-import { SearchService } from './search.service';
+import { SearchService } from './search-service/search.service';
 
 @NgModule({
   imports: [

--- a/src/app/+search-page/search-service/facet-value.model.ts
+++ b/src/app/+search-page/search-service/facet-value.model.ts
@@ -1,0 +1,7 @@
+
+export class FacetValue {
+
+  value: string;
+  count: number;
+  search: string;
+}

--- a/src/app/+search-page/search-service/filter-type.model.ts
+++ b/src/app/+search-page/search-service/filter-type.model.ts
@@ -1,0 +1,5 @@
+export enum FilterType {
+  text,
+  range,
+  hierarchy
+}

--- a/src/app/+search-page/search-service/search-filter-config.model.ts
+++ b/src/app/+search-page/search-service/search-filter-config.model.ts
@@ -6,4 +6,11 @@ export class SearchFilterConfig {
   type: FilterType;
   hasFacets: boolean;
   isOpenByDefault: boolean;
+  /**
+   * Name of this configuration that can be used in a url
+   * @returns Parameter name
+   */
+  get paramName(): string {
+    return 'f.' + this.name;
+  }
 }

--- a/src/app/+search-page/search-service/search-filter-config.model.ts
+++ b/src/app/+search-page/search-service/search-filter-config.model.ts
@@ -1,0 +1,9 @@
+import { FilterType } from './filter-type.model';
+
+export class SearchFilterConfig {
+
+  name: string;
+  type: FilterType;
+  hasFacets: boolean;
+  isOpenByDefault: boolean;
+}

--- a/src/app/+search-page/search-service/search.service.ts
+++ b/src/app/+search-page/search-service/search.service.ts
@@ -46,30 +46,34 @@ export class SearchService {
   );
 
   config: SearchFilterConfig[] = [
-    {
+    Object.assign(new SearchFilterConfig(),
+      {
       name: 'scope',
       type: FilterType.hierarchy,
       hasFacets: true,
       isOpenByDefault: true
-    },
+    }),
+    Object.assign(new SearchFilterConfig(),
     {
       name: 'author',
       type: FilterType.text,
       hasFacets: true,
       isOpenByDefault: false
-    },
+    }),
+    Object.assign(new SearchFilterConfig(),
     {
       name: 'date',
       type: FilterType.range,
       hasFacets: true,
       isOpenByDefault: false
-    },
+    }),
+    Object.assign(new SearchFilterConfig(),
     {
       name: 'subject',
       type: FilterType.text,
       hasFacets: false,
       isOpenByDefault: false
-    }
+    })
   ];
 
   constructor(private itemDataService: ItemDataService) {
@@ -168,7 +172,7 @@ export class SearchService {
       values.push({
         value: value,
         count: Math.floor(Math.random() * 20) + 20 * (5 - i), // make sure first results have the highest (random) count
-        search: 'https://dspace7.4science.it/dspace-spring-rest/api/search?query=' + searchFilterConfigName + ':' + encodeURI(value)
+        search: 'https://dspace7.4science.it/dspace-spring-rest/api/search?f.' + searchFilterConfigName + '=' + encodeURI(value)
       });
     }
     const requestPending = Observable.of(false);

--- a/src/app/+search-page/search-service/search.service.ts
+++ b/src/app/+search-page/search-service/search.service.ts
@@ -1,19 +1,18 @@
 import { Injectable } from '@angular/core';
-
+import { RemoteData } from '../../core/data/remote-data';
 import { Observable } from 'rxjs/Observable';
-
-import { DSpaceObject } from '../core/shared/dspace-object.model';
-import { Item } from '../core/shared/item.model';
-import { ItemSearchResult } from '../object-list/search-result-list-element/item-search-result/item-search-result.model';
-import { Metadatum } from '../core/shared/metadatum.model';
-import { PageInfo } from '../core/shared/page-info.model';
-import { RemoteData } from '../core/data/remote-data';
-import { SearchOptions } from './search-options.model';
-import { SearchResult } from './search-result.model';
-
-import { ItemDataService } from '../core/data/item-data.service';
-
-import { hasValue, isNotEmpty } from '../shared/empty.util';
+import { SearchResult } from '../search-result.model';
+import { ItemDataService } from '../../core/data/item-data.service';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchOptions } from '../search-options.model';
+import { hasValue, isNotEmpty } from '../../shared/empty.util';
+import { Metadatum } from '../../core/shared/metadatum.model';
+import { Item } from '../../core/shared/item.model';
+import { ItemSearchResult } from '../../object-list/search-result-list-element/item-search-result/item-search-result.model';
+import { SearchFilterConfig } from './search-filter-config.model';
+import { FilterType } from './filter-type.model';
+import { FacetValue } from './facet-value.model';
 
 function shuffle(array: any[]) {
   let i = 0;
@@ -45,6 +44,33 @@ export class SearchService {
     '<em>This was blank in the actual item, no abstract</em>',
     '<em>The QSAR DataBank (QsarDB) repository</em>',
   );
+
+  config: SearchFilterConfig[] = [
+    {
+      name: 'scope',
+      type: FilterType.hierarchy,
+      hasFacets: true,
+      isOpenByDefault: true
+    },
+    {
+      name: 'author',
+      type: FilterType.text,
+      hasFacets: true,
+      isOpenByDefault: false
+    },
+    {
+      name: 'date',
+      type: FilterType.range,
+      hasFacets: true,
+      isOpenByDefault: false
+    },
+    {
+      name: 'subject',
+      type: FilterType.text,
+      hasFacets: false,
+      isOpenByDefault: false
+    }
+  ];
 
   constructor(private itemDataService: ItemDataService) {
 
@@ -116,4 +142,50 @@ export class SearchService {
     )
   }
 
+  getConfig(): RemoteData<SearchFilterConfig[]> {
+    const requestPending = Observable.of(false);
+    const responsePending = Observable.of(false);
+    const isSuccessful = Observable.of(true);
+    const errorMessage = Observable.of(undefined);
+    const statusCode = Observable.of('200');
+    const returningPageInfo = Observable.of(new PageInfo());
+    return new RemoteData(
+      Observable.of('https://dspace7.4science.it/dspace-spring-rest/api/search'),
+      requestPending,
+      responsePending,
+      isSuccessful,
+      errorMessage,
+      statusCode,
+      returningPageInfo,
+      Observable.of(this.config)
+    );
+  }
+
+  getFacetValuesFor(searchFilterConfigName: string): RemoteData<FacetValue[]> {
+    const values: FacetValue[] = [];
+    for (let i = 0; i < 5; i++) {
+      const value = searchFilterConfigName + ' ' + (i + 1);
+      values.push({
+        value: value,
+        count: Math.floor(Math.random() * 20) + 20 * (5 - i), // make sure first results have the highest (random) count
+        search: 'https://dspace7.4science.it/dspace-spring-rest/api/search?query=' + searchFilterConfigName + ':' + encodeURI(value)
+      });
+    }
+    const requestPending = Observable.of(false);
+    const responsePending = Observable.of(false);
+    const isSuccessful = Observable.of(true);
+    const errorMessage = Observable.of(undefined);
+    const statusCode = Observable.of('200');
+    const returningPageInfo = Observable.of(new PageInfo());
+    return new RemoteData(
+      Observable.of('https://dspace7.4science.it/dspace-spring-rest/api/search'),
+      requestPending,
+      responsePending,
+      isSuccessful,
+      errorMessage,
+      statusCode,
+      returningPageInfo,
+      Observable.of(values)
+    );
+  }
 }


### PR DESCRIPTION
This PR closes #153.
I added 2 new methods to the mock service that return Remote Data objects with info about facets/filters.
- getConfig(): returns all filter configuration 
- getFacetValuesFor(searchFilterConfigName: string): returns the facet values for a specific filter