### PR TITLE
I18n sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "docs": "typedoc --options typedoc.json ./src/",
     "coverage": "http-server -c-1 -o -p 9875 ./coverage",
     "postinstall": "yarn run patch-protractor",
-    "patch-protractor": "ncp node_modules/webdriver-manager node_modules/protractor/node_modules/webdriver-manager"
+    "patch-protractor": "ncp node_modules/webdriver-manager node_modules/protractor/node_modules/webdriver-manager",
+    "sync-i18n": "node ./scripts/sync-i18n-files.js"
   },
   "dependencies": {
     "@angular/animations": "^6.1.4",
@@ -174,7 +175,9 @@
     "angular2-template-loader": "0.6.2",
     "autoprefixer": "^9.1.3",
     "caniuse-lite": "^1.0.30000697",
+    "cli-progress": "^3.3.1",
     "codelyzer": "^4.4.4",
+    "commander": "^3.0.2",
     "compression-webpack-plugin": "^1.1.6",
     "copy-webpack-plugin": "^4.4.1",
     "copyfiles": "^2.1.1",

--- a/resources/i18n/cs.json5
+++ b/resources/i18n/cs.json5
@@ -769,6 +769,9 @@
   
   // "error.community": "Error fetching community",
   "error.community": "Chyba během stahování komunity",
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
   
   // "error.identifier": "No item found for the identifier",
   // TODO New key - Add a translation

--- a/resources/i18n/cs.json5
+++ b/resources/i18n/cs.json5
@@ -770,6 +770,10 @@
   // "error.community": "Error fetching community",
   "error.community": "Chyba během stahování komunity",
   
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
+  
   // "error.default": "Error",
   "error.default": "Chyba",
   

--- a/resources/i18n/cs.json5
+++ b/resources/i18n/cs.json5
@@ -1,176 +1,3083 @@
 {
+  
+  // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
   "404.help": "Nepodařilo se najít stránku, kterou hledáte. Je možné, že stránka byla přesunuta nebo smazána. Pomocí tlačítka níže můžete přejít na domovskou stránku. ",
+  
+  // "404.link.home-page": "Take me to the home page",
   "404.link.home-page": "Přejít na domovskou stránku",
+  
+  // "404.page-not-found": "page not found",
   "404.page-not-found": "stránka nenalezena",
-
+  
+  
+  
+  // "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  
+  // "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  
+  // "admin.registries.bitstream-formats.create.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.description": "This list of bitstream formats provides information about known formats and their support level.",
   "admin.registries.bitstream-formats.description": "Tento seznam formátů souborů poskytuje informace o známých formátech a o úrovni jejich podpory.",
-  "admin.registries.bitstream-formats.formats.no-items": "Žádné formáty souborů.",
-  "admin.registries.bitstream-formats.formats.table.internal": "interní",
-  "admin.registries.bitstream-formats.formats.table.mimetype": "Typ MIME",
-  "admin.registries.bitstream-formats.formats.table.name": "Název",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.0": "Neznámá",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.1": "Známá",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.2": "Podpora",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.head": "Úroveň podpory",
+  
+  // "admin.registries.bitstream-formats.edit.description.hint": "",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.hint": "",
+  
+  // "admin.registries.bitstream-formats.edit.description.label": "Description",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.label": "Description",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  
+  // "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  
+  // "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  
+  // "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  
+  // "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  
+  // "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  
+  // "admin.registries.bitstream-formats.edit.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  
+  // "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
   "admin.registries.bitstream-formats.head": "Registr formátů souborů",
+  
+  // "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  
+  // "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  
+  // "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  
+  // "admin.registries.bitstream-formats.table.internal": "internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.internal": "internal",
+  
+  // "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.table.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.name": "Name",
+  
+  // "admin.registries.bitstream-formats.table.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.return": "Return",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  
+  // "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Format Registry",
   "admin.registries.bitstream-formats.title": "DSpace Angular :: Registr formátů souborů",
-
+  
+  
+  
+  // "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DSpace requires the qualified Dublin Core schema.",
   "admin.registries.metadata.description": "Registr metadat je seznam všech metadatových polí dostupných v repozitáři. Tyto pole mohou být rozdělena do více schémat. DSpace však vyžaduje použití schématu Kvalifikovaný Dublin Core.",
+  
+  // "admin.registries.metadata.form.create": "Create metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.create": "Create metadata schema",
+  
+  // "admin.registries.metadata.form.edit": "Edit metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.edit": "Edit metadata schema",
+  
+  // "admin.registries.metadata.form.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.name": "Name",
+  
+  // "admin.registries.metadata.form.namespace": "Namespace",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.namespace": "Namespace",
+  
+  // "admin.registries.metadata.head": "Metadata Registry",
   "admin.registries.metadata.head": "Registr metadat",
+  
+  // "admin.registries.metadata.schemas.no-items": "No metadata schemas to show.",
   "admin.registries.metadata.schemas.no-items": "Žádná schémata metadat.",
+  
+  // "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  
+  // "admin.registries.metadata.schemas.table.id": "ID",
   "admin.registries.metadata.schemas.table.id": "ID",
+  
+  // "admin.registries.metadata.schemas.table.name": "Name",
   "admin.registries.metadata.schemas.table.name": "Název",
+  
+  // "admin.registries.metadata.schemas.table.namespace": "Namespace",
   "admin.registries.metadata.schemas.table.namespace": "Jmenný prostor",
+  
+  // "admin.registries.metadata.title": "DSpace Angular :: Metadata Registry",
   "admin.registries.metadata.title": "DSpace Angular :: Registr metadat",
-
+  
+  
+  
+  // "admin.registries.schema.description": "This is the metadata schema for \"{{namespace}}\".",
   "admin.registries.schema.description": "Toto je schéma metadat pro „{{namespace}}“.",
+  
+  // "admin.registries.schema.fields.head": "Schema metadata fields",
   "admin.registries.schema.fields.head": "Pole schématu metadat",
+  
+  // "admin.registries.schema.fields.no-items": "No metadata fields to show.",
   "admin.registries.schema.fields.no-items": "Žádná metadatová pole.",
+  
+  // "admin.registries.schema.fields.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.schema.fields.table.delete": "Delete selected",
+  
+  // "admin.registries.schema.fields.table.field": "Field",
   "admin.registries.schema.fields.table.field": "Pole",
+  
+  // "admin.registries.schema.fields.table.scopenote": "Scope Note",
   "admin.registries.schema.fields.table.scopenote": "Poznámka o rozsahu",
+  
+  // "admin.registries.schema.form.create": "Create metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.create": "Create metadata field",
+  
+  // "admin.registries.schema.form.edit": "Edit metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.edit": "Edit metadata field",
+  
+  // "admin.registries.schema.form.element": "Element",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.element": "Element",
+  
+  // "admin.registries.schema.form.qualifier": "Qualifier",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.qualifier": "Qualifier",
+  
+  // "admin.registries.schema.form.scopenote": "Scope Note",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.scopenote": "Scope Note",
+  
+  // "admin.registries.schema.head": "Metadata Schema",
   "admin.registries.schema.head": "Schéma metadat",
+  
+  // "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.failure": "Error",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.failure": "Error",
+  
+  // "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.success": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.success": "Success",
+  
+  // "admin.registries.schema.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.schema.return": "Return",
+  
+  // "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Registry",
   "admin.registries.schema.title": "DSpace Angular :: Registr schémat metadat",
-
+  
+  
+  
+  // "auth.errors.invalid-user": "Invalid email address or password.",
   "auth.errors.invalid-user": "Neplatná e-mailová adresa nebo heslo.",
+  
+  // "auth.messages.expired": "Your session has expired. Please log in again.",
   "auth.messages.expired": "Vaše relace vypršela. Prosím, znova se přihlaste.",
-
+  
+  
+  
+  // "browse.comcol.by.author": "By Author",
+  // TODO New key - Add a translation
+  "browse.comcol.by.author": "By Author",
+  
+  // "browse.comcol.by.dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "browse.comcol.by.dateissued": "By Issue Date",
+  
+  // "browse.comcol.by.subject": "By Subject",
+  // TODO New key - Add a translation
+  "browse.comcol.by.subject": "By Subject",
+  
+  // "browse.comcol.by.title": "By Title",
+  // TODO New key - Add a translation
+  "browse.comcol.by.title": "By Title",
+  
+  // "browse.comcol.head": "Browse",
+  // TODO New key - Add a translation
+  "browse.comcol.head": "Browse",
+  
+  // "browse.empty": "No items to show.",
+  // TODO New key - Add a translation
+  "browse.empty": "No items to show.",
+  
+  // "browse.metadata.author": "Author",
+  // TODO New key - Add a translation
+  "browse.metadata.author": "Author",
+  
+  // "browse.metadata.dateissued": "Issue Date",
+  // TODO New key - Add a translation
+  "browse.metadata.dateissued": "Issue Date",
+  
+  // "browse.metadata.subject": "Subject",
+  // TODO New key - Add a translation
+  "browse.metadata.subject": "Subject",
+  
+  // "browse.metadata.title": "Title",
+  // TODO New key - Add a translation
+  "browse.metadata.title": "Title",
+  
+  // "browse.startsWith.choose_start": "(Choose start)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_start": "(Choose start)",
+  
+  // "browse.startsWith.choose_year": "(Choose year)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_year": "(Choose year)",
+  
+  // "browse.startsWith.jump": "Jump to a point in the index:",
+  // TODO New key - Add a translation
+  "browse.startsWith.jump": "Jump to a point in the index:",
+  
+  // "browse.startsWith.months.april": "April",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.april": "April",
+  
+  // "browse.startsWith.months.august": "August",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.august": "August",
+  
+  // "browse.startsWith.months.december": "December",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.december": "December",
+  
+  // "browse.startsWith.months.february": "February",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.february": "February",
+  
+  // "browse.startsWith.months.january": "January",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.january": "January",
+  
+  // "browse.startsWith.months.july": "July",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.july": "July",
+  
+  // "browse.startsWith.months.june": "June",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.june": "June",
+  
+  // "browse.startsWith.months.march": "March",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.march": "March",
+  
+  // "browse.startsWith.months.may": "May",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.may": "May",
+  
+  // "browse.startsWith.months.none": "(Choose month)",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.none": "(Choose month)",
+  
+  // "browse.startsWith.months.november": "November",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.november": "November",
+  
+  // "browse.startsWith.months.october": "October",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.october": "October",
+  
+  // "browse.startsWith.months.september": "September",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.september": "September",
+  
+  // "browse.startsWith.submit": "Go",
+  // TODO New key - Add a translation
+  "browse.startsWith.submit": "Go",
+  
+  // "browse.startsWith.type_date": "Or type in a date (year-month):",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_date": "Or type in a date (year-month):",
+  
+  // "browse.startsWith.type_text": "Or enter first few letters:",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_text": "Or enter first few letters:",
+  
+  // "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
   "browse.title": "Prohlížíte {{ collection }} dle {{ field }} {{ value }}",
-
+  
+  
+  
+  // "chips.remove": "Remove chip",
+  // TODO New key - Add a translation
+  "chips.remove": "Remove chip",
+  
+  
+  
+  // "collection.create.head": "Create a Collection",
+  // TODO New key - Add a translation
+  "collection.create.head": "Create a Collection",
+  
+  // "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  
+  // "collection.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.delete.cancel": "Cancel",
+  
+  // "collection.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "collection.delete.confirm": "Confirm",
+  
+  // "collection.delete.head": "Delete Collection",
+  // TODO New key - Add a translation
+  "collection.delete.head": "Delete Collection",
+  
+  // "collection.delete.notification.fail": "Collection could not be deleted",
+  // TODO New key - Add a translation
+  "collection.delete.notification.fail": "Collection could not be deleted",
+  
+  // "collection.delete.notification.success": "Successfully deleted collection",
+  // TODO New key - Add a translation
+  "collection.delete.notification.success": "Successfully deleted collection",
+  
+  // "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  
+  
+  
+  // "collection.edit.delete": "Delete this collection",
+  // TODO New key - Add a translation
+  "collection.edit.delete": "Delete this collection",
+  
+  // "collection.edit.head": "Edit Collection",
+  // TODO New key - Add a translation
+  "collection.edit.head": "Edit Collection",
+  
+  
+  
+  // "collection.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.cancel": "Cancel",
+  
+  // "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  
+  // "collection.edit.item-mapper.confirm": "Map selected items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.confirm": "Map selected items",
+  
+  // "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  
+  // "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  
+  // "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  
+  // "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  
+  // "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  
+  // "collection.edit.item-mapper.tabs.map": "Map new items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.map": "Map new items",
+  
+  
+  
+  // "collection.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "collection.form.abstract": "Short Description",
+  
+  // "collection.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.description": "Introductory text (HTML)",
+  
+  // "collection.form.errors.title.required": "Please enter a collection name",
+  // TODO New key - Add a translation
+  "collection.form.errors.title.required": "Please enter a collection name",
+  
+  // "collection.form.license": "License",
+  // TODO New key - Add a translation
+  "collection.form.license": "License",
+  
+  // "collection.form.provenance": "Provenance",
+  // TODO New key - Add a translation
+  "collection.form.provenance": "Provenance",
+  
+  // "collection.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.rights": "Copyright text (HTML)",
+  
+  // "collection.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.tableofcontents": "News (HTML)",
+  
+  // "collection.form.title": "Name",
+  // TODO New key - Add a translation
+  "collection.form.title": "Name",
+  
+  
+  
+  // "collection.page.browse.recent.head": "Recent Submissions",
   "collection.page.browse.recent.head": "Poslední příspěvky",
+  
+  // "collection.page.browse.recent.empty": "No items to show",
+  // TODO New key - Add a translation
+  "collection.page.browse.recent.empty": "No items to show",
+  
+  // "collection.page.handle": "Permanent URI for this collection",
+  // TODO New key - Add a translation
+  "collection.page.handle": "Permanent URI for this collection",
+  
+  // "collection.page.license": "License",
   "collection.page.license": "Licence",
+  
+  // "collection.page.news": "News",
   "collection.page.news": "Novinky",
-
+  
+  
+  
+  // "collection.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "collection.select.confirm": "Confirm selected",
+  
+  // "collection.select.empty": "No collections to show",
+  // TODO New key - Add a translation
+  "collection.select.empty": "No collections to show",
+  
+  // "collection.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "collection.select.table.title": "Title",
+  
+  
+  
+  // "community.create.head": "Create a Community",
+  // TODO New key - Add a translation
+  "community.create.head": "Create a Community",
+  
+  // "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  
+  // "community.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "community.delete.cancel": "Cancel",
+  
+  // "community.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "community.delete.confirm": "Confirm",
+  
+  // "community.delete.head": "Delete Community",
+  // TODO New key - Add a translation
+  "community.delete.head": "Delete Community",
+  
+  // "community.delete.notification.fail": "Community could not be deleted",
+  // TODO New key - Add a translation
+  "community.delete.notification.fail": "Community could not be deleted",
+  
+  // "community.delete.notification.success": "Successfully deleted community",
+  // TODO New key - Add a translation
+  "community.delete.notification.success": "Successfully deleted community",
+  
+  // "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  
+  // "community.edit.delete": "Delete this community",
+  // TODO New key - Add a translation
+  "community.edit.delete": "Delete this community",
+  
+  // "community.edit.head": "Edit Community",
+  // TODO New key - Add a translation
+  "community.edit.head": "Edit Community",
+  
+  // "community.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "community.form.abstract": "Short Description",
+  
+  // "community.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.description": "Introductory text (HTML)",
+  
+  // "community.form.errors.title.required": "Please enter a community name",
+  // TODO New key - Add a translation
+  "community.form.errors.title.required": "Please enter a community name",
+  
+  // "community.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.rights": "Copyright text (HTML)",
+  
+  // "community.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "community.form.tableofcontents": "News (HTML)",
+  
+  // "community.form.title": "Name",
+  // TODO New key - Add a translation
+  "community.form.title": "Name",
+  
+  // "community.page.handle": "Permanent URI for this community",
+  // TODO New key - Add a translation
+  "community.page.handle": "Permanent URI for this community",
+  
+  // "community.page.license": "License",
   "community.page.license": "Licence",
+  
+  // "community.page.news": "News",
   "community.page.news": "Novinky",
+  
+  // "community.all-lists.head": "Subcommunities and Collections",
+  // TODO New key - Add a translation
+  "community.all-lists.head": "Subcommunities and Collections",
+  
+  // "community.sub-collection-list.head": "Collections of this Community",
   "community.sub-collection-list.head": "Kolekce v této komunitě",
-
+  
+  // "community.sub-community-list.head": "Communities of this Community",
+  // TODO New key - Add a translation
+  "community.sub-community-list.head": "Communities of this Community",
+  
+  
+  
+  // "dso-selector.create.collection.head": "New collection",
+  // TODO New key - Add a translation
+  "dso-selector.create.collection.head": "New collection",
+  
+  // "dso-selector.create.community.head": "New community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.head": "New community",
+  
+  // "dso-selector.create.community.sub-level": "Create a new community in",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.sub-level": "Create a new community in",
+  
+  // "dso-selector.create.community.top-level": "Create a new top-level community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.top-level": "Create a new top-level community",
+  
+  // "dso-selector.create.item.head": "New item",
+  // TODO New key - Add a translation
+  "dso-selector.create.item.head": "New item",
+  
+  // "dso-selector.edit.collection.head": "Edit collection",
+  // TODO New key - Add a translation
+  "dso-selector.edit.collection.head": "Edit collection",
+  
+  // "dso-selector.edit.community.head": "Edit community",
+  // TODO New key - Add a translation
+  "dso-selector.edit.community.head": "Edit community",
+  
+  // "dso-selector.edit.item.head": "Edit item",
+  // TODO New key - Add a translation
+  "dso-selector.edit.item.head": "Edit item",
+  
+  // "dso-selector.no-results": "No {{ type }} found",
+  // TODO New key - Add a translation
+  "dso-selector.no-results": "No {{ type }} found",
+  
+  // "dso-selector.placeholder": "Search for a {{ type }}",
+  // TODO New key - Add a translation
+  "dso-selector.placeholder": "Search for a {{ type }}",
+  
+  
+  
+  // "error.browse-by": "Error fetching items",
   "error.browse-by": "Chyba během stahování záznamů",
+  
+  // "error.collection": "Error fetching collection",
   "error.collection": "Chyba během stahování kolekce",
+  
+  // "error.collections": "Error fetching collections",
+  // TODO New key - Add a translation
+  "error.collections": "Error fetching collections",
+  
+  // "error.community": "Error fetching community",
   "error.community": "Chyba během stahování komunity",
+  
+  // "error.default": "Error",
   "error.default": "Chyba",
+  
+  // "error.item": "Error fetching item",
   "error.item": "Chyba během stahování záznamu",
+  
+  // "error.items": "Error fetching items",
+  // TODO New key - Add a translation
+  "error.items": "Error fetching items",
+  
+  // "error.objects": "Error fetching objects",
   "error.objects": "Chyba během stahování objektů",
+  
+  // "error.recent-submissions": "Error fetching recent submissions",
   "error.recent-submissions": "Chyba během stahování posledních příspěvků",
+  
+  // "error.search-results": "Error fetching search results",
   "error.search-results": "Chyba během stahování výsledků hledání",
+  
+  // "error.sub-collections": "Error fetching sub-collections",
   "error.sub-collections": "Chyba během stahování subkolekcí",
+  
+  // "error.sub-communities": "Error fetching sub-communities",
+  // TODO New key - Add a translation
+  "error.sub-communities": "Error fetching sub-communities",
+  
+  // "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  // TODO New key - Add a translation
+  "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  
+  // "error.top-level-communities": "Error fetching top-level communities",
   "error.top-level-communities": "Chyba během stahování komunit nejvyšší úrovně",
+  
+  // "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
   "error.validation.license.notgranted": "Pro dokončení zaslání Musíte udělit licenci. Pokud v tuto chvíli tuto licenci nemůžete udělit, můžete svou práci uložit a později se k svému příspěveku vrátit nebo jej smazat.",
-  "error.validation.pattern": "Tento vstup je omezen dle vzoru: {{ pattern }}.",
-
+  
+  // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  // TODO New key - Add a translation
+  "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  
+  
+  
+  // "footer.copyright": "copyright © 2002-{{ year }}",
   "footer.copyright": "copyright © 2002-{{ year }}",
+  
+  // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "software DSpace",
+  
+  // "footer.link.duraspace": "DuraSpace",
   "footer.link.duraspace": "DuraSpace",
-
+  
+  
+  
+  // "form.cancel": "Cancel",
   "form.cancel": "Zrušit",
+  
+  // "form.clear": "Clear",
+  // TODO New key - Add a translation
+  "form.clear": "Clear",
+  
+  // "form.clear-help": "Click here to remove the selected value",
+  // TODO New key - Add a translation
+  "form.clear-help": "Click here to remove the selected value",
+  
+  // "form.edit": "Edit",
+  // TODO New key - Add a translation
+  "form.edit": "Edit",
+  
+  // "form.edit-help": "Click here to edit the selected value",
+  // TODO New key - Add a translation
+  "form.edit-help": "Click here to edit the selected value",
+  
+  // "form.first-name": "First name",
   "form.first-name": "Křestní jméno",
+  
+  // "form.group-collapse": "Collapse",
   "form.group-collapse": "Sbalit",
+  
+  // "form.group-collapse-help": "Click here to collapse",
   "form.group-collapse-help": "Kliknutím sem sbalíte",
+  
+  // "form.group-expand": "Expand",
   "form.group-expand": "Rozbalit",
+  
+  // "form.group-expand-help": "Click here to expand and add more elements",
   "form.group-expand-help": "Kliknutím sem rozbalíte a přidáte další prvky",
+  
+  // "form.last-name": "Last name",
   "form.last-name": "Příjmení",
+  
+  // "form.loading": "Loading...",
   "form.loading": "Načítá se...",
+  
+  // "form.no-results": "No results found",
   "form.no-results": "Nebyli nalezeny žádné výsledky",
+  
+  // "form.no-value": "No value entered",
   "form.no-value": "Nebyla zadána hodnota",
+  
+  // "form.other-information": {},
+  // TODO New key - Add a translation
+  "form.other-information": {},
+  
+  // "form.remove": "Remove",
   "form.remove": "Smazat",
+  
+  // "form.save": "Save",
+  // TODO New key - Add a translation
+  "form.save": "Save",
+  
+  // "form.save-help": "Save changes",
+  // TODO New key - Add a translation
+  "form.save-help": "Save changes",
+  
+  // "form.search": "Search",
   "form.search": "Hledat",
+  
+  // "form.search-help": "Click here to looking for an existing correspondence",
+  // TODO New key - Add a translation
+  "form.search-help": "Click here to looking for an existing correspondence",
+  
+  // "form.submit": "Submit",
   "form.submit": "Odeslat",
-
+  
+  
+  
+  // "home.description": "",
   "home.description": "",
+  
+  // "home.title": "DSpace Angular :: Home",
   "home.title": "DSpace Angular :: Domů",
+  
+  // "home.top-level-communities.head": "Communities in DSpace",
   "home.top-level-communities.head": "Komunity v DSpace",
+  
+  // "home.top-level-communities.help": "Select a community to browse its collections.",
   "home.top-level-communities.help": "Vybráním komunity můžete prohlížet její kolekce.",
-
+  
+  
+  
+  // "item.edit.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.delete.cancel": "Cancel",
+  
+  // "item.edit.delete.confirm": "Delete",
+  // TODO New key - Add a translation
+  "item.edit.delete.confirm": "Delete",
+  
+  // "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  // TODO New key - Add a translation
+  "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  
+  // "item.edit.delete.error": "An error occurred while deleting the item",
+  // TODO New key - Add a translation
+  "item.edit.delete.error": "An error occurred while deleting the item",
+  
+  // "item.edit.delete.header": "Delete item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.delete.header": "Delete item: {{ id }}",
+  
+  // "item.edit.delete.success": "The item has been deleted",
+  // TODO New key - Add a translation
+  "item.edit.delete.success": "The item has been deleted",
+  
+  // "item.edit.head": "Edit Item",
+  // TODO New key - Add a translation
+  "item.edit.head": "Edit Item",
+  
+  
+  
+  // "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  
+  // "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  
+  // "item.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.cancel": "Cancel",
+  
+  // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  
+  // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  
+  // "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  
+  // "item.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  
+  // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  
+  // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  
+  // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  
+  // "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  
+  // "item.edit.item-mapper.tabs.map": "Map new collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.map": "Map new collections",
+  
+  
+  
+  // "item.edit.metadata.add-button": "Add",
+  // TODO New key - Add a translation
+  "item.edit.metadata.add-button": "Add",
+  
+  // "item.edit.metadata.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.metadata.discard-button": "Discard",
+  
+  // "item.edit.metadata.edit.buttons.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.edit": "Edit",
+  
+  // "item.edit.metadata.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.remove": "Remove",
+  
+  // "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  
+  // "item.edit.metadata.headers.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.edit": "Edit",
+  
+  // "item.edit.metadata.headers.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.field": "Field",
+  
+  // "item.edit.metadata.headers.language": "Lang",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.language": "Lang",
+  
+  // "item.edit.metadata.headers.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.value": "Value",
+  
+  // "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  
+  // "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  
+  // "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  
+  // "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  
+  // "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  
+  // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  
+  // "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  
+  // "item.edit.metadata.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.metadata.reinstate-button": "Undo",
+  
+  // "item.edit.metadata.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.metadata.save-button": "Save",
+  
+  
+  
+  // "item.edit.modify.overview.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.field": "Field",
+  
+  // "item.edit.modify.overview.language": "Language",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.language": "Language",
+  
+  // "item.edit.modify.overview.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.value": "Value",
+  
+  
+  
+  // "item.edit.move.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.move.cancel": "Cancel",
+  
+  // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  // TODO New key - Add a translation
+  "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  
+  // "item.edit.move.error": "An error occured when attempting to move the item",
+  // TODO New key - Add a translation
+  "item.edit.move.error": "An error occured when attempting to move the item",
+  
+  // "item.edit.move.head": "Move item: {{id}}",
+  // TODO New key - Add a translation
+  "item.edit.move.head": "Move item: {{id}}",
+  
+  // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  
+  // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  
+  // "item.edit.move.move": "Move",
+  // TODO New key - Add a translation
+  "item.edit.move.move": "Move",
+  
+  // "item.edit.move.processing": "Moving...",
+  // TODO New key - Add a translation
+  "item.edit.move.processing": "Moving...",
+  
+  // "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  // TODO New key - Add a translation
+  "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  
+  // "item.edit.move.success": "The item has been moved succesfully",
+  // TODO New key - Add a translation
+  "item.edit.move.success": "The item has been moved succesfully",
+  
+  // "item.edit.move.title": "Move item",
+  // TODO New key - Add a translation
+  "item.edit.move.title": "Move item",
+  
+  
+  
+  // "item.edit.private.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.private.cancel": "Cancel",
+  
+  // "item.edit.private.confirm": "Make it Private",
+  // TODO New key - Add a translation
+  "item.edit.private.confirm": "Make it Private",
+  
+  // "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  
+  // "item.edit.private.error": "An error occurred while making the item private",
+  // TODO New key - Add a translation
+  "item.edit.private.error": "An error occurred while making the item private",
+  
+  // "item.edit.private.header": "Make item private: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.private.header": "Make item private: {{ id }}",
+  
+  // "item.edit.private.success": "The item is now private",
+  // TODO New key - Add a translation
+  "item.edit.private.success": "The item is now private",
+  
+  
+  
+  // "item.edit.public.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.public.cancel": "Cancel",
+  
+  // "item.edit.public.confirm": "Make it Public",
+  // TODO New key - Add a translation
+  "item.edit.public.confirm": "Make it Public",
+  
+  // "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  
+  // "item.edit.public.error": "An error occurred while making the item public",
+  // TODO New key - Add a translation
+  "item.edit.public.error": "An error occurred while making the item public",
+  
+  // "item.edit.public.header": "Make item public: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.public.header": "Make item public: {{ id }}",
+  
+  // "item.edit.public.success": "The item is now public",
+  // TODO New key - Add a translation
+  "item.edit.public.success": "The item is now public",
+  
+  
+  
+  // "item.edit.reinstate.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.cancel": "Cancel",
+  
+  // "item.edit.reinstate.confirm": "Reinstate",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.confirm": "Reinstate",
+  
+  // "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  
+  // "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  
+  // "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  
+  // "item.edit.reinstate.success": "The item was reinstated successfully",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.success": "The item was reinstated successfully",
+  
+  
+  
+  // "item.edit.relationships.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.relationships.discard-button": "Discard",
+  
+  // "item.edit.relationships.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.remove": "Remove",
+  
+  // "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  
+  // "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  
+  // "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  
+  // "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  
+  // "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  
+  // "item.edit.relationships.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.relationships.reinstate-button": "Undo",
+  
+  // "item.edit.relationships.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.relationships.save-button": "Save",
+  
+  
+  
+  // "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  
+  // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  
+  // "item.edit.tabs.curate.head": "Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.head": "Curate",
+  
+  // "item.edit.tabs.curate.title": "Item Edit - Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.title": "Item Edit - Curate",
+  
+  // "item.edit.tabs.metadata.head": "Item Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.head": "Item Metadata",
+  
+  // "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  
+  // "item.edit.tabs.relationships.head": "Item Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.head": "Item Relationships",
+  
+  // "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  
+  // "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  
+  // "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  
+  // "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  
+  // "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  
+  // "item.edit.tabs.status.buttons.move.button": "Move...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.button": "Move...",
+  
+  // "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  
+  // "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  
+  // "item.edit.tabs.status.buttons.private.label": "Make item private",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.label": "Make item private",
+  
+  // "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  
+  // "item.edit.tabs.status.buttons.public.label": "Make item public",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.label": "Make item public",
+  
+  // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  
+  // "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  
+  // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  
+  // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  
+  // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  
+  // "item.edit.tabs.status.head": "Item Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.head": "Item Status",
+  
+  // "item.edit.tabs.status.labels.handle": "Handle",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.handle": "Handle",
+  
+  // "item.edit.tabs.status.labels.id": "Item Internal ID",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.id": "Item Internal ID",
+  
+  // "item.edit.tabs.status.labels.itemPage": "Item Page",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.itemPage": "Item Page",
+  
+  // "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  
+  // "item.edit.tabs.status.title": "Item Edit -  Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.title": "Item Edit -  Status",
+  
+  // "item.edit.tabs.view.head": "View Item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.head": "View Item",
+  
+  // "item.edit.tabs.view.title": "Item Edit -  View",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.title": "Item Edit -  View",
+  
+  
+  
+  // "item.edit.withdraw.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.cancel": "Cancel",
+  
+  // "item.edit.withdraw.confirm": "Withdraw",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.confirm": "Withdraw",
+  
+  // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  
+  // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  
+  // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  
+  // "item.edit.withdraw.success": "The item was withdrawn successfully",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.success": "The item was withdrawn successfully",
+  
+  
+  
+  // "item.page.abstract": "Abstract",
   "item.page.abstract": "Abstrakt",
+  
+  // "item.page.author": "Authors",
   "item.page.author": "Autor",
+  
+  // "item.page.citation": "Citation",
+  // TODO New key - Add a translation
+  "item.page.citation": "Citation",
+  
+  // "item.page.collections": "Collections",
   "item.page.collections": "Kolekce",
+  
+  // "item.page.date": "Date",
   "item.page.date": "Datum",
+  
+  // "item.page.files": "Files",
   "item.page.files": "Soubory",
-  "item.page.filesection.description": "Popis:",
+  
+  // "item.page.filesection.description": "Description:",
+  // TODO New key - Add a translation
+  "item.page.filesection.description": "Description:",
+  
+  // "item.page.filesection.download": "Download",
   "item.page.filesection.download": "Stáhnout",
-  "item.page.filesection.format": "Formát:",
-  "item.page.filesection.name": "Název:",
-  "item.page.filesection.size": "Velikost:",
+  
+  // "item.page.filesection.format": "Format:",
+  // TODO New key - Add a translation
+  "item.page.filesection.format": "Format:",
+  
+  // "item.page.filesection.name": "Name:",
+  // TODO New key - Add a translation
+  "item.page.filesection.name": "Name:",
+  
+  // "item.page.filesection.size": "Size:",
+  // TODO New key - Add a translation
+  "item.page.filesection.size": "Size:",
+  
+  // "item.page.journal.search.title": "Articles in this journal",
+  // TODO New key - Add a translation
+  "item.page.journal.search.title": "Articles in this journal",
+  
+  // "item.page.link.full": "Full item page",
   "item.page.link.full": "Úplný záznam",
+  
+  // "item.page.link.simple": "Simple item page",
   "item.page.link.simple": "Minimální záznam",
+  
+  // "item.page.person.search.title": "Articles by this author",
+  // TODO New key - Add a translation
+  "item.page.person.search.title": "Articles by this author",
+  
+  // "item.page.related-items.view-more": "View more",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-more": "View more",
+  
+  // "item.page.related-items.view-less": "View less",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-less": "View less",
+  
+  // "item.page.subject": "Keywords",
+  // TODO New key - Add a translation
+  "item.page.subject": "Keywords",
+  
+  // "item.page.uri": "URI",
   "item.page.uri": "URI",
-
+  
+  
+  
+  // "item.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "item.select.confirm": "Confirm selected",
+  
+  // "item.select.empty": "No items to show",
+  // TODO New key - Add a translation
+  "item.select.empty": "No items to show",
+  
+  // "item.select.table.author": "Author",
+  // TODO New key - Add a translation
+  "item.select.table.author": "Author",
+  
+  // "item.select.table.collection": "Collection",
+  // TODO New key - Add a translation
+  "item.select.table.collection": "Collection",
+  
+  // "item.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "item.select.table.title": "Title",
+  
+  
+  
+  // "journal.listelement.badge": "Journal",
+  // TODO New key - Add a translation
+  "journal.listelement.badge": "Journal",
+  
+  // "journal.page.description": "Description",
+  // TODO New key - Add a translation
+  "journal.page.description": "Description",
+  
+  // "journal.page.editor": "Editor-in-Chief",
+  // TODO New key - Add a translation
+  "journal.page.editor": "Editor-in-Chief",
+  
+  // "journal.page.issn": "ISSN",
+  // TODO New key - Add a translation
+  "journal.page.issn": "ISSN",
+  
+  // "journal.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "journal.page.publisher": "Publisher",
+  
+  // "journal.page.titleprefix": "Journal: ",
+  // TODO New key - Add a translation
+  "journal.page.titleprefix": "Journal: ",
+  
+  // "journal.search.results.head": "Journal Search Results",
+  // TODO New key - Add a translation
+  "journal.search.results.head": "Journal Search Results",
+  
+  // "journal.search.title": "DSpace Angular :: Journal Search",
+  // TODO New key - Add a translation
+  "journal.search.title": "DSpace Angular :: Journal Search",
+  
+  
+  
+  // "journalissue.listelement.badge": "Journal Issue",
+  // TODO New key - Add a translation
+  "journalissue.listelement.badge": "Journal Issue",
+  
+  // "journalissue.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalissue.page.description": "Description",
+  
+  // "journalissue.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalissue.page.issuedate": "Issue Date",
+  
+  // "journalissue.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-issn": "Journal ISSN",
+  
+  // "journalissue.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-title": "Journal Title",
+  
+  // "journalissue.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "journalissue.page.keyword": "Keywords",
+  
+  // "journalissue.page.number": "Number",
+  // TODO New key - Add a translation
+  "journalissue.page.number": "Number",
+  
+  // "journalissue.page.titleprefix": "Journal Issue: ",
+  // TODO New key - Add a translation
+  "journalissue.page.titleprefix": "Journal Issue: ",
+  
+  
+  
+  // "journalvolume.listelement.badge": "Journal Volume",
+  // TODO New key - Add a translation
+  "journalvolume.listelement.badge": "Journal Volume",
+  
+  // "journalvolume.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalvolume.page.description": "Description",
+  
+  // "journalvolume.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalvolume.page.issuedate": "Issue Date",
+  
+  // "journalvolume.page.titleprefix": "Journal Volume: ",
+  // TODO New key - Add a translation
+  "journalvolume.page.titleprefix": "Journal Volume: ",
+  
+  // "journalvolume.page.volume": "Volume",
+  // TODO New key - Add a translation
+  "journalvolume.page.volume": "Volume",
+  
+  
+  
+  // "loading.browse-by": "Loading items...",
   "loading.browse-by": "Načítají se záznamy...",
+  
+  // "loading.browse-by-page": "Loading page...",
+  // TODO New key - Add a translation
+  "loading.browse-by-page": "Loading page...",
+  
+  // "loading.collection": "Loading collection...",
   "loading.collection": "Načítá se kolekce...",
+  
+  // "loading.collections": "Loading collections...",
+  // TODO New key - Add a translation
+  "loading.collections": "Loading collections...",
+  
+  // "loading.community": "Loading community...",
   "loading.community": "Načítá se komunita...",
+  
+  // "loading.default": "Loading...",
   "loading.default": "Načítá se...",
+  
+  // "loading.item": "Loading item...",
   "loading.item": "Načítá se záznam...",
+  
+  // "loading.items": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.items": "Loading items...",
+  
+  // "loading.mydspace-results": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.mydspace-results": "Loading items...",
+  
+  // "loading.objects": "Loading...",
   "loading.objects": "Načítá se...",
+  
+  // "loading.recent-submissions": "Loading recent submissions...",
   "loading.recent-submissions": "Načítají se poslední příspěvky...",
+  
+  // "loading.search-results": "Loading search results...",
   "loading.search-results": "Načítají se výsledky hledání...",
+  
+  // "loading.sub-collections": "Loading sub-collections...",
   "loading.sub-collections": "Načítají se subkolekce...",
+  
+  // "loading.sub-communities": "Loading sub-communities...",
+  // TODO New key - Add a translation
+  "loading.sub-communities": "Loading sub-communities...",
+  
+  // "loading.top-level-communities": "Loading top-level communities...",
   "loading.top-level-communities": "Načítají se komunity nejvyšší úrovně...",
-
+  
+  
+  
+  // "login.form.email": "Email address",
   "login.form.email": "E-mailová adresa",
+  
+  // "login.form.forgot-password": "Have you forgotten your password?",
   "login.form.forgot-password": "Zapomněli jste své heslo?",
+  
+  // "login.form.header": "Please log in to DSpace",
   "login.form.header": "Prosím, přihlaste se do DSpace",
+  
+  // "login.form.new-user": "New user? Click here to register.",
   "login.form.new-user": "Nový uživatel? Zaregistrujte se kliknutím sem.",
+  
+  // "login.form.password": "Password",
   "login.form.password": "Heslo",
+  
+  // "login.form.submit": "Log in",
   "login.form.submit": "Přihlásit se",
+  
+  // "login.title": "Login",
   "login.title": "Přihlásit se",
-
+  
+  
+  
+  // "logout.form.header": "Log out from DSpace",
   "logout.form.header": "Odhlásit se z DSpace",
+  
+  // "logout.form.submit": "Log out",
   "logout.form.submit": "Odhlásit se",
+  
+  // "logout.title": "Logout",
   "logout.title": "Odhlásit se",
-
-  "nav.home": "Domů",
+  
+  
+  
+  // "menu.header.admin": "Admin",
+  // TODO New key - Add a translation
+  "menu.header.admin": "Admin",
+  
+  // "menu.header.image.logo": "Repository logo",
+  // TODO New key - Add a translation
+  "menu.header.image.logo": "Repository logo",
+  
+  
+  
+  // "menu.section.access_control": "Access Control",
+  // TODO New key - Add a translation
+  "menu.section.access_control": "Access Control",
+  
+  // "menu.section.access_control_authorizations": "Authorizations",
+  // TODO New key - Add a translation
+  "menu.section.access_control_authorizations": "Authorizations",
+  
+  // "menu.section.access_control_groups": "Groups",
+  // TODO New key - Add a translation
+  "menu.section.access_control_groups": "Groups",
+  
+  // "menu.section.access_control_people": "People",
+  // TODO New key - Add a translation
+  "menu.section.access_control_people": "People",
+  
+  
+  
+  // "menu.section.browse_community": "This Community",
+  // TODO New key - Add a translation
+  "menu.section.browse_community": "This Community",
+  
+  // "menu.section.browse_community_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_author": "By Author",
+  
+  // "menu.section.browse_community_by_issue_date": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_issue_date": "By Issue Date",
+  
+  // "menu.section.browse_community_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_title": "By Title",
+  
+  // "menu.section.browse_global": "All of DSpace",
+  // TODO New key - Add a translation
+  "menu.section.browse_global": "All of DSpace",
+  
+  // "menu.section.browse_global_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_author": "By Author",
+  
+  // "menu.section.browse_global_by_dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_dateissued": "By Issue Date",
+  
+  // "menu.section.browse_global_by_subject": "By Subject",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_subject": "By Subject",
+  
+  // "menu.section.browse_global_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_title": "By Title",
+  
+  // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  
+  
+  
+  // "menu.section.control_panel": "Control Panel",
+  // TODO New key - Add a translation
+  "menu.section.control_panel": "Control Panel",
+  
+  // "menu.section.curation_task": "Curation Task",
+  // TODO New key - Add a translation
+  "menu.section.curation_task": "Curation Task",
+  
+  
+  
+  // "menu.section.edit": "Edit",
+  // TODO New key - Add a translation
+  "menu.section.edit": "Edit",
+  
+  // "menu.section.edit_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.edit_collection": "Collection",
+  
+  // "menu.section.edit_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.edit_community": "Community",
+  
+  // "menu.section.edit_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.edit_item": "Item",
+  
+  
+  
+  // "menu.section.export": "Export",
+  // TODO New key - Add a translation
+  "menu.section.export": "Export",
+  
+  // "menu.section.export_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.export_collection": "Collection",
+  
+  // "menu.section.export_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.export_community": "Community",
+  
+  // "menu.section.export_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.export_item": "Item",
+  
+  // "menu.section.export_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.export_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.find": "Find",
+  // TODO New key - Add a translation
+  "menu.section.find": "Find",
+  
+  // "menu.section.find_items": "Items",
+  // TODO New key - Add a translation
+  "menu.section.find_items": "Items",
+  
+  // "menu.section.find_private_items": "Private Items",
+  // TODO New key - Add a translation
+  "menu.section.find_private_items": "Private Items",
+  
+  // "menu.section.find_withdrawn_items": "Withdrawn Items",
+  // TODO New key - Add a translation
+  "menu.section.find_withdrawn_items": "Withdrawn Items",
+  
+  
+  
+  // "menu.section.icon.access_control": "Access Control menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.access_control": "Access Control menu section",
+  
+  // "menu.section.icon.control_panel": "Control Panel menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.control_panel": "Control Panel menu section",
+  
+  // "menu.section.icon.curation_task": "Curation Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.curation_task": "Curation Task menu section",
+  
+  // "menu.section.icon.edit": "Edit menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.edit": "Edit menu section",
+  
+  // "menu.section.icon.export": "Export menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.export": "Export menu section",
+  
+  // "menu.section.icon.find": "Find menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.find": "Find menu section",
+  
+  // "menu.section.icon.import": "Import menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.import": "Import menu section",
+  
+  // "menu.section.icon.new": "New menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.new": "New menu section",
+  
+  // "menu.section.icon.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.pin": "Pin sidebar",
+  
+  // "menu.section.icon.registries": "Registries menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.registries": "Registries menu section",
+  
+  // "menu.section.icon.statistics_task": "Statistics Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.statistics_task": "Statistics Task menu section",
+  
+  // "menu.section.icon.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.import": "Import",
+  // TODO New key - Add a translation
+  "menu.section.import": "Import",
+  
+  // "menu.section.import_batch": "Batch Import (ZIP)",
+  // TODO New key - Add a translation
+  "menu.section.import_batch": "Batch Import (ZIP)",
+  
+  // "menu.section.import_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.import_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.new": "New",
+  // TODO New key - Add a translation
+  "menu.section.new": "New",
+  
+  // "menu.section.new_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.new_collection": "Collection",
+  
+  // "menu.section.new_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.new_community": "Community",
+  
+  // "menu.section.new_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.new_item": "Item",
+  
+  // "menu.section.new_item_version": "Item Version",
+  // TODO New key - Add a translation
+  "menu.section.new_item_version": "Item Version",
+  
+  
+  
+  // "menu.section.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.pin": "Pin sidebar",
+  
+  // "menu.section.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.registries": "Registries",
+  // TODO New key - Add a translation
+  "menu.section.registries": "Registries",
+  
+  // "menu.section.registries_format": "Format",
+  // TODO New key - Add a translation
+  "menu.section.registries_format": "Format",
+  
+  // "menu.section.registries_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.registries_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.statistics": "Statistics",
+  // TODO New key - Add a translation
+  "menu.section.statistics": "Statistics",
+  
+  // "menu.section.statistics_task": "Statistics Task",
+  // TODO New key - Add a translation
+  "menu.section.statistics_task": "Statistics Task",
+  
+  
+  
+  // "menu.section.toggle.access_control": "Toggle Access Control section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.access_control": "Toggle Access Control section",
+  
+  // "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  
+  // "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  
+  // "menu.section.toggle.edit": "Toggle Edit section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.edit": "Toggle Edit section",
+  
+  // "menu.section.toggle.export": "Toggle Export section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.export": "Toggle Export section",
+  
+  // "menu.section.toggle.find": "Toggle Find section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.find": "Toggle Find section",
+  
+  // "menu.section.toggle.import": "Toggle Import section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.import": "Toggle Import section",
+  
+  // "menu.section.toggle.new": "Toggle New section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.new": "Toggle New section",
+  
+  // "menu.section.toggle.registries": "Toggle Registries section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.registries": "Toggle Registries section",
+  
+  // "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  
+  
+  
+  // "mydspace.description": "",
+  // TODO New key - Add a translation
+  "mydspace.description": "",
+  
+  // "mydspace.general.text-here": "HERE",
+  // TODO New key - Add a translation
+  "mydspace.general.text-here": "HERE",
+  
+  // "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  // TODO New key - Add a translation
+  "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  
+  // "mydspace.messages.description-placeholder": "Insert your message here...",
+  // TODO New key - Add a translation
+  "mydspace.messages.description-placeholder": "Insert your message here...",
+  
+  // "mydspace.messages.hide-msg": "Hide message",
+  // TODO New key - Add a translation
+  "mydspace.messages.hide-msg": "Hide message",
+  
+  // "mydspace.messages.mark-as-read": "Mark as read",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-read": "Mark as read",
+  
+  // "mydspace.messages.mark-as-unread": "Mark as unread",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-unread": "Mark as unread",
+  
+  // "mydspace.messages.no-content": "No content.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-content": "No content.",
+  
+  // "mydspace.messages.no-messages": "No messages yet.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-messages": "No messages yet.",
+  
+  // "mydspace.messages.send-btn": "Send",
+  // TODO New key - Add a translation
+  "mydspace.messages.send-btn": "Send",
+  
+  // "mydspace.messages.show-msg": "Show message",
+  // TODO New key - Add a translation
+  "mydspace.messages.show-msg": "Show message",
+  
+  // "mydspace.messages.subject-placeholder": "Subject...",
+  // TODO New key - Add a translation
+  "mydspace.messages.subject-placeholder": "Subject...",
+  
+  // "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  // TODO New key - Add a translation
+  "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  
+  // "mydspace.messages.title": "Messages",
+  // TODO New key - Add a translation
+  "mydspace.messages.title": "Messages",
+  
+  // "mydspace.messages.to": "To",
+  // TODO New key - Add a translation
+  "mydspace.messages.to": "To",
+  
+  // "mydspace.new-submission": "New submission",
+  // TODO New key - Add a translation
+  "mydspace.new-submission": "New submission",
+  
+  // "mydspace.results.head": "Your submissions",
+  // TODO New key - Add a translation
+  "mydspace.results.head": "Your submissions",
+  
+  // "mydspace.results.no-abstract": "No Abstract",
+  // TODO New key - Add a translation
+  "mydspace.results.no-abstract": "No Abstract",
+  
+  // "mydspace.results.no-authors": "No Authors",
+  // TODO New key - Add a translation
+  "mydspace.results.no-authors": "No Authors",
+  
+  // "mydspace.results.no-collections": "No Collections",
+  // TODO New key - Add a translation
+  "mydspace.results.no-collections": "No Collections",
+  
+  // "mydspace.results.no-date": "No Date",
+  // TODO New key - Add a translation
+  "mydspace.results.no-date": "No Date",
+  
+  // "mydspace.results.no-files": "No Files",
+  // TODO New key - Add a translation
+  "mydspace.results.no-files": "No Files",
+  
+  // "mydspace.results.no-results": "There were no items to show",
+  // TODO New key - Add a translation
+  "mydspace.results.no-results": "There were no items to show",
+  
+  // "mydspace.results.no-title": "No title",
+  // TODO New key - Add a translation
+  "mydspace.results.no-title": "No title",
+  
+  // "mydspace.results.no-uri": "No Uri",
+  // TODO New key - Add a translation
+  "mydspace.results.no-uri": "No Uri",
+  
+  // "mydspace.show.workflow": "All tasks",
+  // TODO New key - Add a translation
+  "mydspace.show.workflow": "All tasks",
+  
+  // "mydspace.show.workspace": "Your Submissions",
+  // TODO New key - Add a translation
+  "mydspace.show.workspace": "Your Submissions",
+  
+  // "mydspace.status.archived": "Archived",
+  // TODO New key - Add a translation
+  "mydspace.status.archived": "Archived",
+  
+  // "mydspace.status.validation": "Validation",
+  // TODO New key - Add a translation
+  "mydspace.status.validation": "Validation",
+  
+  // "mydspace.status.waiting-for-controller": "Waiting for controller",
+  // TODO New key - Add a translation
+  "mydspace.status.waiting-for-controller": "Waiting for controller",
+  
+  // "mydspace.status.workflow": "Workflow",
+  // TODO New key - Add a translation
+  "mydspace.status.workflow": "Workflow",
+  
+  // "mydspace.status.workspace": "Workspace",
+  // TODO New key - Add a translation
+  "mydspace.status.workspace": "Workspace",
+  
+  // "mydspace.title": "MyDSpace",
+  // TODO New key - Add a translation
+  "mydspace.title": "MyDSpace",
+  
+  // "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  
+  // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  
+  // "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  
+  // "mydspace.view-btn": "View",
+  // TODO New key - Add a translation
+  "mydspace.view-btn": "View",
+  
+  
+  
+  // "nav.browse.header": "All of DSpace",
+  // TODO New key - Add a translation
+  "nav.browse.header": "All of DSpace",
+  
+  // "nav.community-browse.header": "By Community",
+  // TODO New key - Add a translation
+  "nav.community-browse.header": "By Community",
+  
+  // "nav.language": "Language switch",
+  // TODO New key - Add a translation
+  "nav.language": "Language switch",
+  
+  // "nav.login": "Log In",
   "nav.login": "Přihlásit se",
+  
+  // "nav.logout": "Log Out",
   "nav.logout": "Odhlásit se",
-
+  
+  // "nav.mydspace": "MyDSpace",
+  // TODO New key - Add a translation
+  "nav.mydspace": "MyDSpace",
+  
+  // "nav.search": "Search",
+  // TODO New key - Add a translation
+  "nav.search": "Search",
+  
+  // "nav.statistics.header": "Statistics",
+  // TODO New key - Add a translation
+  "nav.statistics.header": "Statistics",
+  
+  
+  
+  // "orgunit.listelement.badge": "Organizational Unit",
+  // TODO New key - Add a translation
+  "orgunit.listelement.badge": "Organizational Unit",
+  
+  // "orgunit.page.city": "City",
+  // TODO New key - Add a translation
+  "orgunit.page.city": "City",
+  
+  // "orgunit.page.country": "Country",
+  // TODO New key - Add a translation
+  "orgunit.page.country": "Country",
+  
+  // "orgunit.page.dateestablished": "Date established",
+  // TODO New key - Add a translation
+  "orgunit.page.dateestablished": "Date established",
+  
+  // "orgunit.page.description": "Description",
+  // TODO New key - Add a translation
+  "orgunit.page.description": "Description",
+  
+  // "orgunit.page.id": "ID",
+  // TODO New key - Add a translation
+  "orgunit.page.id": "ID",
+  
+  // "orgunit.page.titleprefix": "Organizational Unit: ",
+  // TODO New key - Add a translation
+  "orgunit.page.titleprefix": "Organizational Unit: ",
+  
+  
+  
+  // "pagination.results-per-page": "Results Per Page",
   "pagination.results-per-page": "Výsledků na stránku",
+  
+  // "pagination.showing.detail": "{{ range }} of {{ total }}",
   "pagination.showing.detail": "{{ range }} z {{ total }}",
+  
+  // "pagination.showing.label": "Now showing ",
   "pagination.showing.label": "Zobrazují se záznamy ",
+  
+  // "pagination.sort-direction": "Sort Options",
   "pagination.sort-direction": "Seřazení",
-
+  
+  
+  
+  // "person.listelement.badge": "Person",
+  // TODO New key - Add a translation
+  "person.listelement.badge": "Person",
+  
+  // "person.page.birthdate": "Birth Date",
+  // TODO New key - Add a translation
+  "person.page.birthdate": "Birth Date",
+  
+  // "person.page.email": "Email Address",
+  // TODO New key - Add a translation
+  "person.page.email": "Email Address",
+  
+  // "person.page.firstname": "First Name",
+  // TODO New key - Add a translation
+  "person.page.firstname": "First Name",
+  
+  // "person.page.jobtitle": "Job Title",
+  // TODO New key - Add a translation
+  "person.page.jobtitle": "Job Title",
+  
+  // "person.page.lastname": "Last Name",
+  // TODO New key - Add a translation
+  "person.page.lastname": "Last Name",
+  
+  // "person.page.link.full": "Show all metadata",
+  // TODO New key - Add a translation
+  "person.page.link.full": "Show all metadata",
+  
+  // "person.page.orcid": "ORCID",
+  // TODO New key - Add a translation
+  "person.page.orcid": "ORCID",
+  
+  // "person.page.staffid": "Staff ID",
+  // TODO New key - Add a translation
+  "person.page.staffid": "Staff ID",
+  
+  // "person.page.titleprefix": "Person: ",
+  // TODO New key - Add a translation
+  "person.page.titleprefix": "Person: ",
+  
+  // "person.search.results.head": "Person Search Results",
+  // TODO New key - Add a translation
+  "person.search.results.head": "Person Search Results",
+  
+  // "person.search.title": "DSpace Angular :: Person Search",
+  // TODO New key - Add a translation
+  "person.search.title": "DSpace Angular :: Person Search",
+  
+  
+  
+  // "project.listelement.badge": "Research Project",
+  // TODO New key - Add a translation
+  "project.listelement.badge": "Research Project",
+  
+  // "project.page.contributor": "Contributors",
+  // TODO New key - Add a translation
+  "project.page.contributor": "Contributors",
+  
+  // "project.page.description": "Description",
+  // TODO New key - Add a translation
+  "project.page.description": "Description",
+  
+  // "project.page.expectedcompletion": "Expected Completion",
+  // TODO New key - Add a translation
+  "project.page.expectedcompletion": "Expected Completion",
+  
+  // "project.page.funder": "Funders",
+  // TODO New key - Add a translation
+  "project.page.funder": "Funders",
+  
+  // "project.page.id": "ID",
+  // TODO New key - Add a translation
+  "project.page.id": "ID",
+  
+  // "project.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "project.page.keyword": "Keywords",
+  
+  // "project.page.status": "Status",
+  // TODO New key - Add a translation
+  "project.page.status": "Status",
+  
+  // "project.page.titleprefix": "Research Project: ",
+  // TODO New key - Add a translation
+  "project.page.titleprefix": "Research Project: ",
+  
+  
+  
+  // "publication.listelement.badge": "Publication",
+  // TODO New key - Add a translation
+  "publication.listelement.badge": "Publication",
+  
+  // "publication.page.description": "Description",
+  // TODO New key - Add a translation
+  "publication.page.description": "Description",
+  
+  // "publication.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "publication.page.journal-issn": "Journal ISSN",
+  
+  // "publication.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "publication.page.journal-title": "Journal Title",
+  
+  // "publication.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "publication.page.publisher": "Publisher",
+  
+  // "publication.page.titleprefix": "Publication: ",
+  // TODO New key - Add a translation
+  "publication.page.titleprefix": "Publication: ",
+  
+  // "publication.page.volume-title": "Volume Title",
+  // TODO New key - Add a translation
+  "publication.page.volume-title": "Volume Title",
+  
+  // "publication.search.results.head": "Publication Search Results",
+  // TODO New key - Add a translation
+  "publication.search.results.head": "Publication Search Results",
+  
+  // "publication.search.title": "DSpace Angular :: Publication Search",
+  // TODO New key - Add a translation
+  "publication.search.title": "DSpace Angular :: Publication Search",
+  
+  
+  
+  // "relationships.isAuthorOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isAuthorOf": "Authors",
+  
+  // "relationships.isIssueOf": "Journal Issues",
+  // TODO New key - Add a translation
+  "relationships.isIssueOf": "Journal Issues",
+  
+  // "relationships.isJournalIssueOf": "Journal Issue",
+  // TODO New key - Add a translation
+  "relationships.isJournalIssueOf": "Journal Issue",
+  
+  // "relationships.isJournalOf": "Journals",
+  // TODO New key - Add a translation
+  "relationships.isJournalOf": "Journals",
+  
+  // "relationships.isOrgUnitOf": "Organizational Units",
+  // TODO New key - Add a translation
+  "relationships.isOrgUnitOf": "Organizational Units",
+  
+  // "relationships.isPersonOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isPersonOf": "Authors",
+  
+  // "relationships.isProjectOf": "Research Projects",
+  // TODO New key - Add a translation
+  "relationships.isProjectOf": "Research Projects",
+  
+  // "relationships.isPublicationOf": "Publications",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOf": "Publications",
+  
+  // "relationships.isPublicationOfJournalIssue": "Articles",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOfJournalIssue": "Articles",
+  
+  // "relationships.isSingleJournalOf": "Journal",
+  // TODO New key - Add a translation
+  "relationships.isSingleJournalOf": "Journal",
+  
+  // "relationships.isSingleVolumeOf": "Journal Volume",
+  // TODO New key - Add a translation
+  "relationships.isSingleVolumeOf": "Journal Volume",
+  
+  // "relationships.isVolumeOf": "Journal Volumes",
+  // TODO New key - Add a translation
+  "relationships.isVolumeOf": "Journal Volumes",
+  
+  
+  
+  // "search.description": "",
   "search.description": "",
+  
+  // "search.switch-configuration.title": "Show",
+  // TODO New key - Add a translation
+  "search.switch-configuration.title": "Show",
+  
+  // "search.title": "DSpace Angular :: Search",
   "search.title": "DSpace Angular :: Hledat",
-
+  
+  
+  
+  // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "Autor",
+  
+  // "search.filters.applied.f.dateIssued.max": "End date",
   "search.filters.applied.f.dateIssued.max": "Do data",
+  
+  // "search.filters.applied.f.dateIssued.min": "Start date",
   "search.filters.applied.f.dateIssued.min": "Od data",
+  
+  // "search.filters.applied.f.dateSubmitted": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.dateSubmitted": "Date submitted",
+  
+  // "search.filters.applied.f.entityType": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.entityType": "Item Type",
+  
+  // "search.filters.applied.f.has_content_in_original_bundle": "Has files",
   "search.filters.applied.f.has_content_in_original_bundle": "Má soubory",
+  
+  // "search.filters.applied.f.itemtype": "Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.itemtype": "Type",
+  
+  // "search.filters.applied.f.namedresourcetype": "Status",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.namedresourcetype": "Status",
+  
+  // "search.filters.applied.f.subject": "Subject",
   "search.filters.applied.f.subject": "Předmět",
-
+  
+  // "search.filters.applied.f.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.submitter": "Submitter",
+  
+  
+  
+  // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Autor",
+  
+  // "search.filters.filter.author.placeholder": "Author name",
   "search.filters.filter.author.placeholder": "Jméno autora",
+  
+  // "search.filters.filter.birthDate.head": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.head": "Birth Date",
+  
+  // "search.filters.filter.birthDate.placeholder": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.placeholder": "Birth Date",
+  
+  // "search.filters.filter.creativeDatePublished.head": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.head": "Date Published",
+  
+  // "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  
+  // "search.filters.filter.creativeWorkEditor.head": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.head": "Editor",
+  
+  // "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  
+  // "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  
+  // "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  
+  // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  
+  // "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  
+  // "search.filters.filter.dateIssued.head": "Date",
   "search.filters.filter.dateIssued.head": "Datum",
+  
+  // "search.filters.filter.dateIssued.max.placeholder": "Minimum Date",
   "search.filters.filter.dateIssued.max.placeholder": "Datum od",
+  
+  // "search.filters.filter.dateIssued.min.placeholder": "Maximum Date",
   "search.filters.filter.dateIssued.min.placeholder": "Datum do",
+  
+  // "search.filters.filter.dateSubmitted.head": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.head": "Date submitted",
+  
+  // "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  
+  // "search.filters.filter.entityType.head": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.head": "Item Type",
+  
+  // "search.filters.filter.entityType.placeholder": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.placeholder": "Item Type",
+  
+  // "search.filters.filter.has_content_in_original_bundle.head": "Has files",
   "search.filters.filter.has_content_in_original_bundle.head": "Má soubory",
+  
+  // "search.filters.filter.itemtype.head": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.head": "Type",
+  
+  // "search.filters.filter.itemtype.placeholder": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.placeholder": "Type",
+  
+  // "search.filters.filter.jobTitle.head": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.head": "Job Title",
+  
+  // "search.filters.filter.jobTitle.placeholder": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.placeholder": "Job Title",
+  
+  // "search.filters.filter.knowsLanguage.head": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.head": "Known language",
+  
+  // "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  
+  // "search.filters.filter.namedresourcetype.head": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.head": "Status",
+  
+  // "search.filters.filter.namedresourcetype.placeholder": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.placeholder": "Status",
+  
+  // "search.filters.filter.objectpeople.head": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.head": "People",
+  
+  // "search.filters.filter.objectpeople.placeholder": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.placeholder": "People",
+  
+  // "search.filters.filter.organizationAddressCountry.head": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.head": "Country",
+  
+  // "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  
+  // "search.filters.filter.organizationAddressLocality.head": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.head": "City",
+  
+  // "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  
+  // "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  
+  // "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  
+  // "search.filters.filter.scope.head": "Scope",
   "search.filters.filter.scope.head": "Rozsah",
+  
+  // "search.filters.filter.scope.placeholder": "Scope filter",
   "search.filters.filter.scope.placeholder": "Filtr rozsahu",
+  
+  // "search.filters.filter.show-less": "Collapse",
   "search.filters.filter.show-less": "Sbalit",
+  
+  // "search.filters.filter.show-more": "Show more",
   "search.filters.filter.show-more": "Zobrazit více",
+  
+  // "search.filters.filter.subject.head": "Subject",
   "search.filters.filter.subject.head": "Předmět",
+  
+  // "search.filters.filter.subject.placeholder": "Subject",
   "search.filters.filter.subject.placeholder": "Předmět",
-
+  
+  // "search.filters.filter.submitter.head": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.head": "Submitter",
+  
+  // "search.filters.filter.submitter.placeholder": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.placeholder": "Submitter",
+  
+  
+  
+  // "search.filters.head": "Filters",
   "search.filters.head": "Filtry",
+  
+  // "search.filters.reset": "Reset filters",
   "search.filters.reset": "Obnovit filtry",
-
+  
+  
+  
+  // "search.form.search": "Search",
   "search.form.search": "Hledat",
+  
+  // "search.form.search_dspace": "Search DSpace",
   "search.form.search_dspace": "Hledat v DSpace",
-
+  
+  // "search.form.search_mydspace": "Search MyDSpace",
+  // TODO New key - Add a translation
+  "search.form.search_mydspace": "Search MyDSpace",
+  
+  
+  
+  // "search.results.head": "Search Results",
   "search.results.head": "Výsledky hledání",
+  
+  // "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
   "search.results.no-results": "Nebyli nalezeny žádné výsledky",
-
+  
+  // "search.results.no-results-link": "quotes around it",
+  // TODO New key - Add a translation
+  "search.results.no-results-link": "quotes around it",
+  
+  
+  
+  // "search.sidebar.close": "Back to results",
   "search.sidebar.close": "Zpět na výsledky",
+  
+  // "search.sidebar.filters.title": "Filters",
   "search.sidebar.filters.title": "Filtry",
+  
+  // "search.sidebar.open": "Search Tools",
   "search.sidebar.open": "Vyhledávací nástroje",
+  
+  // "search.sidebar.results": "results",
   "search.sidebar.results": "výsledky",
+  
+  // "search.sidebar.settings.rpp": "Results per page",
   "search.sidebar.settings.rpp": "Výsledků na stránku",
+  
+  // "search.sidebar.settings.sort-by": "Sort By",
   "search.sidebar.settings.sort-by": "Řadit dle",
+  
+  // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "Nastavení",
-
+  
+  
+  
+  // "search.view-switch.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "search.view-switch.show-detail": "Show detail",
+  
+  // "search.view-switch.show-grid": "Show as grid",
   "search.view-switch.show-grid": "Zobrazit mřížku",
+  
+  // "search.view-switch.show-list": "Show as list",
   "search.view-switch.show-list": "Zobrazit seznam",
-
+  
+  
+  
+  // "sorting.dc.title.ASC": "Title Ascending",
   "sorting.dc.title.ASC": "Název vzestupně",
+  
+  // "sorting.dc.title.DESC": "Title Descending",
   "sorting.dc.title.DESC": "Název sestupně",
+  
+  // "sorting.score.DESC": "Relevance",
   "sorting.score.DESC": "Relevance",
-
+  
+  
+  
+  // "submission.edit.title": "Edit Submission",
+  // TODO New key - Add a translation
+  "submission.edit.title": "Edit Submission",
+  
+  // "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  // TODO New key - Add a translation
+  "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  
+  // "submission.general.deposit": "Deposit",
+  // TODO New key - Add a translation
+  "submission.general.deposit": "Deposit",
+  
+  // "submission.general.discard.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.cancel": "Cancel",
+  
+  // "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.general.discard.confirm.title": "Discard submission",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.title": "Discard submission",
+  
+  // "submission.general.discard.submit": "Discard",
+  // TODO New key - Add a translation
+  "submission.general.discard.submit": "Discard",
+  
+  // "submission.general.save": "Save",
+  // TODO New key - Add a translation
+  "submission.general.save": "Save",
+  
+  // "submission.general.save-later": "Save for later",
+  // TODO New key - Add a translation
+  "submission.general.save-later": "Save for later",
+  
+  
+  
+  // "submission.sections.general.add-more": "Add more",
+  // TODO New key - Add a translation
+  "submission.sections.general.add-more": "Add more",
+  
+  // "submission.sections.general.collection": "Collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.collection": "Collection",
+  
+  // "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  
+  // "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  
+  // "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  
+  // "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  
+  // "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  
+  // "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  
+  // "submission.sections.general.no-collection": "No collection found",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-collection": "No collection found",
+  
+  // "submission.sections.general.no-sections": "No options available",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-sections": "No options available",
+  
+  // "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  
+  // "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  
+  // "submission.sections.general.search-collection": "Search for a collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.search-collection": "Search for a collection",
+  
+  // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  // TODO New key - Add a translation
+  "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  
+  
+  
+  // "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  
+  // "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  
+  // "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  
+  // "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  
+  // "submission.sections.submit.progressbar.license": "Deposit license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.license": "Deposit license",
+  
+  // "submission.sections.submit.progressbar.upload": "Upload files",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.upload": "Upload files",
+  
+  
+  
+  // "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  
+  // "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  
+  // "submission.sections.upload.delete.submit": "Delete",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.submit": "Delete",
+  
+  // "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  // TODO New key - Add a translation
+  "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  
+  // "submission.sections.upload.form.access-condition-label": "Access condition type",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.access-condition-label": "Access condition type",
+  
+  // "submission.sections.upload.form.date-required": "Date is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.date-required": "Date is required.",
+  
+  // "submission.sections.upload.form.from-label": "Access grant from",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-label": "Access grant from",
+  
+  // "submission.sections.upload.form.from-placeholder": "From",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-placeholder": "From",
+  
+  // "submission.sections.upload.form.group-label": "Group",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-label": "Group",
+  
+  // "submission.sections.upload.form.group-required": "Group is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-required": "Group is required.",
+  
+  // "submission.sections.upload.form.until-label": "Access grant until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-label": "Access grant until",
+  
+  // "submission.sections.upload.form.until-placeholder": "Until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-placeholder": "Until",
+  
+  // "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  
+  // "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  
+  // "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  // TODO New key - Add a translation
+  "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  
+  // "submission.sections.upload.no-entry": "No",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-entry": "No",
+  
+  // "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  
+  // "submission.sections.upload.save-metadata": "Save metadata",
+  // TODO New key - Add a translation
+  "submission.sections.upload.save-metadata": "Save metadata",
+  
+  // "submission.sections.upload.undo": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.undo": "Cancel",
+  
+  // "submission.sections.upload.upload-failed": "Upload failed",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-failed": "Upload failed",
+  
+  // "submission.sections.upload.upload-successful": "Upload successful",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-successful": "Upload successful",
+  
+  
+  
+  // "submission.submit.title": "Submission",
+  // TODO New key - Add a translation
+  "submission.submit.title": "Submission",
+  
+  
+  
+  // "submission.workflow.generic.delete": "Delete",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete": "Delete",
+  
+  // "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  
+  // "submission.workflow.generic.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit": "Edit",
+  
+  // "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.generic.view": "View",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view": "View",
+  
+  // "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  
+  
+  
+  // "submission.workflow.tasks.claimed.approve": "Approve",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve": "Approve",
+  
+  // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  
+  // "submission.workflow.tasks.claimed.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit": "Edit",
+  
+  // "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  
+  // "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  
+  // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.return": "Return to pool",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return": "Return to pool",
+  
+  // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  
+  
+  
+  // "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  
+  // "submission.workflow.tasks.generic.processing": "Processing...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.processing": "Processing...",
+  
+  // "submission.workflow.tasks.generic.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.submitter": "Submitter",
+  
+  // "submission.workflow.tasks.generic.success": "Operation successful",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.success": "Operation successful",
+  
+  
+  
+  // "submission.workflow.tasks.pool.claim": "Claim",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim": "Claim",
+  
+  // "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  
+  // "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  
+  // "submission.workflow.tasks.pool.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.show-detail": "Show detail",
+  
+  
+  
+  // "title": "DSpace",
   "title": "DSpace",
+  
+  
+  
+  // "uploader.browse": "browse",
+  // TODO New key - Add a translation
+  "uploader.browse": "browse",
+  
+  // "uploader.drag-message": "Drag & Drop your files here",
+  // TODO New key - Add a translation
+  "uploader.drag-message": "Drag & Drop your files here",
+  
+  // "uploader.or": ", or",
+  // TODO New key - Add a translation
+  "uploader.or": ", or",
+  
+  // "uploader.processing": "Processing",
+  // TODO New key - Add a translation
+  "uploader.processing": "Processing",
+  
+  // "uploader.queue-length": "Queue length",
+  // TODO New key - Add a translation
+  "uploader.queue-length": "Queue length",
+  
+  
+  
+
 }

--- a/resources/i18n/de.json5
+++ b/resources/i18n/de.json5
@@ -1,175 +1,3081 @@
 {
+  
+  // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
   "404.help": "Die Seite, die Sie aufrufen wollten, konnte nicht gefunden werden. Sie könnte verschoben oder gelöscht worden sein. Mit dem Link unten kommen Sie zurück zur Startseite. ",
+  
+  // "404.link.home-page": "Take me to the home page",
   "404.link.home-page": "Zurück zur Startseite",
+  
+  // "404.page-not-found": "page not found",
   "404.page-not-found": "Seite nicht gefunden",
-
+  
+  
+  
+  // "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  
+  // "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  
+  // "admin.registries.bitstream-formats.create.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.description": "This list of bitstream formats provides information about known formats and their support level.",
   "admin.registries.bitstream-formats.description": "Diese Liste enhtält die in diesem Repositorium zulässigen Dateiformate und den jeweiligen Unterstützungsgrad.",
-  "admin.registries.bitstream-formats.formats.no-items": "Es gibt keine Formate in dieser Referenzliste.",
-  "admin.registries.bitstream-formats.formats.table.internal": "intern",
-  "admin.registries.bitstream-formats.formats.table.mimetype": "MIME Type",
-  "admin.registries.bitstream-formats.formats.table.name": "Name",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.0": "Unbekannt",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.1": "Bekannt",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.2": "Unterstützt",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.head": "Unterstützungsgrad",
+  
+  // "admin.registries.bitstream-formats.edit.description.hint": "",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.hint": "",
+  
+  // "admin.registries.bitstream-formats.edit.description.label": "Description",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.label": "Description",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  
+  // "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  
+  // "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  
+  // "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  
+  // "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  
+  // "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  
+  // "admin.registries.bitstream-formats.edit.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  
+  // "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
   "admin.registries.bitstream-formats.head": "Referenzliste der Dateiformate",
+  
+  // "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  
+  // "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  
+  // "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  
+  // "admin.registries.bitstream-formats.table.internal": "internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.internal": "internal",
+  
+  // "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.table.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.name": "Name",
+  
+  // "admin.registries.bitstream-formats.table.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.return": "Return",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  
+  // "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Format Registry",
   "admin.registries.bitstream-formats.title": "DSpace Angular :: Referenzliste der Dateiformate",
-
+  
+  
+  
+  // "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DSpace requires the qualified Dublin Core schema.",
   "admin.registries.metadata.description": "Die Metadatenreferenzliste beinhaltet alle Metadatenfelder, die zur Verfügung stehen. Die Felder können in unterschiedlichen Schemata enthalten sein. Nichtsdestotrotz benötigt DSpace mindestens qualifiziertes Dublin Core.",
+  
+  // "admin.registries.metadata.form.create": "Create metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.create": "Create metadata schema",
+  
+  // "admin.registries.metadata.form.edit": "Edit metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.edit": "Edit metadata schema",
+  
+  // "admin.registries.metadata.form.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.name": "Name",
+  
+  // "admin.registries.metadata.form.namespace": "Namespace",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.namespace": "Namespace",
+  
+  // "admin.registries.metadata.head": "Metadata Registry",
   "admin.registries.metadata.head": "Metadatenreferenzliste",
+  
+  // "admin.registries.metadata.schemas.no-items": "No metadata schemas to show.",
   "admin.registries.metadata.schemas.no-items": "Es gbit keine Metadatenschemata.",
+  
+  // "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  
+  // "admin.registries.metadata.schemas.table.id": "ID",
   "admin.registries.metadata.schemas.table.id": "ID",
+  
+  // "admin.registries.metadata.schemas.table.name": "Name",
   "admin.registries.metadata.schemas.table.name": "Name",
+  
+  // "admin.registries.metadata.schemas.table.namespace": "Namespace",
   "admin.registries.metadata.schemas.table.namespace": "Namensraum",
+  
+  // "admin.registries.metadata.title": "DSpace Angular :: Metadata Registry",
   "admin.registries.metadata.title": "DSpace Angular :: Metadatenreferenzliste",
-
+  
+  
+  
+  // "admin.registries.schema.description": "This is the metadata schema for \"{{namespace}}\".",
   "admin.registries.schema.description": "Dies ist das Metadatenschema für  \"{{namespace}}\".",
+  
+  // "admin.registries.schema.fields.head": "Schema metadata fields",
   "admin.registries.schema.fields.head": "Felder in diesem Schema",
+  
+  // "admin.registries.schema.fields.no-items": "No metadata fields to show.",
   "admin.registries.schema.fields.no-items": "Es gibt keine Felder in diesem Schema.",
+  
+  // "admin.registries.schema.fields.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.schema.fields.table.delete": "Delete selected",
+  
+  // "admin.registries.schema.fields.table.field": "Field",
   "admin.registries.schema.fields.table.field": "Feld",
+  
+  // "admin.registries.schema.fields.table.scopenote": "Scope Note",
   "admin.registries.schema.fields.table.scopenote": "Gültigkeitsbereich",
+  
+  // "admin.registries.schema.form.create": "Create metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.create": "Create metadata field",
+  
+  // "admin.registries.schema.form.edit": "Edit metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.edit": "Edit metadata field",
+  
+  // "admin.registries.schema.form.element": "Element",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.element": "Element",
+  
+  // "admin.registries.schema.form.qualifier": "Qualifier",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.qualifier": "Qualifier",
+  
+  // "admin.registries.schema.form.scopenote": "Scope Note",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.scopenote": "Scope Note",
+  
+  // "admin.registries.schema.head": "Metadata Schema",
   "admin.registries.schema.head": "Metadatenschemata",
+  
+  // "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.failure": "Error",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.failure": "Error",
+  
+  // "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.success": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.success": "Success",
+  
+  // "admin.registries.schema.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.schema.return": "Return",
+  
+  // "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Registry",
   "admin.registries.schema.title": "DSpace Angular :: Referenzliste der Metadatenschemata",
-
+  
+  
+  
+  // "auth.errors.invalid-user": "Invalid email address or password.",
   "auth.errors.invalid-user": "Ungültige E-Mail-Adresse oder Passwort.",
+  
+  // "auth.messages.expired": "Your session has expired. Please log in again.",
   "auth.messages.expired": "Ihre Sitzung ist abgelaufen, bitte melden Sie sich erneut an.",
-
+  
+  
+  
+  // "browse.comcol.by.author": "By Author",
+  // TODO New key - Add a translation
+  "browse.comcol.by.author": "By Author",
+  
+  // "browse.comcol.by.dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "browse.comcol.by.dateissued": "By Issue Date",
+  
+  // "browse.comcol.by.subject": "By Subject",
+  // TODO New key - Add a translation
+  "browse.comcol.by.subject": "By Subject",
+  
+  // "browse.comcol.by.title": "By Title",
+  // TODO New key - Add a translation
+  "browse.comcol.by.title": "By Title",
+  
+  // "browse.comcol.head": "Browse",
+  // TODO New key - Add a translation
+  "browse.comcol.head": "Browse",
+  
+  // "browse.empty": "No items to show.",
+  // TODO New key - Add a translation
+  "browse.empty": "No items to show.",
+  
+  // "browse.metadata.author": "Author",
+  // TODO New key - Add a translation
+  "browse.metadata.author": "Author",
+  
+  // "browse.metadata.dateissued": "Issue Date",
+  // TODO New key - Add a translation
+  "browse.metadata.dateissued": "Issue Date",
+  
+  // "browse.metadata.subject": "Subject",
+  // TODO New key - Add a translation
+  "browse.metadata.subject": "Subject",
+  
+  // "browse.metadata.title": "Title",
+  // TODO New key - Add a translation
+  "browse.metadata.title": "Title",
+  
+  // "browse.startsWith.choose_start": "(Choose start)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_start": "(Choose start)",
+  
+  // "browse.startsWith.choose_year": "(Choose year)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_year": "(Choose year)",
+  
+  // "browse.startsWith.jump": "Jump to a point in the index:",
+  // TODO New key - Add a translation
+  "browse.startsWith.jump": "Jump to a point in the index:",
+  
+  // "browse.startsWith.months.april": "April",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.april": "April",
+  
+  // "browse.startsWith.months.august": "August",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.august": "August",
+  
+  // "browse.startsWith.months.december": "December",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.december": "December",
+  
+  // "browse.startsWith.months.february": "February",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.february": "February",
+  
+  // "browse.startsWith.months.january": "January",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.january": "January",
+  
+  // "browse.startsWith.months.july": "July",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.july": "July",
+  
+  // "browse.startsWith.months.june": "June",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.june": "June",
+  
+  // "browse.startsWith.months.march": "March",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.march": "March",
+  
+  // "browse.startsWith.months.may": "May",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.may": "May",
+  
+  // "browse.startsWith.months.none": "(Choose month)",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.none": "(Choose month)",
+  
+  // "browse.startsWith.months.november": "November",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.november": "November",
+  
+  // "browse.startsWith.months.october": "October",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.october": "October",
+  
+  // "browse.startsWith.months.september": "September",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.september": "September",
+  
+  // "browse.startsWith.submit": "Go",
+  // TODO New key - Add a translation
+  "browse.startsWith.submit": "Go",
+  
+  // "browse.startsWith.type_date": "Or type in a date (year-month):",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_date": "Or type in a date (year-month):",
+  
+  // "browse.startsWith.type_text": "Or enter first few letters:",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_text": "Or enter first few letters:",
+  
+  // "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
   "browse.title": "Anzeige {{ collection }} nach {{ field }} {{ value }}",
+  
+  
+  
+  // "chips.remove": "Remove chip",
+  // TODO New key - Add a translation
+  "chips.remove": "Remove chip",
+  
+  
+  
+  // "collection.create.head": "Create a Collection",
+  // TODO New key - Add a translation
+  "collection.create.head": "Create a Collection",
+  
+  // "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  
+  // "collection.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.delete.cancel": "Cancel",
+  
+  // "collection.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "collection.delete.confirm": "Confirm",
+  
+  // "collection.delete.head": "Delete Collection",
+  // TODO New key - Add a translation
+  "collection.delete.head": "Delete Collection",
+  
+  // "collection.delete.notification.fail": "Collection could not be deleted",
+  // TODO New key - Add a translation
+  "collection.delete.notification.fail": "Collection could not be deleted",
+  
+  // "collection.delete.notification.success": "Successfully deleted collection",
+  // TODO New key - Add a translation
+  "collection.delete.notification.success": "Successfully deleted collection",
+  
+  // "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  
+  
+  
+  // "collection.edit.delete": "Delete this collection",
+  // TODO New key - Add a translation
+  "collection.edit.delete": "Delete this collection",
+  
+  // "collection.edit.head": "Edit Collection",
+  // TODO New key - Add a translation
+  "collection.edit.head": "Edit Collection",
+  
+  
+  
+  // "collection.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.cancel": "Cancel",
+  
+  // "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  
+  // "collection.edit.item-mapper.confirm": "Map selected items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.confirm": "Map selected items",
+  
+  // "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  
+  // "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  
+  // "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  
+  // "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  
+  // "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  
+  // "collection.edit.item-mapper.tabs.map": "Map new items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.map": "Map new items",
+  
+  
+  
+  // "collection.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "collection.form.abstract": "Short Description",
+  
+  // "collection.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.description": "Introductory text (HTML)",
+  
+  // "collection.form.errors.title.required": "Please enter a collection name",
+  // TODO New key - Add a translation
+  "collection.form.errors.title.required": "Please enter a collection name",
+  
+  // "collection.form.license": "License",
+  // TODO New key - Add a translation
+  "collection.form.license": "License",
+  
+  // "collection.form.provenance": "Provenance",
+  // TODO New key - Add a translation
+  "collection.form.provenance": "Provenance",
+  
+  // "collection.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.rights": "Copyright text (HTML)",
+  
+  // "collection.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.tableofcontents": "News (HTML)",
+  
+  // "collection.form.title": "Name",
+  // TODO New key - Add a translation
+  "collection.form.title": "Name",
+  
+  
+  
+  // "collection.page.browse.recent.head": "Recent Submissions",
   "collection.page.browse.recent.head": "Aktuellste Veröffentlichungen",
+  
+  // "collection.page.browse.recent.empty": "No items to show",
+  // TODO New key - Add a translation
+  "collection.page.browse.recent.empty": "No items to show",
+  
+  // "collection.page.handle": "Permanent URI for this collection",
+  // TODO New key - Add a translation
+  "collection.page.handle": "Permanent URI for this collection",
+  
+  // "collection.page.license": "License",
   "collection.page.license": "Lizenz",
+  
+  // "collection.page.news": "News",
   "collection.page.news": "Neuigkeiten",
-
+  
+  
+  
+  // "collection.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "collection.select.confirm": "Confirm selected",
+  
+  // "collection.select.empty": "No collections to show",
+  // TODO New key - Add a translation
+  "collection.select.empty": "No collections to show",
+  
+  // "collection.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "collection.select.table.title": "Title",
+  
+  
+  
+  // "community.create.head": "Create a Community",
+  // TODO New key - Add a translation
+  "community.create.head": "Create a Community",
+  
+  // "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  
+  // "community.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "community.delete.cancel": "Cancel",
+  
+  // "community.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "community.delete.confirm": "Confirm",
+  
+  // "community.delete.head": "Delete Community",
+  // TODO New key - Add a translation
+  "community.delete.head": "Delete Community",
+  
+  // "community.delete.notification.fail": "Community could not be deleted",
+  // TODO New key - Add a translation
+  "community.delete.notification.fail": "Community could not be deleted",
+  
+  // "community.delete.notification.success": "Successfully deleted community",
+  // TODO New key - Add a translation
+  "community.delete.notification.success": "Successfully deleted community",
+  
+  // "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  
+  // "community.edit.delete": "Delete this community",
+  // TODO New key - Add a translation
+  "community.edit.delete": "Delete this community",
+  
+  // "community.edit.head": "Edit Community",
+  // TODO New key - Add a translation
+  "community.edit.head": "Edit Community",
+  
+  // "community.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "community.form.abstract": "Short Description",
+  
+  // "community.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.description": "Introductory text (HTML)",
+  
+  // "community.form.errors.title.required": "Please enter a community name",
+  // TODO New key - Add a translation
+  "community.form.errors.title.required": "Please enter a community name",
+  
+  // "community.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.rights": "Copyright text (HTML)",
+  
+  // "community.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "community.form.tableofcontents": "News (HTML)",
+  
+  // "community.form.title": "Name",
+  // TODO New key - Add a translation
+  "community.form.title": "Name",
+  
+  // "community.page.handle": "Permanent URI for this community",
+  // TODO New key - Add a translation
+  "community.page.handle": "Permanent URI for this community",
+  
+  // "community.page.license": "License",
   "community.page.license": "Lizenz",
+  
+  // "community.page.news": "News",
   "community.page.news": "Neuigkeiten",
+  
+  // "community.all-lists.head": "Subcommunities and Collections",
+  // TODO New key - Add a translation
+  "community.all-lists.head": "Subcommunities and Collections",
+  
+  // "community.sub-collection-list.head": "Collections of this Community",
   "community.sub-collection-list.head": "Sammlungen in diesem Bereich",
-
+  
+  // "community.sub-community-list.head": "Communities of this Community",
+  // TODO New key - Add a translation
+  "community.sub-community-list.head": "Communities of this Community",
+  
+  
+  
+  // "dso-selector.create.collection.head": "New collection",
+  // TODO New key - Add a translation
+  "dso-selector.create.collection.head": "New collection",
+  
+  // "dso-selector.create.community.head": "New community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.head": "New community",
+  
+  // "dso-selector.create.community.sub-level": "Create a new community in",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.sub-level": "Create a new community in",
+  
+  // "dso-selector.create.community.top-level": "Create a new top-level community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.top-level": "Create a new top-level community",
+  
+  // "dso-selector.create.item.head": "New item",
+  // TODO New key - Add a translation
+  "dso-selector.create.item.head": "New item",
+  
+  // "dso-selector.edit.collection.head": "Edit collection",
+  // TODO New key - Add a translation
+  "dso-selector.edit.collection.head": "Edit collection",
+  
+  // "dso-selector.edit.community.head": "Edit community",
+  // TODO New key - Add a translation
+  "dso-selector.edit.community.head": "Edit community",
+  
+  // "dso-selector.edit.item.head": "Edit item",
+  // TODO New key - Add a translation
+  "dso-selector.edit.item.head": "Edit item",
+  
+  // "dso-selector.no-results": "No {{ type }} found",
+  // TODO New key - Add a translation
+  "dso-selector.no-results": "No {{ type }} found",
+  
+  // "dso-selector.placeholder": "Search for a {{ type }}",
+  // TODO New key - Add a translation
+  "dso-selector.placeholder": "Search for a {{ type }}",
+  
+  
+  
+  // "error.browse-by": "Error fetching items",
   "error.browse-by": "Fehler beim Laden der Ressourcen",
+  
+  // "error.collection": "Error fetching collection",
   "error.collection": "Fehler beim Laden der Sammlung.",
+  
+  // "error.collections": "Error fetching collections",
+  // TODO New key - Add a translation
+  "error.collections": "Error fetching collections",
+  
+  // "error.community": "Error fetching community",
   "error.community": "Fehler beim Laden des Bereiches.",
+  
+  // "error.default": "Error",
   "error.default": "Fehler",
+  
+  // "error.item": "Error fetching item",
   "error.item": "Fehler beim Laden der Ressource.",
+  
+  // "error.items": "Error fetching items",
+  // TODO New key - Add a translation
+  "error.items": "Error fetching items",
+  
+  // "error.objects": "Error fetching objects",
   "error.objects": "Fehler beim Laden der Objekte.",
+  
+  // "error.recent-submissions": "Error fetching recent submissions",
   "error.recent-submissions": "Fehler beim Laden der aktuellsten Veröffentlichungen.",
+  
+  // "error.search-results": "Error fetching search results",
   "error.search-results": "Fehler beim Laden der Suchergebnisse.",
+  
+  // "error.sub-collections": "Error fetching sub-collections",
   "error.sub-collections": "Fehler beim Laden der untergeordneten Sammlungen.",
+  
+  // "error.sub-communities": "Error fetching sub-communities",
+  // TODO New key - Add a translation
+  "error.sub-communities": "Error fetching sub-communities",
+  
+  // "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  // TODO New key - Add a translation
+  "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  
+  // "error.top-level-communities": "Error fetching top-level communities",
   "error.top-level-communities": "Fehler beim Laden der Hauptbereiche.",
+  
+  // "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
   "error.validation.license.notgranted": "Sie müssen der Lizenz zustimmen, um die Ressource einzureichen. Wenn dies zur Zeit nicht geht, können Sie die Einreichung speichern und später wiederaufnehmen oder löschen.",
-  "error.validation.pattern": "Die Eingabe kann nur folgendes Muster haben: {{ pattern }}.",
-
+  
+  // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  // TODO New key - Add a translation
+  "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  
+  
+  
+  // "footer.copyright": "copyright © 2002-{{ year }}",
   "footer.copyright": "Copyright © 2002-{{ year }}",
+  
+  // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace Software",
+  
+  // "footer.link.duraspace": "DuraSpace",
   "footer.link.duraspace": "DuraSpace",
-
+  
+  
+  
+  // "form.cancel": "Cancel",
   "form.cancel": "Abbrechen",
+  
+  // "form.clear": "Clear",
+  // TODO New key - Add a translation
+  "form.clear": "Clear",
+  
+  // "form.clear-help": "Click here to remove the selected value",
+  // TODO New key - Add a translation
+  "form.clear-help": "Click here to remove the selected value",
+  
+  // "form.edit": "Edit",
+  // TODO New key - Add a translation
+  "form.edit": "Edit",
+  
+  // "form.edit-help": "Click here to edit the selected value",
+  // TODO New key - Add a translation
+  "form.edit-help": "Click here to edit the selected value",
+  
+  // "form.first-name": "First name",
   "form.first-name": "Vorname",
+  
+  // "form.group-collapse": "Collapse",
   "form.group-collapse": "Weniger",
+  
+  // "form.group-collapse-help": "Click here to collapse",
   "form.group-collapse-help": "Hier klicken, um die Anzeige zu reduzieren",
+  
+  // "form.group-expand": "Expand",
   "form.group-expand": "Mehr",
+  
+  // "form.group-expand-help": "Click here to expand and add more elements",
   "form.group-expand-help": "Hier klicken, um mehr Elemente anzuzeigen",
+  
+  // "form.last-name": "Last name",
   "form.last-name": "Nachname",
+  
+  // "form.loading": "Loading...",
   "form.loading": "Am Laden ...",
+  
+  // "form.no-results": "No results found",
   "form.no-results": "Keine Ergebnisse gefunden",
+  
+  // "form.no-value": "No value entered",
   "form.no-value": "Kein Wert eingegeben",
+  
+  // "form.other-information": {},
+  // TODO New key - Add a translation
+  "form.other-information": {},
+  
+  // "form.remove": "Remove",
   "form.remove": "Löschen",
+  
+  // "form.save": "Save",
+  // TODO New key - Add a translation
+  "form.save": "Save",
+  
+  // "form.save-help": "Save changes",
+  // TODO New key - Add a translation
+  "form.save-help": "Save changes",
+  
+  // "form.search": "Search",
   "form.search": "Suchen",
+  
+  // "form.search-help": "Click here to looking for an existing correspondence",
+  // TODO New key - Add a translation
+  "form.search-help": "Click here to looking for an existing correspondence",
+  
+  // "form.submit": "Submit",
   "form.submit": "Los",
-
+  
+  
+  
+  // "home.description": "",
   "home.description": "",
+  
+  // "home.title": "DSpace Angular :: Home",
   "home.title": "DSpace Angular :: Startseite",
+  
+  // "home.top-level-communities.head": "Communities in DSpace",
   "home.top-level-communities.head": "Bereiche in DSpace",
+  
+  // "home.top-level-communities.help": "Select a community to browse its collections.",
   "home.top-level-communities.help": "Wählen Sie einen Bereich, um seine Sammlungen einzusehen.",
-
+  
+  
+  
+  // "item.edit.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.delete.cancel": "Cancel",
+  
+  // "item.edit.delete.confirm": "Delete",
+  // TODO New key - Add a translation
+  "item.edit.delete.confirm": "Delete",
+  
+  // "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  // TODO New key - Add a translation
+  "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  
+  // "item.edit.delete.error": "An error occurred while deleting the item",
+  // TODO New key - Add a translation
+  "item.edit.delete.error": "An error occurred while deleting the item",
+  
+  // "item.edit.delete.header": "Delete item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.delete.header": "Delete item: {{ id }}",
+  
+  // "item.edit.delete.success": "The item has been deleted",
+  // TODO New key - Add a translation
+  "item.edit.delete.success": "The item has been deleted",
+  
+  // "item.edit.head": "Edit Item",
+  // TODO New key - Add a translation
+  "item.edit.head": "Edit Item",
+  
+  
+  
+  // "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  
+  // "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  
+  // "item.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.cancel": "Cancel",
+  
+  // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  
+  // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  
+  // "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  
+  // "item.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  
+  // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  
+  // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  
+  // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  
+  // "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  
+  // "item.edit.item-mapper.tabs.map": "Map new collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.map": "Map new collections",
+  
+  
+  
+  // "item.edit.metadata.add-button": "Add",
+  // TODO New key - Add a translation
+  "item.edit.metadata.add-button": "Add",
+  
+  // "item.edit.metadata.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.metadata.discard-button": "Discard",
+  
+  // "item.edit.metadata.edit.buttons.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.edit": "Edit",
+  
+  // "item.edit.metadata.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.remove": "Remove",
+  
+  // "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  
+  // "item.edit.metadata.headers.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.edit": "Edit",
+  
+  // "item.edit.metadata.headers.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.field": "Field",
+  
+  // "item.edit.metadata.headers.language": "Lang",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.language": "Lang",
+  
+  // "item.edit.metadata.headers.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.value": "Value",
+  
+  // "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  
+  // "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  
+  // "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  
+  // "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  
+  // "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  
+  // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  
+  // "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  
+  // "item.edit.metadata.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.metadata.reinstate-button": "Undo",
+  
+  // "item.edit.metadata.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.metadata.save-button": "Save",
+  
+  
+  
+  // "item.edit.modify.overview.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.field": "Field",
+  
+  // "item.edit.modify.overview.language": "Language",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.language": "Language",
+  
+  // "item.edit.modify.overview.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.value": "Value",
+  
+  
+  
+  // "item.edit.move.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.move.cancel": "Cancel",
+  
+  // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  // TODO New key - Add a translation
+  "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  
+  // "item.edit.move.error": "An error occured when attempting to move the item",
+  // TODO New key - Add a translation
+  "item.edit.move.error": "An error occured when attempting to move the item",
+  
+  // "item.edit.move.head": "Move item: {{id}}",
+  // TODO New key - Add a translation
+  "item.edit.move.head": "Move item: {{id}}",
+  
+  // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  
+  // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  
+  // "item.edit.move.move": "Move",
+  // TODO New key - Add a translation
+  "item.edit.move.move": "Move",
+  
+  // "item.edit.move.processing": "Moving...",
+  // TODO New key - Add a translation
+  "item.edit.move.processing": "Moving...",
+  
+  // "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  // TODO New key - Add a translation
+  "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  
+  // "item.edit.move.success": "The item has been moved succesfully",
+  // TODO New key - Add a translation
+  "item.edit.move.success": "The item has been moved succesfully",
+  
+  // "item.edit.move.title": "Move item",
+  // TODO New key - Add a translation
+  "item.edit.move.title": "Move item",
+  
+  
+  
+  // "item.edit.private.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.private.cancel": "Cancel",
+  
+  // "item.edit.private.confirm": "Make it Private",
+  // TODO New key - Add a translation
+  "item.edit.private.confirm": "Make it Private",
+  
+  // "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  
+  // "item.edit.private.error": "An error occurred while making the item private",
+  // TODO New key - Add a translation
+  "item.edit.private.error": "An error occurred while making the item private",
+  
+  // "item.edit.private.header": "Make item private: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.private.header": "Make item private: {{ id }}",
+  
+  // "item.edit.private.success": "The item is now private",
+  // TODO New key - Add a translation
+  "item.edit.private.success": "The item is now private",
+  
+  
+  
+  // "item.edit.public.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.public.cancel": "Cancel",
+  
+  // "item.edit.public.confirm": "Make it Public",
+  // TODO New key - Add a translation
+  "item.edit.public.confirm": "Make it Public",
+  
+  // "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  
+  // "item.edit.public.error": "An error occurred while making the item public",
+  // TODO New key - Add a translation
+  "item.edit.public.error": "An error occurred while making the item public",
+  
+  // "item.edit.public.header": "Make item public: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.public.header": "Make item public: {{ id }}",
+  
+  // "item.edit.public.success": "The item is now public",
+  // TODO New key - Add a translation
+  "item.edit.public.success": "The item is now public",
+  
+  
+  
+  // "item.edit.reinstate.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.cancel": "Cancel",
+  
+  // "item.edit.reinstate.confirm": "Reinstate",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.confirm": "Reinstate",
+  
+  // "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  
+  // "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  
+  // "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  
+  // "item.edit.reinstate.success": "The item was reinstated successfully",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.success": "The item was reinstated successfully",
+  
+  
+  
+  // "item.edit.relationships.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.relationships.discard-button": "Discard",
+  
+  // "item.edit.relationships.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.remove": "Remove",
+  
+  // "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  
+  // "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  
+  // "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  
+  // "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  
+  // "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  
+  // "item.edit.relationships.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.relationships.reinstate-button": "Undo",
+  
+  // "item.edit.relationships.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.relationships.save-button": "Save",
+  
+  
+  
+  // "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  
+  // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  
+  // "item.edit.tabs.curate.head": "Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.head": "Curate",
+  
+  // "item.edit.tabs.curate.title": "Item Edit - Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.title": "Item Edit - Curate",
+  
+  // "item.edit.tabs.metadata.head": "Item Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.head": "Item Metadata",
+  
+  // "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  
+  // "item.edit.tabs.relationships.head": "Item Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.head": "Item Relationships",
+  
+  // "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  
+  // "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  
+  // "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  
+  // "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  
+  // "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  
+  // "item.edit.tabs.status.buttons.move.button": "Move...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.button": "Move...",
+  
+  // "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  
+  // "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  
+  // "item.edit.tabs.status.buttons.private.label": "Make item private",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.label": "Make item private",
+  
+  // "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  
+  // "item.edit.tabs.status.buttons.public.label": "Make item public",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.label": "Make item public",
+  
+  // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  
+  // "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  
+  // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  
+  // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  
+  // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  
+  // "item.edit.tabs.status.head": "Item Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.head": "Item Status",
+  
+  // "item.edit.tabs.status.labels.handle": "Handle",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.handle": "Handle",
+  
+  // "item.edit.tabs.status.labels.id": "Item Internal ID",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.id": "Item Internal ID",
+  
+  // "item.edit.tabs.status.labels.itemPage": "Item Page",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.itemPage": "Item Page",
+  
+  // "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  
+  // "item.edit.tabs.status.title": "Item Edit -  Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.title": "Item Edit -  Status",
+  
+  // "item.edit.tabs.view.head": "View Item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.head": "View Item",
+  
+  // "item.edit.tabs.view.title": "Item Edit -  View",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.title": "Item Edit -  View",
+  
+  
+  
+  // "item.edit.withdraw.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.cancel": "Cancel",
+  
+  // "item.edit.withdraw.confirm": "Withdraw",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.confirm": "Withdraw",
+  
+  // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  
+  // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  
+  // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  
+  // "item.edit.withdraw.success": "The item was withdrawn successfully",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.success": "The item was withdrawn successfully",
+  
+  
+  
+  // "item.page.abstract": "Abstract",
   "item.page.abstract": "Kurzfassung",
+  
+  // "item.page.author": "Authors",
   "item.page.author": "Autor",
+  
+  // "item.page.citation": "Citation",
+  // TODO New key - Add a translation
+  "item.page.citation": "Citation",
+  
+  // "item.page.collections": "Collections",
   "item.page.collections": "Sammlungen",
+  
+  // "item.page.date": "Date",
   "item.page.date": "Datum",
+  
+  // "item.page.files": "Files",
   "item.page.files": "Dateien",
-  "item.page.filesection.description": "Beschreibung:",
+  
+  // "item.page.filesection.description": "Description:",
+  // TODO New key - Add a translation
+  "item.page.filesection.description": "Description:",
+  
+  // "item.page.filesection.download": "Download",
   "item.page.filesection.download": "Herunterladen",
+  
+  // "item.page.filesection.format": "Format:",
   "item.page.filesection.format": "Format:",
+  
+  // "item.page.filesection.name": "Name:",
   "item.page.filesection.name": "Name:",
-  "item.page.filesection.size": "Größe:",
+  
+  // "item.page.filesection.size": "Size:",
+  // TODO New key - Add a translation
+  "item.page.filesection.size": "Size:",
+  
+  // "item.page.journal.search.title": "Articles in this journal",
+  // TODO New key - Add a translation
+  "item.page.journal.search.title": "Articles in this journal",
+  
+  // "item.page.link.full": "Full item page",
   "item.page.link.full": "Vollanzeige",
+  
+  // "item.page.link.simple": "Simple item page",
   "item.page.link.simple": "Kurzanzeige",
+  
+  // "item.page.person.search.title": "Articles by this author",
+  // TODO New key - Add a translation
+  "item.page.person.search.title": "Articles by this author",
+  
+  // "item.page.related-items.view-more": "View more",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-more": "View more",
+  
+  // "item.page.related-items.view-less": "View less",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-less": "View less",
+  
+  // "item.page.subject": "Keywords",
+  // TODO New key - Add a translation
+  "item.page.subject": "Keywords",
+  
+  // "item.page.uri": "URI",
   "item.page.uri": "URI",
-
+  
+  
+  
+  // "item.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "item.select.confirm": "Confirm selected",
+  
+  // "item.select.empty": "No items to show",
+  // TODO New key - Add a translation
+  "item.select.empty": "No items to show",
+  
+  // "item.select.table.author": "Author",
+  // TODO New key - Add a translation
+  "item.select.table.author": "Author",
+  
+  // "item.select.table.collection": "Collection",
+  // TODO New key - Add a translation
+  "item.select.table.collection": "Collection",
+  
+  // "item.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "item.select.table.title": "Title",
+  
+  
+  
+  // "journal.listelement.badge": "Journal",
+  // TODO New key - Add a translation
+  "journal.listelement.badge": "Journal",
+  
+  // "journal.page.description": "Description",
+  // TODO New key - Add a translation
+  "journal.page.description": "Description",
+  
+  // "journal.page.editor": "Editor-in-Chief",
+  // TODO New key - Add a translation
+  "journal.page.editor": "Editor-in-Chief",
+  
+  // "journal.page.issn": "ISSN",
+  // TODO New key - Add a translation
+  "journal.page.issn": "ISSN",
+  
+  // "journal.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "journal.page.publisher": "Publisher",
+  
+  // "journal.page.titleprefix": "Journal: ",
+  // TODO New key - Add a translation
+  "journal.page.titleprefix": "Journal: ",
+  
+  // "journal.search.results.head": "Journal Search Results",
+  // TODO New key - Add a translation
+  "journal.search.results.head": "Journal Search Results",
+  
+  // "journal.search.title": "DSpace Angular :: Journal Search",
+  // TODO New key - Add a translation
+  "journal.search.title": "DSpace Angular :: Journal Search",
+  
+  
+  
+  // "journalissue.listelement.badge": "Journal Issue",
+  // TODO New key - Add a translation
+  "journalissue.listelement.badge": "Journal Issue",
+  
+  // "journalissue.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalissue.page.description": "Description",
+  
+  // "journalissue.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalissue.page.issuedate": "Issue Date",
+  
+  // "journalissue.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-issn": "Journal ISSN",
+  
+  // "journalissue.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-title": "Journal Title",
+  
+  // "journalissue.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "journalissue.page.keyword": "Keywords",
+  
+  // "journalissue.page.number": "Number",
+  // TODO New key - Add a translation
+  "journalissue.page.number": "Number",
+  
+  // "journalissue.page.titleprefix": "Journal Issue: ",
+  // TODO New key - Add a translation
+  "journalissue.page.titleprefix": "Journal Issue: ",
+  
+  
+  
+  // "journalvolume.listelement.badge": "Journal Volume",
+  // TODO New key - Add a translation
+  "journalvolume.listelement.badge": "Journal Volume",
+  
+  // "journalvolume.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalvolume.page.description": "Description",
+  
+  // "journalvolume.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalvolume.page.issuedate": "Issue Date",
+  
+  // "journalvolume.page.titleprefix": "Journal Volume: ",
+  // TODO New key - Add a translation
+  "journalvolume.page.titleprefix": "Journal Volume: ",
+  
+  // "journalvolume.page.volume": "Volume",
+  // TODO New key - Add a translation
+  "journalvolume.page.volume": "Volume",
+  
+  
+  
+  // "loading.browse-by": "Loading items...",
   "loading.browse-by": "Die Ressourcen werden geladen ...",
+  
+  // "loading.browse-by-page": "Loading page...",
+  // TODO New key - Add a translation
+  "loading.browse-by-page": "Loading page...",
+  
+  // "loading.collection": "Loading collection...",
   "loading.collection": "Die Sammlung wird geladen ...",
+  
+  // "loading.collections": "Loading collections...",
+  // TODO New key - Add a translation
+  "loading.collections": "Loading collections...",
+  
+  // "loading.community": "Loading community...",
   "loading.community": "Der Bereich wird geladen ...",
+  
+  // "loading.default": "Loading...",
   "loading.default": "Am Laden ...",
+  
+  // "loading.item": "Loading item...",
   "loading.item": "Die Ressource wird geladen ...",
+  
+  // "loading.items": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.items": "Loading items...",
+  
+  // "loading.mydspace-results": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.mydspace-results": "Loading items...",
+  
+  // "loading.objects": "Loading...",
   "loading.objects": "Am Laden ...",
+  
+  // "loading.recent-submissions": "Loading recent submissions...",
   "loading.recent-submissions": "Die aktuellsten Veröffentlichungen werden geladen ...",
+  
+  // "loading.search-results": "Loading search results...",
   "loading.search-results": "Die Suchergebnisse werden geladen ...",
+  
+  // "loading.sub-collections": "Loading sub-collections...",
   "loading.sub-collections": "Die untergeordneten Sammlungen werden geladen ...",
+  
+  // "loading.sub-communities": "Loading sub-communities...",
+  // TODO New key - Add a translation
+  "loading.sub-communities": "Loading sub-communities...",
+  
+  // "loading.top-level-communities": "Loading top-level communities...",
   "loading.top-level-communities": "Die Hauptbereiche werden geladen ...",
-
+  
+  
+  
+  // "login.form.email": "Email address",
   "login.form.email": "E-Mail-Adresse",
+  
+  // "login.form.forgot-password": "Have you forgotten your password?",
   "login.form.forgot-password": "Haben Sie Ihr Passwort vergessen?",
+  
+  // "login.form.header": "Please log in to DSpace",
   "login.form.header": "Bitte Loggen Sie sich ein.",
+  
+  // "login.form.new-user": "New user? Click here to register.",
   "login.form.new-user": "Sind Sie neu hier? Klicken Sie hier, um sich zu registrieren.",
+  
+  // "login.form.password": "Password",
   "login.form.password": "Passwort",
+  
+  // "login.form.submit": "Log in",
   "login.form.submit": "Einloggen",
+  
+  // "login.title": "Login",
   "login.title": "Einloggen",
-
+  
+  
+  
+  // "logout.form.header": "Log out from DSpace",
   "logout.form.header": "Ausloggen aus DSpace",
+  
+  // "logout.form.submit": "Log out",
   "logout.form.submit": "Ausloggen",
+  
+  // "logout.title": "Logout",
   "logout.title": "Ausloggen",
-
-  "nav.home": "Zur Startseite",
+  
+  
+  
+  // "menu.header.admin": "Admin",
+  // TODO New key - Add a translation
+  "menu.header.admin": "Admin",
+  
+  // "menu.header.image.logo": "Repository logo",
+  // TODO New key - Add a translation
+  "menu.header.image.logo": "Repository logo",
+  
+  
+  
+  // "menu.section.access_control": "Access Control",
+  // TODO New key - Add a translation
+  "menu.section.access_control": "Access Control",
+  
+  // "menu.section.access_control_authorizations": "Authorizations",
+  // TODO New key - Add a translation
+  "menu.section.access_control_authorizations": "Authorizations",
+  
+  // "menu.section.access_control_groups": "Groups",
+  // TODO New key - Add a translation
+  "menu.section.access_control_groups": "Groups",
+  
+  // "menu.section.access_control_people": "People",
+  // TODO New key - Add a translation
+  "menu.section.access_control_people": "People",
+  
+  
+  
+  // "menu.section.browse_community": "This Community",
+  // TODO New key - Add a translation
+  "menu.section.browse_community": "This Community",
+  
+  // "menu.section.browse_community_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_author": "By Author",
+  
+  // "menu.section.browse_community_by_issue_date": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_issue_date": "By Issue Date",
+  
+  // "menu.section.browse_community_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_title": "By Title",
+  
+  // "menu.section.browse_global": "All of DSpace",
+  // TODO New key - Add a translation
+  "menu.section.browse_global": "All of DSpace",
+  
+  // "menu.section.browse_global_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_author": "By Author",
+  
+  // "menu.section.browse_global_by_dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_dateissued": "By Issue Date",
+  
+  // "menu.section.browse_global_by_subject": "By Subject",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_subject": "By Subject",
+  
+  // "menu.section.browse_global_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_title": "By Title",
+  
+  // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  
+  
+  
+  // "menu.section.control_panel": "Control Panel",
+  // TODO New key - Add a translation
+  "menu.section.control_panel": "Control Panel",
+  
+  // "menu.section.curation_task": "Curation Task",
+  // TODO New key - Add a translation
+  "menu.section.curation_task": "Curation Task",
+  
+  
+  
+  // "menu.section.edit": "Edit",
+  // TODO New key - Add a translation
+  "menu.section.edit": "Edit",
+  
+  // "menu.section.edit_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.edit_collection": "Collection",
+  
+  // "menu.section.edit_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.edit_community": "Community",
+  
+  // "menu.section.edit_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.edit_item": "Item",
+  
+  
+  
+  // "menu.section.export": "Export",
+  // TODO New key - Add a translation
+  "menu.section.export": "Export",
+  
+  // "menu.section.export_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.export_collection": "Collection",
+  
+  // "menu.section.export_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.export_community": "Community",
+  
+  // "menu.section.export_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.export_item": "Item",
+  
+  // "menu.section.export_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.export_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.find": "Find",
+  // TODO New key - Add a translation
+  "menu.section.find": "Find",
+  
+  // "menu.section.find_items": "Items",
+  // TODO New key - Add a translation
+  "menu.section.find_items": "Items",
+  
+  // "menu.section.find_private_items": "Private Items",
+  // TODO New key - Add a translation
+  "menu.section.find_private_items": "Private Items",
+  
+  // "menu.section.find_withdrawn_items": "Withdrawn Items",
+  // TODO New key - Add a translation
+  "menu.section.find_withdrawn_items": "Withdrawn Items",
+  
+  
+  
+  // "menu.section.icon.access_control": "Access Control menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.access_control": "Access Control menu section",
+  
+  // "menu.section.icon.control_panel": "Control Panel menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.control_panel": "Control Panel menu section",
+  
+  // "menu.section.icon.curation_task": "Curation Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.curation_task": "Curation Task menu section",
+  
+  // "menu.section.icon.edit": "Edit menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.edit": "Edit menu section",
+  
+  // "menu.section.icon.export": "Export menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.export": "Export menu section",
+  
+  // "menu.section.icon.find": "Find menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.find": "Find menu section",
+  
+  // "menu.section.icon.import": "Import menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.import": "Import menu section",
+  
+  // "menu.section.icon.new": "New menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.new": "New menu section",
+  
+  // "menu.section.icon.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.pin": "Pin sidebar",
+  
+  // "menu.section.icon.registries": "Registries menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.registries": "Registries menu section",
+  
+  // "menu.section.icon.statistics_task": "Statistics Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.statistics_task": "Statistics Task menu section",
+  
+  // "menu.section.icon.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.import": "Import",
+  // TODO New key - Add a translation
+  "menu.section.import": "Import",
+  
+  // "menu.section.import_batch": "Batch Import (ZIP)",
+  // TODO New key - Add a translation
+  "menu.section.import_batch": "Batch Import (ZIP)",
+  
+  // "menu.section.import_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.import_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.new": "New",
+  // TODO New key - Add a translation
+  "menu.section.new": "New",
+  
+  // "menu.section.new_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.new_collection": "Collection",
+  
+  // "menu.section.new_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.new_community": "Community",
+  
+  // "menu.section.new_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.new_item": "Item",
+  
+  // "menu.section.new_item_version": "Item Version",
+  // TODO New key - Add a translation
+  "menu.section.new_item_version": "Item Version",
+  
+  
+  
+  // "menu.section.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.pin": "Pin sidebar",
+  
+  // "menu.section.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.registries": "Registries",
+  // TODO New key - Add a translation
+  "menu.section.registries": "Registries",
+  
+  // "menu.section.registries_format": "Format",
+  // TODO New key - Add a translation
+  "menu.section.registries_format": "Format",
+  
+  // "menu.section.registries_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.registries_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.statistics": "Statistics",
+  // TODO New key - Add a translation
+  "menu.section.statistics": "Statistics",
+  
+  // "menu.section.statistics_task": "Statistics Task",
+  // TODO New key - Add a translation
+  "menu.section.statistics_task": "Statistics Task",
+  
+  
+  
+  // "menu.section.toggle.access_control": "Toggle Access Control section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.access_control": "Toggle Access Control section",
+  
+  // "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  
+  // "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  
+  // "menu.section.toggle.edit": "Toggle Edit section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.edit": "Toggle Edit section",
+  
+  // "menu.section.toggle.export": "Toggle Export section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.export": "Toggle Export section",
+  
+  // "menu.section.toggle.find": "Toggle Find section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.find": "Toggle Find section",
+  
+  // "menu.section.toggle.import": "Toggle Import section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.import": "Toggle Import section",
+  
+  // "menu.section.toggle.new": "Toggle New section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.new": "Toggle New section",
+  
+  // "menu.section.toggle.registries": "Toggle Registries section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.registries": "Toggle Registries section",
+  
+  // "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  
+  
+  
+  // "mydspace.description": "",
+  // TODO New key - Add a translation
+  "mydspace.description": "",
+  
+  // "mydspace.general.text-here": "HERE",
+  // TODO New key - Add a translation
+  "mydspace.general.text-here": "HERE",
+  
+  // "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  // TODO New key - Add a translation
+  "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  
+  // "mydspace.messages.description-placeholder": "Insert your message here...",
+  // TODO New key - Add a translation
+  "mydspace.messages.description-placeholder": "Insert your message here...",
+  
+  // "mydspace.messages.hide-msg": "Hide message",
+  // TODO New key - Add a translation
+  "mydspace.messages.hide-msg": "Hide message",
+  
+  // "mydspace.messages.mark-as-read": "Mark as read",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-read": "Mark as read",
+  
+  // "mydspace.messages.mark-as-unread": "Mark as unread",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-unread": "Mark as unread",
+  
+  // "mydspace.messages.no-content": "No content.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-content": "No content.",
+  
+  // "mydspace.messages.no-messages": "No messages yet.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-messages": "No messages yet.",
+  
+  // "mydspace.messages.send-btn": "Send",
+  // TODO New key - Add a translation
+  "mydspace.messages.send-btn": "Send",
+  
+  // "mydspace.messages.show-msg": "Show message",
+  // TODO New key - Add a translation
+  "mydspace.messages.show-msg": "Show message",
+  
+  // "mydspace.messages.subject-placeholder": "Subject...",
+  // TODO New key - Add a translation
+  "mydspace.messages.subject-placeholder": "Subject...",
+  
+  // "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  // TODO New key - Add a translation
+  "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  
+  // "mydspace.messages.title": "Messages",
+  // TODO New key - Add a translation
+  "mydspace.messages.title": "Messages",
+  
+  // "mydspace.messages.to": "To",
+  // TODO New key - Add a translation
+  "mydspace.messages.to": "To",
+  
+  // "mydspace.new-submission": "New submission",
+  // TODO New key - Add a translation
+  "mydspace.new-submission": "New submission",
+  
+  // "mydspace.results.head": "Your submissions",
+  // TODO New key - Add a translation
+  "mydspace.results.head": "Your submissions",
+  
+  // "mydspace.results.no-abstract": "No Abstract",
+  // TODO New key - Add a translation
+  "mydspace.results.no-abstract": "No Abstract",
+  
+  // "mydspace.results.no-authors": "No Authors",
+  // TODO New key - Add a translation
+  "mydspace.results.no-authors": "No Authors",
+  
+  // "mydspace.results.no-collections": "No Collections",
+  // TODO New key - Add a translation
+  "mydspace.results.no-collections": "No Collections",
+  
+  // "mydspace.results.no-date": "No Date",
+  // TODO New key - Add a translation
+  "mydspace.results.no-date": "No Date",
+  
+  // "mydspace.results.no-files": "No Files",
+  // TODO New key - Add a translation
+  "mydspace.results.no-files": "No Files",
+  
+  // "mydspace.results.no-results": "There were no items to show",
+  // TODO New key - Add a translation
+  "mydspace.results.no-results": "There were no items to show",
+  
+  // "mydspace.results.no-title": "No title",
+  // TODO New key - Add a translation
+  "mydspace.results.no-title": "No title",
+  
+  // "mydspace.results.no-uri": "No Uri",
+  // TODO New key - Add a translation
+  "mydspace.results.no-uri": "No Uri",
+  
+  // "mydspace.show.workflow": "All tasks",
+  // TODO New key - Add a translation
+  "mydspace.show.workflow": "All tasks",
+  
+  // "mydspace.show.workspace": "Your Submissions",
+  // TODO New key - Add a translation
+  "mydspace.show.workspace": "Your Submissions",
+  
+  // "mydspace.status.archived": "Archived",
+  // TODO New key - Add a translation
+  "mydspace.status.archived": "Archived",
+  
+  // "mydspace.status.validation": "Validation",
+  // TODO New key - Add a translation
+  "mydspace.status.validation": "Validation",
+  
+  // "mydspace.status.waiting-for-controller": "Waiting for controller",
+  // TODO New key - Add a translation
+  "mydspace.status.waiting-for-controller": "Waiting for controller",
+  
+  // "mydspace.status.workflow": "Workflow",
+  // TODO New key - Add a translation
+  "mydspace.status.workflow": "Workflow",
+  
+  // "mydspace.status.workspace": "Workspace",
+  // TODO New key - Add a translation
+  "mydspace.status.workspace": "Workspace",
+  
+  // "mydspace.title": "MyDSpace",
+  // TODO New key - Add a translation
+  "mydspace.title": "MyDSpace",
+  
+  // "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  
+  // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  
+  // "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  
+  // "mydspace.view-btn": "View",
+  // TODO New key - Add a translation
+  "mydspace.view-btn": "View",
+  
+  
+  
+  // "nav.browse.header": "All of DSpace",
+  // TODO New key - Add a translation
+  "nav.browse.header": "All of DSpace",
+  
+  // "nav.community-browse.header": "By Community",
+  // TODO New key - Add a translation
+  "nav.community-browse.header": "By Community",
+  
+  // "nav.language": "Language switch",
+  // TODO New key - Add a translation
+  "nav.language": "Language switch",
+  
+  // "nav.login": "Log In",
   "nav.login": "Anmelden",
+  
+  // "nav.logout": "Log Out",
   "nav.logout": "Abmelden",
-
+  
+  // "nav.mydspace": "MyDSpace",
+  // TODO New key - Add a translation
+  "nav.mydspace": "MyDSpace",
+  
+  // "nav.search": "Search",
+  // TODO New key - Add a translation
+  "nav.search": "Search",
+  
+  // "nav.statistics.header": "Statistics",
+  // TODO New key - Add a translation
+  "nav.statistics.header": "Statistics",
+  
+  
+  
+  // "orgunit.listelement.badge": "Organizational Unit",
+  // TODO New key - Add a translation
+  "orgunit.listelement.badge": "Organizational Unit",
+  
+  // "orgunit.page.city": "City",
+  // TODO New key - Add a translation
+  "orgunit.page.city": "City",
+  
+  // "orgunit.page.country": "Country",
+  // TODO New key - Add a translation
+  "orgunit.page.country": "Country",
+  
+  // "orgunit.page.dateestablished": "Date established",
+  // TODO New key - Add a translation
+  "orgunit.page.dateestablished": "Date established",
+  
+  // "orgunit.page.description": "Description",
+  // TODO New key - Add a translation
+  "orgunit.page.description": "Description",
+  
+  // "orgunit.page.id": "ID",
+  // TODO New key - Add a translation
+  "orgunit.page.id": "ID",
+  
+  // "orgunit.page.titleprefix": "Organizational Unit: ",
+  // TODO New key - Add a translation
+  "orgunit.page.titleprefix": "Organizational Unit: ",
+  
+  
+  
+  // "pagination.results-per-page": "Results Per Page",
   "pagination.results-per-page": "Ergebnisse pro Seite",
+  
+  // "pagination.showing.detail": "{{ range }} of {{ total }}",
   "pagination.showing.detail": "{{ range }} bis {{ total }}",
+  
+  // "pagination.showing.label": "Now showing ",
   "pagination.showing.label": "Anzeige der Treffer ",
+  
+  // "pagination.sort-direction": "Sort Options",
   "pagination.sort-direction": "Sortiermöglichkeiten",
-
+  
+  
+  
+  // "person.listelement.badge": "Person",
+  // TODO New key - Add a translation
+  "person.listelement.badge": "Person",
+  
+  // "person.page.birthdate": "Birth Date",
+  // TODO New key - Add a translation
+  "person.page.birthdate": "Birth Date",
+  
+  // "person.page.email": "Email Address",
+  // TODO New key - Add a translation
+  "person.page.email": "Email Address",
+  
+  // "person.page.firstname": "First Name",
+  // TODO New key - Add a translation
+  "person.page.firstname": "First Name",
+  
+  // "person.page.jobtitle": "Job Title",
+  // TODO New key - Add a translation
+  "person.page.jobtitle": "Job Title",
+  
+  // "person.page.lastname": "Last Name",
+  // TODO New key - Add a translation
+  "person.page.lastname": "Last Name",
+  
+  // "person.page.link.full": "Show all metadata",
+  // TODO New key - Add a translation
+  "person.page.link.full": "Show all metadata",
+  
+  // "person.page.orcid": "ORCID",
+  // TODO New key - Add a translation
+  "person.page.orcid": "ORCID",
+  
+  // "person.page.staffid": "Staff ID",
+  // TODO New key - Add a translation
+  "person.page.staffid": "Staff ID",
+  
+  // "person.page.titleprefix": "Person: ",
+  // TODO New key - Add a translation
+  "person.page.titleprefix": "Person: ",
+  
+  // "person.search.results.head": "Person Search Results",
+  // TODO New key - Add a translation
+  "person.search.results.head": "Person Search Results",
+  
+  // "person.search.title": "DSpace Angular :: Person Search",
+  // TODO New key - Add a translation
+  "person.search.title": "DSpace Angular :: Person Search",
+  
+  
+  
+  // "project.listelement.badge": "Research Project",
+  // TODO New key - Add a translation
+  "project.listelement.badge": "Research Project",
+  
+  // "project.page.contributor": "Contributors",
+  // TODO New key - Add a translation
+  "project.page.contributor": "Contributors",
+  
+  // "project.page.description": "Description",
+  // TODO New key - Add a translation
+  "project.page.description": "Description",
+  
+  // "project.page.expectedcompletion": "Expected Completion",
+  // TODO New key - Add a translation
+  "project.page.expectedcompletion": "Expected Completion",
+  
+  // "project.page.funder": "Funders",
+  // TODO New key - Add a translation
+  "project.page.funder": "Funders",
+  
+  // "project.page.id": "ID",
+  // TODO New key - Add a translation
+  "project.page.id": "ID",
+  
+  // "project.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "project.page.keyword": "Keywords",
+  
+  // "project.page.status": "Status",
+  // TODO New key - Add a translation
+  "project.page.status": "Status",
+  
+  // "project.page.titleprefix": "Research Project: ",
+  // TODO New key - Add a translation
+  "project.page.titleprefix": "Research Project: ",
+  
+  
+  
+  // "publication.listelement.badge": "Publication",
+  // TODO New key - Add a translation
+  "publication.listelement.badge": "Publication",
+  
+  // "publication.page.description": "Description",
+  // TODO New key - Add a translation
+  "publication.page.description": "Description",
+  
+  // "publication.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "publication.page.journal-issn": "Journal ISSN",
+  
+  // "publication.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "publication.page.journal-title": "Journal Title",
+  
+  // "publication.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "publication.page.publisher": "Publisher",
+  
+  // "publication.page.titleprefix": "Publication: ",
+  // TODO New key - Add a translation
+  "publication.page.titleprefix": "Publication: ",
+  
+  // "publication.page.volume-title": "Volume Title",
+  // TODO New key - Add a translation
+  "publication.page.volume-title": "Volume Title",
+  
+  // "publication.search.results.head": "Publication Search Results",
+  // TODO New key - Add a translation
+  "publication.search.results.head": "Publication Search Results",
+  
+  // "publication.search.title": "DSpace Angular :: Publication Search",
+  // TODO New key - Add a translation
+  "publication.search.title": "DSpace Angular :: Publication Search",
+  
+  
+  
+  // "relationships.isAuthorOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isAuthorOf": "Authors",
+  
+  // "relationships.isIssueOf": "Journal Issues",
+  // TODO New key - Add a translation
+  "relationships.isIssueOf": "Journal Issues",
+  
+  // "relationships.isJournalIssueOf": "Journal Issue",
+  // TODO New key - Add a translation
+  "relationships.isJournalIssueOf": "Journal Issue",
+  
+  // "relationships.isJournalOf": "Journals",
+  // TODO New key - Add a translation
+  "relationships.isJournalOf": "Journals",
+  
+  // "relationships.isOrgUnitOf": "Organizational Units",
+  // TODO New key - Add a translation
+  "relationships.isOrgUnitOf": "Organizational Units",
+  
+  // "relationships.isPersonOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isPersonOf": "Authors",
+  
+  // "relationships.isProjectOf": "Research Projects",
+  // TODO New key - Add a translation
+  "relationships.isProjectOf": "Research Projects",
+  
+  // "relationships.isPublicationOf": "Publications",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOf": "Publications",
+  
+  // "relationships.isPublicationOfJournalIssue": "Articles",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOfJournalIssue": "Articles",
+  
+  // "relationships.isSingleJournalOf": "Journal",
+  // TODO New key - Add a translation
+  "relationships.isSingleJournalOf": "Journal",
+  
+  // "relationships.isSingleVolumeOf": "Journal Volume",
+  // TODO New key - Add a translation
+  "relationships.isSingleVolumeOf": "Journal Volume",
+  
+  // "relationships.isVolumeOf": "Journal Volumes",
+  // TODO New key - Add a translation
+  "relationships.isVolumeOf": "Journal Volumes",
+  
+  
+  
+  // "search.description": "",
   "search.description": "",
+  
+  // "search.switch-configuration.title": "Show",
+  // TODO New key - Add a translation
+  "search.switch-configuration.title": "Show",
+  
+  // "search.title": "DSpace Angular :: Search",
   "search.title": "DSpace Angular :: Suche",
-
+  
+  
+  
+  // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "Autor",
+  
+  // "search.filters.applied.f.dateIssued.max": "End date",
   "search.filters.applied.f.dateIssued.max": "Enddatum",
+  
+  // "search.filters.applied.f.dateIssued.min": "Start date",
   "search.filters.applied.f.dateIssued.min": "Anfangsdatum",
+  
+  // "search.filters.applied.f.dateSubmitted": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.dateSubmitted": "Date submitted",
+  
+  // "search.filters.applied.f.entityType": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.entityType": "Item Type",
+  
+  // "search.filters.applied.f.has_content_in_original_bundle": "Has files",
   "search.filters.applied.f.has_content_in_original_bundle": "Besitzt Dateien",
+  
+  // "search.filters.applied.f.itemtype": "Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.itemtype": "Type",
+  
+  // "search.filters.applied.f.namedresourcetype": "Status",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.namedresourcetype": "Status",
+  
+  // "search.filters.applied.f.subject": "Subject",
   "search.filters.applied.f.subject": "Thema",
-
+  
+  // "search.filters.applied.f.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.submitter": "Submitter",
+  
+  
+  
+  // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Autor",
+  
+  // "search.filters.filter.author.placeholder": "Author name",
   "search.filters.filter.author.placeholder": "Autor",
+  
+  // "search.filters.filter.birthDate.head": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.head": "Birth Date",
+  
+  // "search.filters.filter.birthDate.placeholder": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.placeholder": "Birth Date",
+  
+  // "search.filters.filter.creativeDatePublished.head": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.head": "Date Published",
+  
+  // "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  
+  // "search.filters.filter.creativeWorkEditor.head": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.head": "Editor",
+  
+  // "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  
+  // "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  
+  // "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  
+  // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  
+  // "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  
+  // "search.filters.filter.dateIssued.head": "Date",
   "search.filters.filter.dateIssued.head": "Datum",
+  
+  // "search.filters.filter.dateIssued.max.placeholder": "Minimum Date",
   "search.filters.filter.dateIssued.max.placeholder": "Frühestes Datum",
+  
+  // "search.filters.filter.dateIssued.min.placeholder": "Maximum Date",
   "search.filters.filter.dateIssued.min.placeholder": "Ältestes Datum",
+  
+  // "search.filters.filter.dateSubmitted.head": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.head": "Date submitted",
+  
+  // "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  
+  // "search.filters.filter.entityType.head": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.head": "Item Type",
+  
+  // "search.filters.filter.entityType.placeholder": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.placeholder": "Item Type",
+  
+  // "search.filters.filter.has_content_in_original_bundle.head": "Has files",
   "search.filters.filter.has_content_in_original_bundle.head": "Besitzt Dateien",
+  
+  // "search.filters.filter.itemtype.head": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.head": "Type",
+  
+  // "search.filters.filter.itemtype.placeholder": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.placeholder": "Type",
+  
+  // "search.filters.filter.jobTitle.head": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.head": "Job Title",
+  
+  // "search.filters.filter.jobTitle.placeholder": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.placeholder": "Job Title",
+  
+  // "search.filters.filter.knowsLanguage.head": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.head": "Known language",
+  
+  // "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  
+  // "search.filters.filter.namedresourcetype.head": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.head": "Status",
+  
+  // "search.filters.filter.namedresourcetype.placeholder": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.placeholder": "Status",
+  
+  // "search.filters.filter.objectpeople.head": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.head": "People",
+  
+  // "search.filters.filter.objectpeople.placeholder": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.placeholder": "People",
+  
+  // "search.filters.filter.organizationAddressCountry.head": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.head": "Country",
+  
+  // "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  
+  // "search.filters.filter.organizationAddressLocality.head": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.head": "City",
+  
+  // "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  
+  // "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  
+  // "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  
+  // "search.filters.filter.scope.head": "Scope",
   "search.filters.filter.scope.head": "Bereich",
+  
+  // "search.filters.filter.scope.placeholder": "Scope filter",
   "search.filters.filter.scope.placeholder": "Bereichsfilter",
+  
+  // "search.filters.filter.show-less": "Collapse",
   "search.filters.filter.show-less": "Zeige weniger",
+  
+  // "search.filters.filter.show-more": "Show more",
   "search.filters.filter.show-more": "Zeige mehr",
+  
+  // "search.filters.filter.subject.head": "Subject",
   "search.filters.filter.subject.head": "Schlagwort",
+  
+  // "search.filters.filter.subject.placeholder": "Subject",
   "search.filters.filter.subject.placeholder": "Schlagwort",
-
+  
+  // "search.filters.filter.submitter.head": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.head": "Submitter",
+  
+  // "search.filters.filter.submitter.placeholder": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.placeholder": "Submitter",
+  
+  
+  
+  // "search.filters.head": "Filters",
   "search.filters.head": "Filter",
+  
+  // "search.filters.reset": "Reset filters",
   "search.filters.reset": "Filter zurücksetzen",
-
+  
+  
+  
+  // "search.form.search": "Search",
   "search.form.search": "Suche",
+  
+  // "search.form.search_dspace": "Search DSpace",
   "search.form.search_dspace": "DSpace durchsuchen",
-
+  
+  // "search.form.search_mydspace": "Search MyDSpace",
+  // TODO New key - Add a translation
+  "search.form.search_mydspace": "Search MyDSpace",
+  
+  
+  
+  // "search.results.head": "Search Results",
   "search.results.head": "Suchergebnisse",
+  
+  // "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
   "search.results.no-results": "Zu dieser Suche gibt es keine Treffer.",
-
+  
+  // "search.results.no-results-link": "quotes around it",
+  // TODO New key - Add a translation
+  "search.results.no-results-link": "quotes around it",
+  
+  
+  
+  // "search.sidebar.close": "Back to results",
   "search.sidebar.close": "Zurück zu den Ergebnissen",
+  
+  // "search.sidebar.filters.title": "Filters",
   "search.sidebar.filters.title": "Filter",
+  
+  // "search.sidebar.open": "Search Tools",
   "search.sidebar.open": "Suchwerkzeuge",
+  
+  // "search.sidebar.results": "results",
   "search.sidebar.results": "Ergebnisse",
+  
+  // "search.sidebar.settings.rpp": "Results per page",
   "search.sidebar.settings.rpp": "Treffer pro Seite",
+  
+  // "search.sidebar.settings.sort-by": "Sort By",
   "search.sidebar.settings.sort-by": "Sortiere nach",
+  
+  // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "Einstellungen",
-
+  
+  
+  
+  // "search.view-switch.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "search.view-switch.show-detail": "Show detail",
+  
+  // "search.view-switch.show-grid": "Show as grid",
   "search.view-switch.show-grid": "Zeige als Raster",
+  
+  // "search.view-switch.show-list": "Show as list",
   "search.view-switch.show-list": "Zeige als Liste",
-
+  
+  
+  
+  // "sorting.dc.title.ASC": "Title Ascending",
   "sorting.dc.title.ASC": "Titel aufsteigend",
+  
+  // "sorting.dc.title.DESC": "Title Descending",
   "sorting.dc.title.DESC": "Titel absteigend",
+  
+  // "sorting.score.DESC": "Relevance",
   "sorting.score.DESC": "Relevanz",
-
+  
+  
+  
+  // "submission.edit.title": "Edit Submission",
+  // TODO New key - Add a translation
+  "submission.edit.title": "Edit Submission",
+  
+  // "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  // TODO New key - Add a translation
+  "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  
+  // "submission.general.deposit": "Deposit",
+  // TODO New key - Add a translation
+  "submission.general.deposit": "Deposit",
+  
+  // "submission.general.discard.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.cancel": "Cancel",
+  
+  // "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.general.discard.confirm.title": "Discard submission",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.title": "Discard submission",
+  
+  // "submission.general.discard.submit": "Discard",
+  // TODO New key - Add a translation
+  "submission.general.discard.submit": "Discard",
+  
+  // "submission.general.save": "Save",
+  // TODO New key - Add a translation
+  "submission.general.save": "Save",
+  
+  // "submission.general.save-later": "Save for later",
+  // TODO New key - Add a translation
+  "submission.general.save-later": "Save for later",
+  
+  
+  
+  // "submission.sections.general.add-more": "Add more",
+  // TODO New key - Add a translation
+  "submission.sections.general.add-more": "Add more",
+  
+  // "submission.sections.general.collection": "Collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.collection": "Collection",
+  
+  // "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  
+  // "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  
+  // "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  
+  // "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  
+  // "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  
+  // "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  
+  // "submission.sections.general.no-collection": "No collection found",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-collection": "No collection found",
+  
+  // "submission.sections.general.no-sections": "No options available",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-sections": "No options available",
+  
+  // "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  
+  // "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  
+  // "submission.sections.general.search-collection": "Search for a collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.search-collection": "Search for a collection",
+  
+  // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  // TODO New key - Add a translation
+  "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  
+  
+  
+  // "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  
+  // "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  
+  // "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  
+  // "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  
+  // "submission.sections.submit.progressbar.license": "Deposit license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.license": "Deposit license",
+  
+  // "submission.sections.submit.progressbar.upload": "Upload files",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.upload": "Upload files",
+  
+  
+  
+  // "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  
+  // "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  
+  // "submission.sections.upload.delete.submit": "Delete",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.submit": "Delete",
+  
+  // "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  // TODO New key - Add a translation
+  "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  
+  // "submission.sections.upload.form.access-condition-label": "Access condition type",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.access-condition-label": "Access condition type",
+  
+  // "submission.sections.upload.form.date-required": "Date is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.date-required": "Date is required.",
+  
+  // "submission.sections.upload.form.from-label": "Access grant from",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-label": "Access grant from",
+  
+  // "submission.sections.upload.form.from-placeholder": "From",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-placeholder": "From",
+  
+  // "submission.sections.upload.form.group-label": "Group",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-label": "Group",
+  
+  // "submission.sections.upload.form.group-required": "Group is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-required": "Group is required.",
+  
+  // "submission.sections.upload.form.until-label": "Access grant until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-label": "Access grant until",
+  
+  // "submission.sections.upload.form.until-placeholder": "Until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-placeholder": "Until",
+  
+  // "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  
+  // "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  
+  // "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  // TODO New key - Add a translation
+  "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  
+  // "submission.sections.upload.no-entry": "No",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-entry": "No",
+  
+  // "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  
+  // "submission.sections.upload.save-metadata": "Save metadata",
+  // TODO New key - Add a translation
+  "submission.sections.upload.save-metadata": "Save metadata",
+  
+  // "submission.sections.upload.undo": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.undo": "Cancel",
+  
+  // "submission.sections.upload.upload-failed": "Upload failed",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-failed": "Upload failed",
+  
+  // "submission.sections.upload.upload-successful": "Upload successful",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-successful": "Upload successful",
+  
+  
+  
+  // "submission.submit.title": "Submission",
+  // TODO New key - Add a translation
+  "submission.submit.title": "Submission",
+  
+  
+  
+  // "submission.workflow.generic.delete": "Delete",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete": "Delete",
+  
+  // "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  
+  // "submission.workflow.generic.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit": "Edit",
+  
+  // "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.generic.view": "View",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view": "View",
+  
+  // "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  
+  
+  
+  // "submission.workflow.tasks.claimed.approve": "Approve",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve": "Approve",
+  
+  // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  
+  // "submission.workflow.tasks.claimed.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit": "Edit",
+  
+  // "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  
+  // "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  
+  // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.return": "Return to pool",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return": "Return to pool",
+  
+  // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  
+  
+  
+  // "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  
+  // "submission.workflow.tasks.generic.processing": "Processing...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.processing": "Processing...",
+  
+  // "submission.workflow.tasks.generic.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.submitter": "Submitter",
+  
+  // "submission.workflow.tasks.generic.success": "Operation successful",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.success": "Operation successful",
+  
+  
+  
+  // "submission.workflow.tasks.pool.claim": "Claim",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim": "Claim",
+  
+  // "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  
+  // "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  
+  // "submission.workflow.tasks.pool.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.show-detail": "Show detail",
+  
+  
+  
+  // "title": "DSpace",
   "title": "DSpace",
+  
+  
+  
+  // "uploader.browse": "browse",
+  // TODO New key - Add a translation
+  "uploader.browse": "browse",
+  
+  // "uploader.drag-message": "Drag & Drop your files here",
+  // TODO New key - Add a translation
+  "uploader.drag-message": "Drag & Drop your files here",
+  
+  // "uploader.or": ", or",
+  // TODO New key - Add a translation
+  "uploader.or": ", or",
+  
+  // "uploader.processing": "Processing",
+  // TODO New key - Add a translation
+  "uploader.processing": "Processing",
+  
+  // "uploader.queue-length": "Queue length",
+  // TODO New key - Add a translation
+  "uploader.queue-length": "Queue length",
+  
+  
+  
+
 }

--- a/resources/i18n/de.json5
+++ b/resources/i18n/de.json5
@@ -770,6 +770,10 @@
   // "error.community": "Error fetching community",
   "error.community": "Fehler beim Laden des Bereiches.",
   
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
+  
   // "error.default": "Error",
   "error.default": "Fehler",
   

--- a/resources/i18n/de.json5
+++ b/resources/i18n/de.json5
@@ -769,6 +769,9 @@
   
   // "error.community": "Error fetching community",
   "error.community": "Fehler beim Laden des Bereiches.",
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
   
   // "error.identifier": "No item found for the identifier",
   // TODO New key - Add a translation

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -1,845 +1,1688 @@
 {
+
   "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
+
   "404.link.home-page": "Take me to the home page",
+
   "404.page-not-found": "page not found",
 
+
+
   "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+
   "admin.registries.bitstream-formats.create.failure.head": "Failure",
+
   "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+
   "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+
   "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+
   "admin.registries.bitstream-formats.create.success.head": "Success",
+
   "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+
   "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+
   "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+
   "admin.registries.bitstream-formats.delete.success.head": "Success",
+
   "admin.registries.bitstream-formats.description": "This list of bitstream formats provides information about known formats and their support level.",
+
   "admin.registries.bitstream-formats.edit.description.hint": "",
+
   "admin.registries.bitstream-formats.edit.description.label": "Description",
+
   "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+
   "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+
   "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+
   "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+
   "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+
   "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+
   "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+
   "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+
   "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+
   "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+
   "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+
   "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+
   "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+
   "admin.registries.bitstream-formats.edit.success.head": "Success",
+
   "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+
   "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+
   "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
+
   "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+
   "admin.registries.bitstream-formats.table.delete": "Delete selected",
+
   "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+
   "admin.registries.bitstream-formats.table.internal": "internal",
+
   "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+
   "admin.registries.bitstream-formats.table.name": "Name",
+
   "admin.registries.bitstream-formats.table.return": "Return",
+
   "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+
   "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+
   "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+
   "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+
   "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Format Registry",
 
+
+
   "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DSpace requires the qualified Dublin Core schema.",
+
   "admin.registries.metadata.form.create": "Create metadata schema",
+
   "admin.registries.metadata.form.edit": "Edit metadata schema",
+
   "admin.registries.metadata.form.name": "Name",
+
   "admin.registries.metadata.form.namespace": "Namespace",
+
   "admin.registries.metadata.head": "Metadata Registry",
+
   "admin.registries.metadata.schemas.no-items": "No metadata schemas to show.",
+
   "admin.registries.metadata.schemas.table.delete": "Delete selected",
+
   "admin.registries.metadata.schemas.table.id": "ID",
+
   "admin.registries.metadata.schemas.table.name": "Name",
+
   "admin.registries.metadata.schemas.table.namespace": "Namespace",
+
   "admin.registries.metadata.title": "DSpace Angular :: Metadata Registry",
 
+
+
   "admin.registries.schema.description": "This is the metadata schema for \"{{namespace}}\".",
+
   "admin.registries.schema.fields.head": "Schema metadata fields",
+
   "admin.registries.schema.fields.no-items": "No metadata fields to show.",
+
   "admin.registries.schema.fields.table.delete": "Delete selected",
+
   "admin.registries.schema.fields.table.field": "Field",
+
   "admin.registries.schema.fields.table.scopenote": "Scope Note",
+
   "admin.registries.schema.form.create": "Create metadata field",
+
   "admin.registries.schema.form.edit": "Edit metadata field",
+
   "admin.registries.schema.form.element": "Element",
+
   "admin.registries.schema.form.qualifier": "Qualifier",
+
   "admin.registries.schema.form.scopenote": "Scope Note",
+
   "admin.registries.schema.head": "Metadata Schema",
+
   "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+
   "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+
   "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+
   "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+
   "admin.registries.schema.notification.failure": "Error",
+
   "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+
   "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+
   "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+
   "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+
   "admin.registries.schema.notification.success": "Success",
+
   "admin.registries.schema.return": "Return",
+
   "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Registry",
 
+
+
   "auth.errors.invalid-user": "Invalid email address or password.",
+
   "auth.messages.expired": "Your session has expired. Please log in again.",
 
+
+
   "browse.comcol.by.author": "By Author",
+
   "browse.comcol.by.dateissued": "By Issue Date",
+
   "browse.comcol.by.subject": "By Subject",
+
   "browse.comcol.by.title": "By Title",
+
   "browse.comcol.head": "Browse",
+
   "browse.empty": "No items to show.",
+
   "browse.metadata.author": "Author",
+
   "browse.metadata.dateissued": "Issue Date",
+
   "browse.metadata.subject": "Subject",
+
   "browse.metadata.title": "Title",
+
   "browse.startsWith.choose_start": "(Choose start)",
+
   "browse.startsWith.choose_year": "(Choose year)",
+
   "browse.startsWith.jump": "Jump to a point in the index:",
+
   "browse.startsWith.months.april": "April",
+
   "browse.startsWith.months.august": "August",
+
   "browse.startsWith.months.december": "December",
+
   "browse.startsWith.months.february": "February",
+
   "browse.startsWith.months.january": "January",
+
   "browse.startsWith.months.july": "July",
+
   "browse.startsWith.months.june": "June",
+
   "browse.startsWith.months.march": "March",
+
   "browse.startsWith.months.may": "May",
+
   "browse.startsWith.months.none": "(Choose month)",
+
   "browse.startsWith.months.november": "November",
+
   "browse.startsWith.months.october": "October",
+
   "browse.startsWith.months.september": "September",
+
   "browse.startsWith.submit": "Go",
+
   "browse.startsWith.type_date": "Or type in a date (year-month):",
+
   "browse.startsWith.type_text": "Or enter first few letters:",
+
   "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
+
+
 
   "chips.remove": "Remove chip",
 
+
+
   "collection.create.head": "Create a Collection",
+
   "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+
   "collection.delete.cancel": "Cancel",
+
   "collection.delete.confirm": "Confirm",
+
   "collection.delete.head": "Delete Collection",
+
   "collection.delete.notification.fail": "Collection could not be deleted",
+
   "collection.delete.notification.success": "Successfully deleted collection",
+
   "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
 
+
+
   "collection.edit.delete": "Delete this collection",
+
   "collection.edit.head": "Edit Collection",
 
+
+
   "collection.edit.item-mapper.cancel": "Cancel",
+
   "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+
   "collection.edit.item-mapper.confirm": "Map selected items",
+
   "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+
   "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+
   "collection.edit.item-mapper.no-search": "Please enter a query to search",
+
   "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+
   "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+
   "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+
   "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+
   "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+
   "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+
   "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+
   "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+
   "collection.edit.item-mapper.remove": "Remove selected item mappings",
+
   "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+
   "collection.edit.item-mapper.tabs.map": "Map new items",
 
+
+
   "collection.form.abstract": "Short Description",
+
   "collection.form.description": "Introductory text (HTML)",
+
   "collection.form.errors.title.required": "Please enter a collection name",
+
   "collection.form.license": "License",
+
   "collection.form.provenance": "Provenance",
+
   "collection.form.rights": "Copyright text (HTML)",
+
   "collection.form.tableofcontents": "News (HTML)",
+
   "collection.form.title": "Name",
 
+
+
   "collection.page.browse.recent.head": "Recent Submissions",
+
   "collection.page.browse.recent.empty": "No items to show",
+
   "collection.page.handle": "Permanent URI for this collection",
+
   "collection.page.license": "License",
+
   "collection.page.news": "News",
 
+
+
   "collection.select.confirm": "Confirm selected",
+
   "collection.select.empty": "No collections to show",
+
   "collection.select.table.title": "Title",
 
+
+
   "community.create.head": "Create a Community",
+
   "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+
   "community.delete.cancel": "Cancel",
+
   "community.delete.confirm": "Confirm",
+
   "community.delete.head": "Delete Community",
+
   "community.delete.notification.fail": "Community could not be deleted",
+
   "community.delete.notification.success": "Successfully deleted community",
+
   "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+
   "community.edit.delete": "Delete this community",
+
   "community.edit.head": "Edit Community",
+
   "community.form.abstract": "Short Description",
+
   "community.form.description": "Introductory text (HTML)",
+
   "community.form.errors.title.required": "Please enter a community name",
+
   "community.form.rights": "Copyright text (HTML)",
+
   "community.form.tableofcontents": "News (HTML)",
+
   "community.form.title": "Name",
+
   "community.page.handle": "Permanent URI for this community",
+
   "community.page.license": "License",
+
   "community.page.news": "News",
+
   "community.all-lists.head": "Subcommunities and Collections",
+
   "community.sub-collection-list.head": "Collections of this Community",
+
   "community.sub-community-list.head": "Communities of this Community",
 
+
+
   "dso-selector.create.collection.head": "New collection",
+
   "dso-selector.create.community.head": "New community",
+
   "dso-selector.create.community.sub-level": "Create a new community in",
+
   "dso-selector.create.community.top-level": "Create a new top-level community",
+
   "dso-selector.create.item.head": "New item",
+
   "dso-selector.edit.collection.head": "Edit collection",
+
   "dso-selector.edit.community.head": "Edit community",
+
   "dso-selector.edit.item.head": "Edit item",
+
   "dso-selector.no-results": "No {{ type }} found",
+
   "dso-selector.placeholder": "Search for a {{ type }}",
 
+
+
   "error.browse-by": "Error fetching items",
+
   "error.collection": "Error fetching collection",
+
   "error.collections": "Error fetching collections",
+
   "error.community": "Error fetching community",
   "error.identifier": "No item found for the identifier",
   "error.default": "Error",
+
   "error.item": "Error fetching item",
+
   "error.items": "Error fetching items",
+
   "error.objects": "Error fetching objects",
+
   "error.recent-submissions": "Error fetching recent submissions",
+
   "error.search-results": "Error fetching search results",
+
   "error.sub-collections": "Error fetching sub-collections",
+
   "error.sub-communities": "Error fetching sub-communities",
+
   "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+
   "error.top-level-communities": "Error fetching top-level communities",
+
   "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
+
   "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
 
+
+
   "footer.copyright": "copyright © 2002-{{ year }}",
+
   "footer.link.dspace": "DSpace software",
+
   "footer.link.duraspace": "DuraSpace",
 
+
+
   "form.cancel": "Cancel",
+
   "form.clear": "Clear",
+
   "form.clear-help": "Click here to remove the selected value",
+
   "form.edit": "Edit",
+
   "form.edit-help": "Click here to edit the selected value",
+
   "form.first-name": "First name",
+
   "form.group-collapse": "Collapse",
+
   "form.group-collapse-help": "Click here to collapse",
+
   "form.group-expand": "Expand",
+
   "form.group-expand-help": "Click here to expand and add more elements",
+
   "form.last-name": "Last name",
+
   "form.loading": "Loading...",
+
   "form.no-results": "No results found",
+
   "form.no-value": "No value entered",
+
   "form.other-information": {},
+
   "form.remove": "Remove",
+
   "form.save": "Save",
+
   "form.save-help": "Save changes",
+
   "form.search": "Search",
+
   "form.search-help": "Click here to looking for an existing correspondence",
+
   "form.submit": "Submit",
 
+
+
   "home.description": "",
+
   "home.title": "DSpace Angular :: Home",
+
   "home.top-level-communities.head": "Communities in DSpace",
+
   "home.top-level-communities.help": "Select a community to browse its collections.",
 
+
+
   "item.edit.delete.cancel": "Cancel",
+
   "item.edit.delete.confirm": "Delete",
+
   "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+
   "item.edit.delete.error": "An error occurred while deleting the item",
+
   "item.edit.delete.header": "Delete item: {{ id }}",
+
   "item.edit.delete.success": "The item has been deleted",
+
   "item.edit.head": "Edit Item",
 
+
+
   "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+
   "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+
   "item.edit.item-mapper.cancel": "Cancel",
+
   "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+
   "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+
   "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+
   "item.edit.item-mapper.no-search": "Please enter a query to search",
+
   "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+
   "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+
   "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+
   "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+
   "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+
   "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+
   "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+
   "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+
   "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+
   "item.edit.item-mapper.tabs.map": "Map new collections",
 
+
+
   "item.edit.metadata.add-button": "Add",
+
   "item.edit.metadata.discard-button": "Discard",
+
   "item.edit.metadata.edit.buttons.edit": "Edit",
+
   "item.edit.metadata.edit.buttons.remove": "Remove",
+
   "item.edit.metadata.edit.buttons.undo": "Undo changes",
+
   "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+
   "item.edit.metadata.headers.edit": "Edit",
+
   "item.edit.metadata.headers.field": "Field",
+
   "item.edit.metadata.headers.language": "Lang",
+
   "item.edit.metadata.headers.value": "Value",
+
   "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+
   "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+
   "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+
   "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+
   "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+
   "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+
   "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+
   "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+
   "item.edit.metadata.notifications.saved.title": "Metadata saved",
+
   "item.edit.metadata.reinstate-button": "Undo",
+
   "item.edit.metadata.save-button": "Save",
 
+
+
   "item.edit.modify.overview.field": "Field",
+
   "item.edit.modify.overview.language": "Language",
+
   "item.edit.modify.overview.value": "Value",
 
+
+
   "item.edit.move.cancel": "Cancel",
+
   "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+
   "item.edit.move.error": "An error occured when attempting to move the item",
+
   "item.edit.move.head": "Move item: {{id}}",
+
   "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+
   "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+
   "item.edit.move.move": "Move",
+
   "item.edit.move.processing": "Moving...",
+
   "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+
   "item.edit.move.success": "The item has been moved succesfully",
+
   "item.edit.move.title": "Move item",
 
+
+
   "item.edit.private.cancel": "Cancel",
+
   "item.edit.private.confirm": "Make it Private",
+
   "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+
   "item.edit.private.error": "An error occurred while making the item private",
+
   "item.edit.private.header": "Make item private: {{ id }}",
+
   "item.edit.private.success": "The item is now private",
 
+
+
   "item.edit.public.cancel": "Cancel",
+
   "item.edit.public.confirm": "Make it Public",
+
   "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+
   "item.edit.public.error": "An error occurred while making the item public",
+
   "item.edit.public.header": "Make item public: {{ id }}",
+
   "item.edit.public.success": "The item is now public",
 
+
+
   "item.edit.reinstate.cancel": "Cancel",
+
   "item.edit.reinstate.confirm": "Reinstate",
+
   "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+
   "item.edit.reinstate.error": "An error occurred while reinstating the item",
+
   "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+
   "item.edit.reinstate.success": "The item was reinstated successfully",
 
+
+
   "item.edit.relationships.discard-button": "Discard",
+
   "item.edit.relationships.edit.buttons.remove": "Remove",
+
   "item.edit.relationships.edit.buttons.undo": "Undo changes",
+
   "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+
   "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+
   "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+
   "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+
   "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+
   "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+
   "item.edit.relationships.notifications.saved.title": "Relationships saved",
+
   "item.edit.relationships.reinstate-button": "Undo",
+
   "item.edit.relationships.save-button": "Save",
 
+
+
   "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+
   "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+
   "item.edit.tabs.curate.head": "Curate",
+
   "item.edit.tabs.curate.title": "Item Edit - Curate",
+
   "item.edit.tabs.metadata.head": "Item Metadata",
+
   "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+
   "item.edit.tabs.relationships.head": "Item Relationships",
+
   "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+
   "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+
   "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+
   "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+
   "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+
   "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+
   "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+
   "item.edit.tabs.status.buttons.move.button": "Move...",
+
   "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+
   "item.edit.tabs.status.buttons.private.button": "Make it private...",
+
   "item.edit.tabs.status.buttons.private.label": "Make item private",
+
   "item.edit.tabs.status.buttons.public.button": "Make it public...",
+
   "item.edit.tabs.status.buttons.public.label": "Make item public",
+
   "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+
   "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+
   "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+
   "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+
   "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+
   "item.edit.tabs.status.head": "Item Status",
+
   "item.edit.tabs.status.labels.handle": "Handle",
+
   "item.edit.tabs.status.labels.id": "Item Internal ID",
+
   "item.edit.tabs.status.labels.itemPage": "Item Page",
+
   "item.edit.tabs.status.labels.lastModified": "Last Modified",
+
   "item.edit.tabs.status.title": "Item Edit -  Status",
+
   "item.edit.tabs.view.head": "View Item",
+
   "item.edit.tabs.view.title": "Item Edit -  View",
 
+
+
   "item.edit.withdraw.cancel": "Cancel",
+
   "item.edit.withdraw.confirm": "Withdraw",
+
   "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+
   "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+
   "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+
   "item.edit.withdraw.success": "The item was withdrawn successfully",
 
+
+
   "item.page.abstract": "Abstract",
+
   "item.page.author": "Authors",
+
   "item.page.citation": "Citation",
+
   "item.page.collections": "Collections",
+
   "item.page.date": "Date",
+
   "item.page.files": "Files",
+
   "item.page.filesection.description": "Description:",
+
   "item.page.filesection.download": "Download",
+
   "item.page.filesection.format": "Format:",
+
   "item.page.filesection.name": "Name:",
+
   "item.page.filesection.size": "Size:",
+
   "item.page.journal.search.title": "Articles in this journal",
+
   "item.page.link.full": "Full item page",
+
   "item.page.link.simple": "Simple item page",
+
   "item.page.person.search.title": "Articles by this author",
+
   "item.page.related-items.view-more": "View more",
+
   "item.page.related-items.view-less": "View less",
+
   "item.page.subject": "Keywords",
+
   "item.page.uri": "URI",
 
+
+
   "item.select.confirm": "Confirm selected",
+
   "item.select.empty": "No items to show",
+
   "item.select.table.author": "Author",
+
   "item.select.table.collection": "Collection",
+
   "item.select.table.title": "Title",
 
+
+
   "journal.listelement.badge": "Journal",
+
   "journal.page.description": "Description",
+
   "journal.page.editor": "Editor-in-Chief",
+
   "journal.page.issn": "ISSN",
+
   "journal.page.publisher": "Publisher",
+
   "journal.page.titleprefix": "Journal: ",
+
   "journal.search.results.head": "Journal Search Results",
+
   "journal.search.title": "DSpace Angular :: Journal Search",
 
+
+
   "journalissue.listelement.badge": "Journal Issue",
+
   "journalissue.page.description": "Description",
+
   "journalissue.page.issuedate": "Issue Date",
+
   "journalissue.page.journal-issn": "Journal ISSN",
+
   "journalissue.page.journal-title": "Journal Title",
+
   "journalissue.page.keyword": "Keywords",
+
   "journalissue.page.number": "Number",
+
   "journalissue.page.titleprefix": "Journal Issue: ",
 
+
+
   "journalvolume.listelement.badge": "Journal Volume",
+
   "journalvolume.page.description": "Description",
+
   "journalvolume.page.issuedate": "Issue Date",
+
   "journalvolume.page.titleprefix": "Journal Volume: ",
+
   "journalvolume.page.volume": "Volume",
 
+
+
   "loading.browse-by": "Loading items...",
+
   "loading.browse-by-page": "Loading page...",
+
   "loading.collection": "Loading collection...",
+
   "loading.collections": "Loading collections...",
+
   "loading.community": "Loading community...",
+
   "loading.default": "Loading...",
+
   "loading.item": "Loading item...",
+
   "loading.items": "Loading items...",
+
   "loading.mydspace-results": "Loading items...",
+
   "loading.objects": "Loading...",
+
   "loading.recent-submissions": "Loading recent submissions...",
+
   "loading.search-results": "Loading search results...",
+
   "loading.sub-collections": "Loading sub-collections...",
+
   "loading.sub-communities": "Loading sub-communities...",
+
   "loading.top-level-communities": "Loading top-level communities...",
 
+
+
   "login.form.email": "Email address",
+
   "login.form.forgot-password": "Have you forgotten your password?",
+
   "login.form.header": "Please log in to DSpace",
+
   "login.form.new-user": "New user? Click here to register.",
+
   "login.form.password": "Password",
+
   "login.form.submit": "Log in",
+
   "login.title": "Login",
 
+
+
   "logout.form.header": "Log out from DSpace",
+
   "logout.form.submit": "Log out",
+
   "logout.title": "Logout",
 
+
+
   "menu.header.admin": "Admin",
+
   "menu.header.image.logo": "Repository logo",
 
+
+
   "menu.section.access_control": "Access Control",
+
   "menu.section.access_control_authorizations": "Authorizations",
+
   "menu.section.access_control_groups": "Groups",
+
   "menu.section.access_control_people": "People",
 
+
+
   "menu.section.browse_community": "This Community",
+
   "menu.section.browse_community_by_author": "By Author",
+
   "menu.section.browse_community_by_issue_date": "By Issue Date",
+
   "menu.section.browse_community_by_title": "By Title",
+
   "menu.section.browse_global": "All of DSpace",
+
   "menu.section.browse_global_by_author": "By Author",
+
   "menu.section.browse_global_by_dateissued": "By Issue Date",
+
   "menu.section.browse_global_by_subject": "By Subject",
+
   "menu.section.browse_global_by_title": "By Title",
+
   "menu.section.browse_global_communities_and_collections": "Communities & Collections",
 
+
+
   "menu.section.control_panel": "Control Panel",
+
   "menu.section.curation_task": "Curation Task",
 
+
+
   "menu.section.edit": "Edit",
+
   "menu.section.edit_collection": "Collection",
+
   "menu.section.edit_community": "Community",
+
   "menu.section.edit_item": "Item",
 
+
+
   "menu.section.export": "Export",
+
   "menu.section.export_collection": "Collection",
+
   "menu.section.export_community": "Community",
+
   "menu.section.export_item": "Item",
+
   "menu.section.export_metadata": "Metadata",
 
+
+
   "menu.section.find": "Find",
+
   "menu.section.find_items": "Items",
+
   "menu.section.find_private_items": "Private Items",
+
   "menu.section.find_withdrawn_items": "Withdrawn Items",
 
+
+
   "menu.section.icon.access_control": "Access Control menu section",
+
   "menu.section.icon.control_panel": "Control Panel menu section",
+
   "menu.section.icon.curation_task": "Curation Task menu section",
+
   "menu.section.icon.edit": "Edit menu section",
+
   "menu.section.icon.export": "Export menu section",
+
   "menu.section.icon.find": "Find menu section",
+
   "menu.section.icon.import": "Import menu section",
+
   "menu.section.icon.new": "New menu section",
+
   "menu.section.icon.pin": "Pin sidebar",
+
   "menu.section.icon.registries": "Registries menu section",
+
   "menu.section.icon.statistics_task": "Statistics Task menu section",
+
   "menu.section.icon.unpin": "Unpin sidebar",
 
+
+
   "menu.section.import": "Import",
+
   "menu.section.import_batch": "Batch Import (ZIP)",
+
   "menu.section.import_metadata": "Metadata",
 
+
+
   "menu.section.new": "New",
+
   "menu.section.new_collection": "Collection",
+
   "menu.section.new_community": "Community",
+
   "menu.section.new_item": "Item",
+
   "menu.section.new_item_version": "Item Version",
 
+
+
   "menu.section.pin": "Pin sidebar",
+
   "menu.section.unpin": "Unpin sidebar",
 
+
+
   "menu.section.registries": "Registries",
+
   "menu.section.registries_format": "Format",
+
   "menu.section.registries_metadata": "Metadata",
 
+
+
   "menu.section.statistics": "Statistics",
+
   "menu.section.statistics_task": "Statistics Task",
 
+
+
   "menu.section.toggle.access_control": "Toggle Access Control section",
+
   "menu.section.toggle.control_panel": "Toggle Control Panel section",
+
   "menu.section.toggle.curation_task": "Toggle Curation Task section",
+
   "menu.section.toggle.edit": "Toggle Edit section",
+
   "menu.section.toggle.export": "Toggle Export section",
+
   "menu.section.toggle.find": "Toggle Find section",
+
   "menu.section.toggle.import": "Toggle Import section",
+
   "menu.section.toggle.new": "Toggle New section",
+
   "menu.section.toggle.registries": "Toggle Registries section",
+
   "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
 
+
+
   "mydspace.description": "",
+
   "mydspace.general.text-here": "HERE",
+
   "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+
   "mydspace.messages.description-placeholder": "Insert your message here...",
+
   "mydspace.messages.hide-msg": "Hide message",
+
   "mydspace.messages.mark-as-read": "Mark as read",
+
   "mydspace.messages.mark-as-unread": "Mark as unread",
+
   "mydspace.messages.no-content": "No content.",
+
   "mydspace.messages.no-messages": "No messages yet.",
+
   "mydspace.messages.send-btn": "Send",
+
   "mydspace.messages.show-msg": "Show message",
+
   "mydspace.messages.subject-placeholder": "Subject...",
+
   "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+
   "mydspace.messages.title": "Messages",
+
   "mydspace.messages.to": "To",
+
   "mydspace.new-submission": "New submission",
+
   "mydspace.results.head": "Your submissions",
+
   "mydspace.results.no-abstract": "No Abstract",
+
   "mydspace.results.no-authors": "No Authors",
+
   "mydspace.results.no-collections": "No Collections",
+
   "mydspace.results.no-date": "No Date",
+
   "mydspace.results.no-files": "No Files",
+
   "mydspace.results.no-results": "There were no items to show",
+
   "mydspace.results.no-title": "No title",
+
   "mydspace.results.no-uri": "No Uri",
+
   "mydspace.show.workflow": "All tasks",
+
   "mydspace.show.workspace": "Your Submissions",
+
   "mydspace.status.archived": "Archived",
+
   "mydspace.status.validation": "Validation",
+
   "mydspace.status.waiting-for-controller": "Waiting for controller",
+
   "mydspace.status.workflow": "Workflow",
+
   "mydspace.status.workspace": "Workspace",
+
   "mydspace.title": "MyDSpace",
+
   "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+
   "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+
   "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+
   "mydspace.view-btn": "View",
 
+
+
   "nav.browse.header": "All of DSpace",
+
   "nav.community-browse.header": "By Community",
+
   "nav.language": "Language switch",
+
   "nav.login": "Log In",
+
   "nav.logout": "Log Out",
+
   "nav.mydspace": "MyDSpace",
+
   "nav.search": "Search",
+
   "nav.statistics.header": "Statistics",
 
+
+
   "orgunit.listelement.badge": "Organizational Unit",
+
   "orgunit.page.city": "City",
+
   "orgunit.page.country": "Country",
+
   "orgunit.page.dateestablished": "Date established",
+
   "orgunit.page.description": "Description",
+
   "orgunit.page.id": "ID",
+
   "orgunit.page.titleprefix": "Organizational Unit: ",
 
+
+
   "pagination.results-per-page": "Results Per Page",
+
   "pagination.showing.detail": "{{ range }} of {{ total }}",
+
   "pagination.showing.label": "Now showing ",
+
   "pagination.sort-direction": "Sort Options",
 
+
+
   "person.listelement.badge": "Person",
+
   "person.page.birthdate": "Birth Date",
+
   "person.page.email": "Email Address",
+
   "person.page.firstname": "First Name",
+
   "person.page.jobtitle": "Job Title",
+
   "person.page.lastname": "Last Name",
+
   "person.page.link.full": "Show all metadata",
+
   "person.page.orcid": "ORCID",
+
   "person.page.staffid": "Staff ID",
+
   "person.page.titleprefix": "Person: ",
+
   "person.search.results.head": "Person Search Results",
+
   "person.search.title": "DSpace Angular :: Person Search",
 
+
+
   "project.listelement.badge": "Research Project",
+
   "project.page.contributor": "Contributors",
+
   "project.page.description": "Description",
+
   "project.page.expectedcompletion": "Expected Completion",
+
   "project.page.funder": "Funders",
+
   "project.page.id": "ID",
+
   "project.page.keyword": "Keywords",
+
   "project.page.status": "Status",
+
   "project.page.titleprefix": "Research Project: ",
 
+
+
   "publication.listelement.badge": "Publication",
+
   "publication.page.description": "Description",
+
   "publication.page.journal-issn": "Journal ISSN",
+
   "publication.page.journal-title": "Journal Title",
+
   "publication.page.publisher": "Publisher",
+
   "publication.page.titleprefix": "Publication: ",
+
   "publication.page.volume-title": "Volume Title",
+
   "publication.search.results.head": "Publication Search Results",
+
   "publication.search.title": "DSpace Angular :: Publication Search",
 
+
+
   "relationships.isAuthorOf": "Authors",
+
   "relationships.isIssueOf": "Journal Issues",
+
   "relationships.isJournalIssueOf": "Journal Issue",
+
   "relationships.isJournalOf": "Journals",
+
   "relationships.isOrgUnitOf": "Organizational Units",
+
   "relationships.isPersonOf": "Authors",
+
   "relationships.isProjectOf": "Research Projects",
+
   "relationships.isPublicationOf": "Publications",
+
   "relationships.isPublicationOfJournalIssue": "Articles",
+
   "relationships.isSingleJournalOf": "Journal",
+
   "relationships.isSingleVolumeOf": "Journal Volume",
+
   "relationships.isVolumeOf": "Journal Volumes",
 
+
+
   "search.description": "",
+
   "search.switch-configuration.title": "Show",
+
   "search.title": "DSpace Angular :: Search",
 
+
+
   "search.filters.applied.f.author": "Author",
+
   "search.filters.applied.f.dateIssued.max": "End date",
+
   "search.filters.applied.f.dateIssued.min": "Start date",
+
   "search.filters.applied.f.dateSubmitted": "Date submitted",
+
   "search.filters.applied.f.entityType": "Item Type",
+
   "search.filters.applied.f.has_content_in_original_bundle": "Has files",
+
   "search.filters.applied.f.itemtype": "Type",
+
   "search.filters.applied.f.namedresourcetype": "Status",
+
   "search.filters.applied.f.subject": "Subject",
+
   "search.filters.applied.f.submitter": "Submitter",
 
+
+
   "search.filters.filter.author.head": "Author",
+
   "search.filters.filter.author.placeholder": "Author name",
+
   "search.filters.filter.birthDate.head": "Birth Date",
+
   "search.filters.filter.birthDate.placeholder": "Birth Date",
+
   "search.filters.filter.creativeDatePublished.head": "Date Published",
+
   "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+
   "search.filters.filter.creativeWorkEditor.head": "Editor",
+
   "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+
   "search.filters.filter.creativeWorkKeywords.head": "Subject",
+
   "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+
   "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+
   "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+
   "search.filters.filter.dateIssued.head": "Date",
+
   "search.filters.filter.dateIssued.max.placeholder": "Minimum Date",
+
   "search.filters.filter.dateIssued.min.placeholder": "Maximum Date",
+
   "search.filters.filter.dateSubmitted.head": "Date submitted",
+
   "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+
   "search.filters.filter.entityType.head": "Item Type",
+
   "search.filters.filter.entityType.placeholder": "Item Type",
+
   "search.filters.filter.has_content_in_original_bundle.head": "Has files",
+
   "search.filters.filter.itemtype.head": "Type",
+
   "search.filters.filter.itemtype.placeholder": "Type",
+
   "search.filters.filter.jobTitle.head": "Job Title",
+
   "search.filters.filter.jobTitle.placeholder": "Job Title",
+
   "search.filters.filter.knowsLanguage.head": "Known language",
+
   "search.filters.filter.knowsLanguage.placeholder": "Known language",
+
   "search.filters.filter.namedresourcetype.head": "Status",
+
   "search.filters.filter.namedresourcetype.placeholder": "Status",
+
   "search.filters.filter.objectpeople.head": "People",
+
   "search.filters.filter.objectpeople.placeholder": "People",
+
   "search.filters.filter.organizationAddressCountry.head": "Country",
+
   "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+
   "search.filters.filter.organizationAddressLocality.head": "City",
+
   "search.filters.filter.organizationAddressLocality.placeholder": "City",
+
   "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+
   "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+
   "search.filters.filter.scope.head": "Scope",
+
   "search.filters.filter.scope.placeholder": "Scope filter",
+
   "search.filters.filter.show-less": "Collapse",
+
   "search.filters.filter.show-more": "Show more",
+
   "search.filters.filter.subject.head": "Subject",
+
   "search.filters.filter.subject.placeholder": "Subject",
+
   "search.filters.filter.submitter.head": "Submitter",
+
   "search.filters.filter.submitter.placeholder": "Submitter",
 
+
+
   "search.filters.head": "Filters",
+
   "search.filters.reset": "Reset filters",
 
+
+
   "search.form.search": "Search",
+
   "search.form.search_dspace": "Search DSpace",
+
   "search.form.search_mydspace": "Search MyDSpace",
 
+
+
   "search.results.head": "Search Results",
+
   "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
+
   "search.results.no-results-link": "quotes around it",
 
+
+
   "search.sidebar.close": "Back to results",
+
   "search.sidebar.filters.title": "Filters",
+
   "search.sidebar.open": "Search Tools",
+
   "search.sidebar.results": "results",
+
   "search.sidebar.settings.rpp": "Results per page",
+
   "search.sidebar.settings.sort-by": "Sort By",
+
   "search.sidebar.settings.title": "Settings",
 
+
+
   "search.view-switch.show-detail": "Show detail",
+
   "search.view-switch.show-grid": "Show as grid",
+
   "search.view-switch.show-list": "Show as list",
 
+
+
   "sorting.dc.title.ASC": "Title Ascending",
+
   "sorting.dc.title.DESC": "Title Descending",
+
   "sorting.score.DESC": "Relevance",
 
+
+
   "submission.edit.title": "Edit Submission",
+
   "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+
   "submission.general.deposit": "Deposit",
+
   "submission.general.discard.confirm.cancel": "Cancel",
+
   "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+
   "submission.general.discard.confirm.submit": "Yes, I'm sure",
+
   "submission.general.discard.confirm.title": "Discard submission",
+
   "submission.general.discard.submit": "Discard",
+
   "submission.general.save": "Save",
+
   "submission.general.save-later": "Save for later",
 
+
+
   "submission.sections.general.add-more": "Add more",
+
   "submission.sections.general.collection": "Collection",
+
   "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+
   "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+
   "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+
   "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+
   "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+
   "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+
   "submission.sections.general.no-collection": "No collection found",
+
   "submission.sections.general.no-sections": "No options available",
+
   "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+
   "submission.sections.general.save_success_notice": "Submission saved successfully.",
+
   "submission.sections.general.search-collection": "Search for a collection",
+
   "submission.sections.general.sections_not_valid": "There are incomplete sections.",
 
+
+
   "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+
   "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+
   "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+
   "submission.sections.submit.progressbar.describe.stepone": "Describe",
+
   "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+
   "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+
   "submission.sections.submit.progressbar.license": "Deposit license",
+
   "submission.sections.submit.progressbar.upload": "Upload files",
 
+
+
   "submission.sections.upload.delete.confirm.cancel": "Cancel",
+
   "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+
   "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+
   "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+
   "submission.sections.upload.delete.submit": "Delete",
+
   "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+
   "submission.sections.upload.form.access-condition-label": "Access condition type",
+
   "submission.sections.upload.form.date-required": "Date is required.",
+
   "submission.sections.upload.form.from-label": "Access grant from",
+
   "submission.sections.upload.form.from-placeholder": "From",
+
   "submission.sections.upload.form.group-label": "Group",
+
   "submission.sections.upload.form.group-required": "Group is required.",
+
   "submission.sections.upload.form.until-label": "Access grant until",
+
   "submission.sections.upload.form.until-placeholder": "Until",
+
   "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+
   "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+
   "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+
   "submission.sections.upload.no-entry": "No",
+
   "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+
   "submission.sections.upload.save-metadata": "Save metadata",
+
   "submission.sections.upload.undo": "Cancel",
+
   "submission.sections.upload.upload-failed": "Upload failed",
+
   "submission.sections.upload.upload-successful": "Upload successful",
+
+
 
   "submission.submit.title": "Submission",
 
+
+
   "submission.workflow.generic.delete": "Delete",
+
   "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+
   "submission.workflow.generic.edit": "Edit",
+
   "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+
   "submission.workflow.generic.view": "View",
+
   "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
 
+
+
   "submission.workflow.tasks.claimed.approve": "Approve",
+
   "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+
   "submission.workflow.tasks.claimed.edit": "Edit",
+
   "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+
   "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+
   "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+
   "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+
   "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+
   "submission.workflow.tasks.claimed.reject.submit": "Reject",
+
   "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+
   "submission.workflow.tasks.claimed.return": "Return to pool",
+
   "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
 
+
+
   "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+
   "submission.workflow.tasks.generic.processing": "Processing...",
+
   "submission.workflow.tasks.generic.submitter": "Submitter",
+
   "submission.workflow.tasks.generic.success": "Operation successful",
 
+
+
   "submission.workflow.tasks.pool.claim": "Claim",
+
   "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+
   "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+
   "submission.workflow.tasks.pool.show-detail": "Show detail",
+
+
 
   "title": "DSpace",
 
+
+
   "uploader.browse": "browse",
+
   "uploader.drag-message": "Drag & Drop your files here",
+
   "uploader.or": ", or",
+
   "uploader.processing": "Processing",
+
   "uploader.queue-length": "Queue length",
+
 }
+

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -415,7 +415,13 @@
   "error.collections": "Error fetching collections",
 
   "error.community": "Error fetching community",
+<<<<<<< HEAD
   "error.identifier": "No item found for the identifier",
+=======
+
+  "error.identifier": "No item found for the identifier",
+
+>>>>>>> Merged new message keys from dspace/master and ran script again
   "error.default": "Error",
 
   "error.item": "Error fetching item",

--- a/resources/i18n/nl.json5
+++ b/resources/i18n/nl.json5
@@ -769,6 +769,9 @@
   
   // "error.community": "Error fetching community",
   "error.community": "Fout bij het ophalen van een community",
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
   
   // "error.identifier": "No item found for the identifier",
   // TODO New key - Add a translation

--- a/resources/i18n/nl.json5
+++ b/resources/i18n/nl.json5
@@ -1,175 +1,3083 @@
 {
+  
+  // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
   "404.help": "De pagina die u zoekt kan niet gevonden worden. De pagina werd mogelijk verplaatst of verwijderd. U kan onderstaande knop gebruiken om terug naar de homepagina te gaan. ",
+  
+  // "404.link.home-page": "Take me to the home page",
   "404.link.home-page": "Terug naar de homepagina",
+  
+  // "404.page-not-found": "page not found",
   "404.page-not-found": "Pagina niet gevonden",
-
+  
+  
+  
+  // "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  
+  // "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  
+  // "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  
+  // "admin.registries.bitstream-formats.create.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.create.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  
+  // "admin.registries.bitstream-formats.delete.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.delete.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.description": "This list of bitstream formats provides information about known formats and their support level.",
   "admin.registries.bitstream-formats.description": "Deze lijst van Bitstream formaten biedt informatie over de formaten die in deze repository zijn toegelaten en op welke manier ze ondersteund worden. De term Bitstream wordt in DSpace gebruikt om een bestand aan te duiden dat samen met metadata onderdeel uitmaakt van een item. De naam bitstream duidt op het feit dat het bestand achterliggend wordt opgeslaan zonder bestandsextensie.",
-  "admin.registries.bitstream-formats.formats.no-items": "Er kunnen geen bitstreamformaten getoond worden.",
-  "admin.registries.bitstream-formats.formats.table.internal": "intern",
-  "admin.registries.bitstream-formats.formats.table.mimetype": "MIME Type",
-  "admin.registries.bitstream-formats.formats.table.name": "Naam",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.0": "Onbekend",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.1": "Gekend",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.2": "Ondersteund",
-  "admin.registries.bitstream-formats.formats.table.supportLevel.head": "Ondersteuning",
+  
+  // "admin.registries.bitstream-formats.edit.description.hint": "",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.hint": "",
+  
+  // "admin.registries.bitstream-formats.edit.description.label": "Description",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.description.label": "Description",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  
+  // "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extenstion without the dot",
+  
+  // "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  
+  // "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  
+  // "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  
+  // "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are are hidden from the user, and used for administrative purposes.",
+  
+  // "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  
+  // "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  
+  // "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  
+  // "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  
+  // "admin.registries.bitstream-formats.edit.success.head": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.success.head": "Success",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  
+  // "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  
+  // "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
   "admin.registries.bitstream-formats.head": "Bitstream Formaat Register",
+  
+  // "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  
+  // "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  
+  // "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  
+  // "admin.registries.bitstream-formats.table.internal": "internal",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.internal": "internal",
+  
+  // "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  
+  // "admin.registries.bitstream-formats.table.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.name": "Name",
+  
+  // "admin.registries.bitstream-formats.table.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.return": "Return",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  
+  // "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  // TODO New key - Add a translation
+  "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  
+  // "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Format Registry",
   "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Formaat Register",
-
+  
+  
+  
+  // "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DSpace requires the qualified Dublin Core schema.",
   "admin.registries.metadata.description": "Het metadataregister omvat de lijst van alle metadatavelden die beschikbaar zijn in het systeem. Deze velden kunnen verspreid zijn over verschillende metadataschema's. Het qualified Dublin Core schema (dc) is een verplicht schema en kan niet worden verwijderd.",
+  
+  // "admin.registries.metadata.form.create": "Create metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.create": "Create metadata schema",
+  
+  // "admin.registries.metadata.form.edit": "Edit metadata schema",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.edit": "Edit metadata schema",
+  
+  // "admin.registries.metadata.form.name": "Name",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.name": "Name",
+  
+  // "admin.registries.metadata.form.namespace": "Namespace",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.form.namespace": "Namespace",
+  
+  // "admin.registries.metadata.head": "Metadata Registry",
   "admin.registries.metadata.head": "Metadata Register",
+  
+  // "admin.registries.metadata.schemas.no-items": "No metadata schemas to show.",
   "admin.registries.metadata.schemas.no-items": "Er kunnen geen metadataschema's getoond worden.",
+  
+  // "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  
+  // "admin.registries.metadata.schemas.table.id": "ID",
   "admin.registries.metadata.schemas.table.id": "ID",
+  
+  // "admin.registries.metadata.schemas.table.name": "Name",
   "admin.registries.metadata.schemas.table.name": "Naam",
+  
+  // "admin.registries.metadata.schemas.table.namespace": "Namespace",
   "admin.registries.metadata.schemas.table.namespace": "Naamruimte",
+  
+  // "admin.registries.metadata.title": "DSpace Angular :: Metadata Registry",
   "admin.registries.metadata.title": "DSpace Angular :: Metadata Register",
-
+  
+  
+  
+  // "admin.registries.schema.description": "This is the metadata schema for \"{{namespace}}\".",
   "admin.registries.schema.description": "Dit is het metadataschema voor \"{{namespace}}\".",
+  
+  // "admin.registries.schema.fields.head": "Schema metadata fields",
   "admin.registries.schema.fields.head": "Schema metadatavelden",
+  
+  // "admin.registries.schema.fields.no-items": "No metadata fields to show.",
   "admin.registries.schema.fields.no-items": "Er kunnen geen metadatavelden getoond worden.",
+  
+  // "admin.registries.schema.fields.table.delete": "Delete selected",
+  // TODO New key - Add a translation
+  "admin.registries.schema.fields.table.delete": "Delete selected",
+  
+  // "admin.registries.schema.fields.table.field": "Field",
   "admin.registries.schema.fields.table.field": "Veld",
+  
+  // "admin.registries.schema.fields.table.scopenote": "Scope Note",
   "admin.registries.schema.fields.table.scopenote": "Opmerking over bereik",
+  
+  // "admin.registries.schema.form.create": "Create metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.create": "Create metadata field",
+  
+  // "admin.registries.schema.form.edit": "Edit metadata field",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.edit": "Edit metadata field",
+  
+  // "admin.registries.schema.form.element": "Element",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.element": "Element",
+  
+  // "admin.registries.schema.form.qualifier": "Qualifier",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.qualifier": "Qualifier",
+  
+  // "admin.registries.schema.form.scopenote": "Scope Note",
+  // TODO New key - Add a translation
+  "admin.registries.schema.form.scopenote": "Scope Note",
+  
+  // "admin.registries.schema.head": "Metadata Schema",
   "admin.registries.schema.head": "Metadata Schema",
+  
+  // "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  
+  // "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  
+  // "admin.registries.schema.notification.failure": "Error",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.failure": "Error",
+  
+  // "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  
+  // "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  
+  // "admin.registries.schema.notification.success": "Success",
+  // TODO New key - Add a translation
+  "admin.registries.schema.notification.success": "Success",
+  
+  // "admin.registries.schema.return": "Return",
+  // TODO New key - Add a translation
+  "admin.registries.schema.return": "Return",
+  
+  // "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Registry",
   "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Register",
-
+  
+  
+  
+  // "auth.errors.invalid-user": "Invalid email address or password.",
   "auth.errors.invalid-user": "Ongeldig e-mailadres of wachtwoord.",
+  
+  // "auth.messages.expired": "Your session has expired. Please log in again.",
   "auth.messages.expired": "Uw sessie is vervallen. Gelieve opnieuw aan te melden.",
-
+  
+  
+  
+  // "browse.comcol.by.author": "By Author",
+  // TODO New key - Add a translation
+  "browse.comcol.by.author": "By Author",
+  
+  // "browse.comcol.by.dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "browse.comcol.by.dateissued": "By Issue Date",
+  
+  // "browse.comcol.by.subject": "By Subject",
+  // TODO New key - Add a translation
+  "browse.comcol.by.subject": "By Subject",
+  
+  // "browse.comcol.by.title": "By Title",
+  // TODO New key - Add a translation
+  "browse.comcol.by.title": "By Title",
+  
+  // "browse.comcol.head": "Browse",
+  // TODO New key - Add a translation
+  "browse.comcol.head": "Browse",
+  
+  // "browse.empty": "No items to show.",
+  // TODO New key - Add a translation
+  "browse.empty": "No items to show.",
+  
+  // "browse.metadata.author": "Author",
+  // TODO New key - Add a translation
+  "browse.metadata.author": "Author",
+  
+  // "browse.metadata.dateissued": "Issue Date",
+  // TODO New key - Add a translation
+  "browse.metadata.dateissued": "Issue Date",
+  
+  // "browse.metadata.subject": "Subject",
+  // TODO New key - Add a translation
+  "browse.metadata.subject": "Subject",
+  
+  // "browse.metadata.title": "Title",
+  // TODO New key - Add a translation
+  "browse.metadata.title": "Title",
+  
+  // "browse.startsWith.choose_start": "(Choose start)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_start": "(Choose start)",
+  
+  // "browse.startsWith.choose_year": "(Choose year)",
+  // TODO New key - Add a translation
+  "browse.startsWith.choose_year": "(Choose year)",
+  
+  // "browse.startsWith.jump": "Jump to a point in the index:",
+  // TODO New key - Add a translation
+  "browse.startsWith.jump": "Jump to a point in the index:",
+  
+  // "browse.startsWith.months.april": "April",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.april": "April",
+  
+  // "browse.startsWith.months.august": "August",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.august": "August",
+  
+  // "browse.startsWith.months.december": "December",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.december": "December",
+  
+  // "browse.startsWith.months.february": "February",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.february": "February",
+  
+  // "browse.startsWith.months.january": "January",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.january": "January",
+  
+  // "browse.startsWith.months.july": "July",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.july": "July",
+  
+  // "browse.startsWith.months.june": "June",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.june": "June",
+  
+  // "browse.startsWith.months.march": "March",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.march": "March",
+  
+  // "browse.startsWith.months.may": "May",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.may": "May",
+  
+  // "browse.startsWith.months.none": "(Choose month)",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.none": "(Choose month)",
+  
+  // "browse.startsWith.months.november": "November",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.november": "November",
+  
+  // "browse.startsWith.months.october": "October",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.october": "October",
+  
+  // "browse.startsWith.months.september": "September",
+  // TODO New key - Add a translation
+  "browse.startsWith.months.september": "September",
+  
+  // "browse.startsWith.submit": "Go",
+  // TODO New key - Add a translation
+  "browse.startsWith.submit": "Go",
+  
+  // "browse.startsWith.type_date": "Or type in a date (year-month):",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_date": "Or type in a date (year-month):",
+  
+  // "browse.startsWith.type_text": "Or enter first few letters:",
+  // TODO New key - Add a translation
+  "browse.startsWith.type_text": "Or enter first few letters:",
+  
+  // "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
   "browse.title": "Verken {{ collection }} volgens {{ field }} {{ value }}",
-
+  
+  
+  
+  // "chips.remove": "Remove chip",
+  // TODO New key - Add a translation
+  "chips.remove": "Remove chip",
+  
+  
+  
+  // "collection.create.head": "Create a Collection",
+  // TODO New key - Add a translation
+  "collection.create.head": "Create a Collection",
+  
+  // "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  
+  // "collection.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.delete.cancel": "Cancel",
+  
+  // "collection.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "collection.delete.confirm": "Confirm",
+  
+  // "collection.delete.head": "Delete Collection",
+  // TODO New key - Add a translation
+  "collection.delete.head": "Delete Collection",
+  
+  // "collection.delete.notification.fail": "Collection could not be deleted",
+  // TODO New key - Add a translation
+  "collection.delete.notification.fail": "Collection could not be deleted",
+  
+  // "collection.delete.notification.success": "Successfully deleted collection",
+  // TODO New key - Add a translation
+  "collection.delete.notification.success": "Successfully deleted collection",
+  
+  // "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  
+  
+  
+  // "collection.edit.delete": "Delete this collection",
+  // TODO New key - Add a translation
+  "collection.edit.delete": "Delete this collection",
+  
+  // "collection.edit.head": "Edit Collection",
+  // TODO New key - Add a translation
+  "collection.edit.head": "Edit Collection",
+  
+  
+  
+  // "collection.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.cancel": "Cancel",
+  
+  // "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  
+  // "collection.edit.item-mapper.confirm": "Map selected items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.confirm": "Map selected items",
+  
+  // "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  
+  // "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  
+  // "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  
+  // "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  
+  // "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  
+  // "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  
+  // "collection.edit.item-mapper.tabs.map": "Map new items",
+  // TODO New key - Add a translation
+  "collection.edit.item-mapper.tabs.map": "Map new items",
+  
+  
+  
+  // "collection.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "collection.form.abstract": "Short Description",
+  
+  // "collection.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.description": "Introductory text (HTML)",
+  
+  // "collection.form.errors.title.required": "Please enter a collection name",
+  // TODO New key - Add a translation
+  "collection.form.errors.title.required": "Please enter a collection name",
+  
+  // "collection.form.license": "License",
+  // TODO New key - Add a translation
+  "collection.form.license": "License",
+  
+  // "collection.form.provenance": "Provenance",
+  // TODO New key - Add a translation
+  "collection.form.provenance": "Provenance",
+  
+  // "collection.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.rights": "Copyright text (HTML)",
+  
+  // "collection.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "collection.form.tableofcontents": "News (HTML)",
+  
+  // "collection.form.title": "Name",
+  // TODO New key - Add a translation
+  "collection.form.title": "Name",
+  
+  
+  
+  // "collection.page.browse.recent.head": "Recent Submissions",
   "collection.page.browse.recent.head": "Recent toegevoegd",
+  
+  // "collection.page.browse.recent.empty": "No items to show",
+  // TODO New key - Add a translation
+  "collection.page.browse.recent.empty": "No items to show",
+  
+  // "collection.page.handle": "Permanent URI for this collection",
+  // TODO New key - Add a translation
+  "collection.page.handle": "Permanent URI for this collection",
+  
+  // "collection.page.license": "License",
   "collection.page.license": "Licentie",
+  
+  // "collection.page.news": "News",
   "collection.page.news": "Nieuws",
-
+  
+  
+  
+  // "collection.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "collection.select.confirm": "Confirm selected",
+  
+  // "collection.select.empty": "No collections to show",
+  // TODO New key - Add a translation
+  "collection.select.empty": "No collections to show",
+  
+  // "collection.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "collection.select.table.title": "Title",
+  
+  
+  
+  // "community.create.head": "Create a Community",
+  // TODO New key - Add a translation
+  "community.create.head": "Create a Community",
+  
+  // "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  // TODO New key - Add a translation
+  "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  
+  // "community.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "community.delete.cancel": "Cancel",
+  
+  // "community.delete.confirm": "Confirm",
+  // TODO New key - Add a translation
+  "community.delete.confirm": "Confirm",
+  
+  // "community.delete.head": "Delete Community",
+  // TODO New key - Add a translation
+  "community.delete.head": "Delete Community",
+  
+  // "community.delete.notification.fail": "Community could not be deleted",
+  // TODO New key - Add a translation
+  "community.delete.notification.fail": "Community could not be deleted",
+  
+  // "community.delete.notification.success": "Successfully deleted community",
+  // TODO New key - Add a translation
+  "community.delete.notification.success": "Successfully deleted community",
+  
+  // "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  // TODO New key - Add a translation
+  "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  
+  // "community.edit.delete": "Delete this community",
+  // TODO New key - Add a translation
+  "community.edit.delete": "Delete this community",
+  
+  // "community.edit.head": "Edit Community",
+  // TODO New key - Add a translation
+  "community.edit.head": "Edit Community",
+  
+  // "community.form.abstract": "Short Description",
+  // TODO New key - Add a translation
+  "community.form.abstract": "Short Description",
+  
+  // "community.form.description": "Introductory text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.description": "Introductory text (HTML)",
+  
+  // "community.form.errors.title.required": "Please enter a community name",
+  // TODO New key - Add a translation
+  "community.form.errors.title.required": "Please enter a community name",
+  
+  // "community.form.rights": "Copyright text (HTML)",
+  // TODO New key - Add a translation
+  "community.form.rights": "Copyright text (HTML)",
+  
+  // "community.form.tableofcontents": "News (HTML)",
+  // TODO New key - Add a translation
+  "community.form.tableofcontents": "News (HTML)",
+  
+  // "community.form.title": "Name",
+  // TODO New key - Add a translation
+  "community.form.title": "Name",
+  
+  // "community.page.handle": "Permanent URI for this community",
+  // TODO New key - Add a translation
+  "community.page.handle": "Permanent URI for this community",
+  
+  // "community.page.license": "License",
   "community.page.license": "Licentie",
+  
+  // "community.page.news": "News",
   "community.page.news": "Nieuws",
+  
+  // "community.all-lists.head": "Subcommunities and Collections",
+  // TODO New key - Add a translation
+  "community.all-lists.head": "Subcommunities and Collections",
+  
+  // "community.sub-collection-list.head": "Collections of this Community",
   "community.sub-collection-list.head": "Collecties in deze Community",
-
+  
+  // "community.sub-community-list.head": "Communities of this Community",
+  // TODO New key - Add a translation
+  "community.sub-community-list.head": "Communities of this Community",
+  
+  
+  
+  // "dso-selector.create.collection.head": "New collection",
+  // TODO New key - Add a translation
+  "dso-selector.create.collection.head": "New collection",
+  
+  // "dso-selector.create.community.head": "New community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.head": "New community",
+  
+  // "dso-selector.create.community.sub-level": "Create a new community in",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.sub-level": "Create a new community in",
+  
+  // "dso-selector.create.community.top-level": "Create a new top-level community",
+  // TODO New key - Add a translation
+  "dso-selector.create.community.top-level": "Create a new top-level community",
+  
+  // "dso-selector.create.item.head": "New item",
+  // TODO New key - Add a translation
+  "dso-selector.create.item.head": "New item",
+  
+  // "dso-selector.edit.collection.head": "Edit collection",
+  // TODO New key - Add a translation
+  "dso-selector.edit.collection.head": "Edit collection",
+  
+  // "dso-selector.edit.community.head": "Edit community",
+  // TODO New key - Add a translation
+  "dso-selector.edit.community.head": "Edit community",
+  
+  // "dso-selector.edit.item.head": "Edit item",
+  // TODO New key - Add a translation
+  "dso-selector.edit.item.head": "Edit item",
+  
+  // "dso-selector.no-results": "No {{ type }} found",
+  // TODO New key - Add a translation
+  "dso-selector.no-results": "No {{ type }} found",
+  
+  // "dso-selector.placeholder": "Search for a {{ type }}",
+  // TODO New key - Add a translation
+  "dso-selector.placeholder": "Search for a {{ type }}",
+  
+  
+  
+  // "error.browse-by": "Error fetching items",
   "error.browse-by": "Fout bij het ophalen van items",
+  
+  // "error.collection": "Error fetching collection",
   "error.collection": "Fout bij het ophalen van een collectie",
+  
+  // "error.collections": "Error fetching collections",
+  // TODO New key - Add a translation
+  "error.collections": "Error fetching collections",
+  
+  // "error.community": "Error fetching community",
   "error.community": "Fout bij het ophalen van een community",
+  
+  // "error.default": "Error",
   "error.default": "Fout",
+  
+  // "error.item": "Error fetching item",
   "error.item": "Fout bij het ophalen van items",
+  
+  // "error.items": "Error fetching items",
+  // TODO New key - Add a translation
+  "error.items": "Error fetching items",
+  
+  // "error.objects": "Error fetching objects",
   "error.objects": "Fout bij het ophalen van objecten",
+  
+  // "error.recent-submissions": "Error fetching recent submissions",
   "error.recent-submissions": "Fout bij het ophalen van recent toegevoegde items",
+  
+  // "error.search-results": "Error fetching search results",
   "error.search-results": "Fout bij het ophalen van zoekresultaten",
+  
+  // "error.sub-collections": "Error fetching sub-collections",
   "error.sub-collections": "Fout bij het ophalen van sub-collecties",
+  
+  // "error.sub-communities": "Error fetching sub-communities",
+  // TODO New key - Add a translation
+  "error.sub-communities": "Error fetching sub-communities",
+  
+  // "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  // TODO New key - Add a translation
+  "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  
+  // "error.top-level-communities": "Error fetching top-level communities",
   "error.top-level-communities": "Fout bij het inladen van communities op het hoogste niveau",
+  
+  // "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
   "error.validation.license.notgranted": "U moet de invoerlicentie goedkeuren om de invoer af te werken. Indien u deze licentie momenteel niet kan of mag goedkeuren, kan u uw werk opslaan en de invoer later afwerken. U kunt dit nieuwe item ook verwijderen indien u niet voldoet aan de vereisten van de invoerlicentie.",
-  "error.validation.pattern": "Deze invoer is niet toegelaten volgens dit patroon: {{ pattern }}.",
-
+  
+  // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  // TODO New key - Add a translation
+  "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  
+  
+  
+  // "footer.copyright": "copyright © 2002-{{ year }}",
   "footer.copyright": "copyright © 2002-{{ year }}",
+  
+  // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
+  
+  // "footer.link.duraspace": "DuraSpace",
   "footer.link.duraspace": "DuraSpace",
-
+  
+  
+  
+  // "form.cancel": "Cancel",
   "form.cancel": "Annuleer",
+  
+  // "form.clear": "Clear",
+  // TODO New key - Add a translation
+  "form.clear": "Clear",
+  
+  // "form.clear-help": "Click here to remove the selected value",
+  // TODO New key - Add a translation
+  "form.clear-help": "Click here to remove the selected value",
+  
+  // "form.edit": "Edit",
+  // TODO New key - Add a translation
+  "form.edit": "Edit",
+  
+  // "form.edit-help": "Click here to edit the selected value",
+  // TODO New key - Add a translation
+  "form.edit-help": "Click here to edit the selected value",
+  
+  // "form.first-name": "First name",
   "form.first-name": "Voornaam",
+  
+  // "form.group-collapse": "Collapse",
   "form.group-collapse": "Inklappen",
+  
+  // "form.group-collapse-help": "Click here to collapse",
   "form.group-collapse-help": "Klik hier op in te klappen",
+  
+  // "form.group-expand": "Expand",
   "form.group-expand": "Uitklappen",
+  
+  // "form.group-expand-help": "Click here to expand and add more elements",
   "form.group-expand-help": "Klik hier om uit te klappen en om meer onderdelen toe te voegen",
+  
+  // "form.last-name": "Last name",
   "form.last-name": "Achternaam",
+  
+  // "form.loading": "Loading...",
   "form.loading": "Inladen...",
+  
+  // "form.no-results": "No results found",
   "form.no-results": "Geen resultaten gevonden",
+  
+  // "form.no-value": "No value entered",
   "form.no-value": "Geen waarde ingevoerd",
+  
+  // "form.other-information": {},
+  // TODO New key - Add a translation
+  "form.other-information": {},
+  
+  // "form.remove": "Remove",
   "form.remove": "Verwijder",
+  
+  // "form.save": "Save",
+  // TODO New key - Add a translation
+  "form.save": "Save",
+  
+  // "form.save-help": "Save changes",
+  // TODO New key - Add a translation
+  "form.save-help": "Save changes",
+  
+  // "form.search": "Search",
   "form.search": "Zoek",
+  
+  // "form.search-help": "Click here to looking for an existing correspondence",
+  // TODO New key - Add a translation
+  "form.search-help": "Click here to looking for an existing correspondence",
+  
+  // "form.submit": "Submit",
   "form.submit": "Verstuur",
-
+  
+  
+  
+  // "home.description": "",
   "home.description": "",
+  
+  // "home.title": "DSpace Angular :: Home",
   "home.title": "DSpace Angular :: Home",
+  
+  // "home.top-level-communities.head": "Communities in DSpace",
   "home.top-level-communities.head": "Communities in DSpace",
+  
+  // "home.top-level-communities.help": "Select a community to browse its collections.",
   "home.top-level-communities.help": "Selecteer een community om diens collecties te verkennen.",
-
+  
+  
+  
+  // "item.edit.delete.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.delete.cancel": "Cancel",
+  
+  // "item.edit.delete.confirm": "Delete",
+  // TODO New key - Add a translation
+  "item.edit.delete.confirm": "Delete",
+  
+  // "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  // TODO New key - Add a translation
+  "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  
+  // "item.edit.delete.error": "An error occurred while deleting the item",
+  // TODO New key - Add a translation
+  "item.edit.delete.error": "An error occurred while deleting the item",
+  
+  // "item.edit.delete.header": "Delete item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.delete.header": "Delete item: {{ id }}",
+  
+  // "item.edit.delete.success": "The item has been deleted",
+  // TODO New key - Add a translation
+  "item.edit.delete.success": "The item has been deleted",
+  
+  // "item.edit.head": "Edit Item",
+  // TODO New key - Add a translation
+  "item.edit.head": "Edit Item",
+  
+  
+  
+  // "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  
+  // "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  
+  // "item.edit.item-mapper.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.cancel": "Cancel",
+  
+  // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  
+  // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  
+  // "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  
+  // "item.edit.item-mapper.no-search": "Please enter a query to search",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.no-search": "Please enter a query to search",
+  
+  // "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  
+  // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  
+  // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  
+  // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  
+  // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  
+  // "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  
+  // "item.edit.item-mapper.tabs.map": "Map new collections",
+  // TODO New key - Add a translation
+  "item.edit.item-mapper.tabs.map": "Map new collections",
+  
+  
+  
+  // "item.edit.metadata.add-button": "Add",
+  // TODO New key - Add a translation
+  "item.edit.metadata.add-button": "Add",
+  
+  // "item.edit.metadata.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.metadata.discard-button": "Discard",
+  
+  // "item.edit.metadata.edit.buttons.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.edit": "Edit",
+  
+  // "item.edit.metadata.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.remove": "Remove",
+  
+  // "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  
+  // "item.edit.metadata.headers.edit": "Edit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.edit": "Edit",
+  
+  // "item.edit.metadata.headers.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.field": "Field",
+  
+  // "item.edit.metadata.headers.language": "Lang",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.language": "Lang",
+  
+  // "item.edit.metadata.headers.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.value": "Value",
+  
+  // "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  // TODO New key - Add a translation
+  "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  
+  // "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.discarded.title": "Changed discarded",
+  
+  // "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  
+  // "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  
+  // "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.outdated.title": "Changed outdated",
+  
+  // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  
+  // "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  // TODO New key - Add a translation
+  "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  
+  // "item.edit.metadata.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.metadata.reinstate-button": "Undo",
+  
+  // "item.edit.metadata.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.metadata.save-button": "Save",
+  
+  
+  
+  // "item.edit.modify.overview.field": "Field",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.field": "Field",
+  
+  // "item.edit.modify.overview.language": "Language",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.language": "Language",
+  
+  // "item.edit.modify.overview.value": "Value",
+  // TODO New key - Add a translation
+  "item.edit.modify.overview.value": "Value",
+  
+  
+  
+  // "item.edit.move.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.move.cancel": "Cancel",
+  
+  // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  // TODO New key - Add a translation
+  "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  
+  // "item.edit.move.error": "An error occured when attempting to move the item",
+  // TODO New key - Add a translation
+  "item.edit.move.error": "An error occured when attempting to move the item",
+  
+  // "item.edit.move.head": "Move item: {{id}}",
+  // TODO New key - Add a translation
+  "item.edit.move.head": "Move item: {{id}}",
+  
+  // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  
+  // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  
+  // "item.edit.move.move": "Move",
+  // TODO New key - Add a translation
+  "item.edit.move.move": "Move",
+  
+  // "item.edit.move.processing": "Moving...",
+  // TODO New key - Add a translation
+  "item.edit.move.processing": "Moving...",
+  
+  // "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  // TODO New key - Add a translation
+  "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  
+  // "item.edit.move.success": "The item has been moved succesfully",
+  // TODO New key - Add a translation
+  "item.edit.move.success": "The item has been moved succesfully",
+  
+  // "item.edit.move.title": "Move item",
+  // TODO New key - Add a translation
+  "item.edit.move.title": "Move item",
+  
+  
+  
+  // "item.edit.private.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.private.cancel": "Cancel",
+  
+  // "item.edit.private.confirm": "Make it Private",
+  // TODO New key - Add a translation
+  "item.edit.private.confirm": "Make it Private",
+  
+  // "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  
+  // "item.edit.private.error": "An error occurred while making the item private",
+  // TODO New key - Add a translation
+  "item.edit.private.error": "An error occurred while making the item private",
+  
+  // "item.edit.private.header": "Make item private: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.private.header": "Make item private: {{ id }}",
+  
+  // "item.edit.private.success": "The item is now private",
+  // TODO New key - Add a translation
+  "item.edit.private.success": "The item is now private",
+  
+  
+  
+  // "item.edit.public.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.public.cancel": "Cancel",
+  
+  // "item.edit.public.confirm": "Make it Public",
+  // TODO New key - Add a translation
+  "item.edit.public.confirm": "Make it Public",
+  
+  // "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  // TODO New key - Add a translation
+  "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  
+  // "item.edit.public.error": "An error occurred while making the item public",
+  // TODO New key - Add a translation
+  "item.edit.public.error": "An error occurred while making the item public",
+  
+  // "item.edit.public.header": "Make item public: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.public.header": "Make item public: {{ id }}",
+  
+  // "item.edit.public.success": "The item is now public",
+  // TODO New key - Add a translation
+  "item.edit.public.success": "The item is now public",
+  
+  
+  
+  // "item.edit.reinstate.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.cancel": "Cancel",
+  
+  // "item.edit.reinstate.confirm": "Reinstate",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.confirm": "Reinstate",
+  
+  // "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  
+  // "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  
+  // "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  
+  // "item.edit.reinstate.success": "The item was reinstated successfully",
+  // TODO New key - Add a translation
+  "item.edit.reinstate.success": "The item was reinstated successfully",
+  
+  
+  
+  // "item.edit.relationships.discard-button": "Discard",
+  // TODO New key - Add a translation
+  "item.edit.relationships.discard-button": "Discard",
+  
+  // "item.edit.relationships.edit.buttons.remove": "Remove",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.remove": "Remove",
+  
+  // "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  // TODO New key - Add a translation
+  "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  
+  // "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  
+  // "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  
+  // "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.failed.title": "Error deleting relationship",
+  
+  // "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  
+  // "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  
+  // "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  
+  // "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  // TODO New key - Add a translation
+  "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  
+  // "item.edit.relationships.reinstate-button": "Undo",
+  // TODO New key - Add a translation
+  "item.edit.relationships.reinstate-button": "Undo",
+  
+  // "item.edit.relationships.save-button": "Save",
+  // TODO New key - Add a translation
+  "item.edit.relationships.save-button": "Save",
+  
+  
+  
+  // "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.head": "Item Bitstreams",
+  
+  // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  // TODO New key - Add a translation
+  "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  
+  // "item.edit.tabs.curate.head": "Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.head": "Curate",
+  
+  // "item.edit.tabs.curate.title": "Item Edit - Curate",
+  // TODO New key - Add a translation
+  "item.edit.tabs.curate.title": "Item Edit - Curate",
+  
+  // "item.edit.tabs.metadata.head": "Item Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.head": "Item Metadata",
+  
+  // "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  // TODO New key - Add a translation
+  "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
+  
+  // "item.edit.tabs.relationships.head": "Item Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.head": "Item Relationships",
+  
+  // "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  // TODO New key - Add a translation
+  "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  
+  // "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  
+  // "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  
+  // "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  
+  // "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  
+  // "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  
+  // "item.edit.tabs.status.buttons.move.button": "Move...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.button": "Move...",
+  
+  // "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  
+  // "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  
+  // "item.edit.tabs.status.buttons.private.label": "Make item private",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.private.label": "Make item private",
+  
+  // "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  
+  // "item.edit.tabs.status.buttons.public.label": "Make item public",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.public.label": "Make item public",
+  
+  // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  
+  // "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  
+  // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
+  
+  // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  
+  // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  
+  // "item.edit.tabs.status.head": "Item Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.head": "Item Status",
+  
+  // "item.edit.tabs.status.labels.handle": "Handle",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.handle": "Handle",
+  
+  // "item.edit.tabs.status.labels.id": "Item Internal ID",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.id": "Item Internal ID",
+  
+  // "item.edit.tabs.status.labels.itemPage": "Item Page",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.itemPage": "Item Page",
+  
+  // "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  
+  // "item.edit.tabs.status.title": "Item Edit -  Status",
+  // TODO New key - Add a translation
+  "item.edit.tabs.status.title": "Item Edit -  Status",
+  
+  // "item.edit.tabs.view.head": "View Item",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.head": "View Item",
+  
+  // "item.edit.tabs.view.title": "Item Edit -  View",
+  // TODO New key - Add a translation
+  "item.edit.tabs.view.title": "Item Edit -  View",
+  
+  
+  
+  // "item.edit.withdraw.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.cancel": "Cancel",
+  
+  // "item.edit.withdraw.confirm": "Withdraw",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.confirm": "Withdraw",
+  
+  // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  
+  // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  
+  // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  
+  // "item.edit.withdraw.success": "The item was withdrawn successfully",
+  // TODO New key - Add a translation
+  "item.edit.withdraw.success": "The item was withdrawn successfully",
+  
+  
+  
+  // "item.page.abstract": "Abstract",
   "item.page.abstract": "Abstract",
+  
+  // "item.page.author": "Authors",
   "item.page.author": "Auteur",
+  
+  // "item.page.citation": "Citation",
+  // TODO New key - Add a translation
+  "item.page.citation": "Citation",
+  
+  // "item.page.collections": "Collections",
   "item.page.collections": "Collecties",
+  
+  // "item.page.date": "Date",
   "item.page.date": "Datum",
+  
+  // "item.page.files": "Files",
   "item.page.files": "Bestanden",
-  "item.page.filesection.description": "Beschrijving:",
+  
+  // "item.page.filesection.description": "Description:",
+  // TODO New key - Add a translation
+  "item.page.filesection.description": "Description:",
+  
+  // "item.page.filesection.download": "Download",
   "item.page.filesection.download": "Download",
-  "item.page.filesection.format": "Formaat:",
-  "item.page.filesection.name": "Naam:",
-  "item.page.filesection.size": "Grootte:",
+  
+  // "item.page.filesection.format": "Format:",
+  // TODO New key - Add a translation
+  "item.page.filesection.format": "Format:",
+  
+  // "item.page.filesection.name": "Name:",
+  // TODO New key - Add a translation
+  "item.page.filesection.name": "Name:",
+  
+  // "item.page.filesection.size": "Size:",
+  // TODO New key - Add a translation
+  "item.page.filesection.size": "Size:",
+  
+  // "item.page.journal.search.title": "Articles in this journal",
+  // TODO New key - Add a translation
+  "item.page.journal.search.title": "Articles in this journal",
+  
+  // "item.page.link.full": "Full item page",
   "item.page.link.full": "Volledige itemweergave",
+  
+  // "item.page.link.simple": "Simple item page",
   "item.page.link.simple": "Eenvoudige itemweergave",
+  
+  // "item.page.person.search.title": "Articles by this author",
+  // TODO New key - Add a translation
+  "item.page.person.search.title": "Articles by this author",
+  
+  // "item.page.related-items.view-more": "View more",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-more": "View more",
+  
+  // "item.page.related-items.view-less": "View less",
+  // TODO New key - Add a translation
+  "item.page.related-items.view-less": "View less",
+  
+  // "item.page.subject": "Keywords",
+  // TODO New key - Add a translation
+  "item.page.subject": "Keywords",
+  
+  // "item.page.uri": "URI",
   "item.page.uri": "URI",
-
+  
+  
+  
+  // "item.select.confirm": "Confirm selected",
+  // TODO New key - Add a translation
+  "item.select.confirm": "Confirm selected",
+  
+  // "item.select.empty": "No items to show",
+  // TODO New key - Add a translation
+  "item.select.empty": "No items to show",
+  
+  // "item.select.table.author": "Author",
+  // TODO New key - Add a translation
+  "item.select.table.author": "Author",
+  
+  // "item.select.table.collection": "Collection",
+  // TODO New key - Add a translation
+  "item.select.table.collection": "Collection",
+  
+  // "item.select.table.title": "Title",
+  // TODO New key - Add a translation
+  "item.select.table.title": "Title",
+  
+  
+  
+  // "journal.listelement.badge": "Journal",
+  // TODO New key - Add a translation
+  "journal.listelement.badge": "Journal",
+  
+  // "journal.page.description": "Description",
+  // TODO New key - Add a translation
+  "journal.page.description": "Description",
+  
+  // "journal.page.editor": "Editor-in-Chief",
+  // TODO New key - Add a translation
+  "journal.page.editor": "Editor-in-Chief",
+  
+  // "journal.page.issn": "ISSN",
+  // TODO New key - Add a translation
+  "journal.page.issn": "ISSN",
+  
+  // "journal.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "journal.page.publisher": "Publisher",
+  
+  // "journal.page.titleprefix": "Journal: ",
+  // TODO New key - Add a translation
+  "journal.page.titleprefix": "Journal: ",
+  
+  // "journal.search.results.head": "Journal Search Results",
+  // TODO New key - Add a translation
+  "journal.search.results.head": "Journal Search Results",
+  
+  // "journal.search.title": "DSpace Angular :: Journal Search",
+  // TODO New key - Add a translation
+  "journal.search.title": "DSpace Angular :: Journal Search",
+  
+  
+  
+  // "journalissue.listelement.badge": "Journal Issue",
+  // TODO New key - Add a translation
+  "journalissue.listelement.badge": "Journal Issue",
+  
+  // "journalissue.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalissue.page.description": "Description",
+  
+  // "journalissue.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalissue.page.issuedate": "Issue Date",
+  
+  // "journalissue.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-issn": "Journal ISSN",
+  
+  // "journalissue.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "journalissue.page.journal-title": "Journal Title",
+  
+  // "journalissue.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "journalissue.page.keyword": "Keywords",
+  
+  // "journalissue.page.number": "Number",
+  // TODO New key - Add a translation
+  "journalissue.page.number": "Number",
+  
+  // "journalissue.page.titleprefix": "Journal Issue: ",
+  // TODO New key - Add a translation
+  "journalissue.page.titleprefix": "Journal Issue: ",
+  
+  
+  
+  // "journalvolume.listelement.badge": "Journal Volume",
+  // TODO New key - Add a translation
+  "journalvolume.listelement.badge": "Journal Volume",
+  
+  // "journalvolume.page.description": "Description",
+  // TODO New key - Add a translation
+  "journalvolume.page.description": "Description",
+  
+  // "journalvolume.page.issuedate": "Issue Date",
+  // TODO New key - Add a translation
+  "journalvolume.page.issuedate": "Issue Date",
+  
+  // "journalvolume.page.titleprefix": "Journal Volume: ",
+  // TODO New key - Add a translation
+  "journalvolume.page.titleprefix": "Journal Volume: ",
+  
+  // "journalvolume.page.volume": "Volume",
+  // TODO New key - Add a translation
+  "journalvolume.page.volume": "Volume",
+  
+  
+  
+  // "loading.browse-by": "Loading items...",
   "loading.browse-by": "Items worden ingeladen...",
+  
+  // "loading.browse-by-page": "Loading page...",
+  // TODO New key - Add a translation
+  "loading.browse-by-page": "Loading page...",
+  
+  // "loading.collection": "Loading collection...",
   "loading.collection": "Collectie wordt ingeladen...",
+  
+  // "loading.collections": "Loading collections...",
+  // TODO New key - Add a translation
+  "loading.collections": "Loading collections...",
+  
+  // "loading.community": "Loading community...",
   "loading.community": "Community wordt ingeladen...",
+  
+  // "loading.default": "Loading...",
   "loading.default": "Laden...",
+  
+  // "loading.item": "Loading item...",
   "loading.item": "Item wordt ingeladen...",
+  
+  // "loading.items": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.items": "Loading items...",
+  
+  // "loading.mydspace-results": "Loading items...",
+  // TODO New key - Add a translation
+  "loading.mydspace-results": "Loading items...",
+  
+  // "loading.objects": "Loading...",
   "loading.objects": "Laden...",
+  
+  // "loading.recent-submissions": "Loading recent submissions...",
   "loading.recent-submissions": "Recent toegevoegde items worden ingeladen...",
+  
+  // "loading.search-results": "Loading search results...",
   "loading.search-results": "Zoekresultaten worden ingeladen...",
+  
+  // "loading.sub-collections": "Loading sub-collections...",
   "loading.sub-collections": "De sub-collecties worden ingeladen...",
+  
+  // "loading.sub-communities": "Loading sub-communities...",
+  // TODO New key - Add a translation
+  "loading.sub-communities": "Loading sub-communities...",
+  
+  // "loading.top-level-communities": "Loading top-level communities...",
   "loading.top-level-communities": "Inladen van de Communities op het hoogste niveau...",
-
+  
+  
+  
+  // "login.form.email": "Email address",
   "login.form.email": "Email adres",
+  
+  // "login.form.forgot-password": "Have you forgotten your password?",
   "login.form.forgot-password": "Bent u uw wachtwoord vergeten?",
+  
+  // "login.form.header": "Please log in to DSpace",
   "login.form.header": "Gelieve in te loggen in DSpace",
+  
+  // "login.form.new-user": "New user? Click here to register.",
   "login.form.new-user": "Nieuwe gebruiker? Gelieve u hier te registreren",
+  
+  // "login.form.password": "Password",
   "login.form.password": "Wachtwoord",
+  
+  // "login.form.submit": "Log in",
   "login.form.submit": "Aanmelden",
+  
+  // "login.title": "Login",
   "login.title": "Aanmelden",
-
+  
+  
+  
+  // "logout.form.header": "Log out from DSpace",
   "logout.form.header": "Afmelden in DSpace",
+  
+  // "logout.form.submit": "Log out",
   "logout.form.submit": "Afmelden",
+  
+  // "logout.title": "Logout",
   "logout.title": "Afmelden",
-
-  "nav.home": "Home",
+  
+  
+  
+  // "menu.header.admin": "Admin",
+  // TODO New key - Add a translation
+  "menu.header.admin": "Admin",
+  
+  // "menu.header.image.logo": "Repository logo",
+  // TODO New key - Add a translation
+  "menu.header.image.logo": "Repository logo",
+  
+  
+  
+  // "menu.section.access_control": "Access Control",
+  // TODO New key - Add a translation
+  "menu.section.access_control": "Access Control",
+  
+  // "menu.section.access_control_authorizations": "Authorizations",
+  // TODO New key - Add a translation
+  "menu.section.access_control_authorizations": "Authorizations",
+  
+  // "menu.section.access_control_groups": "Groups",
+  // TODO New key - Add a translation
+  "menu.section.access_control_groups": "Groups",
+  
+  // "menu.section.access_control_people": "People",
+  // TODO New key - Add a translation
+  "menu.section.access_control_people": "People",
+  
+  
+  
+  // "menu.section.browse_community": "This Community",
+  // TODO New key - Add a translation
+  "menu.section.browse_community": "This Community",
+  
+  // "menu.section.browse_community_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_author": "By Author",
+  
+  // "menu.section.browse_community_by_issue_date": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_issue_date": "By Issue Date",
+  
+  // "menu.section.browse_community_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_community_by_title": "By Title",
+  
+  // "menu.section.browse_global": "All of DSpace",
+  // TODO New key - Add a translation
+  "menu.section.browse_global": "All of DSpace",
+  
+  // "menu.section.browse_global_by_author": "By Author",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_author": "By Author",
+  
+  // "menu.section.browse_global_by_dateissued": "By Issue Date",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_dateissued": "By Issue Date",
+  
+  // "menu.section.browse_global_by_subject": "By Subject",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_subject": "By Subject",
+  
+  // "menu.section.browse_global_by_title": "By Title",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_by_title": "By Title",
+  
+  // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  // TODO New key - Add a translation
+  "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  
+  
+  
+  // "menu.section.control_panel": "Control Panel",
+  // TODO New key - Add a translation
+  "menu.section.control_panel": "Control Panel",
+  
+  // "menu.section.curation_task": "Curation Task",
+  // TODO New key - Add a translation
+  "menu.section.curation_task": "Curation Task",
+  
+  
+  
+  // "menu.section.edit": "Edit",
+  // TODO New key - Add a translation
+  "menu.section.edit": "Edit",
+  
+  // "menu.section.edit_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.edit_collection": "Collection",
+  
+  // "menu.section.edit_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.edit_community": "Community",
+  
+  // "menu.section.edit_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.edit_item": "Item",
+  
+  
+  
+  // "menu.section.export": "Export",
+  // TODO New key - Add a translation
+  "menu.section.export": "Export",
+  
+  // "menu.section.export_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.export_collection": "Collection",
+  
+  // "menu.section.export_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.export_community": "Community",
+  
+  // "menu.section.export_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.export_item": "Item",
+  
+  // "menu.section.export_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.export_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.find": "Find",
+  // TODO New key - Add a translation
+  "menu.section.find": "Find",
+  
+  // "menu.section.find_items": "Items",
+  // TODO New key - Add a translation
+  "menu.section.find_items": "Items",
+  
+  // "menu.section.find_private_items": "Private Items",
+  // TODO New key - Add a translation
+  "menu.section.find_private_items": "Private Items",
+  
+  // "menu.section.find_withdrawn_items": "Withdrawn Items",
+  // TODO New key - Add a translation
+  "menu.section.find_withdrawn_items": "Withdrawn Items",
+  
+  
+  
+  // "menu.section.icon.access_control": "Access Control menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.access_control": "Access Control menu section",
+  
+  // "menu.section.icon.control_panel": "Control Panel menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.control_panel": "Control Panel menu section",
+  
+  // "menu.section.icon.curation_task": "Curation Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.curation_task": "Curation Task menu section",
+  
+  // "menu.section.icon.edit": "Edit menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.edit": "Edit menu section",
+  
+  // "menu.section.icon.export": "Export menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.export": "Export menu section",
+  
+  // "menu.section.icon.find": "Find menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.find": "Find menu section",
+  
+  // "menu.section.icon.import": "Import menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.import": "Import menu section",
+  
+  // "menu.section.icon.new": "New menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.new": "New menu section",
+  
+  // "menu.section.icon.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.pin": "Pin sidebar",
+  
+  // "menu.section.icon.registries": "Registries menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.registries": "Registries menu section",
+  
+  // "menu.section.icon.statistics_task": "Statistics Task menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.statistics_task": "Statistics Task menu section",
+  
+  // "menu.section.icon.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.icon.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.import": "Import",
+  // TODO New key - Add a translation
+  "menu.section.import": "Import",
+  
+  // "menu.section.import_batch": "Batch Import (ZIP)",
+  // TODO New key - Add a translation
+  "menu.section.import_batch": "Batch Import (ZIP)",
+  
+  // "menu.section.import_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.import_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.new": "New",
+  // TODO New key - Add a translation
+  "menu.section.new": "New",
+  
+  // "menu.section.new_collection": "Collection",
+  // TODO New key - Add a translation
+  "menu.section.new_collection": "Collection",
+  
+  // "menu.section.new_community": "Community",
+  // TODO New key - Add a translation
+  "menu.section.new_community": "Community",
+  
+  // "menu.section.new_item": "Item",
+  // TODO New key - Add a translation
+  "menu.section.new_item": "Item",
+  
+  // "menu.section.new_item_version": "Item Version",
+  // TODO New key - Add a translation
+  "menu.section.new_item_version": "Item Version",
+  
+  
+  
+  // "menu.section.pin": "Pin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.pin": "Pin sidebar",
+  
+  // "menu.section.unpin": "Unpin sidebar",
+  // TODO New key - Add a translation
+  "menu.section.unpin": "Unpin sidebar",
+  
+  
+  
+  // "menu.section.registries": "Registries",
+  // TODO New key - Add a translation
+  "menu.section.registries": "Registries",
+  
+  // "menu.section.registries_format": "Format",
+  // TODO New key - Add a translation
+  "menu.section.registries_format": "Format",
+  
+  // "menu.section.registries_metadata": "Metadata",
+  // TODO New key - Add a translation
+  "menu.section.registries_metadata": "Metadata",
+  
+  
+  
+  // "menu.section.statistics": "Statistics",
+  // TODO New key - Add a translation
+  "menu.section.statistics": "Statistics",
+  
+  // "menu.section.statistics_task": "Statistics Task",
+  // TODO New key - Add a translation
+  "menu.section.statistics_task": "Statistics Task",
+  
+  
+  
+  // "menu.section.toggle.access_control": "Toggle Access Control section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.access_control": "Toggle Access Control section",
+  
+  // "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  
+  // "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  
+  // "menu.section.toggle.edit": "Toggle Edit section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.edit": "Toggle Edit section",
+  
+  // "menu.section.toggle.export": "Toggle Export section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.export": "Toggle Export section",
+  
+  // "menu.section.toggle.find": "Toggle Find section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.find": "Toggle Find section",
+  
+  // "menu.section.toggle.import": "Toggle Import section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.import": "Toggle Import section",
+  
+  // "menu.section.toggle.new": "Toggle New section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.new": "Toggle New section",
+  
+  // "menu.section.toggle.registries": "Toggle Registries section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.registries": "Toggle Registries section",
+  
+  // "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  // TODO New key - Add a translation
+  "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  
+  
+  
+  // "mydspace.description": "",
+  // TODO New key - Add a translation
+  "mydspace.description": "",
+  
+  // "mydspace.general.text-here": "HERE",
+  // TODO New key - Add a translation
+  "mydspace.general.text-here": "HERE",
+  
+  // "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  // TODO New key - Add a translation
+  "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  
+  // "mydspace.messages.description-placeholder": "Insert your message here...",
+  // TODO New key - Add a translation
+  "mydspace.messages.description-placeholder": "Insert your message here...",
+  
+  // "mydspace.messages.hide-msg": "Hide message",
+  // TODO New key - Add a translation
+  "mydspace.messages.hide-msg": "Hide message",
+  
+  // "mydspace.messages.mark-as-read": "Mark as read",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-read": "Mark as read",
+  
+  // "mydspace.messages.mark-as-unread": "Mark as unread",
+  // TODO New key - Add a translation
+  "mydspace.messages.mark-as-unread": "Mark as unread",
+  
+  // "mydspace.messages.no-content": "No content.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-content": "No content.",
+  
+  // "mydspace.messages.no-messages": "No messages yet.",
+  // TODO New key - Add a translation
+  "mydspace.messages.no-messages": "No messages yet.",
+  
+  // "mydspace.messages.send-btn": "Send",
+  // TODO New key - Add a translation
+  "mydspace.messages.send-btn": "Send",
+  
+  // "mydspace.messages.show-msg": "Show message",
+  // TODO New key - Add a translation
+  "mydspace.messages.show-msg": "Show message",
+  
+  // "mydspace.messages.subject-placeholder": "Subject...",
+  // TODO New key - Add a translation
+  "mydspace.messages.subject-placeholder": "Subject...",
+  
+  // "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  // TODO New key - Add a translation
+  "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  
+  // "mydspace.messages.title": "Messages",
+  // TODO New key - Add a translation
+  "mydspace.messages.title": "Messages",
+  
+  // "mydspace.messages.to": "To",
+  // TODO New key - Add a translation
+  "mydspace.messages.to": "To",
+  
+  // "mydspace.new-submission": "New submission",
+  // TODO New key - Add a translation
+  "mydspace.new-submission": "New submission",
+  
+  // "mydspace.results.head": "Your submissions",
+  // TODO New key - Add a translation
+  "mydspace.results.head": "Your submissions",
+  
+  // "mydspace.results.no-abstract": "No Abstract",
+  // TODO New key - Add a translation
+  "mydspace.results.no-abstract": "No Abstract",
+  
+  // "mydspace.results.no-authors": "No Authors",
+  // TODO New key - Add a translation
+  "mydspace.results.no-authors": "No Authors",
+  
+  // "mydspace.results.no-collections": "No Collections",
+  // TODO New key - Add a translation
+  "mydspace.results.no-collections": "No Collections",
+  
+  // "mydspace.results.no-date": "No Date",
+  // TODO New key - Add a translation
+  "mydspace.results.no-date": "No Date",
+  
+  // "mydspace.results.no-files": "No Files",
+  // TODO New key - Add a translation
+  "mydspace.results.no-files": "No Files",
+  
+  // "mydspace.results.no-results": "There were no items to show",
+  // TODO New key - Add a translation
+  "mydspace.results.no-results": "There were no items to show",
+  
+  // "mydspace.results.no-title": "No title",
+  // TODO New key - Add a translation
+  "mydspace.results.no-title": "No title",
+  
+  // "mydspace.results.no-uri": "No Uri",
+  // TODO New key - Add a translation
+  "mydspace.results.no-uri": "No Uri",
+  
+  // "mydspace.show.workflow": "All tasks",
+  // TODO New key - Add a translation
+  "mydspace.show.workflow": "All tasks",
+  
+  // "mydspace.show.workspace": "Your Submissions",
+  // TODO New key - Add a translation
+  "mydspace.show.workspace": "Your Submissions",
+  
+  // "mydspace.status.archived": "Archived",
+  // TODO New key - Add a translation
+  "mydspace.status.archived": "Archived",
+  
+  // "mydspace.status.validation": "Validation",
+  // TODO New key - Add a translation
+  "mydspace.status.validation": "Validation",
+  
+  // "mydspace.status.waiting-for-controller": "Waiting for controller",
+  // TODO New key - Add a translation
+  "mydspace.status.waiting-for-controller": "Waiting for controller",
+  
+  // "mydspace.status.workflow": "Workflow",
+  // TODO New key - Add a translation
+  "mydspace.status.workflow": "Workflow",
+  
+  // "mydspace.status.workspace": "Workspace",
+  // TODO New key - Add a translation
+  "mydspace.status.workspace": "Workspace",
+  
+  // "mydspace.title": "MyDSpace",
+  // TODO New key - Add a translation
+  "mydspace.title": "MyDSpace",
+  
+  // "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  
+  // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  
+  // "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  // TODO New key - Add a translation
+  "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
+  
+  // "mydspace.view-btn": "View",
+  // TODO New key - Add a translation
+  "mydspace.view-btn": "View",
+  
+  
+  
+  // "nav.browse.header": "All of DSpace",
+  // TODO New key - Add a translation
+  "nav.browse.header": "All of DSpace",
+  
+  // "nav.community-browse.header": "By Community",
+  // TODO New key - Add a translation
+  "nav.community-browse.header": "By Community",
+  
+  // "nav.language": "Language switch",
+  // TODO New key - Add a translation
+  "nav.language": "Language switch",
+  
+  // "nav.login": "Log In",
   "nav.login": "Log In",
+  
+  // "nav.logout": "Log Out",
   "nav.logout": "Log Uit",
-
+  
+  // "nav.mydspace": "MyDSpace",
+  // TODO New key - Add a translation
+  "nav.mydspace": "MyDSpace",
+  
+  // "nav.search": "Search",
+  // TODO New key - Add a translation
+  "nav.search": "Search",
+  
+  // "nav.statistics.header": "Statistics",
+  // TODO New key - Add a translation
+  "nav.statistics.header": "Statistics",
+  
+  
+  
+  // "orgunit.listelement.badge": "Organizational Unit",
+  // TODO New key - Add a translation
+  "orgunit.listelement.badge": "Organizational Unit",
+  
+  // "orgunit.page.city": "City",
+  // TODO New key - Add a translation
+  "orgunit.page.city": "City",
+  
+  // "orgunit.page.country": "Country",
+  // TODO New key - Add a translation
+  "orgunit.page.country": "Country",
+  
+  // "orgunit.page.dateestablished": "Date established",
+  // TODO New key - Add a translation
+  "orgunit.page.dateestablished": "Date established",
+  
+  // "orgunit.page.description": "Description",
+  // TODO New key - Add a translation
+  "orgunit.page.description": "Description",
+  
+  // "orgunit.page.id": "ID",
+  // TODO New key - Add a translation
+  "orgunit.page.id": "ID",
+  
+  // "orgunit.page.titleprefix": "Organizational Unit: ",
+  // TODO New key - Add a translation
+  "orgunit.page.titleprefix": "Organizational Unit: ",
+  
+  
+  
+  // "pagination.results-per-page": "Results Per Page",
   "pagination.results-per-page": "Resultaten per pagina",
+  
+  // "pagination.showing.detail": "{{ range }} of {{ total }}",
   "pagination.showing.detail": "{{ range }} van {{ total }}",
+  
+  // "pagination.showing.label": "Now showing ",
   "pagination.showing.label": "Resultaten ",
+  
+  // "pagination.sort-direction": "Sort Options",
   "pagination.sort-direction": "Sorteermogelijkheden",
-
+  
+  
+  
+  // "person.listelement.badge": "Person",
+  // TODO New key - Add a translation
+  "person.listelement.badge": "Person",
+  
+  // "person.page.birthdate": "Birth Date",
+  // TODO New key - Add a translation
+  "person.page.birthdate": "Birth Date",
+  
+  // "person.page.email": "Email Address",
+  // TODO New key - Add a translation
+  "person.page.email": "Email Address",
+  
+  // "person.page.firstname": "First Name",
+  // TODO New key - Add a translation
+  "person.page.firstname": "First Name",
+  
+  // "person.page.jobtitle": "Job Title",
+  // TODO New key - Add a translation
+  "person.page.jobtitle": "Job Title",
+  
+  // "person.page.lastname": "Last Name",
+  // TODO New key - Add a translation
+  "person.page.lastname": "Last Name",
+  
+  // "person.page.link.full": "Show all metadata",
+  // TODO New key - Add a translation
+  "person.page.link.full": "Show all metadata",
+  
+  // "person.page.orcid": "ORCID",
+  // TODO New key - Add a translation
+  "person.page.orcid": "ORCID",
+  
+  // "person.page.staffid": "Staff ID",
+  // TODO New key - Add a translation
+  "person.page.staffid": "Staff ID",
+  
+  // "person.page.titleprefix": "Person: ",
+  // TODO New key - Add a translation
+  "person.page.titleprefix": "Person: ",
+  
+  // "person.search.results.head": "Person Search Results",
+  // TODO New key - Add a translation
+  "person.search.results.head": "Person Search Results",
+  
+  // "person.search.title": "DSpace Angular :: Person Search",
+  // TODO New key - Add a translation
+  "person.search.title": "DSpace Angular :: Person Search",
+  
+  
+  
+  // "project.listelement.badge": "Research Project",
+  // TODO New key - Add a translation
+  "project.listelement.badge": "Research Project",
+  
+  // "project.page.contributor": "Contributors",
+  // TODO New key - Add a translation
+  "project.page.contributor": "Contributors",
+  
+  // "project.page.description": "Description",
+  // TODO New key - Add a translation
+  "project.page.description": "Description",
+  
+  // "project.page.expectedcompletion": "Expected Completion",
+  // TODO New key - Add a translation
+  "project.page.expectedcompletion": "Expected Completion",
+  
+  // "project.page.funder": "Funders",
+  // TODO New key - Add a translation
+  "project.page.funder": "Funders",
+  
+  // "project.page.id": "ID",
+  // TODO New key - Add a translation
+  "project.page.id": "ID",
+  
+  // "project.page.keyword": "Keywords",
+  // TODO New key - Add a translation
+  "project.page.keyword": "Keywords",
+  
+  // "project.page.status": "Status",
+  // TODO New key - Add a translation
+  "project.page.status": "Status",
+  
+  // "project.page.titleprefix": "Research Project: ",
+  // TODO New key - Add a translation
+  "project.page.titleprefix": "Research Project: ",
+  
+  
+  
+  // "publication.listelement.badge": "Publication",
+  // TODO New key - Add a translation
+  "publication.listelement.badge": "Publication",
+  
+  // "publication.page.description": "Description",
+  // TODO New key - Add a translation
+  "publication.page.description": "Description",
+  
+  // "publication.page.journal-issn": "Journal ISSN",
+  // TODO New key - Add a translation
+  "publication.page.journal-issn": "Journal ISSN",
+  
+  // "publication.page.journal-title": "Journal Title",
+  // TODO New key - Add a translation
+  "publication.page.journal-title": "Journal Title",
+  
+  // "publication.page.publisher": "Publisher",
+  // TODO New key - Add a translation
+  "publication.page.publisher": "Publisher",
+  
+  // "publication.page.titleprefix": "Publication: ",
+  // TODO New key - Add a translation
+  "publication.page.titleprefix": "Publication: ",
+  
+  // "publication.page.volume-title": "Volume Title",
+  // TODO New key - Add a translation
+  "publication.page.volume-title": "Volume Title",
+  
+  // "publication.search.results.head": "Publication Search Results",
+  // TODO New key - Add a translation
+  "publication.search.results.head": "Publication Search Results",
+  
+  // "publication.search.title": "DSpace Angular :: Publication Search",
+  // TODO New key - Add a translation
+  "publication.search.title": "DSpace Angular :: Publication Search",
+  
+  
+  
+  // "relationships.isAuthorOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isAuthorOf": "Authors",
+  
+  // "relationships.isIssueOf": "Journal Issues",
+  // TODO New key - Add a translation
+  "relationships.isIssueOf": "Journal Issues",
+  
+  // "relationships.isJournalIssueOf": "Journal Issue",
+  // TODO New key - Add a translation
+  "relationships.isJournalIssueOf": "Journal Issue",
+  
+  // "relationships.isJournalOf": "Journals",
+  // TODO New key - Add a translation
+  "relationships.isJournalOf": "Journals",
+  
+  // "relationships.isOrgUnitOf": "Organizational Units",
+  // TODO New key - Add a translation
+  "relationships.isOrgUnitOf": "Organizational Units",
+  
+  // "relationships.isPersonOf": "Authors",
+  // TODO New key - Add a translation
+  "relationships.isPersonOf": "Authors",
+  
+  // "relationships.isProjectOf": "Research Projects",
+  // TODO New key - Add a translation
+  "relationships.isProjectOf": "Research Projects",
+  
+  // "relationships.isPublicationOf": "Publications",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOf": "Publications",
+  
+  // "relationships.isPublicationOfJournalIssue": "Articles",
+  // TODO New key - Add a translation
+  "relationships.isPublicationOfJournalIssue": "Articles",
+  
+  // "relationships.isSingleJournalOf": "Journal",
+  // TODO New key - Add a translation
+  "relationships.isSingleJournalOf": "Journal",
+  
+  // "relationships.isSingleVolumeOf": "Journal Volume",
+  // TODO New key - Add a translation
+  "relationships.isSingleVolumeOf": "Journal Volume",
+  
+  // "relationships.isVolumeOf": "Journal Volumes",
+  // TODO New key - Add a translation
+  "relationships.isVolumeOf": "Journal Volumes",
+  
+  
+  
+  // "search.description": "",
   "search.description": "",
+  
+  // "search.switch-configuration.title": "Show",
+  // TODO New key - Add a translation
+  "search.switch-configuration.title": "Show",
+  
+  // "search.title": "DSpace Angular :: Search",
   "search.title": "DSpace Angular :: Zoek",
-
+  
+  
+  
+  // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "Auteur",
+  
+  // "search.filters.applied.f.dateIssued.max": "End date",
   "search.filters.applied.f.dateIssued.max": "Einddatum",
+  
+  // "search.filters.applied.f.dateIssued.min": "Start date",
   "search.filters.applied.f.dateIssued.min": "Startdatum",
+  
+  // "search.filters.applied.f.dateSubmitted": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.dateSubmitted": "Date submitted",
+  
+  // "search.filters.applied.f.entityType": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.entityType": "Item Type",
+  
+  // "search.filters.applied.f.has_content_in_original_bundle": "Has files",
   "search.filters.applied.f.has_content_in_original_bundle": "Heeft bestanden",
+  
+  // "search.filters.applied.f.itemtype": "Type",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.itemtype": "Type",
+  
+  // "search.filters.applied.f.namedresourcetype": "Status",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.namedresourcetype": "Status",
+  
+  // "search.filters.applied.f.subject": "Subject",
   "search.filters.applied.f.subject": "Sleutelwoord",
+  
+  // "search.filters.applied.f.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.applied.f.submitter": "Submitter",
+  
+  
+  
+  // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Auteur",
+  
+  // "search.filters.filter.author.placeholder": "Author name",
   "search.filters.filter.author.placeholder": "Auteursnaam",
+  
+  // "search.filters.filter.birthDate.head": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.head": "Birth Date",
+  
+  // "search.filters.filter.birthDate.placeholder": "Birth Date",
+  // TODO New key - Add a translation
+  "search.filters.filter.birthDate.placeholder": "Birth Date",
+  
+  // "search.filters.filter.creativeDatePublished.head": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.head": "Date Published",
+  
+  // "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  
+  // "search.filters.filter.creativeWorkEditor.head": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.head": "Editor",
+  
+  // "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  
+  // "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  
+  // "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  
+  // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  
+  // "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  // TODO New key - Add a translation
+  "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  
+  // "search.filters.filter.dateIssued.head": "Date",
   "search.filters.filter.dateIssued.head": "Datum",
+  
+  // "search.filters.filter.dateIssued.max.placeholder": "Minimum Date",
   "search.filters.filter.dateIssued.max.placeholder": "Vroegste Datum",
+  
+  // "search.filters.filter.dateIssued.min.placeholder": "Maximum Date",
   "search.filters.filter.dateIssued.min.placeholder": "Laatste Datum",
+  
+  // "search.filters.filter.dateSubmitted.head": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.head": "Date submitted",
+  
+  // "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  // TODO New key - Add a translation
+  "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  
+  // "search.filters.filter.entityType.head": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.head": "Item Type",
+  
+  // "search.filters.filter.entityType.placeholder": "Item Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.entityType.placeholder": "Item Type",
+  
+  // "search.filters.filter.has_content_in_original_bundle.head": "Has files",
   "search.filters.filter.has_content_in_original_bundle.head": "Heeft bestanden",
+  
+  // "search.filters.filter.itemtype.head": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.head": "Type",
+  
+  // "search.filters.filter.itemtype.placeholder": "Type",
+  // TODO New key - Add a translation
+  "search.filters.filter.itemtype.placeholder": "Type",
+  
+  // "search.filters.filter.jobTitle.head": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.head": "Job Title",
+  
+  // "search.filters.filter.jobTitle.placeholder": "Job Title",
+  // TODO New key - Add a translation
+  "search.filters.filter.jobTitle.placeholder": "Job Title",
+  
+  // "search.filters.filter.knowsLanguage.head": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.head": "Known language",
+  
+  // "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  // TODO New key - Add a translation
+  "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  
+  // "search.filters.filter.namedresourcetype.head": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.head": "Status",
+  
+  // "search.filters.filter.namedresourcetype.placeholder": "Status",
+  // TODO New key - Add a translation
+  "search.filters.filter.namedresourcetype.placeholder": "Status",
+  
+  // "search.filters.filter.objectpeople.head": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.head": "People",
+  
+  // "search.filters.filter.objectpeople.placeholder": "People",
+  // TODO New key - Add a translation
+  "search.filters.filter.objectpeople.placeholder": "People",
+  
+  // "search.filters.filter.organizationAddressCountry.head": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.head": "Country",
+  
+  // "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  
+  // "search.filters.filter.organizationAddressLocality.head": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.head": "City",
+  
+  // "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  
+  // "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  
+  // "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  // TODO New key - Add a translation
+  "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  
+  // "search.filters.filter.scope.head": "Scope",
   "search.filters.filter.scope.head": "Bereik",
+  
+  // "search.filters.filter.scope.placeholder": "Scope filter",
   "search.filters.filter.scope.placeholder": "Bereikfilter",
+  
+  // "search.filters.filter.show-less": "Collapse",
   "search.filters.filter.show-less": "Inklappen",
+  
+  // "search.filters.filter.show-more": "Show more",
   "search.filters.filter.show-more": "Toon meer",
+  
+  // "search.filters.filter.subject.head": "Subject",
   "search.filters.filter.subject.head": "Onderwerp",
+  
+  // "search.filters.filter.subject.placeholder": "Subject",
   "search.filters.filter.subject.placeholder": "Onderwerp",
-
+  
+  // "search.filters.filter.submitter.head": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.head": "Submitter",
+  
+  // "search.filters.filter.submitter.placeholder": "Submitter",
+  // TODO New key - Add a translation
+  "search.filters.filter.submitter.placeholder": "Submitter",
+  
+  
+  
+  // "search.filters.head": "Filters",
   "search.filters.head": "Filters",
+  
+  // "search.filters.reset": "Reset filters",
   "search.filters.reset": "Filters verwijderen",
-
+  
+  
+  
+  // "search.form.search": "Search",
   "search.form.search": "Zoek",
+  
+  // "search.form.search_dspace": "Search DSpace",
   "search.form.search_dspace": "Zoek in DSpace",
-
+  
+  // "search.form.search_mydspace": "Search MyDSpace",
+  // TODO New key - Add a translation
+  "search.form.search_mydspace": "Search MyDSpace",
+  
+  
+  
+  // "search.results.head": "Search Results",
   "search.results.head": "Zoekresultaten",
+  
+  // "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
   "search.results.no-results": "Er waren geen resultaten voor deze zoekopdracht",
-
+  
+  // "search.results.no-results-link": "quotes around it",
+  // TODO New key - Add a translation
+  "search.results.no-results-link": "quotes around it",
+  
+  
+  
+  // "search.sidebar.close": "Back to results",
   "search.sidebar.close": "Terug naar de resultaten",
+  
+  // "search.sidebar.filters.title": "Filters",
   "search.sidebar.filters.title": "Filters",
+  
+  // "search.sidebar.open": "Search Tools",
   "search.sidebar.open": "Zoek Tools",
+  
+  // "search.sidebar.results": "results",
   "search.sidebar.results": "resultaten",
+  
+  // "search.sidebar.settings.rpp": "Results per page",
   "search.sidebar.settings.rpp": "Resultaten per pagina",
+  
+  // "search.sidebar.settings.sort-by": "Sort By",
   "search.sidebar.settings.sort-by": "Sorteer volgens",
+  
+  // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "Instellingen",
-
+  
+  
+  
+  // "search.view-switch.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "search.view-switch.show-detail": "Show detail",
+  
+  // "search.view-switch.show-grid": "Show as grid",
   "search.view-switch.show-grid": "Toon in raster",
+  
+  // "search.view-switch.show-list": "Show as list",
   "search.view-switch.show-list": "Toon als lijst",
-
+  
+  
+  
+  // "sorting.dc.title.ASC": "Title Ascending",
   "sorting.dc.title.ASC": "Oplopend op titel",
+  
+  // "sorting.dc.title.DESC": "Title Descending",
   "sorting.dc.title.DESC": "Aflopend op titel",
+  
+  // "sorting.score.DESC": "Relevance",
   "sorting.score.DESC": "Relevantie",
-
+  
+  
+  
+  // "submission.edit.title": "Edit Submission",
+  // TODO New key - Add a translation
+  "submission.edit.title": "Edit Submission",
+  
+  // "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  // TODO New key - Add a translation
+  "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
+  
+  // "submission.general.deposit": "Deposit",
+  // TODO New key - Add a translation
+  "submission.general.deposit": "Deposit",
+  
+  // "submission.general.discard.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.cancel": "Cancel",
+  
+  // "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.general.discard.confirm.title": "Discard submission",
+  // TODO New key - Add a translation
+  "submission.general.discard.confirm.title": "Discard submission",
+  
+  // "submission.general.discard.submit": "Discard",
+  // TODO New key - Add a translation
+  "submission.general.discard.submit": "Discard",
+  
+  // "submission.general.save": "Save",
+  // TODO New key - Add a translation
+  "submission.general.save": "Save",
+  
+  // "submission.general.save-later": "Save for later",
+  // TODO New key - Add a translation
+  "submission.general.save-later": "Save for later",
+  
+  
+  
+  // "submission.sections.general.add-more": "Add more",
+  // TODO New key - Add a translation
+  "submission.sections.general.add-more": "Add more",
+  
+  // "submission.sections.general.collection": "Collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.collection": "Collection",
+  
+  // "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  
+  // "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  
+  // "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  
+  // "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  
+  // "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  
+  // "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  // TODO New key - Add a translation
+  "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  
+  // "submission.sections.general.no-collection": "No collection found",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-collection": "No collection found",
+  
+  // "submission.sections.general.no-sections": "No options available",
+  // TODO New key - Add a translation
+  "submission.sections.general.no-sections": "No options available",
+  
+  // "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  
+  // "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  // TODO New key - Add a translation
+  "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  
+  // "submission.sections.general.search-collection": "Search for a collection",
+  // TODO New key - Add a translation
+  "submission.sections.general.search-collection": "Search for a collection",
+  
+  // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  // TODO New key - Add a translation
+  "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  
+  
+  
+  // "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.cclicense": "Creative commons license",
+  
+  // "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  
+  // "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  
+  // "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  
+  // "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
+  
+  // "submission.sections.submit.progressbar.license": "Deposit license",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.license": "Deposit license",
+  
+  // "submission.sections.submit.progressbar.upload": "Upload files",
+  // TODO New key - Add a translation
+  "submission.sections.submit.progressbar.upload": "Upload files",
+  
+  
+  
+  // "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  
+  // "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  
+  // "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  
+  // "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  
+  // "submission.sections.upload.delete.submit": "Delete",
+  // TODO New key - Add a translation
+  "submission.sections.upload.delete.submit": "Delete",
+  
+  // "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  // TODO New key - Add a translation
+  "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  
+  // "submission.sections.upload.form.access-condition-label": "Access condition type",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.access-condition-label": "Access condition type",
+  
+  // "submission.sections.upload.form.date-required": "Date is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.date-required": "Date is required.",
+  
+  // "submission.sections.upload.form.from-label": "Access grant from",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-label": "Access grant from",
+  
+  // "submission.sections.upload.form.from-placeholder": "From",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.from-placeholder": "From",
+  
+  // "submission.sections.upload.form.group-label": "Group",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-label": "Group",
+  
+  // "submission.sections.upload.form.group-required": "Group is required.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.group-required": "Group is required.",
+  
+  // "submission.sections.upload.form.until-label": "Access grant until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-label": "Access grant until",
+  
+  // "submission.sections.upload.form.until-placeholder": "Until",
+  // TODO New key - Add a translation
+  "submission.sections.upload.form.until-placeholder": "Until",
+  
+  // "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  
+  // "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  // TODO New key - Add a translation
+  "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  
+  // "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  // TODO New key - Add a translation
+  "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the fle metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
+  
+  // "submission.sections.upload.no-entry": "No",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-entry": "No",
+  
+  // "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  // TODO New key - Add a translation
+  "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  
+  // "submission.sections.upload.save-metadata": "Save metadata",
+  // TODO New key - Add a translation
+  "submission.sections.upload.save-metadata": "Save metadata",
+  
+  // "submission.sections.upload.undo": "Cancel",
+  // TODO New key - Add a translation
+  "submission.sections.upload.undo": "Cancel",
+  
+  // "submission.sections.upload.upload-failed": "Upload failed",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-failed": "Upload failed",
+  
+  // "submission.sections.upload.upload-successful": "Upload successful",
+  // TODO New key - Add a translation
+  "submission.sections.upload.upload-successful": "Upload successful",
+  
+  
+  
+  // "submission.submit.title": "Submission",
+  // TODO New key - Add a translation
+  "submission.submit.title": "Submission",
+  
+  
+  
+  // "submission.workflow.generic.delete": "Delete",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete": "Delete",
+  
+  // "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  
+  // "submission.workflow.generic.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit": "Edit",
+  
+  // "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.generic.view": "View",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view": "View",
+  
+  // "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  
+  
+  
+  // "submission.workflow.tasks.claimed.approve": "Approve",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve": "Approve",
+  
+  // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  
+  // "submission.workflow.tasks.claimed.edit": "Edit",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit": "Edit",
+  
+  // "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  
+  // "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  
+  // "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  
+  // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  
+  // "submission.workflow.tasks.claimed.return": "Return to pool",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return": "Return to pool",
+  
+  // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  
+  
+  
+  // "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  
+  // "submission.workflow.tasks.generic.processing": "Processing...",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.processing": "Processing...",
+  
+  // "submission.workflow.tasks.generic.submitter": "Submitter",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.submitter": "Submitter",
+  
+  // "submission.workflow.tasks.generic.success": "Operation successful",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.generic.success": "Operation successful",
+  
+  
+  
+  // "submission.workflow.tasks.pool.claim": "Claim",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim": "Claim",
+  
+  // "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  
+  // "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  
+  // "submission.workflow.tasks.pool.show-detail": "Show detail",
+  // TODO New key - Add a translation
+  "submission.workflow.tasks.pool.show-detail": "Show detail",
+  
+  
+  
+  // "title": "DSpace",
   "title": "DSpace",
+  
+  
+  
+  // "uploader.browse": "browse",
+  // TODO New key - Add a translation
+  "uploader.browse": "browse",
+  
+  // "uploader.drag-message": "Drag & Drop your files here",
+  // TODO New key - Add a translation
+  "uploader.drag-message": "Drag & Drop your files here",
+  
+  // "uploader.or": ", or",
+  // TODO New key - Add a translation
+  "uploader.or": ", or",
+  
+  // "uploader.processing": "Processing",
+  // TODO New key - Add a translation
+  "uploader.processing": "Processing",
+  
+  // "uploader.queue-length": "Queue length",
+  // TODO New key - Add a translation
+  "uploader.queue-length": "Queue length",
+  
+  
+  
+
 }

--- a/resources/i18n/nl.json5
+++ b/resources/i18n/nl.json5
@@ -770,6 +770,10 @@
   // "error.community": "Error fetching community",
   "error.community": "Fout bij het ophalen van een community",
   
+  // "error.identifier": "No item found for the identifier",
+  // TODO New key - Add a translation
+  "error.identifier": "No item found for the identifier",
+  
   // "error.default": "Error",
   "error.default": "Fout",
   

--- a/scripts/sync-i18n-files.js
+++ b/scripts/sync-i18n-files.js
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+const commander = require('commander');
+const fs = require('fs');
+const JSON5 = require('json5');
+const _cliProgress = require('cli-progress');
+const _ = require('lodash');
+const {projectRoot} = require('../webpack/helpers');
+
+const program = new commander.Command();
+program.version('1.0.0', '-v, --version');
+
+const NEW_MESSAGE_TODO = '// TODO New key - Add a translation';
+const MESSAGE_CHANGED_TODO = '// TODO Source message changed - Revise the translation';
+const COMMENTS_CHANGED_TODO = '// TODO Source comments changed - Revise the translation';
+
+const DEFAULT_SOURCE_FILE_LOCATION = 'resources/i18n/en.json5';
+const LANGUAGE_FILES_LOCATION = 'resources/i18n';
+
+parseCliInput();
+
+function parseCliInput() {
+  program
+    .option('-d, --output-dir <output-dir>', 'output dir when running script on all language files; mutually exclusive with -o')
+    .option('-t, --target-file <target>', 'target file we compare with and where completed output ends up if -o is not configured and -i is')
+    .option('-i, --edit-in-place', 'edit-in-place; store output straight in target file; mutually exclusive with -o')
+    .option('-s, --source-file <source>', 'source file to be parsed for translation', projectRoot(DEFAULT_SOURCE_FILE_LOCATION))
+    .option('-o, --output-location <output>', 'where output of script ends up; mutually exclusive with -i')
+    .usage('([-d <output-dir>] [-s <source-file>]) || (-t <target-file> (-i | -o <output>) [-s <source-file>])')
+    .parse(process.argv);
+
+  if (!program.targetFile) {
+    fs.readdirSync(projectRoot(LANGUAGE_FILES_LOCATION)).forEach(file => {
+      if (!program.sourceFile.toString().endsWith(file)) {
+        const targetFileLocation = projectRoot(LANGUAGE_FILES_LOCATION + "/" + file);
+        console.log('Syncing file at: ' + targetFileLocation + ' with source file at: ' + program.sourceFile);
+        if (program.outputDir) {
+          if (!fs.existsSync(program.outputDir)) {
+            fs.mkdirSync(program.outputDir);
+          }
+          const outputFileLocation = program.outputDir + "/" + file;
+          console.log('Output location: ' + outputFileLocation);
+          syncFileWithSource(targetFileLocation, outputFileLocation);
+        } else {
+          console.log('Replacing in target location');
+          syncFileWithSource(targetFileLocation, targetFileLocation);
+        }
+      }
+    });
+  } else {
+    if (program.targetFile && !checkIfPathToFileIsValid(program.targetFile)) {
+      console.error('Directory path of target file is not valid.');
+      console.log(program.outputHelp());
+      process.exit(1);
+    }
+    if (program.targetFile && checkIfFileExists(program.targetFile) && !(program.editInPlace || program.outputFile)) {
+      console.error('This target file already exists, if you want to overwrite this add option -i, or add an -o output location');
+      console.log(program.outputHelp());
+      process.exit(1);
+    }
+    if (!checkIfFileExists(program.sourceFile)) {
+      console.error('Path of source file is not valid.');
+      console.log(program.outputHelp());
+      process.exit(1);
+    }
+    if (program.outputFile && !checkIfPathToFileIsValid(program.outputFile)) {
+      console.error('Directory path of output file is not valid.');
+      console.log(program.outputHelp());
+      process.exit(1);
+    }
+
+    syncFileWithSource(program.targetFile, getOutputFileLocationIfExistsElseTargetFileLocation(program.targetFile));
+  }
+}
+
+function syncFileWithSource(pathToTargetFile, pathToOutputFile) {
+  const progressBar = new _cliProgress.SingleBar({}, _cliProgress.Presets.shades_classic);
+  progressBar.start(100, 0);
+
+  const sourceLines = [];
+  const targetLines = [];
+  const existingTargetFile = readFileIfExists(pathToTargetFile);
+  existingTargetFile.toString().split("\n").forEach((function (line) {
+    targetLines.push(line.trim());
+  }));
+  progressBar.update(10);
+  const sourceFile = readFileIfExists(program.sourceFile);
+  sourceFile.toString().split("\n").forEach((function (line) {
+    sourceLines.push(line.trim());
+  }));
+  progressBar.update(20);
+  const sourceChunks = createChunks(sourceLines, progressBar, false);
+  const targetChunks = createChunks(targetLines, progressBar, true);
+
+  const outputChunks = compareChunksAndCreateOutput(sourceChunks, targetChunks, progressBar);
+
+  const file = fs.createWriteStream(pathToOutputFile);
+  file.on('error', function (err) {
+    console.error('Something went wrong writing to output file at: ' + pathToOutputFile + err)
+  });
+  file.write("{\n");
+  outputChunks.forEach(function (chunk) {
+    progressBar.increment();
+    chunk.split("\n").forEach(function (line) {
+      file.write("  " + line + "\n");
+    });
+  });
+  file.write("\n}");
+  file.end();
+  progressBar.update(100);
+  progressBar.stop();
+}
+
+/**
+ * For each of the source chunks:
+ *      - Determine if it's a new key-value => Add it to output, with source comments, source key-value commented, a message indicating it's new and the source-key value uncommented
+ *      - If it's not new, compare it with the corresponding target chunk and log the differences, see createNewChunkComparingSourceAndTarget
+ * @param sourceChunks      All the source chunks, split per key-value pair group
+ * @param targetChunks      All the target chunks, split per key-value pair group
+ * @param progressBar       The progressbar for the CLI
+ * @return {Array}          All the output chunks, split per key-value pair group
+ */
+function compareChunksAndCreateOutput(sourceChunks, targetChunks, progressBar) {
+  const outputChunks = [];
+  sourceChunks.map((sourceChunk) => {
+    progressBar.increment();
+    if (sourceChunk.trim().length !== 0) {
+      let newChunk = [];
+      const sourceList = sourceChunk.split("\n");
+      const keyValueSource = sourceList[sourceList.length - 1];
+      const keySource = getSubStringBeforeLastString(keyValueSource, ":");
+      const commentSource = getSubStringBeforeLastString(sourceChunk, keyValueSource);
+
+      const correspondingTargetChunk = targetChunks.find((targetChunk) => {
+        return targetChunk.includes(keySource);
+      });
+
+      // Create new chunk with: the source comments, the commented source key-value, the todos and either the old target key-value pair or if it's a new pair, the source key-value pair
+      newChunk.push(removeWhiteLines(commentSource));
+      newChunk.push("// " + keyValueSource);
+      if (correspondingTargetChunk === undefined) {
+        newChunk.push(NEW_MESSAGE_TODO);
+        newChunk.push(keyValueSource);
+      } else {
+        createNewChunkComparingSourceAndTarget(correspondingTargetChunk, sourceChunk, commentSource, keyValueSource, newChunk);
+      }
+
+      outputChunks.push(newChunk.filter(Boolean).join("\n"));
+    } else {
+      outputChunks.push(sourceChunk);
+    }
+  });
+  return outputChunks;
+}
+
+/**
+ * If a corresponding target chunk is found:
+ *      - If old key value is not found in comments > Assumed it is new key
+ *      - If the target comments do not contain the source comments (because they have changed since last time) => Add comments changed message
+ *      - If the key-value in the target comments is not the same as the source key-value (because it changes since last time) => Add message changed message
+ *      - Add the old todos if they haven't been added already
+ *      - End with the original target key-value
+ */
+function createNewChunkComparingSourceAndTarget(correspondingTargetChunk, sourceChunk, commentSource, keyValueSource, newChunk) {
+  let commentsOfSourceHaveChanged = false;
+  let messageOfSourceHasChanged = false;
+
+  const targetList = correspondingTargetChunk.split("\n");
+  const oldKeyValueInTargetComments = getSubStringWithRegex(correspondingTargetChunk, "\\s*\\/\\/\\s*\".*");
+  const keyValueTarget = targetList[targetList.length - 1];
+
+  if (oldKeyValueInTargetComments != null) {
+    const oldKeyValueUncommented = getSubStringWithRegex(oldKeyValueInTargetComments[0], "\".*")[0];
+
+    if (!(_.isEmpty(correspondingTargetChunk) && _.isEmpty(commentSource)) && !removeWhiteLines(correspondingTargetChunk).includes(removeWhiteLines(commentSource.trim()))) {
+      commentsOfSourceHaveChanged = true;
+      newChunk.push(COMMENTS_CHANGED_TODO);
+    }
+    const parsedOldKey = JSON5.stringify("{" + oldKeyValueUncommented + "}");
+    const parsedSourceKey = JSON5.stringify("{" + keyValueSource + "}");
+    if (!_.isEqual(parsedOldKey, parsedSourceKey)) {
+      messageOfSourceHasChanged = true;
+      newChunk.push(MESSAGE_CHANGED_TODO);
+    }
+    addOldTodosIfNeeded(targetList, newChunk, commentsOfSourceHaveChanged, messageOfSourceHasChanged);
+  }
+  newChunk.push(keyValueTarget);
+}
+
+// Adds old todos found in target comments if they've not been added already
+function addOldTodosIfNeeded(targetList, newChunk, commentsOfSourceHaveChanged, messageOfSourceHasChanged) {
+  targetList.map((targetLine) => {
+    const foundTODO = getSubStringWithRegex(targetLine, "\\s*//\\s*TODO.*");
+    if (foundTODO != null) {
+      const todo = foundTODO[0];
+      if (!((todo.includes(COMMENTS_CHANGED_TODO) && commentsOfSourceHaveChanged)
+        || (todo.includes(MESSAGE_CHANGED_TODO) && messageOfSourceHasChanged))) {
+        newChunk.push(todo);
+      }
+    }
+  });
+}
+
+/**
+ * Creates chunks from an array of lines, each chunk contains either an empty line or a grouping of comments with their corresponding key-value pair
+ * @param lines             Array of lines, to be grouped into chunks
+ * @param progressBar       Progressbar of the CLI
+ * @return {Array}          Array of chunks, grouped by key-value and their corresponding comments or an empty line
+ */
+function createChunks(lines, progressBar, creatingTarget) {
+  const chunks = [];
+  let nextChunk = [];
+  let onMultiLineComment = false;
+  lines.map((line) => {
+    progressBar.increment();
+    if (line.length === 0) {
+      chunks.push(line);
+    }
+    if (isOneLineCommentLine(line)) {
+      nextChunk.push(line);
+    }
+    if (onMultiLineComment) {
+      nextChunk.push(line);
+      if (isEndOfMultiLineComment(line)) {
+        onMultiLineComment = false;
+      }
+    }
+    if (isStartOfMultiLineComment(line)) {
+      nextChunk.push(line);
+      onMultiLineComment = true;
+    }
+    if (isKeyValuePair(line)) {
+      nextChunk.push(line);
+      const newMessageLineIfExists = nextChunk.find((lineInChunk) => lineInChunk.trim().startsWith(NEW_MESSAGE_TODO));
+      if (newMessageLineIfExists === undefined || !creatingTarget) {
+        chunks.push(nextChunk.join("\n"));
+      }
+      nextChunk = [];
+    }
+  });
+  return chunks;
+}
+
+function readFileIfExists(pathToFile) {
+  if (checkIfFileExists(pathToFile)) {
+    try {
+      return fs.readFileSync(pathToFile, 'utf8');
+    } catch (e) {
+      console.error('Error:', e.stack);
+    }
+  }
+  return null;
+}
+
+function isOneLineCommentLine(line) {
+  return (line.startsWith("//"));
+}
+
+function isStartOfMultiLineComment(line) {
+  return (line.startsWith("/*"));
+}
+
+function isEndOfMultiLineComment(line) {
+  return (line.endsWith("*/"));
+}
+
+function isKeyValuePair(line) {
+  return (line.startsWith("\""));
+}
+
+
+function getSubStringWithRegex(string, regex) {
+  return string.match(regex);
+}
+
+function getSubStringBeforeLastString(string, char) {
+  const lastCharIndex = string.lastIndexOf(char);
+  return string.substr(0, lastCharIndex);
+}
+
+
+function getOutputFileLocationIfExistsElseTargetFileLocation(targetLocation) {
+  if (program.outputFile) {
+    return program.outputFile;
+  }
+  return targetLocation;
+}
+
+function checkIfPathToFileIsValid(pathToCheck) {
+  if (!pathToCheck.includes("/")) {
+    return true;
+  }
+  return checkIfFileExists(getPathOfDirectory(pathToCheck));
+}
+
+function checkIfFileExists(pathToCheck) {
+  return fs.existsSync(pathToCheck);
+}
+
+function getPathOfDirectory(pathToCheck) {
+  return getSubStringBeforeLastString(pathToCheck, "/");
+}
+
+function removeWhiteLines(string) {
+  return string.replace(/^(?=\n)$|^\s*|\s*$|\n\n+/gm, "")
+}

--- a/scripts/sync-i18n-files.js
+++ b/scripts/sync-i18n-files.js
@@ -18,13 +18,23 @@ const LANGUAGE_FILES_LOCATION = 'resources/i18n';
 
 parseCliInput();
 
+/**
+ * Parses the CLI input given by the user
+ *    If no parameters are set (standard usage) -> source file is default (set to DEFAULT_SOURCE_FILE_LOCATION) and all
+ *            other language files in the LANGUAGE_FILES_LOCATION are synced with this one in-place
+ *            (replaced with newly synced file)
+ *    If only target-file -t is set -> either -i in-place or -o output-file must be set
+ *    Source file can be set with -s if it should be something else than DEFAULT_SOURCE_FILE_LOCATION
+ *
+ *    If any of the paths to files/dirs given by user are not valid, an error message is printed and script gets aborted
+ */
 function parseCliInput() {
   program
     .option('-d, --output-dir <output-dir>', 'output dir when running script on all language files; mutually exclusive with -o')
     .option('-t, --target-file <target>', 'target file we compare with and where completed output ends up if -o is not configured and -i is')
     .option('-i, --edit-in-place', 'edit-in-place; store output straight in target file; mutually exclusive with -o')
     .option('-s, --source-file <source>', 'source file to be parsed for translation', projectRoot(DEFAULT_SOURCE_FILE_LOCATION))
-    .option('-o, --output-location <output>', 'where output of script ends up; mutually exclusive with -i')
+    .option('-o, --output-file <output>', 'where output of script ends up; mutually exclusive with -i')
     .usage('([-d <output-dir>] [-s <source-file>]) || (-t <target-file> (-i | -o <output>) [-s <source-file>])')
     .parse(process.argv);
 
@@ -72,6 +82,14 @@ function parseCliInput() {
   }
 }
 
+/**
+ * Creates chunk lists for both the source and the target files (for example en.json5 and nl.json5 respectively)
+ *    > Creates output chunks by comparing the source chunk with corresponding target chunk (based on key of translation)
+ *    > Writes the output chunks to a new valid lang.json5 file, either replacing the target file (-i in-place)
+ *          or sending it to an output file specified by the user
+ * @param pathToTargetFile    Valid path to target file to generate target chunks from
+ * @param pathToOutputFile    Valid path to output file to write output chunks to
+ */
 function syncFileWithSource(pathToTargetFile, pathToOutputFile) {
   const progressBar = new _cliProgress.SingleBar({}, _cliProgress.Presets.shades_classic);
   progressBar.start(100, 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,6 +2053,14 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-progress@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.3.1.tgz#e08fb6853e269c3bc7e0ad8ad0ede59035f5fbce"
+  integrity sha512-cfvv/uuWblzSI6fvpmCNREWxwzI/luelp+P7zoPlguswswWVCfsq334/U6tmh+vusJ7yzbQ3xFni9JNqiF4fAA==
+  dependencies:
+    colors "^1.1.2"
+    string-width "^2.1.1"
+
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
@@ -2224,6 +2232,11 @@ colors@^1.1.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
   integrity sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==
 
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 combine-lists@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/combine-lists/-/combine-lists-1.0.1.tgz#458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6"
@@ -2252,6 +2265,11 @@ commander@^2.12.1, commander@^2.18.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
 commander@~2.13.0:
   version "2.13.0"


### PR DESCRIPTION
This PR adds a script to sync i18n message files to the latest english version. It will add missing keys to the other language files, and add TODO comments above them to indicate to the translator what has changed.

This will enable translators to start their work today, and keep tabs on how complete or incomplete the catalogs are.

To run the script type yarn run sync-i18n in the project root dir.

yarn run sync-i18n -h will give you an overview of the options

Please refer to https://wiki.duraspace.org/pages/viewpage.action?pageId=117735441 for further documentation.