### PR TITLE
Use the improved DSpace Docker Compose files to create the ci image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ before_install:
   - git clone https://github.com/DSpace-Labs/DSpace-Docker-Images.git
 
 install:
+  # Start up DSpace 7 using the entities database dump
   - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.travis.ci.yml up -d
-  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.cli.yml -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/cli.ingest.yml run --rm dspace-cli
+  # Use the dspace-cli image to populate the assetstore.  Trigger a discovery and oai update
+  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.cli.yml -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.cli.assetstore.yml run --rm dspace-cli
   - travis_retry yarn install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
   - git clone https://github.com/DSpace-Labs/DSpace-Docker-Images.git
 
 install:
-  - docker-compose version
-  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose/d7.travis.yml up -d
+  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.travis.ci.yml up -d
+  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.cli.yml -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/cli.ingest.yml run --rm dspace-cli
   - travis_retry yarn install
 
 before_script:
@@ -30,7 +30,7 @@ before_script:
   #- curl http://localhost:8080/
 
 after_script:
-  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose/d7.travis.yml down
+  - docker-compose -f DSpace-Docker-Images/docker-compose-files/dspace-compose-v2/d7.travis.ci.yml down
 
 addons:
   apt:


### PR DESCRIPTION
A new set of docker compose files have been created for DSpace 6 and DSpace 7.  These compose files load a local.cfg file rather than setting properties through environment variables.  These compose files make use of a dedicated image dspace/dspace-cli to invoke command line actions.

https://github.com/DSpace-Labs/DSpace-Docker-Images/tree/master/docker-compose-files/dspace-compose-v2

This PR makes use of the new compose files for the travis ci step.

The d7.cli.assetstore.yml currently indexes the entire repo (including bitstreams) before returning.  These actions could be simplified if this content is not used for ci purposes.  