### PR TITLE
Pagination messaging:  Hiding "Now Showing"

### DIFF
--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -2,8 +2,10 @@
   <div  class="pagination-masked clearfix top">
     <div class="row">
       <div *ngIf="!hidePaginationDetail" class="col-auto pagination-info">
-        <span class="align-middle hidden-xs-down">{{ 'pagination.showing.label' | translate }}</span>
-        <span class="align-middle" *ngIf="collectionSize">{{ 'pagination.showing.detail' | translate:getShowingDetails(collectionSize)}}</span>
+        <ng-container *ngIf="collectionSize">
+          <span class="align-middle hidden-xs-down">{{ 'pagination.showing.label' | translate }}</span>
+          <span class="align-middle">{{ 'pagination.showing.detail' | translate:getShowingDetails(collectionSize)}}</span>
+        </ng-container>
       </div>
       <div class="col">
         <div *ngIf="!hideGear" ngbDropdown #paginationControls="ngbDropdown" placement="bottom-right" class="d-inline-block float-right">


### PR DESCRIPTION
Here is an idea to fix this small bug.
Moving the ngIf directive to wrap both parts of the statement.