### PR TITLE
Content-Type fallback

### DIFF
--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { DSpaceRESTv2Service } from './dspace-rest-v2.service';
+import { DEFAULT_CONTENT_TYPE, DSpaceRESTv2Service } from './dspace-rest-v2.service';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { HttpHeaders } from '@angular/common/http';
@@ -76,7 +76,7 @@ fdescribe('DSpaceRESTv2Service', () => {
       dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}).subscribe();
 
       const req = httpMock.expectOne(url);
-      expect(req.request.headers.get('Content-Type')).toContain('application/json; charset=utf-8');
+      expect(req.request.headers.get('Content-Type')).toContain(DEFAULT_CONTENT_TYPE);
     });
   });
 
@@ -106,14 +106,14 @@ fdescribe('DSpaceRESTv2Service', () => {
       dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}, { headers }).subscribe();
 
       const req = httpMock.expectOne(url);
-      expect(req.request.headers.get('Content-Type')).not.toContain('application/json; charset=utf-8');
+      expect(req.request.headers.get('Content-Type')).not.toContain(DEFAULT_CONTENT_TYPE);
     });
 
     it('when no content-type header is provided, it should use application/json', () => {
       dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}).subscribe();
 
       const req = httpMock.expectOne(url);
-      expect(req.request.headers.get('Content-Type')).toContain('application/json; charset=utf-8');
+      expect(req.request.headers.get('Content-Type')).toContain(DEFAULT_CONTENT_TYPE);
     });
   });
 

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -6,7 +6,7 @@ import { DSpaceObject } from '../shared/dspace-object.model';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { HttpHeaders } from '@angular/common/http';
 
-fdescribe('DSpaceRESTv2Service', () => {
+describe('DSpaceRESTv2Service', () => {
   let dSpaceRESTv2Service: DSpaceRESTv2Service;
   let httpMock: HttpTestingController;
   const url = 'http://www.dspace.org/';

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -6,7 +6,7 @@ import { DSpaceObject } from '../shared/dspace-object.model';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { HttpHeaders } from '@angular/common/http';
 
-describe('DSpaceRESTv2Service', () => {
+fdescribe('DSpaceRESTv2Service', () => {
   let dSpaceRESTv2Service: DSpaceRESTv2Service;
   let httpMock: HttpTestingController;
   const url = 'http://www.dspace.org/';
@@ -101,7 +101,8 @@ describe('DSpaceRESTv2Service', () => {
     });
 
     it('when a content-type header is provided, it should not use application/json', () => {
-      const headers = new HttpHeaders({'Content-Type': 'text/html'});
+      let headers = new HttpHeaders();
+      headers = headers.set('Content-Type', 'text/html');
       dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}, { headers }).subscribe();
 
       const req = httpMock.expectOne(url);

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.spec.ts
@@ -3,6 +3,8 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 
 import { DSpaceRESTv2Service } from './dspace-rest-v2.service';
 import { DSpaceObject } from '../shared/dspace-object.model';
+import { RestRequestMethod } from '../data/rest-request-method';
+import { HttpHeaders } from '@angular/common/http';
 
 describe('DSpaceRESTv2Service', () => {
   let dSpaceRESTv2Service: DSpaceRESTv2Service;
@@ -47,29 +49,71 @@ describe('DSpaceRESTv2Service', () => {
 
       const req = httpMock.expectOne(url);
       expect(req.request.method).toBe('GET');
-      req.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText});
+      req.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText });
+    });
+    it('should throw an error', () => {
+      dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
+        expect(err).toEqual(mockError);
+      });
+      const req = httpMock.expectOne(url);
+      expect(req.request.method).toBe('GET');
+      req.error(mockError);
+    });
+
+    it('should log an error', () => {
+      spyOn(console, 'log');
+
+      dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
+        expect(console.log).toHaveBeenCalled();
+      });
+
+      const req = httpMock.expectOne(url);
+      expect(req.request.method).toBe('GET');
+      req.error(mockError);
+    });
+
+    it('when no content-type header is provided, it should use application/json', () => {
+      dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}).subscribe();
+
+      const req = httpMock.expectOne(url);
+      expect(req.request.headers.get('Content-Type')).toContain('application/json; charset=utf-8');
     });
   });
 
-  it('should throw an error', () => {
-    dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
-      expect(err).toEqual(mockError);
+  describe('#request', () => {
+    it('should return an Observable<DSpaceRESTV2Response>', () => {
+      const mockPayload = {
+        page: 1
+      };
+      const mockStatusCode = 200;
+      const mockStatusText = 'GREAT';
+
+      dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}).subscribe((response) => {
+        expect(response).toBeTruthy();
+        expect(response.statusCode).toEqual(mockStatusCode);
+        expect(response.statusText).toEqual(mockStatusText);
+        expect(response.payload.page).toEqual(mockPayload.page);
+      });
+
+      const req = httpMock.expectOne(url);
+      expect(req.request.method).toBe('POST');
+      req.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText });
     });
-    const req = httpMock.expectOne(url);
-    expect(req.request.method).toBe('GET');
-    req.error(mockError);
-  });
 
