### PR TITLE
Fix #122 : ensure collections are listed based on current community

### DIFF
--- a/src/app/+community-page/community-page.component.html
+++ b/src/app/+community-page/community-page.component.html
@@ -8,7 +8,7 @@
                            [logo]="(logoRDObs | async)?.payload"
                            [alternateText]="'Community Logo'">
       </ds-comcol-page-logo>
-      <!-- Introductionary text -->
+      <!-- Introductory text -->
       <ds-comcol-page-content
         [content]="communityPayload.introductoryText"
         [hasInnerHtml]="true">
@@ -24,7 +24,7 @@
         [content]="communityPayload.copyrightText"
         [hasInnerHtml]="true">
       </ds-comcol-page-content>
-      <ds-community-page-sub-collection-list></ds-community-page-sub-collection-list>
+      <ds-community-page-sub-collection-list [community]="communityPayload"></ds-community-page-sub-collection-list>
     </div>
   </div>
   <ds-error *ngIf="communityRD?.hasFailed" message="{{'error.community' | translate}}"></ds-error>

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.html
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="subCollectionsRD?.hasSucceeded" @fadeIn>
     <h2>{{'community.sub-collection-list.head' | translate}}</h2>
     <ul>
-      <li *ngFor="let collection of subCollectionsRD?.payload?.page">
+      <li *ngFor="let collection of subCollectionsRD?.payload">
         <p>
           <span class="lead"><a [routerLink]="['/collections', collection.id]">{{collection.name}}</a></span><br>
           <span class="text-muted">{{collection.shortDescription}}</span>

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
@@ -1,10 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-import { CollectionDataService } from '../../core/data/collection-data.service';
-import { PaginatedList } from '../../core/data/paginated-list';
 import { RemoteData } from '../../core/data/remote-data';
 import { Collection } from '../../core/shared/collection.model';
+import { Community } from '../../core/shared/community.model';
 
 import { fadeIn } from '../../shared/animations/fade';
 
@@ -15,13 +14,10 @@ import { fadeIn } from '../../shared/animations/fade';
   animations:[fadeIn]
 })
 export class CommunityPageSubCollectionListComponent implements OnInit {
-  subCollectionsRDObs: Observable<RemoteData<PaginatedList<Collection>>>;
-
-  constructor(private cds: CollectionDataService) {
-
-  }
+  @Input() community: Community;
+  subCollectionsRDObs: Observable<RemoteData<Collection[]>>;
 
   ngOnInit(): void {
-    this.subCollectionsRDObs = this.cds.findAll();
+    this.subCollectionsRDObs = this.community.collections;
   }
 }


### PR DESCRIPTION
Fixes #122 

Ensures that Collection listing is generated from `/community/[uuid]/collections` endpoint, instead of `/collections` (which lists all Collections, regardless of parent).

This is a quick fix for the known bug.  

**Pagination Notes for Further Discussion:**

This implementation does NOT yet include pagination (which would be ideal, since the number of Collections under a Community may be large).  The reason I left out pagination is that I couldn't figure out an easy way to use the `/community/[uuid]/collections` endpoint (i.e. the Community model's [`collections` property](https://github.com/DSpace/dspace-angular/blob/master/src/app/core/shared/community.model.ts#L61)) with the existing PaginatedList component.

(Unless I'm missing something) The current PaginatedList component seems to be built more specifically to the structure of the [search endpoint](https://github.com/DSpace/Rest7Contract/blob/master/search-endpoint.md) in the REST API for two main reasons:
1. Currently, you can only (seemingly) [create a PaginatedList using findAll()](https://github.com/DSpace/dspace-angular/blob/master/src/app/core/data/data.service.ts#L67)
2. And that `findAll()` method seems to expect you to use endpoints that utilize a `scope` parameter to limit results to children within a specific parent object. This is exactly how the search endpoint behaves,
 but *not* how the [`/community/[uuid]/collections` endpoint](https://github.com/DSpace/Rest7Contract/blob/master/communities.md#collections) behaves.

As I'm admittedly still getting back up to speed on Angular & I ran into the above issue, I wasn't entirely certain how to easily achieve pagination of Collections.  It seems to me that we may have a mismatch here between how the Angular UI currently implements pagination and the existing REST API contract.  I'm not yet certain which needs updating, but wanted to point out this mismatch.