### PR TITLE
Pagination on community page

### DIFF
--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.html
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.html
@@ -1,14 +1,13 @@
 <ng-container *ngVar="(subCollectionsRDObs | async) as subCollectionsRD">
   <div *ngIf="subCollectionsRD?.hasSucceeded && subCollectionsRD?.payload.totalElements > 0" @fadeIn>
     <h2>{{'community.sub-collection-list.head' | translate}}</h2>
-    <ul>
-      <li *ngFor="let collection of subCollectionsRD?.payload.page">
-        <p>
-          <span class="lead"><a [routerLink]="['/collections', collection.id]">{{collection.name}}</a></span><br>
-          <span class="text-muted">{{collection.shortDescription}}</span>
-        </p>
-      </li>
-    </ul>
+    <ds-viewable-collection
+      [config]="config"
+      [sortConfig]="sortConfig"
+      [objects]="subCollectionsRD"
+      [hideGear]="false"
+      (paginationChange)="onPaginationChange($event)">
+    </ds-viewable-collection>
   </div>
   <ds-error *ngIf="subCollectionsRD?.hasFailed" message="{{'error.sub-collections' | translate}}"></ds-error>
   <ds-loading *ngIf="subCollectionsRD?.isLoading" message="{{'loading.sub-collections' | translate}}"></ds-loading>

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.spec.ts
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.spec.ts
@@ -1,0 +1,169 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { CommunityPageSubCollectionListComponent } from './community-page-sub-collection-list.component';
+import { Community } from '../../core/shared/community.model';
+import { SharedModule } from '../../shared/shared.module';
+import { CollectionDataService } from '../../core/data/collection-data.service';
+import { FindListOptions } from '../../core/data/request.models';
+import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
+import { PaginatedList } from '../../core/data/paginated-list';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { HostWindowService } from '../../shared/host-window.service';
+import { HostWindowServiceStub } from '../../shared/testing/host-window-service-stub';
+
+describe('CommunityPageSubCollectionListComponent Component', () => {
+  let comp: CommunityPageSubCollectionListComponent;
+  let fixture: ComponentFixture<CommunityPageSubCollectionListComponent>;
+  let collectionDataServiceStub: any;
+  let subCollList = [];
+
+  const collections = [Object.assign(new Community(), {
+    id: '123456789-1',
+    metadata: {
+      'dc.title': [
+        { language: 'en_US', value: 'Collection 1' }
+      ]
+    }
+  }),
+    Object.assign(new Community(), {
+      id: '123456789-2',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 2' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-3',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 3' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-4',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 4' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-5',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 5' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-6',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 6' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-7',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'Collection 7' }
+        ]
+      }
+    })
+  ];
+
+  const mockCommunity = Object.assign(new Community(), {
+    id: '123456789',
+    metadata: {
+      'dc.title': [
+        { language: 'en_US', value: 'Test title' }
+      ]
+    }
+  });
+
+  collectionDataServiceStub = {
+    findByParent(parentUUID: string, options: FindListOptions = {}) {
+      let currentPage = options.currentPage;
+      let elementsPerPage = options.elementsPerPage;
+      if (currentPage === undefined) {
+        currentPage = 1
+      }
+      elementsPerPage = 5;
+      const startPageIndex = (currentPage - 1) * elementsPerPage;
+      let endPageIndex = (currentPage * elementsPerPage);
+      if (endPageIndex > subCollList.length) {
+        endPageIndex = subCollList.length;
+      }
+      return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), subCollList.slice(startPageIndex, endPageIndex)));
+
+    }
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), SharedModule,
+        RouterTestingModule.withRoutes([]),
+        NoopAnimationsModule],
+      declarations: [CommunityPageSubCollectionListComponent],
+      providers: [
+        { provide: CollectionDataService, useValue: collectionDataServiceStub },
+        { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CommunityPageSubCollectionListComponent);
+    comp = fixture.componentInstance;
+    comp.community = mockCommunity;
+  });
+
+  it('should display a list of collections', () => {
+    subCollList = collections;
+    fixture.detectChanges();
+
+    const collList = fixture.debugElement.queryAll(By.css('li'));
+    expect(collList.length).toEqual(5);
+    expect(collList[0].nativeElement.textContent).toContain('Collection 1');
+    expect(collList[1].nativeElement.textContent).toContain('Collection 2');
+    expect(collList[2].nativeElement.textContent).toContain('Collection 3');
+    expect(collList[3].nativeElement.textContent).toContain('Collection 4');
+    expect(collList[4].nativeElement.textContent).toContain('Collection 5');
+  });
+
+  it('should not display the header when collection list is empty', () => {
+    subCollList = [];
+    fixture.detectChanges();
+
+    const subComHead = fixture.debugElement.queryAll(By.css('h2'));
+    expect(subComHead.length).toEqual(0);
+  });
+
+  it('should update list of collection on pagination change', () => {
+    subCollList = collections;
+    fixture.detectChanges();
+
+    const pagination = Object.create({});
+    pagination.pageId = comp.pageId;
+    pagination.page = 2;
+    pagination.pageSize = 5;
+    pagination.sortField = 'dc.title';
+    pagination.sortDirection = 'ASC';
+    comp.onPaginationChange(pagination);
+    fixture.detectChanges();
+
+    const collList = fixture.debugElement.queryAll(By.css('li'));
+    expect(collList.length).toEqual(2);
+    expect(collList[0].nativeElement.textContent).toContain('Collection 6');
+    expect(collList[1].nativeElement.textContent).toContain('Collection 7');
+  });
+});

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.spec.ts
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.spec.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
 import { CommunityPageSubCollectionListComponent } from './community-page-sub-collection-list.component';
 import { Community } from '../../core/shared/community.model';
 import { SharedModule } from '../../shared/shared.module';
