### PR TITLE
AoT build error fix

### DIFF
--- a/src/app/+lookup-by-id/lookup-by-id-routing.module.ts
+++ b/src/app/+lookup-by-id/lookup-by-id-routing.module.ts
@@ -8,25 +8,7 @@ import { hasValue, isNotEmpty } from '../shared/empty.util';
   imports: [
     RouterModule.forChild([
       {
-        matcher: (url) => {
-          // The expected path is :idType/:id
-          const idType = url[0].path;
-          // Allow for handles that are delimited with a forward slash.
-          const id = url
-            .slice(1)
-            .map((us: UrlSegment) => us.path)
-            .join('/');
-          if (isNotEmpty(idType) && isNotEmpty(id)) {
-            return {
-              consumed: url,
-              posParams: {
-                idType: new UrlSegment(idType, {}),
-                id: new UrlSegment(id, {})
-              }
-            };
-          }
-          return null;
-        },
+        matcher: urlMatcher,
         canActivate: [LookupGuard],
         component: ObjectNotFoundComponent  }
     ])
@@ -38,4 +20,24 @@ import { hasValue, isNotEmpty } from '../shared/empty.util';
 
 export class LookupRoutingModule {
 
+}
+
+export function urlMatcher(url) {
+  // The expected path is :idType/:id
+  const idType = url[0].path;
+  // Allow for handles that are delimited with a forward slash.
+  const id = url
+    .slice(1)
+    .map((us: UrlSegment) => us.path)
+    .join('/');
+  if (isNotEmpty(idType) && isNotEmpty(id)) {
+    return {
+      consumed: url,
+      posParams: {
+        idType: new UrlSegment(idType, {}),
+        id: new UrlSegment(id, {})
+      }
+    };
+  }
+  return null;
 }


### PR DESCRIPTION
As of the recent merge of #490 , running an AoT build results in the following error:

```
ERROR in Error during template compile of 'LookupRoutingModule'
      Function expressions are not supported in decorators in 'ɵ0'
        'ɵ0' contains the error at app/+lookup-by-id/lookup-by-id-routing.module.ts(11,18)
          Consider changing the function expression into an exported function.
```

As angular suggests, a simple solution is to move the lambda function on that line into an exported function.
This solves the error during the AoT build.