### PR TITLE
Ensure all nav links in header are classed appropriately (for easier Bootstrap theming)

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -5,7 +5,11 @@
         </a>
 
         <nav class="navbar navbar-light navbar-expand-md float-right px-0">
-            <a routerLink="/search" class="px-1"><i class="fas fa-search fa-lg fa-fw" [title]="'nav.search' | translate"></i></a>
+            <ul class="navbar-nav">
+                <li>
+                    <a routerLink="/search" class="nav-link px-1"><i class="fas fa-search fa-lg fa-fw" [title]="'nav.search' | translate"></i></a>
+                </li>
+            </ul>
             <ds-lang-switch></ds-lang-switch>
             <ds-auth-nav-menu></ds-auth-nav-menu>
             <div class="pl-2">

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
@@ -1,25 +1,25 @@
 <ul class="navbar-nav" [ngClass]="{'mr-auto': (isXsOrSm$ | async)}">
   <li *ngIf="!(isAuthenticated | async) && !(isXsOrSm$ | async) && (showAuth | async)" class="nav-item" (click)="$event.stopPropagation();">
     <div ngbDropdown placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="#" id="dropdownLogin" (click)="$event.preventDefault()" ngbDropdownToggle class="px-1">{{ 'nav.login' | translate }}</a>
+      <a href="#" id="dropdownLogin" (click)="$event.preventDefault()" ngbDropdownToggle class="nav-link px-1">{{ 'nav.login' | translate }}</a>
       <div id="loginDropdownMenu" [ngClass]="{'pl-3 pr-3': (loading | async)}" ngbDropdownMenu aria-labelledby="dropdownLogin">
         <ds-log-in></ds-log-in>
       </div>
     </div>
   </li>
   <li *ngIf="!(isAuthenticated | async) && (isXsOrSm$ | async)" class="nav-item">
-    <a id="loginLink" routerLink="/login" routerLinkActive="active" class="px-1" >{{ 'nav.login' | translate }}<span class="sr-only">(current)</span></a>
+    <a id="loginLink" routerLink="/login" routerLinkActive="active" class="nav-link px-1" >{{ 'nav.login' | translate }}<span class="sr-only">(current)</span></a>
   </li>
   <li *ngIf="(isAuthenticated | async) && !(isXsOrSm$ | async) && (showAuth | async)" class="nav-item">
     <div ngbDropdown placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="#" id="dropdownUser" (click)="$event.preventDefault()" class="px-1" ngbDropdownToggle><i class="fas fa-user-circle fa-lg fa-fw" [title]="'nav.logout' | translate"></i></a>
+      <a href="#" id="dropdownUser" (click)="$event.preventDefault()" class="nav-link px-1" ngbDropdownToggle><i class="fas fa-user-circle fa-lg fa-fw" [title]="'nav.logout' | translate"></i></a>
       <div id="logoutDropdownMenu" ngbDropdownMenu aria-labelledby="dropdownUser">
         <ds-user-menu></ds-user-menu>
       </div>
     </div>
   </li>
   <li *ngIf="(isAuthenticated | async) && (isXsOrSm$ | async)" class="nav-item">
-    <a id="logoutLink" routerLink="/logout" routerLinkActive="active" class="px-1"><i class="fas fa-user-circle fa-lg fa-fw" [title]="'nav.logout' | translate"></i><span class="sr-only">(current)</span></a>
+    <a id="logoutLink" routerLink="/logout" routerLinkActive="active" class="nav-link px-1"><i class="fas fa-user-circle fa-lg fa-fw" [title]="'nav.logout' | translate"></i><span class="sr-only">(current)</span></a>
   </li>
 </ul>
 

--- a/src/app/shared/lang-switch/lang-switch.component.html
+++ b/src/app/shared/lang-switch/lang-switch.component.html
@@ -1,5 +1,5 @@
 <div ngbDropdown class="navbar-nav" *ngIf="moreThanOneLanguage">
-  <a href="#" id="dropdownLang" role="button" class="px-1" (click)="$event.preventDefault()" data-toggle="dropdown" ngbDropdownToggle>
+  <a href="#" id="dropdownLang" role="button" class="nav-link px-1" (click)="$event.preventDefault()" data-toggle="dropdown" ngbDropdownToggle>
     <i class="fas fa-globe-asia fa-lg fa-fw" [title]="'nav.language' | translate"></i>
   </a>
   <ul ngbDropdownMenu class="dropdown-menu" aria-labelledby="dropdownLang">


### PR DESCRIPTION
This small PR ensures that the nav links in the header (specifically search icon, language selector and login menu) are properly styled using Bootstrap. (I came across this bug while preparing a theming demo for the upcoming North American DSpace User Group meeting.)

Currently, on latest master, if you change any `$navbar-*` SCSS variables, they only affect the links in the lower nav bar (e.g. "All of DSpace" and Statistics). The styles of the upper nav bar (search, language, login) remain unchanged. I feel both of these navbars should use the same variables by default, as it makes theming the header/navbar much much easier.

To test this PR:
1. Create a new theme (or make minor modifications to an existing one like `default`). 
2. In your `_themed_bootstrap_variables.scss`, set `$navbar-light-color: red;` 
3. On `master`, this simple change will only turn the lower navbar links red. However, with this PR applied, the upper navbar links will now also turn red.

@artlowel : Any chance you could give this a quick look?  This would greatly simplify my theming demo next Monday.