### PR TITLE
Fetching and parsing browse entries

### DIFF
--- a/src/app/+search-page/search-service/search.service.ts
+++ b/src/app/+search-page/search-service/search.service.ts
@@ -23,6 +23,7 @@ import { RequestService } from '../../core/data/request.service';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
 import { GenericConstructor } from '../../core/shared/generic-constructor';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
+import { configureRequest } from '../../core/shared/operators';
 import { URLCombiner } from '../../core/url-combiner/url-combiner';
 import { hasValue, isEmpty, isNotEmpty } from '../../shared/empty.util';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
@@ -78,7 +79,7 @@ export class SearchService implements OnDestroy {
           }
         });
       }),
-      tap((request: RestRequest) => this.requestService.configure(request)),
+      configureRequest(this.requestService)
     );
     const requestEntryObs = requestObs.pipe(
       flatMap((request: RestRequest) => this.requestService.getByHref(request.href))
@@ -153,7 +154,7 @@ export class SearchService implements OnDestroy {
           }
         });
       }),
-      tap((request: RestRequest) => this.requestService.configure(request)),
+      configureRequest(this.requestService)
     );
 
     const requestEntryObs = requestObs.pipe(
@@ -188,7 +189,7 @@ export class SearchService implements OnDestroy {
           }
         });
       }),
