### PR TITLE
Add missing ResourcePolicyService

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -60,6 +60,7 @@ import { HALEndpointService } from './shared/hal-endpoint.service';
 import { FacetValueResponseParsingService } from './data/facet-value-response-parsing.service';
 import { FacetValueMapResponseParsingService } from './data/facet-value-map-response-parsing.service';
 import { FacetConfigResponseParsingService } from './data/facet-config-response-parsing.service';
+import { ResourcePolicyService } from './data/resource-policy.service';
 import { RegistryService } from './registry/registry.service';
 import { RegistryMetadataschemasResponseParsingService } from './data/registry-metadataschemas-response-parsing.service';
 import { RegistryMetadatafieldsResponseParsingService } from './data/registry-metadatafields-response-parsing.service';
@@ -125,6 +126,7 @@ const PROVIDERS = [
   MetadataService,
   ObjectCacheService,
   PaginationComponentOptions,
+  ResourcePolicyService,
   RegistryService,
   NormalizedObjectBuildService,
   RemoteDataBuildService,

--- a/src/app/core/data/metadata-schema-data.service.ts
+++ b/src/app/core/data/metadata-schema-data.service.ts
@@ -13,15 +13,38 @@ import { MetadataSchema } from '../metadata/metadataschema.model';
 import { NormalizedObjectBuildService } from '../cache/builders/normalized-object-build.service';
 import { HttpClient } from '@angular/common/http';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { ChangeAnalyzer } from './change-analyzer';
 import { DefaultChangeAnalyzer } from './default-change-analyzer.service';
+
+/* tslint:disable:max-classes-per-file */
+class DataServiceImpl extends DataService<MetadataSchema> {
+  protected linkPath = 'metadataschemas';
+  protected forceBypassCache = false;
+
+  constructor(
+    protected requestService: RequestService,
+    protected rdbService: RemoteDataBuildService,
+    protected dataBuildService: NormalizedObjectBuildService,
+    protected store: Store<CoreState>,
+    protected objectCache: ObjectCacheService,
+    protected halService: HALEndpointService,
+    protected notificationsService: NotificationsService,
+    protected http: HttpClient,
+    protected comparator: ChangeAnalyzer<MetadataSchema>) {
+    super();
+  }
+
+  getBrowseEndpoint(options: FindAllOptions = {}, linkPath: string = this.linkPath): Observable<string> {
+    return this.halService.getEndpoint(linkPath);
+  }
+}
 
 /**
  * A service responsible for fetching/sending data from/to the REST API on the metadataschemas endpoint
  */
 @Injectable()
-export class MetadataSchemaDataService extends DataService<MetadataSchema> {
-  protected linkPath = 'metadataschemas';
-  protected forceBypassCache = false;
+export class MetadataSchemaDataService {
+  private dataService: DataServiceImpl;
 
   constructor(
     protected requestService: RequestService,
@@ -33,17 +56,6 @@ export class MetadataSchemaDataService extends DataService<MetadataSchema> {
     protected dataBuildService: NormalizedObjectBuildService,
     protected http: HttpClient,
     protected notificationsService: NotificationsService) {
-    super();
+    this.dataService = new DataServiceImpl(requestService, rdbService, dataBuildService, null, objectCache, halService, notificationsService, http, comparator);
   }
-
-  /**
-   * Get the endpoint for browsing metadataschemas
-   * @param {FindAllOptions} options
-   * @returns {Observable<string>}
-   */
-  public getBrowseEndpoint(options: FindAllOptions = {}, linkPath: string = this.linkPath): Observable<string> {
-
-    return null;
-  }
-
 }

--- a/src/app/core/data/resource-policy.service.spec.ts
+++ b/src/app/core/data/resource-policy.service.spec.ts
@@ -1,0 +1,70 @@
+import { cold, getTestScheduler } from 'jasmine-marbles';
+import { TestScheduler } from 'rxjs/testing';
+import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { ResourcePolicy } from '../shared/resource-policy.model';
+import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { FindByIDRequest } from './request.models';
+import { RequestService } from './request.service';
+import { ResourcePolicyService } from './resource-policy.service';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { HttpClient } from '@angular/common/http';
+import { NormalizedObjectBuildService } from '../cache/builders/normalized-object-build.service';
+
+describe('ResourcePolicyService', () => {
+  let scheduler: TestScheduler;
+  let service: ResourcePolicyService;
+  let requestService: RequestService;
+  let rdbService: RemoteDataBuildService;
+  let objectCache: ObjectCacheService;
+  const testObject = {
+    id: 1
+  } as ResourcePolicy;
+  const requestURL = `https://rest.api/rest/api/resourcepolicies/${testObject.id}`;
+  const requestID = 1;
+
+  beforeEach(() => {
+    scheduler = getTestScheduler();
+
+    requestService = jasmine.createSpyObj('requestService', {
+      generateRequestId: requestID,
+      configure: true
+    });
+    rdbService = jasmine.createSpyObj('rdbService', {
+      buildSingle: cold('a', {
+        a: {
+          payload: testObject
+        }
+      })
+    });
+    objectCache = {} as ObjectCacheService;
+    const halService = {} as HALEndpointService;
+    const notificationsService = {} as NotificationsService;
+    const http = {} as HttpClient;
+    const comparator = {} as any;
+    const dataBuildService = {} as NormalizedObjectBuildService;
+
+    service = new ResourcePolicyService(
+      requestService,
+      rdbService,
+      dataBuildService,
+      objectCache,
+      halService,
+      notificationsService,
+      http,
+      comparator
+    )
+  });
+
+  describe('findByHref', () => {
+    it('should return a RemoteData<ResourcePolicy> for the object with the given URL', () => {
+      const result = service.findByHref(requestURL);
+      const expected = cold('a', {
+        a: {
+          payload: testObject
+        }
+      });
+      expect(result).toBeObservable(expected);
+    });
+  });
+});

--- a/src/app/core/data/resource-policy.service.spec.ts
+++ b/src/app/core/data/resource-policy.service.spec.ts
@@ -57,6 +57,13 @@ describe('ResourcePolicyService', () => {
   });
 
   describe('findByHref', () => {
+    it('should configure the proper GetRequest', () => {
+      scheduler.schedule(() => service.findByHref(requestURL));
+      scheduler.flush();
+
+      expect(requestService.configure).toHaveBeenCalledWith(new GetRequest(requestUUID, requestURL, null), false);
+    });
+
     it('should return a RemoteData<ResourcePolicy> for the object with the given URL', () => {
       const result = service.findByHref(requestURL);
       const expected = cold('a', {

--- a/src/app/core/data/resource-policy.service.spec.ts
+++ b/src/app/core/data/resource-policy.service.spec.ts
@@ -3,7 +3,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { ResourcePolicy } from '../shared/resource-policy.model';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
-import { FindByIDRequest } from './request.models';
+import { GetRequest } from './request.models';
 import { RequestService } from './request.service';
 import { ResourcePolicyService } from './resource-policy.service';
 import { ObjectCacheService } from '../cache/object-cache.service';
@@ -18,16 +18,16 @@ describe('ResourcePolicyService', () => {
   let rdbService: RemoteDataBuildService;
   let objectCache: ObjectCacheService;
   const testObject = {
-    id: 1
+    uuid: '664184ee-b254-45e8-970d-220e5ccc060b'
   } as ResourcePolicy;
-  const requestURL = `https://rest.api/rest/api/resourcepolicies/${testObject.id}`;
-  const requestID = 1;
+  const requestURL = `https://rest.api/rest/api/resourcepolicies/${testObject.uuid}`;
+  const requestUUID = '8b3c613a-5a4b-438b-9686-be1d5b4a1c5a';
 
   beforeEach(() => {
     scheduler = getTestScheduler();
 
     requestService = jasmine.createSpyObj('requestService', {
-      generateRequestId: requestID,
+      generateRequestId: requestUUID,
       configure: true
     });
     rdbService = jasmine.createSpyObj('rdbService', {

--- a/src/app/core/data/resource-policy.service.ts
+++ b/src/app/core/data/resource-policy.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import { DataService } from '../data/data.service';
+import { RequestService } from '../data/request.service';
+import { FindAllOptions } from '../data/request.models';
+import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { ResourcePolicy } from '../shared/resource-policy.model';
+import { RemoteData } from '../data/remote-data';
+import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { CoreState } from '../core.reducers';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { NormalizedObjectBuildService } from '../cache/builders/normalized-object-build.service';
+import { ChangeAnalyzer } from './change-analyzer';
+import { DefaultChangeAnalyzer } from '../data/default-change-analyzer.service';
+import { HttpOptions } from '../dspace-rest-v2/dspace-rest-v2.service';
+
+/* tslint:disable:max-classes-per-file */
+class DataServiceImpl extends DataService<ResourcePolicy> {
+  protected linkPath = 'resourcepolicies';
+  protected forceBypassCache = false;
+
+  constructor(
+    protected requestService: RequestService,
+    protected rdbService: RemoteDataBuildService,
+    protected dataBuildService: NormalizedObjectBuildService,
+    protected store: Store<CoreState>,
+    protected objectCache: ObjectCacheService,
+    protected halService: HALEndpointService,
+    protected notificationsService: NotificationsService,
+    protected http: HttpClient,
+    protected comparator: ChangeAnalyzer<ResourcePolicy>) {
+    super();
+  }
+
+  getBrowseEndpoint(options: FindAllOptions = {}, linkPath: string = this.linkPath): Observable<string> {
+    return this.halService.getEndpoint(linkPath);
+  }
+}
+
+/**
+ * A service responsible for fetching/sending data from/to the REST API on the resourcepolicies endpoint
+ */
+@Injectable()
+export class ResourcePolicyService {
+  private dataService: DataServiceImpl;
+
+  constructor(
+    protected requestService: RequestService,
+    protected rdbService: RemoteDataBuildService,
+    protected dataBuildService: NormalizedObjectBuildService,
+    protected objectCache: ObjectCacheService,
+    protected halService: HALEndpointService,
+    protected notificationsService: NotificationsService,
+    protected http: HttpClient,
+    protected comparator: DefaultChangeAnalyzer<ResourcePolicy>) {
+    this.dataService = new DataServiceImpl(requestService, rdbService, dataBuildService, null, objectCache, halService, notificationsService, http, comparator);
+  }
+
+  findByHref(href: string, options?: HttpOptions): Observable<RemoteData<ResourcePolicy>> {
+    return this.dataService.findByHref(href, options);
+  }
+}

--- a/src/app/submission/sections/upload/section-upload.component.spec.ts
+++ b/src/app/submission/sections/upload/section-upload.component.spec.ts
@@ -30,6 +30,7 @@ import { GroupEpersonService } from '../../../core/eperson/group-eperson.service
 import { cold, hot } from 'jasmine-marbles';
 import { Collection } from '../../../core/shared/collection.model';
 import { ResourcePolicy } from '../../../core/shared/resource-policy.model';
+import { ResourcePolicyService } from '../../../core/data/resource-policy.service';
 import { RemoteData } from '../../../core/data/remote-data';
 import { ConfigData } from '../../../core/config/config-data';
 import { PageInfo } from '../../../core/shared/page-info.model';
@@ -47,8 +48,7 @@ function getMockSubmissionUploadsConfigService(): SubmissionFormsConfigService {
 
 function getMockCollectionDataService(): CollectionDataService {
   return jasmine.createSpyObj('CollectionDataService', {
-    findById: jasmine.createSpy('findById'),
-    findByHref: jasmine.createSpy('findByHref')
+    findById: jasmine.createSpy('findById')
   });
 }
 
@@ -56,6 +56,12 @@ function getMockGroupEpersonService(): GroupEpersonService {
   return jasmine.createSpyObj('GroupEpersonService', {
     findById: jasmine.createSpy('findById'),
 
+  });
+}
+
+function getMockResourcePolicyService(): ResourcePolicyService {
+  return jasmine.createSpyObj('ResourcePolicyService', {
+    findByHref: jasmine.createSpy('findByHref')
   });
 }
 
@@ -80,6 +86,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
   let sectionsServiceStub: SectionsServiceStub;
   let collectionDataService: any;
   let groupService: any;
+  let resourcePolicyService: any;
   let uploadsConfigService: any;
   let bitstreamService: any;
 
@@ -120,6 +127,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
       providers: [
         { provide: CollectionDataService, useValue: getMockCollectionDataService() },
         { provide: GroupEpersonService, useValue: getMockGroupEpersonService() },
+        { provide: ResourcePolicyService, useValue: getMockResourcePolicyService() },
         { provide: SubmissionUploadsConfigService, useValue: getMockSubmissionUploadsConfigService() },
         { provide: SectionsService, useClass: SectionsServiceStub },
         { provide: SubmissionService, useClass: SubmissionServiceStub },
@@ -166,6 +174,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
       sectionsServiceStub = TestBed.get(SectionsService);
       collectionDataService = TestBed.get(CollectionDataService);
       groupService = TestBed.get(GroupEpersonService);
+      resourcePolicyService = TestBed.get(ResourcePolicyService);
       uploadsConfigService = TestBed.get(SubmissionUploadsConfigService);
       bitstreamService = TestBed.get(SectionUploadService);
     });
@@ -184,7 +193,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
         new RemoteData(false, false, true,
         undefined, mockCollection)));
 
-      collectionDataService.findByHref.and.returnValue(observableOf(
+      resourcePolicyService.findByHref.and.returnValue(observableOf(
         new RemoteData(false, false, true,
           undefined, mockDefaultAccessCondition)
       ));
@@ -230,7 +239,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
         new RemoteData(false, false, true,
           undefined, mockCollection)));
 
-      collectionDataService.findByHref.and.returnValue(observableOf(
+      resourcePolicyService.findByHref.and.returnValue(observableOf(
         new RemoteData(false, false, true,
           undefined, mockDefaultAccessCondition)
       ));

--- a/src/app/submission/sections/upload/section-upload.component.ts
+++ b/src/app/submission/sections/upload/section-upload.component.ts
@@ -8,6 +8,7 @@ import { hasValue, isNotEmpty, isNotUndefined, isUndefined } from '../../../shar
 import { SectionUploadService } from './section-upload.service';
 import { CollectionDataService } from '../../../core/data/collection-data.service';
 import { GroupEpersonService } from '../../../core/eperson/group-eperson.service';
+import { ResourcePolicyService } from '../../../core/data/resource-policy.service';
 import { SubmissionUploadsConfigService } from '../../../core/config/submission-uploads-config.service';
 import { SubmissionUploadsModel } from '../../../core/config/models/config-submission-uploads.model';
 import { SubmissionFormsModel } from '../../../core/config/models/config-submission-forms.model';
@@ -116,6 +117,7 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
    * @param {ChangeDetectorRef} changeDetectorRef
    * @param {CollectionDataService} collectionDataService
    * @param {GroupEpersonService} groupService
+   * @param {ResourcePolicyService} resourcePolicyService
    * @param {SectionsService} sectionService
    * @param {SubmissionService} submissionService
    * @param {SubmissionUploadsConfigService} uploadsConfigService
@@ -126,6 +128,7 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
               private changeDetectorRef: ChangeDetectorRef,
               private collectionDataService: CollectionDataService,
               private groupService: GroupEpersonService,
+              private resourcePolicyService: ResourcePolicyService,
               protected sectionService: SectionsService,
               private submissionService: SubmissionService,
               private uploadsConfigService: SubmissionUploadsConfigService,
@@ -155,7 +158,7 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
         find((rd: RemoteData<Collection>) => isNotUndefined((rd.payload))),
         tap((collectionRemoteData: RemoteData<Collection>) => this.collectionName = collectionRemoteData.payload.name),
         flatMap((collectionRemoteData: RemoteData<Collection>) => {
-          return this.collectionDataService.findByHref(
+          return this.resourcePolicyService.findByHref(
             (collectionRemoteData.payload as any)._links.defaultAccessConditions
           );
         }),


### PR DESCRIPTION
This adds the missing `ResourcePolicyService`. The call to `this.collectionDataService.findByHref` only succeeds, because the full href is used and typescript does not check the return type.

I do not know if the `resouce-policy.service.ts` file should be placed in something like `src/app/core/authz/`, but it's only a single file.