### PR TITLE
Fixed e2e search page test

### DIFF
--- a/e2e/search-page/search-page.po.ts
+++ b/e2e/search-page/search-page.po.ts
@@ -39,8 +39,8 @@ export class ProtractorPage {
   getRandomScopeOption(): promise.Promise<string> {
     const options = element(by.css('select[name="scope"]')).all(by.tagName('option'));
     return options.count().then((c: number) => {
-      const index: number = Math.floor(Math.random() * c);
-      return options.get(index).getAttribute('value');
+      const index: number = Math.floor(Math.random() * (c - 1));
+      return options.get(index + 1).getAttribute('value');
     });
   }
 


### PR DESCRIPTION
This PR closes #175 
Fixed an issue with an e2e test where sometimes the default scope was selected, which resulted in no scope being visible in the URL. This made the test fail once in a while.