### PR TITLE
Remove e2e tests from the ci task

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "debug:server": "node-nightly --inspect --debug-brk dist/server.js",
     "debug:build": "node-nightly --inspect --debug-brk node_modules/webpack/bin/webpack.js --mode development",
     "debug:build:prod": "node-nightly --inspect --debug-brk node_modules/webpack/bin/webpack.js --env.aot --env.client --env.server --mode production",
-    "ci": "yarn run lint && yarn run build:aot && yarn run test:headless && npm-run-all -p -r server e2e",
+    "ci": "yarn run lint && yarn run build:aot && yarn run test:headless",
     "protractor": "node node_modules/protractor/bin/protractor",
     "pree2e": "yarn run webdriver:update",
     "e2e": "yarn run protractor",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -5,7 +5,7 @@
 var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
-  allScriptsTimeout: 600000,
+  allScriptsTimeout: 11000,
   // -----------------------------------------------------------------
   // Uncomment to run tests using a remote Selenium server
   //seleniumAddress: 'http://selenium.address:4444/wd/hub',
@@ -73,7 +73,7 @@ exports.config = {
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 600000,
+    defaultTimeoutInterval: 30000,
     print: function () {}
   },
   useAllAngular2AppRoots: true,


### PR DESCRIPTION
This PR connects to #453 

It removes e2e tests from the Travis CI npm script, and restores the protractor timeouts that were increased fix the issues with Travis