### PR TITLE
Correct baseUrl in local.cfg used by e2e tests

### DIFF
--- a/docker/local.cfg
+++ b/docker/local.cfg
@@ -1,6 +1,6 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.hostname=dspace
-dspace.baseUrl=http://localhost:8080
+dspace.baseUrl=http://localhost:8080/server
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr


### PR DESCRIPTION
This is a tiny PR to fix #498 after the server-side received a fix in https://github.com/DSpace/DSpace/pull/2554

This PR simply corrects the `dspace.baseUrl` in the `local.cfg` used by our e2e tests.

I'm creating this as a PR to ensure Travis succeeds before merging