### PR TITLE
ComCol Tree - e2e tests

### DIFF
--- a/e2e/community-list-page/community-list-page.e2e-spec.ts
+++ b/e2e/community-list-page/community-list-page.e2e-spec.ts
@@ -1,0 +1,28 @@
+import { CommunityListPageProtractor } from './community-list-page.po';
+
+describe('protractor CommunityListPage', () => {
+  let page: CommunityListPageProtractor;
+
+  beforeEach(() => {
+    page = new CommunityListPageProtractor();
+  });
+
+  it('should contain page-limited top communities (at least 1 expandable community)', () => {
+    page.navigateToCommunityList();
+    expect<any>(page.anExpandableCommunityIsPresent()).toEqual(true)
+  });
+
+  describe('if expanded a node and navigating away, tree state gets saved', () => {
+    it('if navigating back, same node is expanded', () => {
+      page.navigateToCommunityList();
+      const linkOfSecondNodeBeforeExpanding = page.getLinkOfSecondNode();
+      page.toggleExpandFirstExpandableCommunity();
+      const linkOfSecondNodeAfterExpanding = page.getLinkOfSecondNode();
+      page.navigateToHome();
+      page.navigateToCommunityList();
+      expect<any>(page.getLinkOfSecondNode()).toEqual(linkOfSecondNodeAfterExpanding);
+      page.toggleExpandFirstExpandableCommunity();
+      expect<any>(page.getLinkOfSecondNode()).toEqual(linkOfSecondNodeBeforeExpanding);
+    });
+  });
+});

--- a/e2e/community-list-page/community-list-page.po.ts
+++ b/e2e/community-list-page/community-list-page.po.ts
@@ -1,0 +1,32 @@
+import { browser, by, element, protractor } from 'protractor';
+
+export class CommunityListPageProtractor {
+  HOMEPAGE = '/home';
+  COMMUNITY_LIST = '/community-list';
+
+  navigateToHome() {
+    return browser.get(this.HOMEPAGE);
+  }
+
+  navigateToCommunityList() {
+    browser.get(this.COMMUNITY_LIST);
+    const loading = element(by.css('.ds-loading'));
+    browser.wait(protractor.ExpectedConditions.invisibilityOf(loading), 10000);
+    return;
+
+  }
+
+  anExpandableCommunityIsPresent() {
+    console.log(element(by.css('body')));
+    return element(by.css('.expandable-node h5 a')).isPresent();
+  }
+
+  toggleExpandFirstExpandableCommunity() {
+    element(by.css('.expandable-node button')).click();
+  }
+
+  getLinkOfSecondNode() {
+    return element(by.css('.cdk-tree-node h5 a')).getAttribute('href');
+  }
+
+}


### PR DESCRIPTION
This reverts commit 43680155

Tests were removed in PR #505 because they failed on travis, despite running fine locally using various backends, including the one used by travis via docker-compose.

docker-compose -f ./docker/docker-compose-travis.yml up -d
docker-compose -f ./docker/cli.yml -f ./docker/cli.assetstore.yml run --rm dspace-cli

Backend set in angular at: http://localhost:8080/server/#/server/api 
(To turn off: docker-compose -f ./docker/docker-compose-travis.yml down)
yrw/yarn start and yarn e2e runs fine locally.