### PR TITLE
Issue 311: No files item page bugfix

### DIFF
--- a/src/app/core/metadata/metadata.service.spec.ts
+++ b/src/app/core/metadata/metadata.service.spec.ts
@@ -34,6 +34,9 @@ import { MockItem } from '../../shared/mocks/mock-item';
 import { MockTranslateLoader } from '../../shared/mocks/mock-translate-loader';
 import { BrowseService } from '../browse/browse.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { PaginatedList } from '../data/paginated-list';
+import { PageInfo } from '../shared/page-info.model';
+import { EmptyError } from 'rxjs/util/EmptyError';
 
 /* tslint:disable:max-classes-per-file */
 @Component({
@@ -180,6 +183,22 @@ describe('MetadataService', () => {
     expect(tagStore.get('title')[0].content).toEqual('Dummy Title');
     expect(tagStore.get('description')[0].content).toEqual('This is a dummy item component for testing!');
   }));
+
+  describe('when the item has no bitstreams', () => {
+
+    beforeEach(() => {
+      spyOn(MockItem, 'getFiles').and.returnValue(Observable.of([]));
+    });
+
+    it('processRemoteData should not produce an EmptyError', fakeAsync(() => {
+      spyOn(itemDataService, 'findById').and.returnValue(mockRemoteData(MockItem));
+      spyOn(metadataService, 'processRemoteData').and.callThrough();
+      router.navigate(['/items/0ec7ff22-f211-40ab-a69e-c819b0b1f357']);
+      tick();
+      expect(metadataService.processRemoteData).not.toThrow(new EmptyError());
+    }));
+
+  });
 
   const mockRemoteData = (mockItem: Item): Observable<RemoteData<Item>> => {
     return Observable.of(new RemoteData<Item>(

--- a/src/app/core/metadata/metadata.service.ts
+++ b/src/app/core/metadata/metadata.service.ts
@@ -269,8 +269,11 @@ export class MetadataService {
   private setCitationPdfUrlTag(): void {
     if (this.currentObject.value instanceof Item) {
       const item = this.currentObject.value as Item;
-      item.getFiles().filter((files) => isNotEmpty(files)).first().subscribe((bitstreams: Bitstream[]) => {
-        for (const bitstream of bitstreams) {
+      item.getFiles()
+        .first((files) => isNotEmpty(files))
+        .catch((error) => { console.debug(error); return [] })
+        .subscribe((bitstreams: Bitstream[]) => {
+          for (const bitstream of bitstreams) {
           bitstream.format.first()
             .map((rd: RemoteData<BitstreamFormat>) => rd.payload)
             .filter((format: BitstreamFormat) => hasValue(format))


### PR DESCRIPTION
This PR closes #311 

The Error occurs when calling the `first()` operator on an observable that doesn't emit any values. 
There are two ways around this issue. One is to use the `take(1)` operator, which does the exact same, but doesn't throw an error when no value is being emitted by the observable. The other is to catch the error thrown by the `first()` operator.

I decided catching the error and returning an empty array is the most elegant solution to the issue.

I also added a test case to metadata-service which tests if the error is being thrown or not.