-      tap((request: RestRequest) => this.requestService.configure(request)),
+      configureRequest(this.requestService)
     );
 
     const requestEntryObs = requestObs.pipe(

--- a/src/app/core/browse/browse.service.ts
+++ b/src/app/core/browse/browse.service.ts
@@ -1,15 +1,34 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { GLOBAL_CONFIG } from '../../../config';
-import { GlobalConfig } from '../../../config/global-config.interface';
-import { isEmpty, isNotEmpty } from '../../shared/empty.util';
-import { BrowseSuccessResponse, ErrorResponse, RestResponse } from '../cache/response-cache.models';
+import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
+import {
+  ensureArrayHasValue,
+  hasValueOperator,
+  isEmpty,
+  isNotEmpty,
+  isNotEmptyOperator
+} from '../../shared/empty.util';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { SortOptions } from '../cache/models/sort-options.model';
+import { GenericSuccessResponse } from '../cache/response-cache.models';
 import { ResponseCacheEntry } from '../cache/response-cache.reducer';
 import { ResponseCacheService } from '../cache/response-cache.service';
-import { BrowseEndpointRequest, RestRequest } from '../data/request.models';
+import { PaginatedList } from '../data/paginated-list';
+import { RemoteData } from '../data/remote-data';
+import { BrowseEndpointRequest, BrowseEntriesRequest, RestRequest } from '../data/request.models';
 import { RequestService } from '../data/request.service';
 import { BrowseDefinition } from '../shared/browse-definition.model';
+import { BrowseEntry } from '../shared/browse-entry.model';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
+import {
+  configureRequest,
+  filterSuccessfulResponses,
+  getRemoteDataPayload,
+  getRequestFromSelflink,
+  getResponseFromSelflink
+} from '../shared/operators';
+import { URLCombiner } from '../url-combiner/url-combiner';
 
 @Injectable()
 export class BrowseService {
@@ -31,42 +50,106 @@ export class BrowseService {
   constructor(
     protected responseCache: ResponseCacheService,
     protected requestService: RequestService,
-    protected halService: HALEndpointService) {
+    protected halService: HALEndpointService,
+    private rdb: RemoteDataBuildService,
+  ) {
+  }
+
+  getBrowseDefinitions(): Observable<RemoteData<BrowseDefinition[]>> {
+    const request$ = this.halService.getEndpoint(this.linkPath).pipe(
+      isNotEmptyOperator(),
+      distinctUntilChanged(),
+      map((endpointURL: string) => new BrowseEndpointRequest(this.requestService.generateRequestId(), endpointURL)),
+      configureRequest(this.requestService)
+    );
+
+    const href$ = request$.pipe(map((request: RestRequest) => request.href));
+    const requestEntry$ = href$.pipe(getRequestFromSelflink(this.requestService));
+    const responseCache$ = href$.pipe(getResponseFromSelflink(this.responseCache));
+    const payload$ = responseCache$.pipe(
+      filterSuccessfulResponses(),
+      map((entry: ResponseCacheEntry) => entry.response),
+      map((response: GenericSuccessResponse<BrowseDefinition[]>) => response.payload),
+      ensureArrayHasValue(),
+      distinctUntilChanged()
+    );
+
+    return this.rdb.toRemoteDataObservable(requestEntry$, responseCache$, payload$);
+  }
+
+  getBrowseEntriesFor(definitionID: string, options: {
+    pagination?: PaginationComponentOptions;
+    sort?: SortOptions;
+  } = {}): Observable<RemoteData<PaginatedList<BrowseEntry>>> {
+    const request$ = this.getBrowseDefinitions().pipe(
+      getRemoteDataPayload(),
+      map((browseDefinitions: BrowseDefinition[]) => browseDefinitions
+        .find((def: BrowseDefinition) => def.id === definitionID && def.metadataBrowse === true)
+      ),
+      map((def: BrowseDefinition) => {
+        if (isNotEmpty(def)) {
+          return def._links;
+        } else {
+          throw new Error(`No metadata browse definition could be found for id '${definitionID}'`);
+        }
+      }),
+      hasValueOperator(),
+      map((_links: any) => _links.entries),
+      hasValueOperator(),
+      map((href: string) => {
+        // TODO nearly identical to PaginatedSearchOptions => refactor
+        const args = [];
+        if (isNotEmpty(options.sort)) {
+          args.push(`sort=${options.sort.field},${options.sort.direction}`);
+        }
+        if (isNotEmpty(options.pagination)) {
+          args.push(`page=${options.pagination.currentPage - 1}`);
+          args.push(`size=${options.pagination.pageSize}`);
+        }
+        if (isNotEmpty(args)) {
+          href = new URLCombiner(href, `?${args.join('&')}`).toString();
+        }
+        return href;
+      }),
+      map((endpointURL: string) => new BrowseEntriesRequest(this.requestService.generateRequestId(), endpointURL)),
+      configureRequest(this.requestService)
+    );
+
+    const href$ = request$.pipe(map((request: RestRequest) => request.href));
+
+    const requestEntry$ = href$.pipe(getRequestFromSelflink(this.requestService));
+    const responseCache$ = href$.pipe(getResponseFromSelflink(this.responseCache));
+
+    const payload$ = responseCache$.pipe(
+      filterSuccessfulResponses(),
+      map((entry: ResponseCacheEntry) => entry.response),
+      map((response: GenericSuccessResponse<BrowseEntry[]>) => new PaginatedList(response.pageInfo, response.payload)),
+      distinctUntilChanged()
+    );
+
+    return this.rdb.toRemoteDataObservable(requestEntry$, responseCache$, payload$);
   }
 
   getBrowseURLFor(metadatumKey: string, linkPath: string): Observable<string> {
     const searchKeyArray = BrowseService.toSearchKeyArray(metadatumKey);
-    return this.halService.getEndpoint(this.linkPath)
-      .filter((href: string) => isNotEmpty(href))
-      .distinctUntilChanged()
-      .map((endpointURL: string) => new BrowseEndpointRequest(this.requestService.generateRequestId(), endpointURL))
-      .do((request: RestRequest) => this.requestService.configure(request))
-      .flatMap((request: RestRequest) => {
-        const [successResponse, errorResponse] = this.responseCache.get(request.href)
-          .map((entry: ResponseCacheEntry) => entry.response)
-          .partition((response: RestResponse) => response.isSuccessful);
-
-        return Observable.merge(
-          errorResponse.flatMap((response: ErrorResponse) =>
-            Observable.throw(new Error(`Couldn't retrieve the browses endpoint`))),
-          successResponse
-            .filter((response: BrowseSuccessResponse) => isNotEmpty(response.browseDefinitions))
-            .map((response: BrowseSuccessResponse) => response.browseDefinitions)
-            .map((browseDefinitions: BrowseDefinition[]) => browseDefinitions
-              .find((def: BrowseDefinition) => {
-                const matchingKeys = def.metadataKeys.find((key: string) => searchKeyArray.indexOf(key) >= 0);
-                return isNotEmpty(matchingKeys);
-              })
-            ).map((def: BrowseDefinition) => {
-            if (isEmpty(def) || isEmpty(def._links) || isEmpty(def._links[linkPath])) {
-              throw new Error(`A browse endpoint for ${linkPath} on ${metadatumKey} isn't configured`);
-            } else {
-              return def._links[linkPath];
-            }
-          })
-        );
-      }).startWith(undefined)
-      .distinctUntilChanged();
+    return this.getBrowseDefinitions().pipe(
+      getRemoteDataPayload(),
+      map((browseDefinitions: BrowseDefinition[]) => browseDefinitions
+        .find((def: BrowseDefinition) => {
+          const matchingKeys = def.metadataKeys.find((key: string) => searchKeyArray.indexOf(key) >= 0);
+          return isNotEmpty(matchingKeys);
+        })
+      ),
+      map((def: BrowseDefinition) => {
+        if (isEmpty(def) || isEmpty(def._links) || isEmpty(def._links[linkPath])) {
+          throw new Error(`A browse endpoint for ${linkPath} on ${metadatumKey} isn't configured`);
+        } else {
+          return def._links[linkPath];
+        }
+      }),
+      startWith(undefined),
+      distinctUntilChanged()
+    );
   }
 
 }

--- a/src/app/core/cache/builders/remote-data-build.service.ts
+++ b/src/app/core/cache/builders/remote-data-build.service.ts
@@ -1,28 +1,25 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { map, tap } from 'rxjs/operators';
-import { NormalizedSearchResult } from '../../../+search-page/normalized-search-result.model';
-import { SearchResult } from '../../../+search-page/search-result.model';
-import { SearchQueryResponse } from '../../../+search-page/search-service/search-query-response.model';
-import { hasValue, isEmpty, isNotEmpty } from '../../../shared/empty.util';
+import { distinctUntilChanged, flatMap, map, startWith } from 'rxjs/operators';
+import { hasValue, hasValueOperator, isEmpty, isNotEmpty } from '../../../shared/empty.util';
 import { PaginatedList } from '../../data/paginated-list';
 import { RemoteData } from '../../data/remote-data';
 import { RemoteDataError } from '../../data/remote-data-error';
-import { GetRequest, RestRequest } from '../../data/request.models';
+import { GetRequest } from '../../data/request.models';
 import { RequestEntry } from '../../data/request.reducer';
 import { RequestService } from '../../data/request.service';
-import { DSpaceObject } from '../../shared/dspace-object.model';
-import { GenericConstructor } from '../../shared/generic-constructor';
-import { NormalizedDSpaceObject } from '../models/normalized-dspace-object.model';
-import { NormalizedObjectFactory } from '../models/normalized-object-factory';
-
-import { CacheableObject } from '../object-cache.reducer';
+import { NormalizedObject } from '../models/normalized-object.model';
 import { ObjectCacheService } from '../object-cache.service';
-import { DSOSuccessResponse, ErrorResponse, SearchSuccessResponse } from '../response-cache.models';
+import { DSOSuccessResponse, ErrorResponse } from '../response-cache.models';
 import { ResponseCacheEntry } from '../response-cache.reducer';
 import { ResponseCacheService } from '../response-cache.service';
 import { getMapsTo, getRelationMetadata, getRelationships } from './build-decorators';
-import { NormalizedObject } from '../models/normalized-object.model';
+import {
+  getRequestFromSelflink,
+  getResourceLinksFromResponse,
+  getResponseFromSelflink,
+  filterSuccessfulResponses
+} from '../../shared/operators';
 
 @Injectable()
 export class RemoteDataBuildService {
@@ -31,43 +28,42 @@ export class RemoteDataBuildService {
               protected requestService: RequestService) {
   }
 
-  buildSingle<TNormalized extends NormalizedObject, TDomain>(hrefObs: string | Observable<string>): Observable<RemoteData<TDomain>> {
-    if (typeof hrefObs === 'string') {
-      hrefObs = Observable.of(hrefObs);
+  buildSingle<TNormalized extends NormalizedObject, TDomain>(href$: string | Observable<string>): Observable<RemoteData<TDomain>> {
+    if (typeof href$ === 'string') {
+      href$ = Observable.of(href$);
     }
-    const requestHrefObs = hrefObs.flatMap((href: string) =>
-      this.objectCache.getRequestHrefBySelfLink(href));
+    const requestHref$ = href$.pipe(flatMap((href: string) =>
+      this.objectCache.getRequestHrefBySelfLink(href)));
 
-    const requestEntryObs = Observable.race(
-      hrefObs.flatMap((href: string) => this.requestService.getByHref(href))
-        .filter((entry) => hasValue(entry)),
-      requestHrefObs.flatMap((requestHref) =>
-        this.requestService.getByHref(requestHref)).filter((entry) => hasValue(entry))
+    const requestEntry$ = Observable.race(
+      href$.pipe(getRequestFromSelflink(this.requestService)),
+      requestHref$.pipe(getRequestFromSelflink(this.requestService))
     );
 
-    const responseCacheObs = Observable.race(
-      hrefObs.flatMap((href: string) => this.responseCache.get(href))
-        .filter((entry) => hasValue(entry)),
-      requestHrefObs.flatMap((requestHref) => this.responseCache.get(requestHref)).filter((entry) => hasValue(entry))
+    const responseCache$ = Observable.race(
+      href$.pipe(getResponseFromSelflink(this.responseCache)),
+      requestHref$.pipe(getResponseFromSelflink(this.responseCache))
     );
 
     // always use self link if that is cached, only if it isn't, get it via the response.
-    const payloadObs =
+    const payload$ =
       Observable.combineLatest(
-        hrefObs.flatMap((href: string) => this.objectCache.getBySelfLink<TNormalized>(href))
-          .startWith(undefined),
-        responseCacheObs
-          .filter((entry: ResponseCacheEntry) => entry.response.isSuccessful)
-          .map((entry: ResponseCacheEntry) => (entry.response as DSOSuccessResponse).resourceSelfLinks)
-          .flatMap((resourceSelfLinks: string[]) => {
+        href$.pipe(
+          flatMap((href: string) => this.objectCache.getBySelfLink<TNormalized>(href)),
+          startWith(undefined)
+        ),
+        responseCache$.pipe(
+          getResourceLinksFromResponse(),
+          flatMap((resourceSelfLinks: string[]) => {
             if (isNotEmpty(resourceSelfLinks)) {
               return this.objectCache.getBySelfLink(resourceSelfLinks[0]);
             } else {
               return Observable.of(undefined);
             }
-          })
-          .distinctUntilChanged()
-          .startWith(undefined),
+          }),
+          distinctUntilChanged(),
+          startWith(undefined)
+        ),
         (fromSelfLink, fromResponse) => {
           if (hasValue(fromSelfLink)) {
             return fromSelfLink;
@@ -75,17 +71,19 @@ export class RemoteDataBuildService {
             return fromResponse;
           }
         }
-      ).filter((normalized) => hasValue(normalized))
-        .map((normalized: TNormalized) => {
+      ).pipe(
+        hasValueOperator(),
+        map((normalized: TNormalized) => {
           return this.build<TNormalized, TDomain>(normalized);
-        })
-        .startWith(undefined)
-        .distinctUntilChanged();
-    return this.toRemoteDataObservable(requestEntryObs, responseCacheObs, payloadObs);
+        }),
+        startWith(undefined),
+        distinctUntilChanged()
+      );
+    return this.toRemoteDataObservable(requestEntry$, responseCache$, payload$);
   }
 
-  toRemoteDataObservable<T>(requestEntryObs: Observable<RequestEntry>, responseCacheObs: Observable<ResponseCacheEntry>, payloadObs: Observable<T>) {
-    return Observable.combineLatest(requestEntryObs, responseCacheObs.startWith(undefined), payloadObs,
+  toRemoteDataObservable<T>(requestEntry$: Observable<RequestEntry>, responseCache$: Observable<ResponseCacheEntry>, payload$: Observable<T>) {
+    return Observable.combineLatest(requestEntry$, responseCache$.startWith(undefined), payload$,
       (reqEntry: RequestEntry, resEntry: ResponseCacheEntry, payload: T) => {
         const requestPending = hasValue(reqEntry.requestPending) ? reqEntry.requestPending : true;
         const responsePending = hasValue(reqEntry.responsePending) ? reqEntry.responsePending : false;
@@ -109,33 +107,31 @@ export class RemoteDataBuildService {
       });
   }
 
-  buildList<TNormalized extends NormalizedObject, TDomain>(hrefObs: string | Observable<string>): Observable<RemoteData<TDomain[] | PaginatedList<TDomain>>> {
-    if (typeof hrefObs === 'string') {
-      hrefObs = Observable.of(hrefObs);
+  buildList<TNormalized extends NormalizedObject, TDomain>(href$: string | Observable<string>): Observable<RemoteData<TDomain[] | PaginatedList<TDomain>>> {
+    if (typeof href$ === 'string') {
+      href$ = Observable.of(href$);
     }
 
-    const requestEntryObs = hrefObs.flatMap((href: string) => this.requestService.getByHref(href))
-      .filter((entry) => hasValue(entry));
-    const responseCacheObs = hrefObs.flatMap((href: string) => this.responseCache.get(href))
-      .filter((entry) => hasValue(entry));
+    const requestEntry$ = href$.pipe(getRequestFromSelflink(this.requestService));
+    const responseCache$ = href$.pipe(getResponseFromSelflink(this.responseCache));
 
-    const tDomainListObs = responseCacheObs
-      .filter((entry: ResponseCacheEntry) => entry.response.isSuccessful)
-      .map((entry: ResponseCacheEntry) => (entry.response as DSOSuccessResponse).resourceSelfLinks)
-      .flatMap((resourceUUIDs: string[]) => {
+    const tDomainList$ = responseCache$.pipe(
+      getResourceLinksFromResponse(),
+      flatMap((resourceUUIDs: string[]) => {
         return this.objectCache.getList(resourceUUIDs)
           .map((normList: TNormalized[]) => {
             return normList.map((normalized: TNormalized) => {
               return this.build<TNormalized, TDomain>(normalized);
             });
           });
-      })
-      .startWith([])
-      .distinctUntilChanged();
+      }),
+      startWith([]),
+      distinctUntilChanged()
+    );
 
-    const pageInfoObs = responseCacheObs
-      .filter((entry: ResponseCacheEntry) => entry.response.isSuccessful)
-      .map((entry: ResponseCacheEntry) => {
+    const pageInfo$ = responseCache$.pipe(
+      filterSuccessfulResponses(),
+      map((entry: ResponseCacheEntry) => {
         if (hasValue((entry.response as DSOSuccessResponse).pageInfo)) {
           const resPageInfo = (entry.response as DSOSuccessResponse).pageInfo;
           if (isNotEmpty(resPageInfo) && resPageInfo.currentPage >= 0) {
@@ -144,9 +140,10 @@ export class RemoteDataBuildService {
             return resPageInfo;
           }
         }
-      });
+      })
+  );
 
-    const payloadObs = Observable.combineLatest(tDomainListObs, pageInfoObs, (tDomainList, pageInfo) => {
+    const payload$ = Observable.combineLatest(tDomainList$, pageInfo$, (tDomainList, pageInfo) => {
       if (hasValue(pageInfo)) {
         return new PaginatedList(pageInfo, tDomainList);
       } else {
@@ -154,7 +151,7 @@ export class RemoteDataBuildService {
       }
     });
 
-    return this.toRemoteDataObservable(requestEntryObs, responseCacheObs, payloadObs);
+    return this.toRemoteDataObservable(requestEntry$, responseCache$, payload$);
   }
 
   build<TNormalized, TDomain>(normalized: TNormalized): TDomain {

--- a/src/app/core/cache/response-cache.models.ts
+++ b/src/app/core/cache/response-cache.models.ts
@@ -1,5 +1,6 @@
 import { SearchQueryResponse } from '../../+search-page/search-service/search-query-response.model';
 import { RequestError } from '../data/request.models';
+import { BrowseEntry } from '../shared/browse-entry.model';
 import { PageInfo } from '../shared/page-info.model';
 import { BrowseDefinition } from '../shared/browse-definition.model';
 import { ConfigObject } from '../shared/config/config.model';
@@ -78,10 +79,11 @@ export class EndpointMapSuccessResponse extends RestResponse {
   }
 }
 
-export class BrowseSuccessResponse extends RestResponse {
+export class GenericSuccessResponse<T> extends RestResponse {
   constructor(
-    public browseDefinitions: BrowseDefinition[],
-    public statusCode: string
+    public payload: T,
+    public statusCode: string,
+    public pageInfo?: PageInfo
   ) {
     super(true, statusCode);
   }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -15,6 +15,7 @@ import { coreReducers } from './core.reducers';
 import { isNotEmpty } from '../shared/empty.util';
 
 import { ApiService } from '../shared/api.service';
+import { BrowseEntriesResponseParsingService } from './data/browse-entries-response-parsing.service';
 import { CollectionDataService } from './data/collection-data.service';
 import { CommunityDataService } from './data/community-data.service';
 import { DebugResponseParsingService } from './data/debug-response-parsing.service';
@@ -83,6 +84,7 @@ const PROVIDERS = [
   SearchResponseParsingService,
   ServerResponseService,
   BrowseResponseParsingService,
+  BrowseEntriesResponseParsingService,
   BrowseService,
   ConfigResponseParsingService,
   RouteService,

--- a/src/app/core/data/browse-entries-response-parsing.service.spec.ts
+++ b/src/app/core/data/browse-entries-response-parsing.service.spec.ts
@@ -1,0 +1,146 @@
+import { getMockObjectCacheService } from '../../shared/mocks/mock-object-cache.service';
+import { ErrorResponse, GenericSuccessResponse } from '../cache/response-cache.models';
+import { DSpaceRESTV2Response } from '../dspace-rest-v2/dspace-rest-v2-response.model';
+import { BrowseEntriesResponseParsingService } from './browse-entries-response-parsing.service';
+import { BrowseEntriesRequest } from './request.models';
+
+describe('BrowseEntriesResponseParsingService', () => {
+  let service: BrowseEntriesResponseParsingService;
+
+  beforeEach(() => {
+    service = new BrowseEntriesResponseParsingService(undefined, getMockObjectCacheService());
+  });
+
+  describe('parse', () => {
+    const request = new BrowseEntriesRequest('client/f5b4ccb8-fbb0-4548-b558-f234d9fdfad6', 'https://rest.api/discover/browses/author/entries');
+
+    const validResponse = {
+      payload: {
+        _embedded: {
+          browseEntries: [
+            {
+              authority: null,
+              value: 'Arulmozhiyal, Ramaswamy',
+              valueLang: null,
+              count: 1,
+              type: 'browseEntry',
+              _links: {
+                items: {
+                  href: 'https://rest.api/discover/browses/author/items?filterValue=Arulmozhiyal, Ramaswamy'
+                }
+              }
+            },
+            {
+              authority: null,
+              value: 'Bastida-Jumilla, Ma Consuelo',
+              valueLang: null,
+              count: 1,
+              type: 'browseEntry',
+              _links: {
+                items: {
+                  href: 'https://rest.api/discover/browses/author/items?filterValue=Bastida-Jumilla, Ma Consuelo'
+                }
+              }
+            },
+            {
+              authority: null,
+              value: 'Cao, Binggang',
+              valueLang: null,
+              count: 1,
+              type: 'browseEntry',
+              _links: {
+                items: {
+                  href: 'https://rest.api/discover/browses/author/items?filterValue=Cao, Binggang'
+                }
+              }
+            },
+            {
+              authority: null,
+              value: 'Castelli, Mauro',
+              valueLang: null,
+              count: 1,
+              type: 'browseEntry',
+              _links: {
+                items: {
+                  href: 'https://rest.api/discover/browses/author/items?filterValue=Castelli, Mauro'
+                }
+              }
+            },
+            {
+              authority: null,
+              value: 'Cat, Lily',
+              valueLang: null,
+              count: 1,
+              type: 'browseEntry',
+              _links: {
+                items: {
+                  href: 'https://rest.api/discover/browses/author/items?filterValue=Cat, Lily'
+                }
+              }
+            }
+          ]
+        },
+        _links: {
+          first: {
+            href: 'https://rest.api/discover/browses/author/entries?page=0&size=5'
+          },
+          self: {
+            href: 'https://rest.api/discover/browses/author/entries'
+          },
+          next: {
+            href: 'https://rest.api/discover/browses/author/entries?page=1&size=5'
+          },
+          last: {
+            href: 'https://rest.api/discover/browses/author/entries?page=9&size=5'
+          }
+        },
+        page: {
+          size: 5,
+          totalElements: 50,
+          totalPages: 10,
+          number: 0
+        }
+      },
+      statusCode: '200'
+    } as DSpaceRESTV2Response;
+
+    const invalidResponseNotAList = {
+      payload: {
+        authority: null,
+        value: 'Arulmozhiyal, Ramaswamy',
+        valueLang: null,
+        count: 1,
+        type: 'browseEntry',
+        _links: {
+          self: {
+            href: 'https://rest.api/discover/browses/author/entries'
+          },
+          items: {
+            href: 'https://rest.api/discover/browses/author/items?filterValue=Arulmozhiyal, Ramaswamy'
+          }
+        },
+      },
+      statusCode: '200'
+    } as DSpaceRESTV2Response;
+
+    const invalidResponseStatusCode = {
+      payload: {}, statusCode: '500'
+    } as DSpaceRESTV2Response;
+
+    it('should return a GenericSuccessResponse if data contains a valid browse entries response', () => {
+      const response = service.parse(request, validResponse);
+      expect(response.constructor).toBe(GenericSuccessResponse);
+    });
+
+    it('should return an ErrorResponse if data contains an invalid browse entries response', () => {
+      const response = service.parse(request, invalidResponseNotAList);
+      expect(response.constructor).toBe(ErrorResponse);
+    });
+
+    it('should return an ErrorResponse if data contains a statuscode other than 200', () => {
+      const response = service.parse(request, invalidResponseStatusCode);
+      expect(response.constructor).toBe(ErrorResponse);
+    });
+
+  });
+});

--- a/src/app/core/data/browse-entries-response-parsing.service.ts
+++ b/src/app/core/data/browse-entries-response-parsing.service.ts
@@ -1,0 +1,48 @@
+import { Inject, Injectable } from '@angular/core';
+import { GLOBAL_CONFIG } from '../../../config';
+import { GlobalConfig } from '../../../config/global-config.interface';
+import { isNotEmpty } from '../../shared/empty.util';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import {
+  ErrorResponse,
+  GenericSuccessResponse,
+  RestResponse
+} from '../cache/response-cache.models';
+import { DSpaceRESTV2Response } from '../dspace-rest-v2/dspace-rest-v2-response.model';
+import { DSpaceRESTv2Serializer } from '../dspace-rest-v2/dspace-rest-v2.serializer';
+import { BrowseEntry } from '../shared/browse-entry.model';
+import { BaseResponseParsingService } from './base-response-parsing.service';
+import { ResponseParsingService } from './parsing.service';
+import { RestRequest } from './request.models';
+
+@Injectable()
+export class BrowseEntriesResponseParsingService extends BaseResponseParsingService implements ResponseParsingService {
+
+  protected objectFactory = {
+    getConstructor: () => BrowseEntry
+  };
+  protected toCache = false;
+
+  constructor(
+    @Inject(GLOBAL_CONFIG) protected EnvConfig: GlobalConfig,
+    protected objectCache: ObjectCacheService,
+  ) { super();
+  }
+
+  parse(request: RestRequest, data: DSpaceRESTV2Response): RestResponse {
+    if (isNotEmpty(data.payload) && isNotEmpty(data.payload._embedded)
+      && Array.isArray(data.payload._embedded[Object.keys(data.payload._embedded)[0]])) {
+      const serializer = new DSpaceRESTv2Serializer(BrowseEntry);
+      const browseEntries = serializer.deserializeArray(data.payload._embedded[Object.keys(data.payload._embedded)[0]]);
+      return new GenericSuccessResponse(browseEntries, data.statusCode, this.processPageInfo(data.payload));
+    } else {
+      return new ErrorResponse(
+        Object.assign(
+          new Error('Unexpected response from browse endpoint'),
+          { statusText: data.statusCode }
+        )
+      );
+    }
+  }
+
+}

--- a/src/app/core/data/browse-response-parsing.service.spec.ts
+++ b/src/app/core/data/browse-response-parsing.service.spec.ts
@@ -12,7 +12,7 @@ describe('BrowseResponseParsingService', () => {
   });
 
   describe('parse', () => {
-    const validRequest = new BrowseEndpointRequest('clients/b186e8ce-e99c-4183-bc9a-42b4821bdb78', 'https://rest.api/discover/browses');
+    const validRequest = new BrowseEndpointRequest('client/b186e8ce-e99c-4183-bc9a-42b4821bdb78', 'https://rest.api/discover/browses');
 
     const validResponse = {
       payload: {

--- a/src/app/core/data/browse-response-parsing.service.spec.ts
+++ b/src/app/core/data/browse-response-parsing.service.spec.ts
@@ -1,6 +1,6 @@
 import { BrowseResponseParsingService } from './browse-response-parsing.service';
 import { BrowseEndpointRequest } from './request.models';
-import { BrowseSuccessResponse, ErrorResponse } from '../cache/response-cache.models';
+import { GenericSuccessResponse, ErrorResponse } from '../cache/response-cache.models';
 import { BrowseDefinition } from '../shared/browse-definition.model';
 import { DSpaceRESTV2Response } from '../dspace-rest-v2/dspace-rest-v2-response.model';
 
@@ -138,9 +138,9 @@ describe('BrowseResponseParsingService', () => {
       })
     ];
 
-    it('should return a BrowseSuccessResponse if data contains a valid browse endpoint response', () => {
+    it('should return a GenericSuccessResponse if data contains a valid browse endpoint response', () => {
       const response = service.parse(validRequest, validResponse);
-      expect(response.constructor).toBe(BrowseSuccessResponse);
+      expect(response.constructor).toBe(GenericSuccessResponse);
     });
 
     it('should return an ErrorResponse if data contains an invalid browse endpoint response', () => {
@@ -155,9 +155,9 @@ describe('BrowseResponseParsingService', () => {
       expect(response.constructor).toBe(ErrorResponse);
     });
 
-    it('should return a BrowseSuccessResponse with the BrowseDefinitions in data', () => {
+    it('should return a GenericSuccessResponse with the BrowseDefinitions in data', () => {
       const response = service.parse(validRequest, validResponse);
-      expect((response as BrowseSuccessResponse).browseDefinitions).toEqual(definitions);
+      expect((response as GenericSuccessResponse<BrowseDefinition[]>).payload).toEqual(definitions);
     });
 
   });

--- a/src/app/core/data/browse-response-parsing.service.ts
+++ b/src/app/core/data/browse-response-parsing.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ResponseParsingService } from './parsing.service';
 import { RestRequest } from './request.models';
 import { DSpaceRESTV2Response } from '../dspace-rest-v2/dspace-rest-v2-response.model';
-import { BrowseSuccessResponse, ErrorResponse, RestResponse } from '../cache/response-cache.models';
+import { GenericSuccessResponse, ErrorResponse, RestResponse } from '../cache/response-cache.models';
 import { isNotEmpty } from '../../shared/empty.util';
 import { DSpaceRESTv2Serializer } from '../dspace-rest-v2/dspace-rest-v2.serializer';
 import { BrowseDefinition } from '../shared/browse-definition.model';
@@ -15,7 +15,7 @@ export class BrowseResponseParsingService implements ResponseParsingService {
       && Array.isArray(data.payload._embedded[Object.keys(data.payload._embedded)[0]])) {
       const serializer = new DSpaceRESTv2Serializer(BrowseDefinition);
       const browseDefinitions = serializer.deserializeArray(data.payload._embedded[Object.keys(data.payload._embedded)[0]]);
-      return new BrowseSuccessResponse(browseDefinitions, data.statusCode);
+      return new GenericSuccessResponse(browseDefinitions, data.statusCode);
     } else {
       return new ErrorResponse(
         Object.assign(

--- a/src/app/core/data/request.models.ts
+++ b/src/app/core/data/request.models.ts
@@ -2,6 +2,7 @@ import { SortOptions } from '../cache/models/sort-options.model';
 import { GenericConstructor } from '../shared/generic-constructor';
 import { GlobalConfig } from '../../../config/global-config.interface';
 import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+import { BrowseEntriesResponseParsingService } from './browse-entries-response-parsing.service';
 import { DSOResponseParsingService } from './dso-response-parsing.service';
 import { ResponseParsingService } from './parsing.service';
 import { EndpointMapResponseParsingService } from './endpoint-map-response-parsing.service';
@@ -161,6 +162,12 @@ export class BrowseEndpointRequest extends GetRequest {
 
   getResponseParser(): GenericConstructor<ResponseParsingService> {
     return BrowseResponseParsingService;
+  }
+}
+
+export class BrowseEntriesRequest extends GetRequest {
+  getResponseParser(): GenericConstructor<ResponseParsingService> {
+    return BrowseEntriesResponseParsingService;
   }
 }
 

--- a/src/app/core/shared/browse-definition.model.ts
+++ b/src/app/core/shared/browse-definition.model.ts
@@ -3,6 +3,9 @@ import { SortOption } from './sort-option.model';
 
 export class BrowseDefinition {
   @autoserialize
+  id: string;
+
+  @autoserialize
   metadataBrowse: boolean;
 
   @autoserialize

--- a/src/app/core/shared/browse-entry.model.ts
+++ b/src/app/core/shared/browse-entry.model.ts
@@ -1,0 +1,20 @@
+import { autoserialize, autoserializeAs } from 'cerialize';
+
+export class BrowseEntry {
+
+  @autoserialize
+  type: string;
+
+  @autoserialize
+  authority: string;
+
+  @autoserialize
+  value: string;
+
+  @autoserializeAs('valueLang')
+  language: string;
+
+  @autoserialize
+  count: number;
+
+}

--- a/src/app/core/shared/operators.spec.ts
+++ b/src/app/core/shared/operators.spec.ts
@@ -14,7 +14,6 @@ import {
   getResponseFromSelflink
 } from './operators';
 
-
 describe('Core Module - RxJS Operators', () => {
   let scheduler: TestScheduler;
   let requestService: RequestService;

--- a/src/app/core/shared/operators.spec.ts
+++ b/src/app/core/shared/operators.spec.ts
@@ -1,0 +1,153 @@
+import { cold, getTestScheduler, hot } from 'jasmine-marbles';
+import { TestScheduler } from '../../../../node_modules/rxjs';
+import { getMockRequestService } from '../../shared/mocks/mock-request.service';
+import { getMockResponseCacheService } from '../../shared/mocks/mock-response-cache.service';
+import { ResponseCacheEntry } from '../cache/response-cache.reducer';
+import { ResponseCacheService } from '../cache/response-cache.service';
+import { GetRequest, RestRequest } from '../data/request.models';
+import { RequestEntry } from '../data/request.reducer';
+import { RequestService } from '../data/request.service';
+import {
+  configureRequest,
+  filterSuccessfulResponses, getRemoteDataPayload,
+  getRequestFromSelflink, getResourceLinksFromResponse,
+  getResponseFromSelflink
+} from './operators';
+
+
+describe('Core Module - RxJS Operators', () => {
+  let scheduler: TestScheduler;
+  let requestService: RequestService;
+  const testSelfLink = 'https://rest.api/';
+
+  const testRCEs = {
+    a: { response: { isSuccessful: true, resourceSelfLinks: ['a', 'b', 'c', 'd'] } },
+    b: { response: { isSuccessful: false, resourceSelfLinks: ['e', 'f'] } },
+    c: { response: { isSuccessful: undefined, resourceSelfLinks: ['g', 'h', 'i'] } },
+    d: { response: { isSuccessful: true, resourceSelfLinks: ['j', 'k', 'l', 'm', 'n'] } },
+    e: { response: { isSuccessful: 1, resourceSelfLinks: [] } }
+  };
+
+  beforeEach(() => {
+    scheduler = getTestScheduler();
+  });
+
+  describe('getRequestFromSelflink', () => {
+
+    it('should return the RequestEntry corresponding to the self link in the source', () => {
+      requestService = getMockRequestService();
+
+      const source = hot('a', { a: testSelfLink });
+      const result = source.pipe(getRequestFromSelflink(requestService));
+      const expected = cold('a', { a: new RequestEntry()});
+
+      expect(result).toBeObservable(expected)
+    });
+
+    it('should use the requestService to fetch the request by its self link', () => {
+      requestService = getMockRequestService();
+
+      const source = hot('a', { a: testSelfLink });
+      scheduler.schedule(() => source.pipe(getRequestFromSelflink(requestService)).subscribe());
+      scheduler.flush();
+
+      expect(requestService.getByHref).toHaveBeenCalledWith(testSelfLink)
+    });
+
+    it('shouldn\'t return anything if there is no request matching the self link', () => {
+      requestService = getMockRequestService(cold('a', { a: undefined }));
+
+      const source = hot('a', { a: testSelfLink });
+      const result = source.pipe(getRequestFromSelflink(requestService));
+      const expected = cold('-');
+
+      expect(result).toBeObservable(expected)
+    });
+  });
+
+  describe('getResponseFromSelflink', () => {
+    let responseCacheService: ResponseCacheService;
+
+    beforeEach(() => {
+      scheduler = getTestScheduler();
+    });
+
+    it('should return the ResponseCacheEntry corresponding to the self link in the source', () => {
+      responseCacheService = getMockResponseCacheService();
+
+      const source = hot('a', { a: testSelfLink });
+      const result = source.pipe(getResponseFromSelflink(responseCacheService));
+      const expected = cold('a', { a: new ResponseCacheEntry()});
+
+      expect(result).toBeObservable(expected)
+    });
+
+    it('should use the responseCacheService to fetch the response by the request\'s link', () => {
+      responseCacheService = getMockResponseCacheService();
+
+      const source = hot('a', { a: testSelfLink });
+      scheduler.schedule(() => source.pipe(getResponseFromSelflink(responseCacheService)).subscribe());
+      scheduler.flush();
+
+      expect(responseCacheService.get).toHaveBeenCalledWith(testSelfLink)
+    });
+
+    it('shouldn\'t return anything if there is no response matching the request\'s link', () => {
+      responseCacheService = getMockResponseCacheService(undefined, cold('a', { a: undefined }));
+
+      const source = hot('a', { a: testSelfLink });
+      const result = source.pipe(getResponseFromSelflink(responseCacheService));
+      const expected = cold('-');
+
+      expect(result).toBeObservable(expected)
+    });
+  });
+
+  describe('filterSuccessfulResponses', () => {
+    it('should only return responses for which isSuccessful === true', () => {
+      const source = hot('abcde', testRCEs);
+      const result = source.pipe(filterSuccessfulResponses());
+      const expected = cold('a--d-', testRCEs);
+
+      expect(result).toBeObservable(expected)
+    });
+  });
+
+  describe('getResourceLinksFromResponse', () => {
+    it('should return the resourceSelfLinks for all successful responses', () => {
+      const source = hot('abcde', testRCEs);
+      const result = source.pipe(getResourceLinksFromResponse());
+      const expected = cold('a--d-', {
+        a: testRCEs.a.response.resourceSelfLinks,
+        d: testRCEs.d.response.resourceSelfLinks
+      });
+
+      expect(result).toBeObservable(expected)
+    });
+  });
+
+  describe('configureRequest', () => {
+    it('should call requestService.configure with the source request', () => {
+      requestService = getMockRequestService();
+      const testRequest = new GetRequest('6b789e31-f026-4ff8-8993-4eb3b730c841', testSelfLink);
+      const source = hot('a', { a: testRequest });
+      scheduler.schedule(() => source.pipe(configureRequest(requestService)).subscribe());
+      scheduler.flush();
+
+      expect(requestService.configure).toHaveBeenCalledWith(testRequest)
+    });
+  });
+
+  describe('getRemoteDataPayload', () => {
+    it('should return the payload of the source RemoteData', () => {
+      const testRD = { a: { payload: 'a' } };
+      const source = hot('a', testRD);
+      const result = source.pipe(getRemoteDataPayload());
+      const expected = cold('a', {
+        a: testRD.a.payload,
+      });
+
+      expect(result).toBeObservable(expected)
+    });
+  });
+});

--- a/src/app/core/shared/operators.ts
+++ b/src/app/core/shared/operators.ts
@@ -29,7 +29,7 @@ export const getResponseFromSelflink = (responseCache: ResponseCacheService) =>
 
 export const filterSuccessfulResponses = () =>
   (source: Observable<ResponseCacheEntry>): Observable<ResponseCacheEntry> =>
-    source.pipe(filter((entry: ResponseCacheEntry) => entry.response.isSuccessful));
+    source.pipe(filter((entry: ResponseCacheEntry) => entry.response.isSuccessful === true));
 
 export const getResourceLinksFromResponse = () =>
   (source: Observable<ResponseCacheEntry>): Observable<string[]> =>

--- a/src/app/core/shared/operators.ts
+++ b/src/app/core/shared/operators.ts
@@ -1,0 +1,47 @@
+import { Observable } from 'rxjs/Observable';
+import { filter, flatMap, map, tap } from 'rxjs/operators';
+import { hasValueOperator } from '../../shared/empty.util';
+import { DSOSuccessResponse } from '../cache/response-cache.models';
+import { ResponseCacheEntry } from '../cache/response-cache.reducer';
+import { ResponseCacheService } from '../cache/response-cache.service';
+import { RemoteData } from '../data/remote-data';
+import { RestRequest } from '../data/request.models';
+import { RequestEntry } from '../data/request.reducer';
+import { RequestService } from '../data/request.service';
+
+/**
+ * This file contains custom RxJS operators that can be used in multiple places
+ */
+
+export const getRequestFromSelflink = (requestService: RequestService) =>
+  (source: Observable<string>): Observable<RequestEntry> =>
+    source.pipe(
+      flatMap((href: string) => requestService.getByHref(href)),
+      hasValueOperator()
+    );
+
+export const getResponseFromSelflink = (responseCache: ResponseCacheService) =>
+  (source: Observable<string>): Observable<ResponseCacheEntry> =>
+    source.pipe(
+      flatMap((href: string) => responseCache.get(href)),
+      hasValueOperator()
+    );
+
+export const filterSuccessfulResponses = () =>
+  (source: Observable<ResponseCacheEntry>): Observable<ResponseCacheEntry> =>
+    source.pipe(filter((entry: ResponseCacheEntry) => entry.response.isSuccessful));
+
+export const getResourceLinksFromResponse = () =>
+  (source: Observable<ResponseCacheEntry>): Observable<string[]> =>
+    source.pipe(
+      filterSuccessfulResponses(),
+      map((entry: ResponseCacheEntry) => (entry.response as DSOSuccessResponse).resourceSelfLinks),
+    );
+
+export const configureRequest = (requestService: RequestService) =>
+  (source: Observable<RestRequest>): Observable<RestRequest> =>
+    source.pipe(tap((request: RestRequest) => requestService.configure(request)));
+
+export const getRemoteDataPayload = () =>
+  <T>(source: Observable<RemoteData<T>>): Observable<T> =>
+    source.pipe(map((remoteData: RemoteData<T>) => remoteData.payload));

--- a/src/app/shared/empty.util.spec.ts
+++ b/src/app/shared/empty.util.spec.ts
@@ -1,6 +1,16 @@
+import { cold, hot } from 'jasmine-marbles';
 import {
-  isEmpty, hasNoValue, hasValue, isNotEmpty, isNull, isNotNull,
-  isUndefined, isNotUndefined
+  ensureArrayHasValue,
+  hasNoValue,
+  hasValue,
+  hasValueOperator,
+  isEmpty,
+  isNotEmpty,
+  isNotEmptyOperator,
+  isNotNull,
+  isNotUndefined,
+  isNull,
+  isUndefined
 } from './empty.util';
 
 describe('Empty Utils', () => {
@@ -274,6 +284,25 @@ describe('Empty Utils', () => {
 
   });
 
+  describe('hasValueOperator', () => {
+    it('should only include items from the source observable for which hasValue is true, and omit all others', () => {
+      const testData = {
+        a: null,
+        b: 'test',
+        c: true,
+        d: undefined,
+        e: 1,
+        f: {}
+      };
+
+      const source$ = hot('abcdef', testData);
+      const expected$ = cold('-bc-ef', testData);
+      const result$ = source$.pipe(hasValueOperator());
+
+      expect(result$).toBeObservable(expected$);
+    });
+  });
+
   describe('isEmpty', () => {
     it('should return true for null', () => {
       expect(isEmpty(null)).toBe(true);
@@ -392,5 +421,57 @@ describe('Empty Utils', () => {
       expect(isNotEmpty(fullMap)).toBe(true);
     });
 
+  });
+
+  describe('isNotEmptyOperator', () => {
+    it('should only include items from the source observable for which isNotEmpty is true, and omit all others', () => {
+      const testData = {
+        a: null,
+        b: 'test',
+        c: true,
+        d: undefined,
+        e: 1,
+        f: {},
+        g: '',
+        h: ' '
+      };
+
+      const source$ = hot('abcdefgh', testData);
+      const expected$ = cold('-bc-e--h', testData);
+      const result$ = source$.pipe(isNotEmptyOperator());
+
+      expect(result$).toBeObservable(expected$);
+    });
+  });
+
+  describe('ensureArrayHasValue', () => {
+    it('should let all arrays pass unchanged, and turn everything else in to empty arrays', () => {
+      const sourceData = {
+        a: { a: 'b' },
+        b: ['a', 'b', 'c'],
+        c: null,
+        d: [1],
+        e: undefined,
+        f: [],
+        g: () => true,
+        h: {},
+        i: ''
+      };
+
+      const expectedData = Object.assign({}, sourceData, {
+        a: [],
+        c: [],
+        e: [],
+        g: [],
+        h: [],
+        i: []
+      });
+
+      const source$ = hot('abcdefghi', sourceData);
+      const expected$ = cold('abcdefghi', expectedData);
+      const result$ = source$.pipe(ensureArrayHasValue());
+
+      expect(result$).toBeObservable(expected$);
+    });
   });
 });

--- a/src/app/shared/empty.util.ts
+++ b/src/app/shared/empty.util.ts
@@ -1,3 +1,6 @@
+import { Observable } from 'rxjs/Observable';
+import { filter, map } from 'rxjs/operators';
+
 /**
  * Returns true if the passed value is null.
  * isNull();              // false
@@ -83,6 +86,14 @@ export function hasValue(obj?: any): boolean {
 }
 
 /**
+ * Filter items emitted by the source Observable by only emitting those for
+ * which hasValue is true
+ */
+export const hasValueOperator = () =>
+  <T>(source: Observable<T>): Observable<T> =>
+    source.pipe(filter((obj: T) => hasValue(obj)));
+
+/**
  * Verifies that a value is `null` or an empty string, empty array,
  * or empty function.
  * isEmpty();                // true
@@ -148,3 +159,21 @@ export function isEmpty(obj?: any): boolean {
 export function isNotEmpty(obj?: any): boolean {
   return !isEmpty(obj);
 }
+
+/**
+ * Filter items emitted by the source Observable by only emitting those for
+ * which isNotEmpty is true
+ */
+export const isNotEmptyOperator = () =>
+  <T>(source: Observable<T>): Observable<T> =>
+    source.pipe(filter((obj: T) => isNotEmpty(obj)));
+
+/**
+ * Tests each value emitted by the source Observable,
+ * let's arrays pass through, turns other values in to
+ * empty arrays. Used to be able to chain array operators
+ * on something that may not have a value
+ */
+export const ensureArrayHasValue = () =>
+  <T>(source: Observable<T[]>): Observable<T[]> =>
+    source.pipe(map((arr: T[]): T[] => Array.isArray(arr) ? arr : []));

--- a/src/app/shared/mocks/mock-remote-data-build.service.ts
+++ b/src/app/shared/mocks/mock-remote-data-build.service.ts
@@ -1,0 +1,23 @@
+import { Observable } from 'rxjs/Observable';
+import { map, take } from 'rxjs/operators';
+import { RemoteDataBuildService } from '../../core/cache/builders/remote-data-build.service';
+import { ResponseCacheEntry } from '../../core/cache/response-cache.reducer';
+import { RemoteData } from '../../core/data/remote-data';
+import { RequestEntry } from '../../core/data/request.reducer';
+import { hasValue } from '../empty.util';
+
+export function getMockRemoteDataBuildService(toRemoteDataObservable$?: Observable<RemoteData<any>>): RemoteDataBuildService {
+  return {
+    toRemoteDataObservable: (requestEntry$: Observable<RequestEntry>, responseCache$: Observable<ResponseCacheEntry>, payload$: Observable<any>) => {
+
+      if (hasValue(toRemoteDataObservable$)) {
+        return toRemoteDataObservable$;
+      } else {
+        return payload$.pipe(map((payload) => ({
+          payload
+        } as RemoteData<any>)))
+      }
+    }
+  } as RemoteDataBuildService;
+
+}

--- a/src/app/shared/mocks/mock-request.service.ts
+++ b/src/app/shared/mocks/mock-request.service.ts
@@ -1,10 +1,11 @@
+import { Observable } from 'rxjs/Observable';
 import { RequestService } from '../../core/data/request.service';
 import { RequestEntry } from '../../core/data/request.reducer';
 
-export function getMockRequestService(): RequestService {
+export function getMockRequestService(getByHref$: Observable<RequestEntry> = Observable.of(new RequestEntry())): RequestService {
   return jasmine.createSpyObj('requestService', {
-    configure: () => false,
-    generateRequestId: () => 'clients/b186e8ce-e99c-4183-bc9a-42b4821bdb78',
-    getByHref: (uuid: string) => new RequestEntry()
+    configure: false,
+    generateRequestId: 'clients/b186e8ce-e99c-4183-bc9a-42b4821bdb78',
+    getByHref: getByHref$
   });
 }

--- a/src/app/shared/mocks/mock-response-cache.service.ts
+++ b/src/app/shared/mocks/mock-response-cache.service.ts
@@ -1,12 +1,16 @@
-import { ResponseCacheService } from '../../core/cache/response-cache.service';
+import { Observable } from 'rxjs/Observable';
 import { ResponseCacheEntry } from '../../core/cache/response-cache.reducer';
-import { RestResponse } from '../../core/cache/response-cache.models';
+import { ResponseCacheService } from '../../core/cache/response-cache.service';
 
-export function getMockResponseCacheService(): ResponseCacheService {
+export function getMockResponseCacheService(
+  add$: Observable<ResponseCacheEntry> = Observable.of(new ResponseCacheEntry()),
+  get$: Observable<ResponseCacheEntry> = Observable.of(new ResponseCacheEntry()),
+  has: boolean = false
+): ResponseCacheService {
   return jasmine.createSpyObj('ResponseCacheService', {
-    add: (key: string, response: RestResponse, msToLive: number) => new ResponseCacheEntry(),
-    get: (key: string) => new ResponseCacheEntry(),
-    has: (key: string) => false,
+    add: add$,
+    get: get$,
+    has,
   });
 
 }


### PR DESCRIPTION
This PR closes #255.

It adds `getBrowseDefinitions` and `getBrowseEntriesFor()` to `BrowseService`

`getBrowseDefinitions()` fetches and parses the browse definitions at: https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4science.it/dspace-spring-rest/api/discover/browses
And `getBrowseEntriesFor()` will fetch and parse the `entries` endpoint for a given definition ID: e.g. https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4science.it/dspace-spring-rest/api/discover/browses/author/entries