### PR TITLE
or2018 - add accounts to the news component

### DIFF
--- a/src/app/+home-page/home-news/home-news.component.html
+++ b/src/app/+home-page/home-news/home-news.component.html
@@ -16,5 +16,14 @@
       </li>
       <li>preserve digital assets over the long term</li>
     </ul>
+    <br>
+    <p>The following Demo Users are set up in the system (all users have password equal to the lowercase name of this software):</p>
+    <ul>
+      <li>Demo Site Administrator = dspacedemo+admin@gmail.com</li>
+      <li>Demo Community Administrator = dspacedemo+commadmin@gmail.com</li>
+      <li>Demo Collection Administrator = dspacedemo+colladmin@gmail.com</li>
+      <li>Demo Collection Validator = dspacedemo+validator@gmail.com</li>
+      <li>Demo Submitter = dspacedemo+submit@gmail.com</li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
Adds the demo accounts on the rest server to the home page news