### PR TITLE
[Docker] .dockerignore doesn't ignore "node_modules"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,28 @@
 .git
-node-modules
-__build__
-__server_build__
+.idea
+.vscode
+.DS_Store
+*.iml
+
+# Build folders
+node_modules
+build
+dist
 typings
 tsd_typings
-npm-debug.log
-dist
 coverage
-.idea
-*.iml
+__build__
+__server_build__
+
+# Node
+*.log
+npm-debug.log.*
+
+# Angular files
 *.ngfactory.ts
 *.css.shim.ts
 *.scss.shim.ts
-.DS_Store
+
+# Webpack files
 webpack.records.json
-npm-debug.log.*
-morgan.log
-yarn-error.log
-*.css
 package-lock.json


### PR DESCRIPTION
This is a minor, but important bugfix to our `.dockerignore` file.  Currently in `master` the `node_modules` folder is listed as `node-modules` (hyphen instead of underscore).  

This causes Docker to NOT ignore the `node_modules` folder, and attempt to use it in the Docker build process (it also slows the Docker build down significantly -- by minutes).

I've corrected this mistake & reorged the `.dockerignore` file into sections, aligned with our .gitignore.

Once Travis approves, I'll merge this immediately as it's not a UI code change, just a correction to the Docker build process.