### PR TITLE
Fix truncated text being difficult to select

### DIFF
--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.scss
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.scss
@@ -23,6 +23,7 @@
             max-width: 150px;
             height: $height;
             background: linear-gradient(to right, rgba(255, 255, 255, 0), $body-bg 70%);
+            pointer-events: none;
         }
     }
 }


### PR DESCRIPTION
Related to Google Chrome browser and the issue #234, this minor fix works since the `::after` pseudo element blocks elements behind it. Adding `pointer-events: none` to the `::after` pseudo element fixed the issue.