### PR TITLE
Upgrade morgan to 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "jwt-decode": "^2.2.0",
     "methods": "1.1.2",
     "moment": "^2.22.1",
-    "morgan": "1.9.0",
+    "morgan": "^1.9.1",
     "ng-mocks": "^6.2.1",
     "ng2-file-upload": "1.2.1",
     "ng2-nouislider": "^1.7.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6530,14 +6530,14 @@ moment@^2.22.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
-morgan@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
-  integrity sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
   dependencies:
     basic-auth "~2.0.0"
     debug "2.6.9"
-    depd "~1.1.1"
+    depd "~1.1.2"
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 


### PR DESCRIPTION
This fixes [CVE-2019-5413](https://nvd.nist.gov/vuln/detail/CVE-2019-5413)