### PR TITLE
Reverted #424

### DIFF
--- a/src/app/+search-page/search-service/search.service.ts
+++ b/src/app/+search-page/search-service/search.service.ts
@@ -354,10 +354,7 @@ export class SearchService implements OnDestroy {
    * @returns {string} The base path to the search page
    */
   getSearchLink(): string {
-    const urlTree = this.router.parseUrl(this.router.url);
-    const g: UrlSegmentGroup = urlTree.root.children[PRIMARY_OUTLET];
-    const searchLink: any = '/' + g.toString();
-    return (searchLink !== '/search' && searchLink !== '/mydspace') ? '/search' : searchLink;
+    return '/search';
   }
 
   /**

--- a/src/app/+search-page/search-settings/search-settings.component.html
+++ b/src/app/+search-page/search-settings/search-settings.component.html
@@ -1,4 +1,3 @@
-<script src="../search-switch-configuration/search-switch-configuration.component.ts"></script>
 <ng-container *ngVar="(searchOptions$ | async) as config">
     <h3>{{ 'search.sidebar.settings.title' | translate}}</h3>
     <div *ngIf="config?.sort" class="setting-option result-order-settings mb-3 p-3">


### PR DESCRIPTION
I reverted the changes from #424.
This issue was fixed earlier in this commit https://github.com/DSpace/dspace-angular/commit/49dc4b86e22b64f8136fab95de52746ab42c5dd3#diff-c793158e8f9f65b6e8317b40dcb28bc9

I believe that the SearchService:getSearchLink() method should not return a different path for each page that could possibly contain a search page, like for example the MyDSpace page.
If we were to do this anyway, we would also need this method to return the search links for the journal and person pages, because these also contain search pages; similar to the MyDSpace page.

This is why I refactored this in #398 to make sure the `InPlaceSearch` boolean was added to the necessary components, that - when true - will make sure to use the current page as a search page instead of the `/search` page.