### PR TITLE
Fix travis github ratelimit issue when downloading gecko webdriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:headless": "karma start --single-run --browsers ChromeHeadless",
     "test:watch": "karma start --no-single-run --auto-watch",
     "webdriver:start": "node node_modules/protractor/bin/webdriver-manager start --seleniumPort 4444",
-    "webdriver:update": "node node_modules/protractor/bin/webdriver-manager update --standalone",
+    "webdriver:update": "node node_modules/protractor/bin/webdriver-manager update --standalone --gecko false",
     "lint": "tslint \"src/**/*.ts\" && tslint \"e2e/**/*.ts\"",
     "docs": "typedoc --options typedoc.json ./src/",
     "coverage": "http-server -c-1 -o -p 9875 ./coverage"


### PR DESCRIPTION
I disabled the gecko webdriver, as we're not using it, and downloading it can cause rate limit issues on github