### PR TITLE
Remove duplicated "SearchFilterService"

### DIFF
--- a/src/app/+search-page/search-page.module.ts
+++ b/src/app/+search-page/search-page.module.ts
@@ -81,7 +81,6 @@ const components = [
     SearchFilterService,
     SearchFixedFilterService,
     ConfigurationSearchPageGuard,
-    SearchFilterService,
     SearchConfigurationService
   ],
   entryComponents: [


### PR DESCRIPTION
A "SearchFilterService" declaration is duplicated.