### PR TITLE
Fix pagination issue on change page size

### DIFF
--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -178,8 +178,9 @@ export class PaginationComponent implements OnDestroy, OnInit {
           const fixedProperties = this.validateParams(queryParams);
           if (isNotEmpty(fixedProperties)) {
             this.fixRoute(fixedProperties);
+          } else {
+            this.setFields();
           }
-          this.setFields();
         }
       }));
   }
@@ -374,10 +375,10 @@ export class PaginationComponent implements OnDestroy, OnInit {
     const filteredSize = this.validatePageSize(params.pageSize);
     const fixedFields: any = {};
     if (+params.page !== validPage) {
-      fixedFields.page = validPage;
+      fixedFields.page = validPage.toString();
     }
     if (+params.pageSize !== filteredSize) {
-      fixedFields.pageSize = filteredSize;
+      fixedFields.pageSize = filteredSize.toString();
     }
     return fixedFields;
   }


### PR DESCRIPTION
Fix a issue on PaginationComponent. 

In a paginated page, when page size is changed out of PaginationComponent and in the route is missing page parameter (it happens in the search page) this generate a infinite loop in the navigation.

To see the issue remove the totalElements limit here
 https://github.com/DSpace/dspace-angular/blob/90c3d16e8e99b4810b6b44e3f0ce7cb3e986a2ad/src/app/%2Bsearch-page/search-service/search.service.ts#L143

navigate to the search page and change the "Result per page" option