### PR TITLE
Enable webpack polling (once per second). Ignore node_modules

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -16,6 +16,8 @@ module.exports = {
     },
     watchOptions: {
         aggregateTimeout: 50,
+        poll: 1000,
+        ignored: /node_modules/
     },
     node: {
         fs: "empty",


### PR DESCRIPTION
This change is necessary to ensure webpack "watches" directories when using Docker.  It is a companion PR to https://github.com/DSpace-Labs/DSpace-Docker-Images/pull/137.

In this PR, I'm enabling polling in Webpack, and configuring it to run once per second, and ignore the `node_modules` subdirectory.  See: https://webpack.js.org/configuration/watch/#watchoptionspoll

Without this change,  https://github.com/DSpace-Labs/DSpace-Docker-Images/pull/137 only seems to work for the *first* change you make.  So, Webpack will see that first change and reload.  After that, any additional changes are ignored until you restart your Docker container.

I'd appreciate feedback/testing from @artlowel or @LotteHofstede to ensure this small change doesn't have an adverse affect in other development environments.  If it does, we can hold off on this change until we can determine a better way to do this polling both within Docker and within a local install.  If we have any concerns here, we could hold off until after OR2019, as needed.