@@ -15,8 +17,9 @@ import { PaginatedList } from '../../core/data/paginated-list';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { HostWindowService } from '../../shared/host-window.service';
 import { HostWindowServiceStub } from '../../shared/testing/host-window-service-stub';
+import { SelectableListService } from '../../shared/object-list/selectable-list/selectable-list.service';
 
-describe('CommunityPageSubCollectionListComponent Component', () => {
+describe('CommunityPageSubCollectionList Component', () => {
   let comp: CommunityPageSubCollectionListComponent;
   let fixture: ComponentFixture<CommunityPageSubCollectionListComponent>;
   let collectionDataServiceStub: any;
@@ -109,13 +112,18 @@ describe('CommunityPageSubCollectionListComponent Component', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), SharedModule,
+      imports: [
+        TranslateModule.forRoot(),
+        SharedModule,
         RouterTestingModule.withRoutes([]),
-        NoopAnimationsModule],
+        NgbModule.forRoot(),
+        NoopAnimationsModule
+      ],
       declarations: [CommunityPageSubCollectionListComponent],
       providers: [
         { provide: CollectionDataService, useValue: collectionDataServiceStub },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
+        { provide: SelectableListService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -140,7 +148,7 @@ describe('CommunityPageSubCollectionListComponent Component', () => {
     expect(collList[4].nativeElement.textContent).toContain('Collection 5');
   });
 
-  it('should not display the header when collection list is empty', () => {
+  it('should not display the header when list of collections is empty', () => {
     subCollList = [];
     fixture.detectChanges();
 
@@ -148,16 +156,21 @@ describe('CommunityPageSubCollectionListComponent Component', () => {
     expect(subComHead.length).toEqual(0);
   });
 
-  it('should update list of collection on pagination change', () => {
+  it('should update list of collections on pagination change', () => {
     subCollList = collections;
     fixture.detectChanges();
 
-    const pagination = Object.create({});
-    pagination.pageId = comp.pageId;
-    pagination.page = 2;
-    pagination.pageSize = 5;
-    pagination.sortField = 'dc.title';
-    pagination.sortDirection = 'ASC';
+    const pagination = Object.create({
+      pagination:{
+        id: comp.pageId,
+        currentPage: 2,
+        pageSize: 5
+      },
+      sort: {
+        field: 'dc.title',
+        direction: 'ASC'
+      }
+    });
     comp.onPaginationChange(pagination);
     fixture.detectChanges();
 

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
@@ -57,10 +57,10 @@ export class CommunityPageSubCollectionListComponent implements OnInit {
    * @param event The new pagination data
    */
   onPaginationChange(event) {
-    this.config.currentPage = event.page;
-    this.config.pageSize = event.pageSize;
-    this.sortConfig.field = event.sortField;
-    this.sortConfig.direction = event.sortDirection;
+    this.config.currentPage = event.pagination.currentPage;
+    this.config.pageSize = event.pagination.pageSize;
+    this.sortConfig.field = event.sort.field;
+    this.sortConfig.direction = event.sort.direction;
     this.updatePage();
   }
 

--- a/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
+++ b/src/app/+community-page/sub-collection-list/community-page-sub-collection-list.component.ts
@@ -1,12 +1,16 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+
+import { BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { RemoteData } from '../../core/data/remote-data';
 import { Collection } from '../../core/shared/collection.model';
 import { Community } from '../../core/shared/community.model';
-
 import { fadeIn } from '../../shared/animations/fade';
 import { PaginatedList } from '../../core/data/paginated-list';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
+import { CollectionDataService } from '../../core/data/collection-data.service';
 
 @Component({
   selector: 'ds-community-page-sub-collection-list',
@@ -16,9 +20,60 @@ import { PaginatedList } from '../../core/data/paginated-list';
 })
 export class CommunityPageSubCollectionListComponent implements OnInit {
   @Input() community: Community;
-  subCollectionsRDObs: Observable<RemoteData<PaginatedList<Collection>>>;
+
+  /**
+   * The pagination configuration
+   */
+  config: PaginationComponentOptions;
+
+  /**
+   * The pagination id
+   */
+  pageId = 'community-collections-pagination';
+
+  /**
+   * The sorting configuration
+   */
+  sortConfig: SortOptions;
+
+  /**
+   * A list of remote data objects of communities' collections
+   */
+  subCollectionsRDObs: BehaviorSubject<RemoteData<PaginatedList<Collection>>> = new BehaviorSubject<RemoteData<PaginatedList<Collection>>>({} as any);
+
+  constructor(private cds: CollectionDataService) {}
 
   ngOnInit(): void {
-    this.subCollectionsRDObs = this.community.collections;
+    this.config = new PaginationComponentOptions();
+    this.config.id = this.pageId;
+    this.config.pageSize = 5;
+    this.config.currentPage = 1;
+    this.sortConfig = new SortOptions('dc.title', SortDirection.ASC);
+    this.updatePage();
+  }
+
+  /**
+   * Called when one of the pagination settings is changed
+   * @param event The new pagination data
+   */
+  onPaginationChange(event) {
+    this.config.currentPage = event.page;
+    this.config.pageSize = event.pageSize;
+    this.sortConfig.field = event.sortField;
+    this.sortConfig.direction = event.sortDirection;
+    this.updatePage();
+  }
+
+  /**
+   * Update the list of collections
+   */
+  updatePage() {
+    this.cds.findByParent(this.community.id,{
+      currentPage: this.config.currentPage,
+      elementsPerPage: this.config.pageSize,
+      sort: { field: this.sortConfig.field, direction: this.sortConfig.direction }
+    }).pipe(take(1)).subscribe((results) => {
+      this.subCollectionsRDObs.next(results);
+    });
   }
 }

--- a/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.html
+++ b/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.html
@@ -1,14 +1,13 @@
 <ng-container *ngVar="(subCommunitiesRDObs | async) as subCommunitiesRD">
   <div *ngIf="subCommunitiesRD?.hasSucceeded && subCommunitiesRD?.payload.totalElements > 0" @fadeIn>
     <h2>{{'community.sub-community-list.head' | translate}}</h2>
-    <ul>
-      <li *ngFor="let community of subCommunitiesRD?.payload.page">
-        <p>
-          <span class="lead"><a [routerLink]="['/communities', community.id]">{{community.name}}</a></span><br>
-          <span class="text-muted">{{community.shortDescription}}</span>
-        </p>
-      </li>
-    </ul>
+    <ds-viewable-collection
+      [config]="config"
+      [sortConfig]="sortConfig"
+      [objects]="subCommunitiesRD"
+      [hideGear]="false"
+      (paginationChange)="onPaginationChange($event)">
+    </ds-viewable-collection>
   </div>
   <ds-error *ngIf="subCommunitiesRD?.hasFailed" message="{{'error.sub-communities' | translate}}"></ds-error>
   <ds-loading *ngIf="subCommunitiesRD?.isLoading" message="{{'loading.sub-communities' | translate}}"></ds-loading>

--- a/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.spec.ts
+++ b/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.spec.ts
@@ -1,21 +1,26 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {TranslateModule} from '@ngx-translate/core';
-import {NO_ERRORS_SCHEMA} from '@angular/core';
-import {CommunityPageSubCommunityListComponent} from './community-page-sub-community-list.component';
-import {Community} from '../../core/shared/community.model';
-import {RemoteData} from '../../core/data/remote-data';
-import {PaginatedList} from '../../core/data/paginated-list';
-import {PageInfo} from '../../core/shared/page-info.model';
-import {SharedModule} from '../../shared/shared.module';
-import {RouterTestingModule} from '@angular/router/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {By} from '@angular/platform-browser';
-import {of as observableOf,  Observable } from 'rxjs';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+
+import { CommunityPageSubCommunityListComponent } from './community-page-sub-community-list.component';
+import { Community } from '../../core/shared/community.model';
+import { PaginatedList } from '../../core/data/paginated-list';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { SharedModule } from '../../shared/shared.module';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
+import { FindListOptions } from '../../core/data/request.models';
+import { HostWindowService } from '../../shared/host-window.service';
+import { HostWindowServiceStub } from '../../shared/testing/host-window-service-stub';
+import { CommunityDataService } from '../../core/data/community-data.service';
 
 describe('SubCommunityList Component', () => {
   let comp: CommunityPageSubCommunityListComponent;
   let fixture: ComponentFixture<CommunityPageSubCommunityListComponent>;
+  let communityDataServiceStub: any;
+  let subCommList = [];
 
   const subcommunities = [Object.assign(new Community(), {
     id: '123456789-1',
@@ -32,27 +37,76 @@ describe('SubCommunityList Component', () => {
           { language: 'en_US', value: 'SubCommunity 2' }
         ]
       }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-3',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'SubCommunity 3' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '12345678942',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'SubCommunity 4' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-5',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'SubCommunity 5' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-6',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'SubCommunity 6' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-7',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'SubCommunity 7' }
+        ]
+      }
     })
   ];
 
-  const emptySubCommunitiesCommunity = Object.assign(new Community(), {
+  const mockCommunity = Object.assign(new Community(), {
+    id: '123456789',
     metadata: {
       'dc.title': [
         { language: 'en_US', value: 'Test title' }
       ]
-    },
-    subcommunities: createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
+    }
   });
 
-  const mockCommunity = Object.assign(new Community(), {
-      metadata: {
-        'dc.title': [
-          { language: 'en_US', value: 'Test title' }
-        ]
-      },
-      subcommunities: createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), subcommunities))
-    })
-  ;
+  communityDataServiceStub = {
+    findByParent(parentUUID: string, options: FindListOptions = {}) {
+      let currentPage = options.currentPage;
+      let elementsPerPage = options.elementsPerPage;
+      if (currentPage === undefined) {
+        currentPage = 1
+      }
+      elementsPerPage = 5;
+
+      const startPageIndex = (currentPage - 1) * elementsPerPage;
+      let endPageIndex = (currentPage * elementsPerPage);
+      if (endPageIndex > subCommList.length) {
+        endPageIndex = subCommList.length;
+      }
+      return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), subCommList.slice(startPageIndex, endPageIndex)));
+
+    }
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -60,6 +114,10 @@ describe('SubCommunityList Component', () => {
         RouterTestingModule.withRoutes([]),
         NoopAnimationsModule],
       declarations: [CommunityPageSubCommunityListComponent],
+      providers: [
+        { provide: CommunityDataService, useValue: communityDataServiceStub },
+        { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
+      ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   }));
@@ -67,23 +125,47 @@ describe('SubCommunityList Component', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CommunityPageSubCommunityListComponent);
     comp = fixture.componentInstance;
+    comp.community = mockCommunity;
+
   });
 
   it('should display a list of subCommunities', () => {
-    comp.community = mockCommunity;
+    subCommList = subcommunities;
     fixture.detectChanges();
 
     const subComList = fixture.debugElement.queryAll(By.css('li'));
-    expect(subComList.length).toEqual(2);
+    expect(subComList.length).toEqual(5);
     expect(subComList[0].nativeElement.textContent).toContain('SubCommunity 1');
     expect(subComList[1].nativeElement.textContent).toContain('SubCommunity 2');
+    expect(subComList[2].nativeElement.textContent).toContain('SubCommunity 3');
+    expect(subComList[3].nativeElement.textContent).toContain('SubCommunity 4');
+    expect(subComList[4].nativeElement.textContent).toContain('SubCommunity 5');
   });
 
   it('should not display the header when subCommunities are empty', () => {
-    comp.community = emptySubCommunitiesCommunity;
+    subCommList = [];
     fixture.detectChanges();
 
     const subComHead = fixture.debugElement.queryAll(By.css('h2'));
     expect(subComHead.length).toEqual(0);
+  });
+
+  it('should update list of collection on pagination change', () => {
+    subCommList = subcommunities;
+    fixture.detectChanges();
+
+    const pagination = Object.create({});
+    pagination.pageId = comp.pageId;
+    pagination.page = 2;
+    pagination.pageSize = 5;
+    pagination.sortField = 'dc.title';
+    pagination.sortDirection = 'ASC';
+    comp.onPaginationChange(pagination);
+    fixture.detectChanges();
+
+    const collList = fixture.debugElement.queryAll(By.css('li'));
+    expect(collList.length).toEqual(2);
+    expect(collList[0].nativeElement.textContent).toContain('SubCommunity 6');
+    expect(collList[1].nativeElement.textContent).toContain('SubCommunity 7');
   });
 });

--- a/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.spec.ts
+++ b/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.spec.ts
@@ -5,6 +5,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
 import { CommunityPageSubCommunityListComponent } from './community-page-sub-community-list.component';
 import { Community } from '../../core/shared/community.model';
 import { PaginatedList } from '../../core/data/paginated-list';
@@ -15,8 +17,9 @@ import { FindListOptions } from '../../core/data/request.models';
 import { HostWindowService } from '../../shared/host-window.service';
 import { HostWindowServiceStub } from '../../shared/testing/host-window-service-stub';
 import { CommunityDataService } from '../../core/data/community-data.service';
+import { SelectableListService } from '../../shared/object-list/selectable-list/selectable-list.service';
 
-describe('SubCommunityList Component', () => {
+describe('CommunityPageSubCommunityListComponent Component', () => {
   let comp: CommunityPageSubCommunityListComponent;
   let fixture: ComponentFixture<CommunityPageSubCommunityListComponent>;
   let communityDataServiceStub: any;
@@ -110,13 +113,18 @@ describe('SubCommunityList Component', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), SharedModule,
+      imports: [
+        TranslateModule.forRoot(),
+        SharedModule,
         RouterTestingModule.withRoutes([]),
-        NoopAnimationsModule],
+        NgbModule.forRoot(),
+        NoopAnimationsModule
+      ],
       declarations: [CommunityPageSubCommunityListComponent],
       providers: [
         { provide: CommunityDataService, useValue: communityDataServiceStub },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
+        { provide: SelectableListService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -129,7 +137,7 @@ describe('SubCommunityList Component', () => {
 
   });
 
-  it('should display a list of subCommunities', () => {
+  it('should display a list of sub-communities', () => {
     subCommList = subcommunities;
     fixture.detectChanges();
 
@@ -142,7 +150,7 @@ describe('SubCommunityList Component', () => {
     expect(subComList[4].nativeElement.textContent).toContain('SubCommunity 5');
   });
 
-  it('should not display the header when subCommunities are empty', () => {
+  it('should not display the header when list of sub-communities is empty', () => {
     subCommList = [];
     fixture.detectChanges();
 
@@ -150,16 +158,21 @@ describe('SubCommunityList Component', () => {
     expect(subComHead.length).toEqual(0);
   });
 
-  it('should update list of collection on pagination change', () => {
+  it('should update list of sub-communities on pagination change', () => {
     subCommList = subcommunities;
     fixture.detectChanges();
 
-    const pagination = Object.create({});
-    pagination.pageId = comp.pageId;
-    pagination.page = 2;
-    pagination.pageSize = 5;
-    pagination.sortField = 'dc.title';
-    pagination.sortDirection = 'ASC';
+    const pagination = Object.create({
+      pagination:{
+        id: comp.pageId,
+        currentPage: 2,
+        pageSize: 5
+      },
+      sort: {
+        field: 'dc.title',
+        direction: 'ASC'
+      }
+    });
     comp.onPaginationChange(pagination);
     fixture.detectChanges();
 

--- a/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.ts
+++ b/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.ts
@@ -1,26 +1,82 @@
 import { Component, Input, OnInit } from '@angular/core';
 
+import { BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
+
 import { RemoteData } from '../../core/data/remote-data';
 import { Community } from '../../core/shared/community.model';
-
 import { fadeIn } from '../../shared/animations/fade';
 import { PaginatedList } from '../../core/data/paginated-list';
-import {Observable} from 'rxjs';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
+import { CommunityDataService } from '../../core/data/community-data.service';
 
 @Component({
   selector: 'ds-community-page-sub-community-list',
   styleUrls: ['./community-page-sub-community-list.component.scss'],
   templateUrl: './community-page-sub-community-list.component.html',
-  animations:[fadeIn]
+  animations: [fadeIn]
 })
 /**
  * Component to render the sub-communities of a Community
  */
 export class CommunityPageSubCommunityListComponent implements OnInit {
   @Input() community: Community;
-  subCommunitiesRDObs: Observable<RemoteData<PaginatedList<Community>>>;
+
+  /**
+   * The pagination configuration
+   */
+  config: PaginationComponentOptions;
+
+  /**
+   * The pagination id
+   */
+  pageId = 'community-subCommunities-pagination';
+
+  /**
+   * The sorting configuration
+   */
+  sortConfig: SortOptions;
+
+  /**
+   * A list of remote data objects of communities' collections
+   */
+  subCommunitiesRDObs: BehaviorSubject<RemoteData<PaginatedList<Community>>> = new BehaviorSubject<RemoteData<PaginatedList<Community>>>({} as any);
+
+  constructor(private cds: CommunityDataService) {
+  }
 
   ngOnInit(): void {
-    this.subCommunitiesRDObs = this.community.subcommunities;
+    this.config = new PaginationComponentOptions();
+    this.config.id = this.pageId;
+    this.config.pageSize = 5;
+    this.config.currentPage = 1;
+    this.sortConfig = new SortOptions('dc.title', SortDirection.ASC);
+    this.updatePage();
+  }
+
+  /**
+   * Called when one of the pagination settings is changed
+   * @param event The new pagination data
+   */
+  onPaginationChange(event) {
+    this.config.currentPage = event.page;
+    this.config.pageSize = event.pageSize;
+    this.sortConfig.field = event.sortField;
+    this.sortConfig.direction = event.sortDirection;
+    this.updatePage();
+  }
+
+  /**
+   * Update the list of sub-communities
+   */
+  updatePage() {
+    this.cds.findByParent(this.community.id, {
+      currentPage: this.config.currentPage,
+      elementsPerPage: this.config.pageSize,
+      sort: { field: this.sortConfig.field, direction: this.sortConfig.direction }
+    }).pipe(take(1)).subscribe((results) => {
+      this.subCommunitiesRDObs.next(results);
+    });
   }
 }

--- a/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.ts
+++ b/src/app/+community-page/sub-community-list/community-page-sub-community-list.component.ts
@@ -60,10 +60,10 @@ export class CommunityPageSubCommunityListComponent implements OnInit {
    * @param event The new pagination data
    */
   onPaginationChange(event) {
-    this.config.currentPage = event.page;
-    this.config.pageSize = event.pageSize;
-    this.sortConfig.field = event.sortField;
-    this.sortConfig.direction = event.sortDirection;
+    this.config.currentPage = event.pagination.currentPage;
+    this.config.pageSize = event.pagination.pageSize;
+    this.sortConfig.field = event.sort.field;
+    this.sortConfig.direction = event.sort.direction;
     this.updatePage();
   }
 

--- a/src/app/+home-page/top-level-community-list/top-level-community-list.component.spec.ts
+++ b/src/app/+home-page/top-level-community-list/top-level-community-list.component.spec.ts
@@ -1,0 +1,161 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { TopLevelCommunityListComponent } from './top-level-community-list.component';
+import { Community } from '../../core/shared/community.model';
+import { PaginatedList } from '../../core/data/paginated-list';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { SharedModule } from '../../shared/shared.module';
+import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
+import { FindListOptions } from '../../core/data/request.models';
+import { HostWindowService } from '../../shared/host-window.service';
+import { HostWindowServiceStub } from '../../shared/testing/host-window-service-stub';
+import { CommunityDataService } from '../../core/data/community-data.service';
+import { SelectableListService } from '../../shared/object-list/selectable-list/selectable-list.service';
+
+describe('TopLevelCommunityList Component', () => {
+  let comp: TopLevelCommunityListComponent;
+  let fixture: ComponentFixture<TopLevelCommunityListComponent>;
+  let communityDataServiceStub: any;
+
+  const topCommList = [Object.assign(new Community(), {
+    id: '123456789-1',
+    metadata: {
+      'dc.title': [
+        { language: 'en_US', value: 'TopCommunity 1' }
+      ]
+    }
+  }),
+    Object.assign(new Community(), {
+      id: '123456789-2',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 2' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-3',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 3' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '12345678942',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 4' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-5',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 5' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-6',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 6' }
+        ]
+      }
+    }),
+    Object.assign(new Community(), {
+      id: '123456789-7',
+      metadata: {
+        'dc.title': [
+          { language: 'en_US', value: 'TopCommunity 7' }
+        ]
+      }
+    })
+  ];
+
+  communityDataServiceStub = {
+    findTop(options: FindListOptions = {}) {
+      let currentPage = options.currentPage;
+      let elementsPerPage = options.elementsPerPage;
+      if (currentPage === undefined) {
+        currentPage = 1
+      }
+      elementsPerPage = 5;
+
+      const startPageIndex = (currentPage - 1) * elementsPerPage;
+      let endPageIndex = (currentPage * elementsPerPage);
+      if (endPageIndex > topCommList.length) {
+        endPageIndex = topCommList.length;
+      }
+      return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), topCommList.slice(startPageIndex, endPageIndex)));
+
+    }
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        SharedModule,
+        RouterTestingModule.withRoutes([]),
+        NgbModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      declarations: [TopLevelCommunityListComponent],
+      providers: [
+        { provide: CommunityDataService, useValue: communityDataServiceStub },
+        { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
+        { provide: SelectableListService, useValue: {} },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopLevelCommunityListComponent);
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+
+  });
+
+  it('should display a list of top-communities', () => {
+    const subComList = fixture.debugElement.queryAll(By.css('li'));
+
+    expect(subComList.length).toEqual(5);
+    expect(subComList[0].nativeElement.textContent).toContain('TopCommunity 1');
+    expect(subComList[1].nativeElement.textContent).toContain('TopCommunity 2');
+    expect(subComList[2].nativeElement.textContent).toContain('TopCommunity 3');
+    expect(subComList[3].nativeElement.textContent).toContain('TopCommunity 4');
+    expect(subComList[4].nativeElement.textContent).toContain('TopCommunity 5');
+  });
+
+  it('should update list of top-communities on pagination change', () => {
+    const pagination = Object.create({
+      pagination:{
+        id: comp.pageId,
+        currentPage: 2,
+        pageSize: 5
+      },
+      sort: {
+        field: 'dc.title',
+        direction: 'ASC'
+      }
+    });
+    comp.onPaginationChange(pagination);
+    fixture.detectChanges();
+
+    const collList = fixture.debugElement.queryAll(By.css('li'));
+    expect(collList.length).toEqual(2);
+    expect(collList[0].nativeElement.textContent).toContain('TopCommunity 6');
+    expect(collList[1].nativeElement.textContent).toContain('TopCommunity 7');
+  });
+});

--- a/src/app/+home-page/top-level-community-list/top-level-community-list.component.ts
+++ b/src/app/+home-page/top-level-community-list/top-level-community-list.component.ts
@@ -1,15 +1,15 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+
+import { BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
+
 import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
 import { CommunityDataService } from '../../core/data/community-data.service';
 import { PaginatedList } from '../../core/data/paginated-list';
-
 import { RemoteData } from '../../core/data/remote-data';
 import { Community } from '../../core/shared/community.model';
-
 import { fadeInOut } from '../../shared/animations/fade';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
-import { take } from 'rxjs/operators';
 
 /**
  * this component renders the Top-Level Community list
@@ -34,13 +34,18 @@ export class TopLevelCommunityListComponent implements OnInit {
   config: PaginationComponentOptions;
 
   /**
+   * The pagination id
+   */
+  pageId = 'top-level-pagination';
+
+  /**
    * The sorting configuration
    */
   sortConfig: SortOptions;
 
   constructor(private cds: CommunityDataService) {
     this.config = new PaginationComponentOptions();
-    this.config.id = 'top-level-pagination';
+    this.config.id = this.pageId;
     this.config.pageSize = 5;
     this.config.currentPage = 1;
     this.sortConfig = new SortOptions('dc.title', SortDirection.ASC);
@@ -55,10 +60,10 @@ export class TopLevelCommunityListComponent implements OnInit {
    * @param event The new pagination data
    */
   onPaginationChange(event) {
-    this.config.currentPage = event.page;
-    this.config.pageSize = event.pageSize;
-    this.sortConfig.field = event.sortField;
-    this.sortConfig.direction = event.sortDirection;
+    this.config.currentPage = event.pagination.currentPage;
+    this.config.pageSize = event.pagination.pageSize;
+    this.sortConfig.field = event.sort.field;
+    this.sortConfig.direction = event.sort.direction;
     this.updatePage();
   }
 

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -225,10 +225,14 @@ export class PaginationComponent implements OnDestroy, OnInit {
   }
 
   /**
+   * @param cdRef
+   *    ChangeDetectorRef is a singleton service provided by Angular.
    * @param route
    *    Route is a singleton service provided by Angular.
    * @param router
    *    Router is a singleton service provided by Angular.
+   * @param hostWindowService
+   *    the HostWindowService singleton.
    */
   constructor(private cdRef: ChangeDetectorRef,
               private route: ActivatedRoute,
@@ -243,7 +247,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The page being navigated to.
    */
   public doPageChange(page: number) {
-    this.updateRoute({ page: page.toString() });
+    this.updateRoute({ pageId: this.id, page: page.toString() });
   }
 
   /**
@@ -253,7 +257,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The page size being navigated to.
    */
   public doPageSizeChange(pageSize: number) {
-    this.updateRoute({ page: 1, pageSize: pageSize });
+    this.updateRoute({ pageId: this.id, page: 1, pageSize: pageSize });
   }
 
   /**
@@ -263,7 +267,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The sort direction being navigated to.
    */
   public doSortDirectionChange(sortDirection: SortDirection) {
-    this.updateRoute({ page: 1, sortDirection: sortDirection });
+    this.updateRoute({ pageId: this.id, page: 1, sortDirection: sortDirection });
   }
 
   /**
@@ -273,7 +277,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    *    The sort field being navigated to.
    */
   public doSortFieldChange(field: string) {
-    this.updateRoute({ page: 1, sortField: field });
+    this.updateRoute({ pageId: this.id, page: 1, sortField: field });
   }
 
   /**
@@ -413,27 +417,30 @@ export class PaginationComponent implements OnDestroy, OnInit {
    * Method to update all pagination variables to the current query parameters
    */
   private setFields() {
-    // (+) converts string to a number
-    const page = this.currentQueryParams.page;
-    if (this.currentPage !== +page) {
-      this.setPage(+page);
-    }
+    // set fields only when page id is the one configured for this pagination instance
+    if (this.currentQueryParams.pageId === this.id) {
+      // (+) converts string to a number
+      const page = this.currentQueryParams.page;
+      if (this.currentPage !== +page) {
+        this.setPage(+page);
+      }
 
-    const pageSize = this.currentQueryParams.pageSize;
-    if (this.pageSize !== +pageSize) {
-      this.setPageSize(+pageSize);
-    }
+      const pageSize = this.currentQueryParams.pageSize;
+      if (this.pageSize !== +pageSize) {
+        this.setPageSize(+pageSize);
+      }
 
-    const sortDirection = this.currentQueryParams.sortDirection;
-    if (this.sortDirection !== sortDirection) {
-      this.setSortDirection(sortDirection);
-    }
+      const sortDirection = this.currentQueryParams.sortDirection;
+      if (this.sortDirection !== sortDirection) {
+        this.setSortDirection(sortDirection);
+      }
 
-    const sortField = this.currentQueryParams.sortField;
-    if (this.sortField !== sortField) {
-      this.setSortField(sortField);
+      const sortField = this.currentQueryParams.sortField;
+      if (this.sortField !== sortField) {
+        this.setSortField(sortField);
+      }
+      this.cdRef.detectChanges();
     }
-    this.cdRef.detectChanges();
   }
 
   /**


### PR DESCRIPTION
This PR added pagination for sub-communities and collections in the Community page.

Currently sub-communities and collections are limited to the ones embedded in the Community object, so is not possible to navigate through them all