### PR TITLE
WIP: DS-3533 Use correct json property name for embedded collections

### DIFF
--- a/src/app/core/data/mapped-collections-reponse-parsing.service.ts
+++ b/src/app/core/data/mapped-collections-reponse-parsing.service.ts
@@ -15,8 +15,8 @@ export class MappedCollectionsReponseParsingService implements ResponseParsingSe
   parse(request: RestRequest, data: DSpaceRESTV2Response): RestResponse {
     const payload = data.payload;
 
-    if (payload._embedded && payload._embedded.mappedCollections) {
-      const mappedCollections = payload._embedded.mappedCollections;
+    if (payload._embedded && payload._embedded.collections) {
+      const mappedCollections = payload._embedded.collections;
       // TODO: When the API supports it, change this to fetch a paginated list, instead of creating static one
       // Reason: Pagination is currently not supported on the mappedCollections endpoint
       const paginatedMappedCollections = new PaginatedList(Object.assign(new PageInfo(), {


### PR DESCRIPTION
**Updated Description 2020/01/07:**

This PR introduces an issue with the items/uuid/edit/mapper page when an item is not mapped. I have put it back in WIP state...waiting for some adjustments to the associated REST PR. I will update the description when ready.

**Original Description**

This is a minor adjustment that should be merged when the corresponding REST PR is merged:

https://github.com/DSpace/DSpace/pull/2625

This property name changed in order to be consistent with other embedded list property names.