### PR TITLE
MyDSpace ClaimedTask link resolving fixes

### DIFF
--- a/src/app/+my-dspace-page/my-dspace-page.component.ts
+++ b/src/app/+my-dspace-page/my-dspace-page.component.ts
@@ -29,6 +29,8 @@ import { ViewMode } from '../core/shared/view-mode.model';
 import { MyDSpaceRequest } from '../core/data/request.models';
 import { SearchResult } from '../shared/search/search-result.model';
 import { Context } from '../core/shared/context.model';
+import { followLink } from '../shared/utils/follow-link-config.model';
+import { ClaimedTask } from '../core/tasks/models/claimed-task-object.model';
 
 export const MYDSPACE_ROUTE = '/mydspace';
 export const SEARCH_CONFIG_SERVICE: InjectionToken<SearchConfigurationService> = new InjectionToken<SearchConfigurationService>('searchConfigurationService');
@@ -126,7 +128,10 @@ export class MyDSpacePageComponent implements OnInit {
     this.searchOptions$ = this.searchConfigService.paginatedSearchOptions;
     this.sub = this.searchOptions$.pipe(
       tap(() => this.resultsRD$.next(null)),
-      switchMap((options: PaginatedSearchOptions) => this.service.search(options).pipe(getSucceededRemoteData())))
+      switchMap((options: PaginatedSearchOptions) =>
+        this.service.search<ClaimedTask>(options, undefined,
+          followLink('workflowitem', undefined, followLink('item'), followLink('submitter')),
+          followLink('owner')).pipe(getSucceededRemoteData())))
       .subscribe((results) => {
         this.resultsRD$.next(results);
       });

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -18,6 +18,8 @@ import { RemoteData } from '../data/remote-data';
 import { PaginatedList } from '../data/paginated-list';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
+import { dataService } from '../cache/builders/build-decorators';
+import { GROUP } from './models/group.resource-type';
 
 /**
  * Provides methods to retrieve eperson group resources.
@@ -25,6 +27,7 @@ import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
 @Injectable({
   providedIn: 'root'
 })
+@dataService(GROUP)
 export class GroupDataService extends DataService<Group> {
   protected linkPath = 'groups';
   protected browseEndpoint = '';

--- a/src/app/core/tasks/models/claimed-task-object.model.ts
+++ b/src/app/core/tasks/models/claimed-task-object.model.ts
@@ -1,6 +1,5 @@
 import { inheritSerialization } from 'cerialize';
-import { typedObject } from '../../cache/builders/build-decorators';
-import { DSpaceObject } from '../../shared/dspace-object.model';
+import { inheritLinkAnnotations, typedObject } from '../../cache/builders/build-decorators';
 import { CLAIMED_TASK } from './claimed-task-object.resource-type';
 import { TaskObject } from './task-object.model';
 
@@ -8,7 +7,8 @@ import { TaskObject } from './task-object.model';
  * A model class for a ClaimedTask.
  */
 @typedObject
-@inheritSerialization(DSpaceObject)
+@inheritSerialization(TaskObject)
+@inheritLinkAnnotations(TaskObject)
 export class ClaimedTask extends TaskObject {
   static type = CLAIMED_TASK;
 }

--- a/src/app/core/tasks/models/task-object.model.ts
+++ b/src/app/core/tasks/models/task-object.model.ts
@@ -12,6 +12,7 @@ import { DSpaceObject } from '../../shared/dspace-object.model';
 import { HALLink } from '../../shared/hal-link.model';
 import { WorkflowItem } from '../../submission/models/workflowitem.model';
 import { TASK_OBJECT } from './task-object.resource-type';
+import { WORKFLOWITEM } from '../../eperson/models/workflowitem.resource-type';
 
 /**
  * An abstract model class for a TaskObject.
@@ -45,7 +46,7 @@ export class TaskObject extends DSpaceObject implements CacheableObject {
   @deserialize
   _links: {
     self: HALLink;
-    eperson: HALLink;
+    owner: HALLink;
     group: HALLink;
     workflowitem: HALLink;
   };
@@ -54,7 +55,7 @@ export class TaskObject extends DSpaceObject implements CacheableObject {
    * The EPerson for this task
    * Will be undefined unless the eperson {@link HALLink} has been resolved.
    */
-  @link(EPERSON)
+  @link(EPERSON, false, 'owner')
   eperson?: Observable<RemoteData<EPerson>>;
 
   /**
@@ -68,7 +69,7 @@ export class TaskObject extends DSpaceObject implements CacheableObject {
    * The WorkflowItem for this task
    * Will be undefined unless the workflowitem {@link HALLink} has been resolved.
    */
-  @link(WorkflowItem.type)
+  @link(WORKFLOWITEM)
   workflowitem?: Observable<RemoteData<WorkflowItem>> | WorkflowItem;
 
 }

