### PR TITLE
Get requests fail second time

### DIFF
--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -436,9 +436,18 @@ describe('RequestService', () => {
     });
 
     describe('when the request is added to the store', () => {
+      beforeEach(() => {
+        spyOn(service, 'getByHref').and.returnValue(Observable.of({
+          request,
+          requestPending: false,
+          responsePending: true,
+          completed: false
+        }));
+      });
+
       it('should stop tracking the request', () => {
-        (store.select as any).and.returnValues(Observable.of({ request }));
         serviceAsAny.trackRequestsOnTheirWayToTheStore(request);
+        expect(service.getByHref).toHaveBeenCalledWith(request.href);
         expect(serviceAsAny.requestsOnTheirWayToTheStore.includes(request.href)).toBeFalsy();
       });
     });

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -118,7 +118,7 @@ export class RequestService {
    */
   private trackRequestsOnTheirWayToTheStore(request: GetRequest) {
     this.requestsOnTheirWayToTheStore = [...this.requestsOnTheirWayToTheStore, request.href];
-    this.store.select(this.entryFromUUIDSelector(request.href))
+    this.getByHref(request.href)
       .filter((re: RequestEntry) => hasValue(re))
       .take(1)
       .subscribe((re: RequestEntry) => {


### PR DESCRIPTION
This PR closes #216 

The reason for the issue was that the request pending status was never removed after a request was completed, due to a mistake in the switch from hrefs to uuids as identifiers for requests. Subsequent requests for the same URL (after something had been removed from the cache) wouldn't be executed because the request seemed to be already pending

This PR contains a test for the issue, and a fix.