### PR TITLE
DS-4380 and DS-4257: Minor updates to Docker configs for JDK11 and new URL configs

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -5,7 +5,7 @@ services:
     container_name: dspace
     depends_on:
     - dspacedb
-    image: dspace/dspace:dspace-7_x-jdk8-test
+    image: dspace/dspace:dspace-7_x-test
     networks:
       dspacenet:
     ports:

--- a/docker/docker-compose-travis.yml
+++ b/docker/docker-compose-travis.yml
@@ -5,7 +5,7 @@ services:
     container_name: dspace
     depends_on:
     - dspacedb
-    image: dspace/dspace:dspace-7_x-jdk8-test
+    image: dspace/dspace:dspace-7_x-test
     networks:
       dspacenet:
     ports:

--- a/docker/local.cfg
+++ b/docker/local.cfg
@@ -1,6 +1,5 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
-dspace.hostname=dspace
-dspace.baseUrl=http://localhost:8080/server
+dspace.server.url=http://localhost:8080/server
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr


### PR DESCRIPTION
This PR includes minor updates the the Docker configurations for dspace-angular required by these backend PRs:
* https://github.com/DSpace/DSpace/pull/2654 : PR to upgrade to JDK11
* https://github.com/DSpace/DSpace/pull/2657 : PR to change DSpace URL configs

This PR should be merged **only after the above two PRs are merged on the backend**.

NOTE: Please be aware this PR is expected to error in Travis CI, as it depends on changes in the above two PRs.  Therefore, it will only succeed in Travis once the above two PRs are merged.