### PR TITLE
One-sided relationship filtering and refactoring

### DIFF
--- a/src/app/+item-page/simple/item-types/publication/publication.component.ts
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../shared/items/item-type-decorator';
 import { ItemComponent } from '../shared/item.component';
 import { MetadataRepresentation } from '../../../../core/shared/metadata-representation/metadata-representation.model';
-import { filterRelationsByTypeLabel, relationsToItems } from '../shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../shared/item-relationships-utils';
 
 @rendersItemType('Publication', ItemViewMode.Full)
 @rendersItemType(DEFAULT_ITEM_TYPE, ItemViewMode.Full)
@@ -46,18 +46,15 @@ export class PublicationComponent extends ItemComponent implements OnInit {
       this.authors$ = this.buildRepresentations('Person', 'dc.contributor.author');
 
       this.projects$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isProjectOfPublication'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isProjectOfPublication')
       );
 
       this.orgUnits$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isOrgUnitOfPublication'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isOrgUnitOfPublication')
       );
 
       this.journalIssues$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isJournalIssueOfPublication'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isJournalIssueOfPublication')
       );
 
     }

--- a/src/app/+item-page/simple/item-types/shared/item-relationships-utils.ts
+++ b/src/app/+item-page/simple/item-types/shared/item-relationships-utils.ts
@@ -60,8 +60,8 @@ export const filterRelationsByTypeLabel = (label: string, thisId?: string) =>
             hasValue(relTypesCurrentPage[idx]) && (
               (hasNoValue(thisId) && (relTypesCurrentPage[idx].leftLabel === label ||
                 relTypesCurrentPage[idx].rightLabel === label)) ||
-              (thisId === arr[idx][0].id && relTypesCurrentPage[idx].rightLabel === label) ||
-              (thisId === arr[idx][1].id && relTypesCurrentPage[idx].leftLabel === label)
+              (thisId === arr[idx][0].id && relTypesCurrentPage[idx].leftLabel === label) ||
+              (thisId === arr[idx][1].id && relTypesCurrentPage[idx].rightLabel === label)
             )
           ))
         );

--- a/src/app/+item-page/simple/item-types/shared/item.component.spec.ts
+++ b/src/app/+item-page/simple/item-types/shared/item.component.spec.ts
@@ -104,7 +104,9 @@ export function containsFieldInput(fields: DebugElement[], metadataKey: string):
 export function createRelationshipsObservable() {
   return observableOf(new RemoteData(false, false, true, null, new PaginatedList(new PageInfo(), [
     Object.assign(new Relationship(), {
-      relationshipType: observableOf(new RemoteData(false, false, true, null, new RelationshipType()))
+      relationshipType: observableOf(new RemoteData(false, false, true, null, new RelationshipType())),
+      leftItem: observableOf(new RemoteData(false, false, true, null, new Item())),
+      rightItem: observableOf(new RemoteData(false, false, true, null, new Item()))
     })
   ])));
 }

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.ts
@@ -4,10 +4,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { ItemViewMode, rendersItemType } from '../../../../shared/items/item-type-decorator';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('JournalIssue', ItemViewMode.Full)
 @Component({
@@ -34,12 +31,10 @@ export class JournalIssueComponent extends ItemComponent {
 
     if (isNotEmpty(this.resolvedRelsAndTypes$)) {
       this.volumes$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isJournalVolumeOfIssue'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isJournalVolumeOfIssue')
       );
       this.publications$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPublicationOfJournalIssue'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPublicationOfJournalIssue')
       );
     }
   }

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.ts
@@ -4,10 +4,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { ItemViewMode, rendersItemType } from '../../../../shared/items/item-type-decorator';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('JournalVolume', ItemViewMode.Full)
 @Component({
@@ -34,12 +31,10 @@ export class JournalVolumeComponent extends ItemComponent {
 
     if (isNotEmpty(this.resolvedRelsAndTypes$)) {
       this.journals$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isJournalOfVolume'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isJournalOfVolume')
       );
       this.issues$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isIssueOfJournalVolume'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isIssueOfJournalVolume')
       );
     }
   }

--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.ts
@@ -4,10 +4,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { ItemViewMode, rendersItemType } from '../../../../shared/items/item-type-decorator';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('Journal', ItemViewMode.Full)
 @Component({
@@ -29,8 +26,7 @@ export class JournalComponent extends ItemComponent {
 
     if (isNotEmpty(this.resolvedRelsAndTypes$)) {
       this.volumes$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isVolumeOfJournal'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isVolumeOfJournal')
       );
     }
   }