-  it('should log an error', () => {
-    spyOn(console, 'log');
+    it('when a content-type header is provided, it should not use application/json', () => {
+      const headers = new HttpHeaders({'Content-Type': 'text/html'});
+      dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}, { headers }).subscribe();
 
-    dSpaceRESTv2Service.get(url).subscribe(() => undefined, (err) => {
-      expect(console.log).toHaveBeenCalled();
+      const req = httpMock.expectOne(url);
+      expect(req.request.headers.get('Content-Type')).not.toContain('application/json; charset=utf-8');
     });
 
-    const req = httpMock.expectOne(url);
-    expect(req.request.method).toBe('GET');
-    req.error(mockError);
+    it('when no content-type header is provided, it should use application/json', () => {
+      dSpaceRESTv2Service.request(RestRequestMethod.POST, url, {}).subscribe();
+
+      const req = httpMock.expectOne(url);
+      expect(req.request.headers.get('Content-Type')).toContain('application/json; charset=utf-8');
+    });
   });
 
   describe('buildFormData', () => {

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
@@ -9,6 +9,7 @@ import { RestRequestMethod } from '../data/rest-request-method';
 import { isNotEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
 
+export const DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8';
 export interface HttpOptions {
   body?: any;
   headers?: HttpHeaders;
@@ -40,9 +41,8 @@ export class DSpaceRESTv2Service {
   get(absoluteURL: string): Observable<DSpaceRESTV2Response> {
     const requestOptions = {
       observe: 'response' as any,
-      headers: new HttpHeaders()
+      headers: new HttpHeaders({'Content-Type': DEFAULT_CONTENT_TYPE})
     };
-    requestOptions.headers = requestOptions.headers.set( 'Content-Type', 'application/json; charset=utf-8' );
     return this.http.get(absoluteURL, requestOptions).pipe(
       map((res: HttpResponse<any>) => ({
         payload: res.body,
@@ -91,7 +91,7 @@ export class DSpaceRESTv2Service {
 
     if (!requestOptions.headers.has('Content-Type')) {
       // Because HttpHeaders is immutable, the set method returns a new object instead of updating the existing headers
-      requestOptions.headers = requestOptions.headers.set('Content-Type', 'application/json; charset=utf-8');
+      requestOptions.headers = requestOptions.headers.set('Content-Type', DEFAULT_CONTENT_TYPE);
     }
     return this.http.request(method, url, requestOptions).pipe(
       map((res) => ({

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
@@ -8,7 +8,6 @@ import { HttpObserve } from '@angular/common/http/src/client';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { isNotEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
-import { cloneDeep } from 'lodash';
 
 export interface HttpOptions {
   body?: any;
@@ -41,8 +40,9 @@ export class DSpaceRESTv2Service {
   get(absoluteURL: string): Observable<DSpaceRESTV2Response> {
     const requestOptions = {
       observe: 'response' as any,
-      headers: new HttpHeaders({ 'Content-Type': 'application/json; charset=utf-8' })
+      headers: new HttpHeaders()
     };
+    requestOptions.headers = requestOptions.headers.set( 'Content-Type', 'application/json; charset=utf-8' );
     return this.http.get(absoluteURL, requestOptions).pipe(
       map((res: HttpResponse<any>) => ({
         payload: res.body,
@@ -82,27 +82,17 @@ export class DSpaceRESTv2Service {
     if (options && options.responseType) {
       requestOptions.responseType = options.responseType;
     }
-    // WORKING OPTION
-    // requestOptions.headers = ((options && options.headers) || new HttpHeaders()).set('blaat', 'bla').delete('blaat');
 
-    // OPTION 1
-    // requestOptions.headers = ((options && options.headers) || new HttpHeaders());
+    if (options && options.headers) {
+      requestOptions.headers = Object.assign(new HttpHeaders(), options.headers);
+    } else {
+      requestOptions.headers = new HttpHeaders();
+    }
 
-    // OPTION 2
-    // requestOptions.headers = new HttpHeaders();
-    // if (options && options.headers) {
-    //   options.headers.keys().forEach((key) => {
-    //     options.headers.getAll(key).forEach((header) => {
-    //       // Because HttpHeaders is immutable, the set method returns a new object instead of updating the existing headers
-    //       requestOptions.headers = requestOptions.headers.set(key, header);
-    //     })
-    //   });
-    // }
-    //
-    // if (!requestOptions.headers.has('Content-Type')) {
-    //   // Because HttpHeaders is immutable, the set method returns a new object instead of updating the existing headers
-    //   requestOptions.headers = requestOptions.headers.set('Content-Type', 'application/json; charset=utf-8');
-    // }
+    if (!requestOptions.headers.has('Content-Type')) {
+      // Because HttpHeaders is immutable, the set method returns a new object instead of updating the existing headers
+      requestOptions.headers = requestOptions.headers.set('Content-Type', 'application/json; charset=utf-8');
+    }
     return this.http.request(method, url, requestOptions).pipe(
       map((res) => ({
         payload: res.body,

--- a/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
+++ b/src/app/core/dspace-rest-v2/dspace-rest-v2.service.ts
@@ -6,7 +6,7 @@ import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/comm
 import { DSpaceRESTV2Response } from './dspace-rest-v2-response.model';
 import { HttpObserve } from '@angular/common/http/src/client';
 import { RestRequestMethod } from '../data/rest-request-method';
-import { isNotEmpty } from '../../shared/empty.util';
+import { hasNoValue, isNotEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
 
 export const DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8';
@@ -83,10 +83,10 @@ export class DSpaceRESTv2Service {
       requestOptions.responseType = options.responseType;
     }
 
-    if (options && options.headers) {
-      requestOptions.headers = Object.assign(new HttpHeaders(), options.headers);
-    } else {
+    if (hasNoValue(options) || hasNoValue(options.headers)) {
       requestOptions.headers = new HttpHeaders();
+    } else {
+      requestOptions.headers = options.headers;
     }
 
     if (!requestOptions.headers.has('Content-Type')) {


### PR DESCRIPTION
This PR fixes an issue with missing Content-Types and relates to https://jira.duraspace.org/browse/DS-4216

In some requests, the Content-Type HTTP header was missing.
This PR makes sure `application/json; charset=utf-8` is added as a default Content-Type HTTP header, when no Content-Type header has previously been set.