### PR TITLE
Use Angulartics' Routerless module

### DIFF
--- a/src/modules/app/browser-app.module.ts
+++ b/src/modules/app/browser-app.module.ts
@@ -18,7 +18,7 @@ import { DSpaceTransferState } from '../transfer-state/dspace-transfer-state.ser
 import { ClientCookieService } from '../../app/core/services/client-cookie.service';
 import { CookieService } from '../../app/core/services/cookie.service';
 import { AuthService } from '../../app/core/auth/auth.service';
-import { Angulartics2Module } from 'angulartics2';
+import { Angulartics2RouterlessModule } from 'angulartics2/routerlessmodule';
 import { SubmissionService } from '../../app/submission/submission.service';
 import { StatisticsModule } from '../../app/statistics/statistics.module';
 
@@ -48,7 +48,7 @@ export function getRequest(transferState: TransferState): any {
       IdlePreload
     }),
     StatisticsModule.forRoot(),
-    Angulartics2Module.forRoot(),
+    Angulartics2RouterlessModule.forRoot(),
     BrowserAnimationsModule,
     DSpaceBrowserTransferStateModule,
     TranslateModule.forRoot({

--- a/src/modules/app/server-app.module.ts
+++ b/src/modules/app/server-app.module.ts
@@ -23,7 +23,7 @@ import { AngularticsMock } from '../../app/shared/mocks/mock-angulartics.service
 import { SubmissionService } from '../../app/submission/submission.service';
 import { ServerSubmissionService } from '../../app/submission/server-submission.service';
 import { Angulartics2DSpace } from '../../app/statistics/angulartics/dspace-provider';
-import { Angulartics2Module } from 'angulartics2';
+import { Angulartics2RouterlessModule } from 'angulartics2/routerlessmodule';
 
 export function createTranslateLoader() {
   return new TranslateJson5UniversalLoader('dist/assets/i18n/', '.json5');
@@ -47,7 +47,7 @@ export function createTranslateLoader() {
         deps: []
       }
     }),
-    Angulartics2Module.forRoot(),
+    Angulartics2RouterlessModule.forRoot(),
     ServerModule,
     AppModule
   ],


### PR DESCRIPTION
This is a fix for https://github.com/DSpace/dspace-angular/issues/560: The Serverside-rendering is broken on specific pages where Angulartics is active

Usage of the Routerless module is considered experimental according to [the readme](https://github.com/angulartics/angulartics2#using-without-a-router) but I have not seen a problem with it. I have tested that requests for both DSpace statistics and Google Analytics are being still being fired in the browser. And the server side rendering is now working as expected.