### PR TITLE
Disregard the response body for statistic event calls

### DIFF
--- a/src/app/core/data/status-code-only-response-parsing.service.spec.ts
+++ b/src/app/core/data/status-code-only-response-parsing.service.spec.ts
@@ -11,6 +11,17 @@ describe('StatusCodeOnlyResponseParsingService', () => {
 
   describe('parse', () => {
 
+    it('should return a RestResponse that doesn\'t contain the response body', () => {
+      const payload = 'd9128e44-183b-479d-aa2e-d39435838bf6';
+      const result = service.parse(undefined, {
+        payload,
+        statusCode: 201,
+        statusText: '201'
+      });
+
+      expect(JSON.stringify(result).indexOf(payload)).toBe(-1);
+    });
+
     describe('when the response is successful', () => {
       beforeEach(() => {
         statusCode = 201;

--- a/src/app/core/data/status-code-only-response-parsing.service.spec.ts
+++ b/src/app/core/data/status-code-only-response-parsing.service.spec.ts
@@ -1,0 +1,82 @@
+import { StatusCodeOnlyResponseParsingService } from './status-code-only-response-parsing.service';
+
+describe('StatusCodeOnlyResponseParsingService', () => {
+  let service;
+  let statusCode;
+  let statusText;
+
+  beforeEach(() => {
+    service = new StatusCodeOnlyResponseParsingService();
+  });
+
+  describe('parse', () => {
+
+    describe('when the response is successful', () => {
+      beforeEach(() => {
+        statusCode = 201;
+        statusText = `${statusCode}`;
+      });
+
+      it('should return a success RestResponse', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.isSuccessful).toBe(true);
+      });
+
+      it('should return a RestResponse with the correct status code', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.statusCode).toBe(statusCode);
+      });
+
+      it('should return a RestResponse with the correct status text', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.statusText).toBe(statusText);
+      });
+    });
+
+    describe('when the response is unsuccessful', () => {
+      beforeEach(() => {
+        statusCode = 400;
+        statusText = `${statusCode}`;
+      });
+
+      it('should return an error RestResponse', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.isSuccessful).toBe(false);
+      });
+
+      it('should return a RestResponse with the correct status code', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.statusCode).toBe(statusCode);
+      });
+
+      it('should return a RestResponse with the correct status text', () => {
+        const result = service.parse(undefined, {
+          statusCode,
+          statusText
+        });
+
+        expect(result.statusText).toBe(statusText);
+      });
+    });
+  });
+});

--- a/src/app/core/data/status-code-only-response-parsing.service.ts
+++ b/src/app/core/data/status-code-only-response-parsing.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { RestResponse } from '../cache/response.models';
+import { DSpaceRESTV2Response } from '../dspace-rest-v2/dspace-rest-v2-response.model';
+import { ResponseParsingService } from './parsing.service';
+import { RestRequest } from './request.models';
+
+/**
+ * A responseparser that will only look at the status code and status
+ * text of the response, and ignore anything else that might be there
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class StatusCodeOnlyResponseParsingService implements ResponseParsingService {
+
+  /**
+   * Parse the response and only extract the status code and status text
+   *
+   * @param request The request that was sent to the server
+   * @param data The response to parse
+   */
+  parse(request: RestRequest, data: DSpaceRESTV2Response): RestResponse {
+    const isSuccessful = data.statusCode >= 200 && data.statusCode < 300;
+    return new RestResponse(isSuccessful, data.statusCode, data.statusText);
+  }
+}

--- a/src/app/statistics/track-request.model.ts
+++ b/src/app/statistics/track-request.model.ts
@@ -1,4 +1,11 @@
+import { ResponseParsingService } from '../core/data/parsing.service';
 import { PostRequest } from '../core/data/request.models';
+import { StatusCodeOnlyResponseParsingService } from '../core/data/status-code-only-response-parsing.service';
+import { GenericConstructor } from '../core/shared/generic-constructor';
 
 export class TrackRequest extends PostRequest {
+
+  getResponseParser(): GenericConstructor<ResponseParsingService> {
+    return StatusCodeOnlyResponseParsingService;
+  }
 }


### PR DESCRIPTION
This PR fixes an error that is sometimes thrown when the statistics/viewevents endpoint returns an object with an `id: null`. While this shouldn't happen, and this will be fixed on the rest side as well, the UI also shouldn't parse the response beyond the status code, as we don't need the data for anything.

This PR adds a new StatusCodeOnlyResponseParsingService that will ignore everything but the statuscode, status text and whether the response was successful or not

It will use that service to parse statistic event responses.