### PR TITLE
Fix the labels on edit collection and community pages

### DIFF
--- a/src/app/shared/comcol-forms/comcol-form/comcol-form.component.ts
+++ b/src/app/shared/comcol-forms/comcol-form/comcol-form.component.ts
@@ -9,6 +9,7 @@ import { DynamicFormControlModel } from '@ng-dynamic-forms/core/src/model/dynami
 import { TranslateService } from '@ngx-translate/core';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { MetadataMap, MetadataValue } from '../../../core/shared/metadata.models';
+import { ResourceType } from '../../../core/shared/resource-type';
 import { isNotEmpty } from '../../empty.util';
 import { Community } from '../../../core/shared/community.model';
 
@@ -29,7 +30,7 @@ export class ComColFormComponent<T extends DSpaceObject> implements OnInit {
   /**
    * Type of DSpaceObject that the form represents
    */
-  protected type;
+  protected type: ResourceType;
 
   /**
    * @type {string} Key prefix used to generate form labels
@@ -110,11 +111,11 @@ export class ComColFormComponent<T extends DSpaceObject> implements OnInit {
   private updateFieldTranslations() {
     this.formModel.forEach(
       (fieldModel: DynamicInputModel) => {
-        fieldModel.label = this.translate.instant(this.type + this.LABEL_KEY_PREFIX + fieldModel.id);
+        fieldModel.label = this.translate.instant(this.type.value + this.LABEL_KEY_PREFIX + fieldModel.id);
         if (isNotEmpty(fieldModel.validators)) {
           fieldModel.errorMessages = {};
           Object.keys(fieldModel.validators).forEach((key) => {
-            fieldModel.errorMessages[key] = this.translate.instant(this.type + this.ERROR_KEY_PREFIX + fieldModel.id + '.' + key);
+            fieldModel.errorMessages[key] = this.translate.instant(this.type.value + this.ERROR_KEY_PREFIX + fieldModel.id + '.' + key);
           });
         }
       }


### PR DESCRIPTION
The i18n labels on edit collection and community pages are based on the resource type. It used to be a string, but was changed in to an object recently causing the i18n labels to break:

![image](https://user-images.githubusercontent.com/1567693/62944685-88ad6d80-bddd-11e9-9d64-a5f294302a9e.png)

This PR fixes that
