### PR TITLE
Update webdriver-manager library

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "tslint": "5.11.0",
     "typedoc": "^0.9.0",
     "typescript": "^2.9.1",
-    "webdriver-manager": "^12.1.6",
+    "webdriver-manager": "^12.1.7",
     "webpack": "^4.17.1",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-middleware": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11355,10 +11355,10 @@ webdriver-manager@^12.0.6:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
-webdriver-manager@^12.1.6:
-  version "12.1.6"
-  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.1.6.tgz#9e5410c506d1a7e0a7aa6af91ba3d5bb37f362b6"
-  integrity sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==
+webdriver-manager@^12.1.7:
+  version "12.1.7"
+  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.1.7.tgz#ed4eaee8f906b33c146e869b55e850553a1b1162"
+  integrity sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==
   dependencies:
     adm-zip "^0.4.9"
     chalk "^1.1.1"


### PR DESCRIPTION
Update for the e2e tests to work with the current version of chrome on travis