### PR TITLE
Fixed issue where facets could not be changed when you are logged in

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -340,14 +340,10 @@ export class AuthService {
     this.getRedirectUrl()
       .first()
       .subscribe((redirectUrl) => {
+
         if (isNotEmpty(redirectUrl)) {
           this.clearRedirectUrl();
-
-          // override the route reuse strategy
-          this.router.routeReuseStrategy.shouldReuseRoute = () => {
-            return false;
-          };
-          this.router.navigated = false;
+          this.router.onSameUrlNavigation = 'reload';
           const url = decodeURIComponent(redirectUrl);
           this.router.navigateByUrl(url);
           /* TODO Reenable hard redirect when REST API can handle x-forwarded-for, see https://github.com/DSpace/DSpace/pull/2207 */


### PR DESCRIPTION
Overriding `this.router.routeReuseStrategy.shouldReuseRoute` breaks navigating to the same url but with different query parameters. This causes visible issues when you are logged in and try to add or remove facets on the search page.

I replaced this by using `this.router.onSameUrlNavigation = 'reload'` instead, as suggested here:
https://github.com/angular/angular/issues/13831#issuecomment-422683314 