### PR TITLE
DS-4223 Metadata Schemas for configurable entities

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -609,6 +609,34 @@
         "birthDate": {
           "placeholder": "Birth Date",
           "head": "Birth Date"
+        },
+        "creativeWorkPublisher": {
+          "placeholder": "Publisher",
+          "head": "Publisher"
+        },
+        "creativeWorkEditor": {
+          "placeholder": "Editor",
+          "head": "Editor"
+        },
+        "creativeWorkKeywords": {
+          "placeholder": "Subject",
+          "head": "Subject"
+        },
+        "creativeDatePublished": {
+          "placeholder": "Date Published",
+          "head": "Date Published"
+        },
+        "organizationAddressCountry": {
+          "placeholder": "Country",
+          "head": "Country"
+        },
+        "organizationAddressLocality": {
+          "placeholder": "City",
+          "head": "City"
+        },
+        "organizationFoundingDate": {
+          "placeholder": "Date Founded",
+          "head": "Date Founded"
         }
       }
     }

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -386,7 +386,10 @@
       "titleprefix": "Publication: ",
       "journal-title": "Journal Title",
       "journal-issn": "Journal ISSN",
-      "volume-title": "Volume Title"
+      "volume-title": "Volume Title",
+      "publisher": "Publisher",
+      "description": "Description"
+
     },
     "listelement": {
       "badge": "Publication"

--- a/src/app/+item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.html
@@ -21,6 +21,10 @@
       [fields]="['journalvolume.identifier.name']"
       [label]="'publication.page.volume-title'">
     </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="item"
+      [fields]="['dc.publisher']"
+      [label]="'publication.page.publisher'">
+    </ds-generic-item-page-field>
   </div>
   <div class="col-xs-12 col-md-6">
     <ds-metadata-representation-list
@@ -40,6 +44,11 @@
       [label]="'relationships.isJournalIssueOf' | translate">
     </ds-related-items>
     <ds-item-page-abstract-field [item]="item"></ds-item-page-abstract-field>
+    <ds-generic-item-page-field [item]="item"
+      [fields]="['dc.description']"
+      [label]="'publication.page.description'">
+    </ds-generic-item-page-field>
+
     <ds-generic-item-page-field [item]="item"
       [fields]="['dc.subject']"
       [separator]="','"

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.html
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.html
@@ -4,9 +4,9 @@
     [innerHTML]="firstMetadataValue('dc.title')"></a>
   <span class="text-muted">
     <ds-truncatable-part [id]="item.id" [minLines]="1">
-            <span *ngIf="item.allMetadata(['publicationVolume.volumeNumber']).length > 0"
+            <span *ngIf="item.allMetadata(['publicationvolume.volumeNumber']).length > 0"
                   class="item-list-journal-issues">
-                    <span *ngFor="let value of allMetadataValues(['publicationVolume.volumeNumber']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['publicationvolume.volumeNumber']); let last=last;">
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
                 <span *ngIf="item.allMetadata(['publicationissue.issueNumber']).length > 0"

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.html
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.html
@@ -4,14 +4,14 @@
     [innerHTML]="firstMetadataValue('dc.title')"></a>
   <span class="text-muted">
     <ds-truncatable-part [id]="item.id" [minLines]="1">
-            <span *ngIf="item.allMetadata(['journalvolume.identifier.volume']).length > 0"
+            <span *ngIf="item.allMetadata(['publicationVolume.volumeNumber']).length > 0"
                   class="item-list-journal-issues">
-                    <span *ngFor="let value of allMetadataValues(['journalvolume.identifier.volume']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['publicationVolume.volumeNumber']); let last=last;">
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
-                <span *ngIf="item.allMetadata(['journalissue.identifier.number']).length > 0"
+                <span *ngIf="item.allMetadata(['publicationissue.issueNumber']).length > 0"
                       class="item-list-journal-issue-numbers">
-                    <span *ngFor="let value of allMetadataValues(['journalissue.identifier.number']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['publicationissue.issueNumber']); let last=last;">
                         <span> - </span><span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
                 </span>

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.spec.ts
@@ -20,13 +20,13 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'journalvolume.identifier.volume': [
+    'publicationVolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'
       }
     ],
