### PR TITLE
Use full projection for submission REST requests

### DIFF
--- a/src/app/core/submission/submission-rest.service.spec.ts
+++ b/src/app/core/submission/submission-rest.service.spec.ts
@@ -26,7 +26,7 @@ describe('SubmissionRestService test suite', () => {
   const resourceEndpoint = 'workspaceitems';
   const resourceScope = '260';
   const body = { test: new FormFieldMetadataValueObject('test')};
-  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope;
+  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope + '?projection=full';
   const timestampResponse = 1545994811992;
 
   function initTestService() {

--- a/src/app/core/submission/submission-rest.service.ts
+++ b/src/app/core/submission/submission-rest.service.ts
@@ -71,8 +71,9 @@ export class SubmissionRestService {
    */
   protected getEndpointByIDHref(endpoint, resourceID, collectionId?: string): string {
     let url = isNotEmpty(resourceID) ? `${endpoint}/${resourceID}` : `${endpoint}`;
+    url = new URLCombiner(url, '?projection=full').toString();
     if (collectionId) {
-      url = new URLCombiner(url, `?owningCollection=${collectionId}`).toString();
+      url = new URLCombiner(url, `&owningCollection=${collectionId}`).toString();
     }
     return url;
   }


### PR DESCRIPTION
This is a replacement for https://github.com/DSpace/dspace-angular/pull/582 that requests full projection for all HTTP verbs on submission rest endpoints, to cover submission creation and edit use cases that were failing prior. 