### PR TITLE
Fix travis chrome install issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     sources:
       - google-chrome
     packages:
+      - dpkg
       - google-chrome-stable
 
 language: node_js


### PR DESCRIPTION
The travis trusty image [has an issue installing chrome](https://github.com/DSpace/dspace-angular/pull/348#issuecomment-530304706). This PR adds a workaround: it [updates dpkg manually](https://github.com/travis-ci/travis-ci/issues/9361#issuecomment-408431262) before installing chrome. However we should [switch to a newer ubuntu image](https://github.com/DSpace/dspace-angular/issues/481) to prevent similar issues in the future.