--- a/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.ts
+++ b/src/app/entity-groups/research-entities/item-pages/orgunit/orgunit.component.ts
@@ -4,10 +4,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { ItemViewMode, rendersItemType } from '../../../../shared/items/item-type-decorator';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('OrgUnit', ItemViewMode.Full)
 @Component({
@@ -39,18 +36,15 @@ export class OrgunitComponent extends ItemComponent implements OnInit {
 
     if (isNotEmpty(this.resolvedRelsAndTypes$)) {
       this.people$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPersonOfOrgUnit'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPersonOfOrgUnit')
       );
 
       this.projects$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isProjectOfOrgUnit'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isProjectOfOrgUnit')
       );
 
       this.publications$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPublicationOfOrgUnit'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPublicationOfOrgUnit')
       );
     }
   }}

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.ts
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.ts
@@ -6,10 +6,7 @@ import { ITEM } from '../../../../shared/items/switcher/item-type-switcher.compo
 import { SearchFixedFilterService } from '../../../../+search-page/search-filters/search-filter/search-fixed-filter.service';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('Person', ItemViewMode.Full)
 @Component({
@@ -57,18 +54,15 @@ export class PersonComponent extends ItemComponent {
 
     if (isNotEmpty(this.resolvedRelsAndTypes$)) {
       this.publications$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPublicationOfAuthor'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPublicationOfAuthor')
       );
 
       this.projects$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isProjectOfPerson'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isProjectOfPerson')
       );
 
       this.orgUnits$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isOrgUnitOfPerson'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isOrgUnitOfPerson')
       );
 
       this.fixedFilterQuery = this.fixedFilterService.getQueryByRelations('isAuthorOfPublication', this.item.id);

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.ts
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.ts
@@ -5,10 +5,7 @@ import { MetadataRepresentation } from '../../../../core/shared/metadata-represe
 import { ItemViewMode, rendersItemType } from '../../../../shared/items/item-type-decorator';
 import { isNotEmpty } from '../../../../shared/empty.util';
 import { ItemComponent } from '../../../../+item-page/simple/item-types/shared/item.component';
-import {
-  filterRelationsByTypeLabel,
-  relationsToItems
-} from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
+import { getRelatedItemsByTypeLabel } from '../../../../+item-page/simple/item-types/shared/item-relationships-utils';
 
 @rendersItemType('Project', ItemViewMode.Full)
 @Component({
@@ -47,18 +44,15 @@ export class ProjectComponent extends ItemComponent implements OnInit {
       this.contributors$ = this.buildRepresentations('OrgUnit', 'project.contributor.other');
 
       this.people$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPersonOfProject'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPersonOfProject')
       );
 
       this.publications$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isPublicationOfProject'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isPublicationOfProject')
       );
 
       this.orgUnits$ = this.resolvedRelsAndTypes$.pipe(
-        filterRelationsByTypeLabel('isOrgUnitOfProject'),
-        relationsToItems(this.item.id)
+        getRelatedItemsByTypeLabel(this.item.id, 'isOrgUnitOfProject')
       );
     }
   }


### PR DESCRIPTION
This PR allows for filtering a list of relationships on one side, depending on the item you're fetching relationships for. This can be useful in cases where two entities of the same type have a relationship with each other, for example child-parent relationships. Without one-sided filtering, you wouldn’t know when to display the parent or child relationship on item pages.

To achieve this, `filterRelationsByTypeLabel` now has an optional parameter for the item's ID. Using the item's ID, we can filter out irrelevant relationships where the item is on the same side as the label requested.

To avoid having to call both operators every time you're filtering relations, I’ve also added a new operator called `getRelatedItemsByTypeLabel`, essentially combining the other two operators into one.

All entity pages have been refactored to use this new operator.

Some example code of how you would fetch parent and child related items for Organisational Units:

```
  this.parentOrgUnits$ = this.resolvedRelsAndTypes$.pipe(
    getRelatedItemsByTypeLabel(this.item.id, 'isParentOrgUnitOf')
  );

  this.childOrgUnits$ = this.resolvedRelsAndTypes$.pipe(
    getRelatedItemsByTypeLabel(this.item.id, 'isChildOrgUnitOf')
  );
```