### PR TITLE
Fixed configuration-search-page fixedFilterQuery parameter

### DIFF
--- a/src/app/+search-page/configuration-search-page.component.ts
+++ b/src/app/+search-page/configuration-search-page.component.ts
@@ -62,7 +62,7 @@ export class ConfigurationSearchPageComponent extends SearchComponent implements
       this.routeService.setParameter('configuration', this.configuration);
     }
     if (hasValue(this.fixedFilterQuery)) {
-      this.routeService.setParameter('fixedFilter', this.fixedFilterQuery);
+      this.routeService.setParameter('fixedFilterQuery', this.fixedFilterQuery);
     }
   }
 }


### PR DESCRIPTION
The parameter name was incorrect
This causes e.g. https://dspace7-demo.atmire.com/items/03dce7cb-687d-44c8-8945-1b9b6623eecd to display all publications in the search instead of just https://dspace7-demo.atmire.com/items/0157eef4-2dc8-4ddd-8124-94cdabc15f6e