-    'journalissue.identifier.number': [
+    'publicationissue.issueNumber': [
       {
         language: 'en_US',
         value: '5678'

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-issue/journal-issue-list-element.component.spec.ts
@@ -20,7 +20,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'publicationVolume.volumeNumber': [
+    'publicationvolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.html
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.html
@@ -10,9 +10,9 @@
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
             </span>
-            <span *ngIf="item.allMetadata(['publicationVolume.volumeNumber']).length > 0"
+            <span *ngIf="item.allMetadata(['publicationvolume.volumeNumber']).length > 0"
                   class="item-list-journal-volume-identifiers">
-                    <span *ngFor="let value of allMetadataValues(['publicationVolume.volumeNumber']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['publicationvolume.volumeNumber']); let last=last;">
                         <span> (</span><span [innerHTML]="value"><span [innerHTML]="value"></span></span><span>)</span>
                     </span>
             </span>

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.html
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.html
@@ -10,9 +10,9 @@
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
             </span>
-            <span *ngIf="item.allMetadata(['journalvolume.identifier.volume']).length > 0"
+            <span *ngIf="item.allMetadata(['publicationVolume.volumeNumber']).length > 0"
                   class="item-list-journal-volume-identifiers">
-                    <span *ngFor="let value of allMetadataValues(['journalvolume.identifier.volume']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['publicationVolume.volumeNumber']); let last=last;">
                         <span> (</span><span [innerHTML]="value"><span [innerHTML]="value"></span></span><span>)</span>
                     </span>
             </span>

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.spec.ts
@@ -26,7 +26,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another journal title'
       }
     ],
-    'publicationVolume.volumeNumber': [
+    'publicationvolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal-volume/journal-volume-list-element.component.spec.ts
@@ -26,7 +26,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another journal title'
       }
     ],
-    'journalvolume.identifier.volume': [
+    'publicationVolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal/journal-list-element.component.html
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal/journal-list-element.component.html
@@ -4,9 +4,9 @@
     [innerHTML]="firstMetadataValue('dc.title')"></a>
   <span class="text-muted">
     <ds-truncatable-part [id]="item.id" [minLines]="1">
-            <span *ngIf="item.allMetadata(['journal.identifier.issn']).length > 0"
+            <span *ngIf="item.allMetadata(['creativeworkseries.issn']).length > 0"
                   class="item-list-journals">
-                    <span *ngFor="let value of allMetadataValues(['journal.identifier.issn']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['creativeworkseries.issn']); let last=last;">
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
             </span>

--- a/src/app/entity-groups/journal-entities/item-list-elements/journal/journal-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/journal/journal-list-element.component.spec.ts
@@ -20,7 +20,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'journal.identifier.issn': [
+    'creativeworkseries.issn': [
       {
         language: 'en_US',
         value: '1234'

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
@@ -7,6 +7,10 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
+      [fields]="['publicationvolume.volumeNumber']"
+      [label]="'journalvolume.page.volume'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="item"
       [fields]="['publicationissue.issueNumber']"
       [label]="'journalissue.page.number'">
     </ds-generic-item-page-field>

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
@@ -7,11 +7,11 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalissue.identifier.number']"
+      [fields]="['publicationissue.issueNumber']"
       [label]="'journalissue.page.number'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalissue.issuedate']"
+      [fields]="['creativework.datePublished']"
       [label]="'journalissue.page.issuedate'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
@@ -19,7 +19,7 @@
       [label]="'journalissue.page.journal-title'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journal.identifier.issn']"
+      [fields]="['creativeworkseries.issn']"
       [label]="'journalissue.page.journal-issn'">
     </ds-generic-item-page-field>
   </div>
@@ -34,11 +34,11 @@
       [label]="'relationships.isPublicationOfJournalIssue' | translate">
     </ds-related-items>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalissue.identifier.description']"
+      [fields]="['dc.description']"
       [label]="'journalissue.page.description'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalissue.identifier.keyword']"
+      [fields]="['creativework.keywords']"
       [label]="'journalissue.page.keyword'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.spec.ts
@@ -12,25 +12,25 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'journalissue.identifier.number': [
+    'publicationissue.issueNumber': [
       {
         language: 'en_US',
         value: '1234'
       }
     ],
-    'journalissue.issuedate': [
+    'creativework.datePublished': [
       {
         language: 'en_US',
         value: '2018'
       }
     ],
-    'journalissue.identifier.description': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'desc'
       }
     ],
-    'journalissue.identifier.keyword': [
+    'creativework.keywords': [
       {
         language: 'en_US',
         value: 'keyword'

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
@@ -7,7 +7,7 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['publicationVolume.volumeNumber']"
+      [fields]="['publicationvolume.volumeNumber']"
       [label]="'journalvolume.page.volume'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
@@ -7,11 +7,11 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalvolume.identifier.volume']"
+      [fields]="['publicationVolume.volumeNumber']"
       [label]="'journalvolume.page.volume'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalvolume.issuedate']"
+      [fields]="['creativework.datePublished']"
       [label]="'journalvolume.page.issuedate'">
     </ds-generic-item-page-field>
   </div>
@@ -25,7 +25,7 @@
       [label]="'relationships.isIssueOf' | translate">
     </ds-related-items>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journalvolume.identifier.description']"
+      [fields]="['dc.description']"
       [label]="'journalvolume.page.description'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.spec.ts
@@ -12,7 +12,7 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'publicationVolume.volumeNumber': [
+    'publicationvolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.spec.ts
@@ -12,19 +12,19 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'journalvolume.identifier.volume': [
+    'publicationVolume.volumeNumber': [
       {
         language: 'en_US',
         value: '1234'
       }
     ],
-    'journalvolume.issuedate': [
+    'creativework.datePublished': [
       {
         language: 'en_US',
         value: '2018'
       }
     ],
-    'journalvolume.identifier.description': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'desc'

--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
@@ -7,15 +7,15 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field class="item-page-fields" [item]="item"
-      [fields]="['journal.identifier.issn']"
+      [fields]="['creativeworkseries.issn']"
       [label]="'journal.page.issn'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field class="item-page-fields" [item]="item"
-      [fields]="['journal.publisher']"
+      [fields]="['creativework.publisher']"
       [label]="'journal.page.publisher'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['journal.contributor.editor']"
+      [fields]="['creativework.editor']"
       [label]="'journal.page.editor'">
     </ds-generic-item-page-field>
   </div>
@@ -25,7 +25,7 @@
       [label]="'relationships.isVolumeOf' | translate">
     </ds-related-items>
     <ds-generic-item-page-field class="item-page-fields" [item]="item"
-      [fields]="['journal.identifier.description']"
+      [fields]="['dc.description']"
       [label]="'journal.page.description'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.spec.ts
@@ -22,19 +22,19 @@ let fixture: ComponentFixture<JournalComponent>;
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'journal.identifier.issn': [
+    'creativeworkseries.issn': [
       {
         language: 'en_US',
         value: '1234'
       }
     ],
-    'journal.publisher': [
+    'creativework.publisher': [
       {
         language: 'en_US',
         value: 'a publisher'
       }
     ],
-    'journal.identifier.description': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'desc'

--- a/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-list-element.component.html
@@ -1,13 +1,13 @@
 <ds-truncatable [id]="item.id">
   <a
     [routerLink]="['/items/' + item.id]" class="lead"
-    [innerHTML]="firstMetadataValue('orgunit.identifier.name')"></a>
+    [innerHTML]="firstMetadataValue('organization.legalName')"></a>
   <span class="text-muted">
     <ds-truncatable-part [id]="item.id" [minLines]="3">
-            <span *ngIf="item.allMetadata(['orgunit.identifier.description']).length > 0"
+            <span *ngIf="item.allMetadata(['dc.description']).length > 0"
                   class="item-list-orgunit-description">
                 <ds-truncatable-part [id]="item.id" [minLines]="3"><span
-                  [innerHTML]="firstMetadataValue('orgunit.identifier.description')"></span>
+                  [innerHTML]="firstMetadataValue('dc.description')"></span>
                 </ds-truncatable-part>
             </span>
         </ds-truncatable-part>

--- a/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-list-element.component.spec.ts
@@ -20,7 +20,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'orgunit.identifier.description': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'A description about the OrgUnit'

--- a/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-metadata-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/orgunit/orgunit-metadata-list-element.component.html
@@ -1,13 +1,13 @@
 <ng-template #descTemplate>
   <span class="text-muted">
-      <span *ngIf="item.allMetadata(['orgunit.identifier.description']).length > 0"
+      <span *ngIf="item.allMetadata(['dc.description']).length > 0"
             class="item-list-job-title">
-        <span [innerHTML]="firstMetadataValue(['orgunit.identifier.description'])"></span>
+        <span [innerHTML]="firstMetadataValue(['dc.description'])"></span>
       </span>
   </span>
 </ng-template>
 <ds-truncatable [id]="item.id">
   <a [routerLink]="['/items/' + item.id]"
-     [innerHTML]="firstMetadataValue('orgunit.identifier.name')"
+     [innerHTML]="firstMetadataValue('organization.legalName')"
      [tooltip]="descTemplate"></a>
 </ds-truncatable>

--- a/src/app/entity-groups/research-entities/item-list-elements/person/person-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/person/person-list-element.component.html
@@ -1,12 +1,12 @@
 <ds-truncatable [id]="item.id">
   <a
     [routerLink]="['/items/' + item.id]" class="lead"
-    [innerHTML]="firstMetadataValue('dc.contributor.author')"></a>
+    [innerHTML]="firstMetadataValue('person.familyName') + ', ' + firstMetadataValue('person.givenName')"></a>
   <span class="text-muted">
     <ds-truncatable-part [id]="item.id" [minLines]="1">
-            <span *ngIf="item.allMetadata(['person.identifier.jobtitle']).length > 0"
+            <span *ngIf="item.allMetadata(['person.jobTitle']).length > 0"
                   class="item-list-job-title">
-                    <span *ngFor="let value of allMetadataValues(['person.identifier.jobtitle']); let last=last;">
+                    <span *ngFor="let value of allMetadataValues(['person.jobTitle']); let last=last;">
                         <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
                     </span>
             </span>

--- a/src/app/entity-groups/research-entities/item-list-elements/person/person-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/person/person-list-element.component.spec.ts
@@ -20,7 +20,7 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'person.identifier.jobtitle': [
+    'person.jobTitle': [
       {
         language: 'en_US',
         value: 'Developer'

--- a/src/app/entity-groups/research-entities/item-list-elements/person/person-metadata-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/person/person-metadata-list-element.component.html
@@ -10,6 +10,6 @@
 </ng-template>
 <ds-truncatable [id]="item.id">
   <a [routerLink]="['/items/' + item.id]"
-     [innerHTML]="firstMetadataValue('dc.contributor.author')"
+     [innerHTML]="firstMetadataValue('person.familyName') + ', ' + firstMetadataValue('person.givenName')"
      [tooltip]="descTemplate"></a>
 </ds-truncatable>

--- a/src/app/entity-groups/research-entities/item-list-elements/person/person-metadata-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/person/person-metadata-list-element.component.html
@@ -1,8 +1,8 @@
 <ng-template #descTemplate>
   <span class="text-muted">
-      <span *ngIf="item.allMetadata(['person.identifier.jobtitle']).length > 0"
+      <span *ngIf="item.allMetadata(['person.jobTitle']).length > 0"
             class="item-list-job-title">
-              <span *ngFor="let value of allMetadataValues(['person.identifier.jobtitle']); let last=last;">
+              <span *ngFor="let value of allMetadataValues(['person.jobTitle']); let last=last;">
                   <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
               </span>
       </span>

--- a/src/app/entity-groups/research-entities/item-list-elements/project/project-list-element.component.html
+++ b/src/app/entity-groups/research-entities/item-list-elements/project/project-list-element.component.html
@@ -1,16 +1,16 @@
 <ds-truncatable [id]="item.id">
   <a
     [routerLink]="['/items/' + item.id]" class="lead"
-    [innerHTML]="firstMetadataValue('project.identifier.name')"></a>
-  <span class="text-muted">
-    <ds-truncatable-part [id]="item.id" [minLines]="1">
-            <span *ngIf="item.allMetadata(['project.identifier.status']).length > 0"
-                  class="item-list-status">
-                    <span *ngFor="let value of allMetadataValues(['project.identifier.status']); let last=last;">
-                        <span [innerHTML]="value"><span [innerHTML]="value"></span></span>
-                    </span>
-            </span>
-        </ds-truncatable-part>
-  </span>
+    [innerHTML]="firstMetadataValue('dc.title')"></a>
+  <!--<span class="text-muted">-->
+    <!--<ds-truncatable-part [id]="item.id" [minLines]="1">-->
+            <!--<span *ngIf="item.allMetadata(['project.identifier.status']).length > 0"-->
+                  <!--class="item-list-status">-->
+                    <!--<span *ngFor="let value of allMetadataValues(['project.identifier.status']); let last=last;">-->
+                        <!--<span [innerHTML]="value"><span [innerHTML]="value"></span></span>-->
+                    <!--</span>-->
+            <!--</span>-->
+        <!--</ds-truncatable-part>-->
+  <!--</span>-->
 </ds-truncatable>
 

--- a/src/app/entity-groups/research-entities/item-list-elements/project/project-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/project/project-list-element.component.spec.ts
@@ -20,12 +20,12 @@ const mockItemWithMetadata: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'project.identifier.status': [
-      {
-        language: 'en_US',
-        value: 'A status about the project'
-      }
-    ]
+    // 'project.identifier.status': [
+    //   {
+    //     language: 'en_US',
+    //     value: 'A status about the project'
+    //   }
+    // ]
   }
 });
 const mockItemWithoutMetadata: Item = Object.assign(new Item(), {
@@ -61,27 +61,27 @@ describe('ProjectListElementComponent', () => {
 
   }));
 
-  describe('When the item has a status', () => {
-    beforeEach(() => {
-      projectListElementComponent.item = mockItemWithMetadata;
-      fixture.detectChanges();
-    });
-
-    it('should show the status span', () => {
-      const statusField = fixture.debugElement.query(By.css('span.item-list-status'));
-      expect(statusField).not.toBeNull();
-    });
-  });
-
-  describe('When the item has no status', () => {
-    beforeEach(() => {
-      projectListElementComponent.item = mockItemWithoutMetadata;
-      fixture.detectChanges();
-    });
-
-    it('should not show the status span', () => {
-      const statusField = fixture.debugElement.query(By.css('span.item-list-status'));
-      expect(statusField).toBeNull();
-    });
-  });
+  // describe('When the item has a status', () => {
+  //   beforeEach(() => {
+  //     projectListElementComponent.item = mockItemWithMetadata;
+  //     fixture.detectChanges();
+  //   });
+  //
+  //   it('should show the status span', () => {
+  //     const statusField = fixture.debugElement.query(By.css('span.item-list-status'));
+  //     expect(statusField).not.toBeNull();
+  //   });
+  // });
+  //
+  // describe('When the item has no status', () => {
+  //   beforeEach(() => {
+  //     projectListElementComponent.item = mockItemWithoutMetadata;
+  //     fixture.detectChanges();
+  //   });
+  //
+  //   it('should not show the status span', () => {
+  //     const statusField = fixture.debugElement.query(By.css('span.item-list-status'));
+  //     expect(statusField).toBeNull();
+  //   });
+  // });
 });

--- a/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.html
@@ -1,5 +1,5 @@
 <h2 class="item-page-title-field">
-  {{'orgunit.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="item?.allMetadata(['orgunit.identifier.name'])"></ds-metadata-values>
+  {{'orgunit.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="item?.allMetadata(['organization.legalName'])"></ds-metadata-values>
 </h2>
 <div class="row">
   <div class="col-xs-12 col-md-4">
@@ -7,19 +7,19 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async" [defaultImage]="'assets/images/orgunit-placeholder.svg'"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['orgunit.identifier.dateestablished']"
+      [fields]="['organization.foundingDate']"
       [label]="'orgunit.page.dateestablished'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['orgunit.identifier.city']"
+      [fields]="['organization.address.addressLocality']"
       [label]="'orgunit.page.city'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['orgunit.identifier.country']"
+      [fields]="['organization.adress.addressCountry']"
       [label]="'orgunit.page.country'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['orgunit.identifier.id']"
+      [fields]="['dc.identifier']"
       [label]="'orgunit.page.id'">
     </ds-generic-item-page-field>
   </div>
@@ -37,7 +37,7 @@
       [label]="'relationships.isPublicationOf' | translate">
     </ds-related-items>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['orgunit.identifier.description']"
+      [fields]="['dc.description']"
       [label]="'orgunit.page.description'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.spec.ts
@@ -12,31 +12,31 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'orgunit.identifier.dateestablished': [
+    'organization.foundingDate': [
       {
         language: 'en_US',
         value: '2018'
       }
     ],
-    'orgunit.identifier.city': [
+    'organization.address.addressLocality': [
       {
         language: 'en_US',
         value: 'New York'
       }
     ],
-    'orgunit.identifier.country': [
+    'organization.adress.addressCountry': [
       {
         language: 'en_US',
         value: 'USA'
       }
     ],
-    'orgunit.identifier.id': [
+    'dc.identifier': [
       {
         language: 'en_US',
         value: '1'
       }
     ],
-    'orgunit.identifier.description': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'desc'

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.html
@@ -1,5 +1,5 @@
 <h2 class="item-page-title-field">
-  {{'person.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="item?.allMetadata(['dc.contributor.author'])"></ds-metadata-values>
+  {{'person.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="[item?.firstMetadata('person.familyName'), item?.firstMetadata('person.givenName')]" [separator]="', '"></ds-metadata-values>
 </h2>
 <div class="row">
   <div class="col-xs-12 col-md-4">

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.html
@@ -7,21 +7,21 @@
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async" [defaultImage]="'assets/images/person-placeholder.svg'"></ds-thumbnail>
     </ds-metadata-field-wrapper>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.email']"
+      [fields]="['person.email']"
       [label]="'person.page.email'">
     </ds-generic-item-page-field>
+    <!--<ds-generic-item-page-field [item]="item"-->
+      <!--[fields]="['person.identifier.orcid']"-->
+      <!--[label]="'person.page.orcid'">-->
+    <!--</ds-generic-item-page-field>-->
     <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.orcid']"
-      [label]="'person.page.orcid'">
-    </ds-generic-item-page-field>
-    <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.birthdate']"
+      [fields]="['person.birthDate']"
       [label]="'person.page.birthdate'">
     </ds-generic-item-page-field>
-    <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.staffid']"
-      [label]="'person.page.staffid'">
-    </ds-generic-item-page-field>
+    <!--<ds-generic-item-page-field [item]="item"-->
+      <!--[fields]="['person.identifier.staffid']"-->
+      <!--[label]="'person.page.staffid'">-->
+    <!--</ds-generic-item-page-field>-->
   </div>
   <div class="col-xs-12 col-md-6">
     <ds-related-items
@@ -33,15 +33,15 @@
       [label]="'relationships.isOrgUnitOf' | translate">
     </ds-related-items>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.jobtitle']"
+      [fields]="['person.jobTitle']"
       [label]="'person.page.jobtitle'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.lastname']"
+      [fields]="['person.familyName']"
       [label]="'person.page.lastname'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['person.identifier.firstname']"
+      [fields]="['person.givenName']"
       [label]="'person.page.firstname'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.spec.ts
@@ -12,43 +12,43 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'person.identifier.email': [
+    'person.email': [
       {
         language: 'en_US',
         value: 'fake@email.com'
       }
     ],
-    'person.identifier.orcid': [
-      {
-        language: 'en_US',
-        value: 'ORCID-1'
-      }
-    ],
-    'person.identifier.birthdate': [
+    // 'person.identifier.orcid': [
+    //   {
+    //     language: 'en_US',
+    //     value: 'ORCID-1'
+    //   }
+    // ],
+    'person.birthDate': [
       {
         language: 'en_US',
         value: '1993'
       }
     ],
-    'person.identifier.staffid': [
-      {
-        language: 'en_US',
-        value: '1'
-      }
-    ],
-    'person.identifier.jobtitle': [
+    // 'person.identifier.staffid': [
+    //   {
+    //     language: 'en_US',
+    //     value: '1'
+    //   }
+    // ],
+    'person.jobTitle': [
       {
         language: 'en_US',
         value: 'Developer'
       }
     ],
-    'person.identifier.lastname': [
+    'person.familyName': [
       {
         language: 'en_US',
         value: 'Doe'
       }
     ],
-    'person.identifier.firstname': [
+    'person.givenName': [
       {
         language: 'en_US',
         value: 'John'

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.html
@@ -1,15 +1,15 @@
 <h2 class="item-page-title-field">
-  {{'project.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="item?.allMetadata(['project.identifier.name'])"></ds-metadata-values>
+  {{'project.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="item?.allMetadata(['dc.title'])"></ds-metadata-values>
 </h2>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>
       <ds-thumbnail [thumbnail]="this.item.getThumbnail() | async" [defaultImage]="'assets/images/project-placeholder.svg'"></ds-thumbnail>
     </ds-metadata-field-wrapper>
-    <ds-generic-item-page-field [item]="item"
-      [fields]="['project.identifier.status']"
-      [label]="'project.page.status'">
-    </ds-generic-item-page-field>
+    <!--<ds-generic-item-page-field [item]="item"-->
+      <!--[fields]="['project.identifier.status']"-->
+      <!--[label]="'project.page.status'">-->
+    <!--</ds-generic-item-page-field>-->
     <ds-metadata-representation-list
       [label]="'project.page.contributor' | translate"
       [representations]="contributors$ | async">
@@ -19,13 +19,13 @@
       [label]="'project.page.funder'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['project.identifier.id']"
+      [fields]="['dc.identifier']"
       [label]="'project.page.id'">
     </ds-generic-item-page-field>
-    <ds-generic-item-page-field [item]="item"
-      [fields]="['project.identifier.expectedcompletion']"
-      [label]="'project.page.expectedcompletion'">
-    </ds-generic-item-page-field>
+    <!--<ds-generic-item-page-field [item]="item"-->
+      <!--[fields]="['project.identifier.expectedcompletion']"-->
+      <!--[label]="'project.page.expectedcompletion'">-->
+    <!--</ds-generic-item-page-field>-->
   </div>
   <div class="col-xs-12 col-md-6">
     <ds-related-items
@@ -41,11 +41,11 @@
       [label]="'relationships.isOrgUnitOf' | translate">
     </ds-related-items>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['project.identifier.description']"
+      [fields]="['dc.description']"
       [label]="'project.page.description'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="item"
-      [fields]="['project.identifier.keyword']"
+      [fields]="['dc.subject']"
       [label]="'project.page.keyword'">
     </ds-generic-item-page-field>
     <div>

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.spec.ts
@@ -12,31 +12,31 @@ import {
 const mockItem: Item = Object.assign(new Item(), {
   bitstreams: observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), []))),
   metadata: {
-    'project.identifier.status': [
-      {
-        language: 'en_US',
-        value: 'published'
-      }
-    ],
-    'project.identifier.id': [
+    // 'project.identifier.status': [
+    //   {
+    //     language: 'en_US',
+    //     value: 'published'
+    //   }
+    // ],
+    'dc.identifier': [
       {
         language: 'en_US',
         value: '1'
       }
     ],
-    'project.identifier.expectedcompletion': [
-      {
-        language: 'en_US',
-        value: 'exp comp'
-      }
-    ],
-    'project.identifier.description': [
+    // 'project.identifier.expectedcompletion': [
+    //   {
+    //     language: 'en_US',
+    //     value: 'exp comp'
+    //   }
+    // ],
+    'dc.description': [
       {
         language: 'en_US',
         value: 'keyword'
       }
     ],
-    'project.identifier.keyword': [
+    'dc.subject': [
       {
         language: 'en_US',
         value: 'keyword'


### PR DESCRIPTION
One of the priorities identified in https://wiki.duraspace.org/display/DSPACE/2019-05-23+DSpace+7+Entities+WG+Meeting was the migration of the metadata fields for new entity types to schema.org
This PR removes the temporary metadata fields from phase 1 of the configurable entities which is also part of https://jira.duraspace.org/browse/DS-4223 and includes the new metadata fields and search facets on the item pages

Of course any other flat metadata schema can also be configured, DSpace does support the metadata registry to easily configure the desired metadata schema

This is related to https://github.com/DSpace/DSpace/pull/2443 and would preferably be merged simultaneously with that PR