### PR TITLE
Update environment.js with new demo site path

### DIFF
--- a/config/environment.default.js
+++ b/config/environment.default.js
@@ -13,7 +13,7 @@ module.exports = {
     host: 'dspace7.4science.cloud',
     port: 443,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
-    nameSpace: '/dspace-spring-rest/api'
+    nameSpace: '/server/api'
   },
   // Caching settings
   cache: {


### PR DESCRIPTION
After the merger of https://github.com/DSpace/DSpace/pull/2459, the REST API demo site has been updated to use the new default `/server` path.  It's now available at https://dspace7.4science.cloud/server

This PR updates the Angular UI to use that new path by default.