### PR TITLE
Replaced Http with HttpClient

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule, APP_BASE_HREF } from '@angular/common';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule, MetaReducer, META_REDUCERS } from '@ngrx/store';
@@ -51,7 +51,7 @@ if (!ENV_CONFIG.production) {
 @NgModule({
   imports: [
     CommonModule,
-    HttpModule,
+    HttpClientModule,
     AppRoutingModule,
     CoreModule.forRoot(),
     NgbModule.forRoot(),

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { DSpaceRESTv2Service } from './dspace-rest-v2.service';
+
+describe('DSpaceRESTv2Service', () => {
+  let dSpaceRESTv2Service: DSpaceRESTv2Service;
+  let httpMock: HttpTestingController;
+  const mockDSpaceRESTV2Response = {};
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [DSpaceRESTv2Service]
+    });
+
+    dSpaceRESTv2Service = TestBed.get(DSpaceRESTv2Service);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should be created', inject([DSpaceRESTv2Service], (service: DSpaceRESTv2Service) => {
+    expect(service).toBeTruthy();
+  }));
+
+  describe('#get', () => {
+    it('should return an Observable<DSpaceRESTV2Response>', () => {
+      const url = 'http://www.dspace.org/';
+      dSpaceRESTv2Service.get(url).subscribe((response) => {
+        expect(response).toBeTruthy();
+      });
+
+      const req = httpMock.expectOne(url);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockDSpaceRESTV2Response);
+    });
+  });
+});

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -6,7 +6,8 @@ import { DSpaceRESTv2Service } from './dspace-rest-v2.service';
 describe('DSpaceRESTv2Service', () => {
   let dSpaceRESTv2Service: DSpaceRESTv2Service;
   let httpMock: HttpTestingController;
-  const mockDSpaceRESTV2Response = {};
+  const url = 'http://www.dspace.org/';
+  const mockError = new ErrorEvent('test error');
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -18,20 +19,50 @@ describe('DSpaceRESTv2Service', () => {
     httpMock = TestBed.get(HttpTestingController);
   });
 
+  afterEach(() => httpMock.verify());
+
   it('should be created', inject([DSpaceRESTv2Service], (service: DSpaceRESTv2Service) => {
     expect(service).toBeTruthy();
   }));
 
   describe('#get', () => {
     it('should return an Observable<DSpaceRESTV2Response>', () => {
-      const url = 'http://www.dspace.org/';
+      const mockPayload = {
+        page: 1
+      };
+      const mockStatusCode = 'GREAT';
+
       dSpaceRESTv2Service.get(url).subscribe((response) => {
         expect(response).toBeTruthy();
+        expect(response.statusCode).toEqual(mockStatusCode);
+        expect(response.payload.page).toEqual(mockPayload.page);
       });
 
       const req = httpMock.expectOne(url);
       expect(req.request.method).toBe('GET');
-      req.flush(mockDSpaceRESTV2Response);
+      req.flush(mockPayload, { statusText: mockStatusCode});
     });
+  });
+
+  it('should throw an error', () => {
+    dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
+      expect(err.error).toBe(mockError);
+    });
+
+    const req = httpMock.expectOne(url);
+    expect(req.request.method).toBe('GET');
+    req.error(mockError);
+  });
+
+  it('should log an error', () => {
+    spyOn(console, 'log');
+
+    dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    const req = httpMock.expectOne(url);
+    expect(req.request.method).toBe('GET');
+    req.error(mockError);
   });
 });

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
@@ -1,8 +1,7 @@
-import { Inject, Injectable } from '@angular/core';
-import { Http, RequestOptionsArgs } from '@angular/http';
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
-import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
 import { DSpaceRESTV2Response } from './dspace-rest-v2-response.model';
 
 import { GLOBAL_CONFIG, GlobalConfig } from '../../../config';
@@ -13,7 +12,7 @@ import { GLOBAL_CONFIG, GlobalConfig } from '../../../config';
 @Injectable()
 export class DSpaceRESTv2Service {
 
-  constructor(private http: Http, @Inject(GLOBAL_CONFIG) private EnvConfig: GlobalConfig) {
+  constructor(private http: HttpClient) {
 
   }
 
@@ -23,13 +22,12 @@ export class DSpaceRESTv2Service {
    * @param absoluteURL
    *      A URL
    * @param options
-   *      A RequestOptionsArgs object, with options for the http call.
-   * @return {Observable<string>}
-   *      An Observable<string> containing the response from the server
+   *      An object, with options for the http call.
+   * @return {Observable<DSpaceRESTV2Response>}
+   *      An Observable<DSpaceRESTV2Response> containing the response from the server
    */
-  get(absoluteURL: string, options?: RequestOptionsArgs): Observable<DSpaceRESTV2Response> {
+  get(absoluteURL: string, options?: {}): Observable<DSpaceRESTV2Response> {
     return this.http.get(absoluteURL, options)
-      .map((res) => ({ payload: res.json(), statusCode: res.statusText }))
       .catch((err) => {
         console.log('Error: ', err);
         return Observable.throw(err);

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
 import { DSpaceRESTV2Response } from './dspace-rest-v2-response.model';
-
-import { GLOBAL_CONFIG, GlobalConfig } from '../../../config';
 
 /**
  * Service to access DSpace's REST API
@@ -26,8 +24,9 @@ export class DSpaceRESTv2Service {
    * @return {Observable<DSpaceRESTV2Response>}
    *      An Observable<DSpaceRESTV2Response> containing the response from the server
    */
-  get(absoluteURL: string, options?: {}): Observable<DSpaceRESTV2Response> {
-    return this.http.get(absoluteURL, options)
+  get(absoluteURL: string): Observable<DSpaceRESTV2Response> {
+    return this.http.get(absoluteURL, { observe: 'response' })
+      .map((res: HttpResponse<any>) => ({ payload: res.body, statusCode: res.statusText }))
       .catch((err) => {
         console.log('Error: ', err);
         return Observable.throw(err);

--- a/src/app/shared/api.service.ts
+++ b/src/app/shared/api.service.ts
@@ -1,14 +1,13 @@
 import 'rxjs/add/observable/throw';
-import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 
 import { Injectable } from '@angular/core';
-import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class ApiService {
-  constructor(public _http: Http) {
+  constructor(public _http: HttpClient) {
 
   }
 
@@ -17,7 +16,6 @@ export class ApiService {
    */
   get(url: string, options?: any) {
     return this._http.get(url, options)
-      .map((res) => res.json())
       .catch((err) => {
         console.log('Error: ', err);
         return Observable.throw(err);


### PR DESCRIPTION
Relates to #194 

I tried to replace Http with HttpClient in the DSpaceRESTv2Service and ApiService, removing unused imports.

It doesn't seem like ApiService is used, so I didn't add tests, but I did add a test suite for the DSpaceRESTv2Service. It is pretty much a boilerplate HTTP test suite though because I'm not sure how to create a mock DSpaceRESTv2Response (it's just an empty object for now).

Yet again, I don't really know what I'm doing, so I'd appreciate any suggestions on how to improve this PR! Thank you :)