### PR TITLE
Fix broken tests on master

### DIFF
--- a/src/app/core/data/dso-redirect-data.service.spec.ts
+++ b/src/app/core/data/dso-redirect-data.service.spec.ts
@@ -110,7 +110,7 @@ describe('DsoRedirectDataService', () => {
       scheduler.schedule(() => service.findById(dsoUUID, IdentifierType.UUID));
       scheduler.flush();
 
-      expect(requestService.configure).toHaveBeenCalledWith(new FindByIDRequest(requestUUID, requestUUIDURL, dsoUUID), false);
+      expect(requestService.configure).toHaveBeenCalledWith(new FindByIDRequest(requestUUID, requestUUIDURL, dsoUUID));
     });
 
     it('should configure the proper FindByIDRequest for handle', () => {
@@ -118,7 +118,7 @@ describe('DsoRedirectDataService', () => {
       scheduler.schedule(() => service.findById(dsoHandle, IdentifierType.HANDLE));
       scheduler.flush();
 
-      expect(requestService.configure).toHaveBeenCalledWith(new FindByIDRequest(requestUUID, requestHandleURL, dsoHandle), false);
+      expect(requestService.configure).toHaveBeenCalledWith(new FindByIDRequest(requestUUID, requestHandleURL, dsoHandle));
     });
 
     it('should navigate to item route', () => {


### PR DESCRIPTION
After merging #468 followed by #490, a few of the new tests created by #490 failed.  This is because they were not aligned with the updates in #468.  

This is a small PR to fix the broken tests of #490 to align with changes in #468