### PR TITLE
Fixed renamed TSLint rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,7 @@
     ],
     "no-access-missing-member": false,
     "no-arg": true,
-    "no-attribute-parameter-decorator": true,
+    "no-attribute-decorator": true,
     "no-bitwise": true,
     "no-console": [
       true,
@@ -81,9 +81,8 @@
       false
     ],
     "prefer-const": true,
-    "pipe-naming": [
+    "pipe-prefix": [
       true,
-      "camelCase",
       "ds"
     ],
     "quotemark": [
@@ -147,10 +146,10 @@
     "no-input-rename": true,
     "no-output-rename": true,
     "templates-use-public": false,
-    "use-host-property-decorator": true,
-    "use-input-property-decorator": true,
+    "no-host-metadata-property": true,
+    "no-inputs-metadata-property": true,
     "use-life-cycle-interface": false,
-    "use-output-property-decorator": true,
+    "no-outputs-metadata-property": true,
     "use-pipe-transform-interface": true
 //    "rxjs-collapse-imports": true,
 //    "rxjs-pipeable-operators-only": true,


### PR DESCRIPTION
The changes in [the recently merged Angular 7 PR](https://github.com/DSpace/dspace-angular/pull/547) also updated Codelyzer to a more recent version. This version of Codelyzer [renamed some tslint rules](https://github.com/mgechev/codelyzer/blob/master/CHANGELOG.md#breaking-changes), that have not been updated in our code base yet. This PR fixes the broken rules by replacing the deprecated names.