### PR TITLE
Changed search filter cursor to pointer

### DIFF
--- a/src/app/+search-page/search-filters/search-filter/search-filter.component.scss
+++ b/src/app/+search-page/search-filters/search-filter/search-filter.component.scss
@@ -2,11 +2,12 @@
 @import '../../../../styles/mixins.scss';
 
 :host {
-    border: 1px solid map-get($theme-colors, light);
-    .search-filter-wrapper.closed {
-        overflow: hidden;
-    }
-    .filter-toggle {
-        line-height: $line-height-base;
-    }
+  border: 1px solid map-get($theme-colors, light);
+  cursor: pointer;
+  .search-filter-wrapper.closed {
+    overflow: hidden;
+  }
+  .filter-toggle {
+    line-height: $line-height-base;
+  }
 }


### PR DESCRIPTION
Changed search filters cursor to pointer so it is more obvious that the search filters are clickable.

As an aside, I noticed that although most files use two spaces for indentation, some use four. I just changed this one to be a bit more consistent.