--- a/src/app/entity-groups/research-entities/metadata-representations/org-unit/org-unit-item-metadata-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/metadata-representations/org-unit/org-unit-item-metadata-list-element.component.spec.ts
@@ -27,12 +27,12 @@ describe('OrgUnitItemMetadataListElementComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     fixture = TestBed.createComponent(OrgUnitItemMetadataListElementComponent);
     comp = fixture.componentInstance;
     comp.metadataRepresentation = mockItemMetadataRepresentation;
     fixture.detectChanges();
-  }));
+  });
 
   it('should show the name of the organisation as a link', () => {
     const linkText = fixture.debugElement.query(By.css('a')).nativeElement.textContent;

--- a/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.html
+++ b/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.html
@@ -1,7 +1,9 @@
-<ds-item-list-preview *ngIf="workflowitem"
-                      [item]="(workflowitem.item | async)?.payload"
-                      [object]="object"
-                      [showSubmitter]="showSubmitter"
-                      [status]="status"></ds-item-list-preview>
+<ng-container *ngVar="(workflowitemRD$ | async)?.payload as workflowitem">
+  <ds-item-list-preview *ngIf="workflowitem"
+                        [item]="(workflowitem?.item | async)?.payload"
+                        [object]="object"
+                        [showSubmitter]="showSubmitter"
+                        [status]="status"></ds-item-list-preview>
 
-<ds-claimed-task-actions *ngIf="workflowitem" [object]="dso"></ds-claimed-task-actions>
+  <ds-claimed-task-actions *ngIf="workflowitem" [object]="dso"></ds-claimed-task-actions>
+</ng-container>

--- a/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.spec.ts
@@ -12,6 +12,7 @@ import { WorkflowItem } from '../../../../core/submission/models/workflowitem.mo
 import { createSuccessfulRemoteDataObject } from '../../../testing/utils';
 import { ClaimedTaskSearchResult } from '../../../object-collection/shared/claimed-task-search-result.model';
 import { TruncatableService } from '../../../truncatable/truncatable.service';
+import { VarDirective } from '../../../utils/var.directive';
 
 let component: ClaimedSearchResultListElementComponent;
 let fixture: ComponentFixture<ClaimedSearchResultListElementComponent>;
@@ -59,7 +60,7 @@ describe('ClaimedSearchResultListElementComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
-      declarations: [ClaimedSearchResultListElementComponent],
+      declarations: [ClaimedSearchResultListElementComponent, VarDirective],
       providers: [
         { provide: TruncatableService, useValue: {} },
       ],
@@ -79,8 +80,11 @@ describe('ClaimedSearchResultListElementComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should init item properly', () => {
-    expect(component.workflowitem).toEqual(workflowitem);
+  it('should init item properly', (done) => {
+    component.workflowitemRD$.subscribe((workflowitemRD) => {
+      expect(workflowitemRD.payload).toEqual(workflowitem);
+      done();
+    });
   });
 
   it('should have properly status', () => {

--- a/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-search-result-list-element.component.ts
@@ -2,11 +2,9 @@ import { Component } from '@angular/core';
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 
 import { Observable } from 'rxjs';
-import { find } from 'rxjs/operators';
 
 import { ViewMode } from '../../../../core/shared/view-mode.model';
 import { RemoteData } from '../../../../core/data/remote-data';
-import { isNotUndefined } from '../../../empty.util';
 import { WorkflowItem } from '../../../../core/submission/models/workflowitem.model';
 import { ClaimedTask } from '../../../../core/tasks/models/claimed-task-object.model';
 import { MyDspaceItemStatusType } from '../../../object-collection/shared/mydspace-item-status/my-dspace-item-status-type';
@@ -40,24 +38,13 @@ export class ClaimedSearchResultListElementComponent extends SearchResultListEle
   /**
    * The workflowitem object that belonging to the result object
    */
-  public workflowitem: WorkflowItem;
+  public workflowitemRD$: Observable<RemoteData<WorkflowItem>>;
 
   /**
    * Initialize all instance variables
    */
   ngOnInit() {
     super.ngOnInit();
-    this.initWorkflowItem(this.dso.workflowitem as Observable<RemoteData<WorkflowItem>>);
-  }
-
-  /**
-   * Retrieve workflowitem from result object
-   */
-  initWorkflowItem(wfi$: Observable<RemoteData<WorkflowItem>>) {
-    wfi$.pipe(
-      find((rd: RemoteData<WorkflowItem>) => (rd.hasSucceeded && isNotUndefined(rd.payload)))
-    ).subscribe((rd: RemoteData<WorkflowItem>) => {
-      this.workflowitem = rd.payload;
-    });
+    this.workflowitemRD$ = this.dso.workflowitem as Observable<RemoteData<WorkflowItem>>;
   }
 }


### PR DESCRIPTION
As of recently, the MyDSpace workflow page at `/mydspace?configuration=workflow` stopped displaying claimed tasks.
Due to the changes from #578, it is now required to specify which links should be resolved when fetching object(s) from the REST API.
On the MyDSpace page, Claimed Tasks were being fetched using the search api, but no “followLinks” were provided, resulting in the Claimed Tasks not containing a workflowitem or owner (and the workflowitem not containing an item and submitter as well).

I’ve fixed this issue by allowing to pass “followLinks” to the search method of the search-service to specify which links should be resolved for the resulting objects.
On top of this, I’ve added `@inheritLinkAnnotations(TaskObject)` to the claimed-task model, as this is necessary to inherit the workflowitem and owner links.

After applying these fixes, the page should display Claimed Tasks (and their information) again like it used to before.