### PR TITLE
Remove bad characters from en.json5

### DIFF
--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -415,13 +415,9 @@
   "error.collections": "Error fetching collections",
 
   "error.community": "Error fetching community",
-<<<<<<< HEAD
-  "error.identifier": "No item found for the identifier",
-=======
 
   "error.identifier": "No item found for the identifier",
 
->>>>>>> Merged new message keys from dspace/master and ran script again
   "error.default": "Error",
 
   "error.item": "Error fetching item",


### PR DESCRIPTION
We accidentally ended up with some bad characters in `en.json5` during the merger of #504 (earlier today). These characters were added accidentally during a merge conflict resolution.  They were causing `e2e` test failures in Travis currently: https://travis-ci.org/DSpace/dspace-angular/jobs/612448996#L5424

The error message from Travis is:
`Error in SSR, serving for direct CSR. Error details :  { SyntaxError: JSON5: invalid character '<' at 418:1`

This is a tiny, obvious PR to fix those parse errors. If Travis approves of this, I'll merge immediately.