### PR TITLE
Add Node v10 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ language: node_js
 node_js:
   - "8"
   - "9"
+  - "10"
 
 cache:
   yarn: true


### PR DESCRIPTION
Tiny PR to update Travis CI to also trigger a Node v10 build.  This is a simple test to see if Node v10 works properly for us.