### PR TITLE
Small bug-fix due to changes to relationship-type

### DIFF
--- a/src/app/+item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
@@ -38,8 +38,8 @@ describe('EditRelationshipListComponent', () => {
     relationshipType = Object.assign(new RelationshipType(), {
       id: '1',
       uuid: '1',
-      leftLabel: 'isAuthorOfPublication',
-      rightLabel: 'isPublicationOfAuthor'
+      leftwardType: 'isAuthorOfPublication',
+      rightwardType: 'isPublicationOfAuthor'
     });
 
     relationships = [
@@ -119,7 +119,7 @@ describe('EditRelationshipListComponent', () => {
     de = fixture.debugElement;
     comp.item = item;
     comp.url = url;
-    comp.relationshipLabel = relationshipType.leftLabel;
+    comp.relationshipLabel = relationshipType.leftwardType;
     fixture.detectChanges();
   });
 

--- a/src/app/+item-page/edit-item-page/item-relationships/edit-relationship/edit-relationship.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/edit-relationship/edit-relationship.component.spec.ts
@@ -34,8 +34,8 @@ describe('EditRelationshipComponent', () => {
     relationshipType = Object.assign(new RelationshipType(), {
       id: '1',
       uuid: '1',
-      leftLabel: 'isAuthorOfPublication',
-      rightLabel: 'isPublicationOfAuthor'
+      leftwardType: 'isAuthorOfPublication',
+      rightwardType: 'isPublicationOfAuthor'
     });
 
     relationships = [

--- a/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.spec.ts
@@ -68,8 +68,8 @@ describe('ItemRelationshipsComponent', () => {
     relationshipType = Object.assign(new RelationshipType(), {
       id: '1',
       uuid: '1',
-      leftLabel: 'isAuthorOfPublication',
-      rightLabel: 'isPublicationOfAuthor'
+      leftwardType: 'isAuthorOfPublication',
+      rightwardType: 'isPublicationOfAuthor'
     });
 
     relationships = [

--- a/src/app/core/data/relationship.service.spec.ts
+++ b/src/app/core/data/relationship.service.spec.ts
@@ -5,7 +5,6 @@ import { getMockRemoteDataBuildService } from '../../shared/mocks/mock-remote-da
 import { of as observableOf } from 'rxjs/internal/observable/of';
 import { RequestEntry } from './request.reducer';
 import { RelationshipType } from '../shared/item-relationships/relationship-type.model';
-import { ResourceType } from '../shared/resource-type';
 import { Relationship } from '../shared/item-relationships/relationship.model';
 import { RemoteData } from './remote-data';
 import { getMockRequestService } from '../../shared/mocks/mock-request.service';
@@ -33,8 +32,8 @@ describe('RelationshipService', () => {
   const relationshipType = Object.assign(new RelationshipType(), {
     id: '1',
     uuid: '1',
-    leftLabel: 'isAuthorOfPublication',
-    rightLabel: 'isPublicationOfAuthor'
+    leftwardType: 'isAuthorOfPublication',
+    rightwardType: 'isPublicationOfAuthor'
   });
 
   const relationship1 = Object.assign(new Relationship(), {
@@ -129,7 +128,7 @@ describe('RelationshipService', () => {
   describe('getItemRelationshipLabels', () => {
     it('should return the correct labels', () => {
       service.getItemRelationshipLabels(item).subscribe((result) => {
-        expect(result).toEqual([relationshipType.rightLabel]);
+        expect(result).toEqual([relationshipType.rightwardType]);
       });
     });
   });

--- a/src/app/core/data/relationship.service.spec.ts
+++ b/src/app/core/data/relationship.service.spec.ts
@@ -143,7 +143,7 @@ describe('RelationshipService', () => {
 
   describe('getRelatedItemsByLabel', () => {
     it('should return the related items by label', () => {
-      service.getRelatedItemsByLabel(item, relationshipType.rightLabel).subscribe((result) => {
+      service.getRelatedItemsByLabel(item, relationshipType.rightwardType).subscribe((result) => {
         expect(result).toEqual(relatedItems);
       });
     });

--- a/src/app/core/data/relationship.service.ts
+++ b/src/app/core/data/relationship.service.ts
@@ -182,9 +182,9 @@ export class RelationshipService {
       map(([leftItems, rightItems, relTypesCurrentPage]) => {
         return relTypesCurrentPage.map((type, index) => {
           if (leftItems[index].uuid === item.uuid) {
-            return type.leftLabel;
+            return type.leftwardType;
           } else {
-            return type.rightLabel;
+            return type.rightwardType;
           }
         });
       }),


### PR DESCRIPTION
After the recent merge of #461 into master, my local builds were failing.
This is the error I received:
```
ERROR in src/app/core/data/relationship.service.ts(185,25): error TS2339: Property 'leftLabel' does not exist on type 'RelationshipType'.
    src/app/core/data/relationship.service.ts(187,25): error TS2339: Property 'rightLabel' does not exist on type 'RelationshipType'.
```

I renamed these leftover properties to their appropriate name (as they seem to have been forgotten in the PR mentioned above).