### PR TITLE
Notice regarding the availability of new version on item pages

### DIFF
--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -1110,6 +1110,10 @@
 
 
 
+  "item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
+
+
+
   "journal.listelement.badge": "Journal",
 
   "journal.page.description": "Description",

--- a/src/app/+item-page/full/full-item-page.component.html
+++ b/src/app/+item-page/full/full-item-page.component.html
@@ -1,6 +1,7 @@
 <div class="container" *ngVar="(itemRD$ | async) as itemRD">
   <div class="item-page" *ngIf="itemRD?.hasSucceeded" @fadeInOut>
     <div *ngIf="itemRD?.payload as item">
+      <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
       <ds-view-tracker [object]="item"></ds-view-tracker>
       <ds-item-page-title-field [item]="item"></ds-item-page-title-field>
       <div class="simple-view-link my-3">

--- a/src/app/+item-page/simple/item-page.component.html
+++ b/src/app/+item-page/simple/item-page.component.html
@@ -1,6 +1,7 @@
 <div class="container" *ngVar="(itemRD$ | async) as itemRD">
   <div class="item-page" *ngIf="itemRD?.hasSucceeded" @fadeInOut>
     <div *ngIf="itemRD?.payload as item">
+      <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
       <ds-view-tracker [object]="item"></ds-view-tracker>
       <ds-listable-object-component-loader [object]="item" [viewMode]="viewMode"></ds-listable-object-component-loader>
       <ds-item-versions class="mt-2" [item]="item"></ds-item-versions>

--- a/src/app/shared/item/item-versions/notice/item-versions-notice.component.html
+++ b/src/app/shared/item/item-versions/notice/item-versions-notice.component.html
@@ -1,0 +1,5 @@
+<ds-alert *ngIf="isLatestVersion$ && !(isLatestVersion$ | async)"
+          [content]="('item.version.notice' | translate:{ destination: getItemPage(((latestVersion$ | async)?.item | async)?.payload) })"
+          [dismissible]="false"
+          [type]="AlertTypeEnum.Warning">
+</ds-alert>

--- a/src/app/shared/item/item-versions/notice/item-versions-notice.component.spec.ts
+++ b/src/app/shared/item/item-versions/notice/item-versions-notice.component.spec.ts
@@ -1,0 +1,93 @@
+import { ItemVersionsNoticeComponent } from './item-versions-notice.component';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { VersionHistory } from '../../../../core/shared/version-history.model';
+import { Version } from '../../../../core/shared/version.model';
+import { createPaginatedList, createSuccessfulRemoteDataObject$ } from '../../../testing/utils';
+import { Item } from '../../../../core/shared/item.model';
+import { VersionHistoryDataService } from '../../../../core/data/version-history-data.service';
+import { By } from '@angular/platform-browser';
+
+describe('ItemVersionsNoticeComponent', () => {
+  let component: ItemVersionsNoticeComponent;
+  let fixture: ComponentFixture<ItemVersionsNoticeComponent>;
+
+  const versionHistory = Object.assign(new VersionHistory(), {
+    id: '1'
+  });
+  const firstVersion = Object.assign(new Version(), {
+    id: '1',
+    version: 1,
+    created: new Date(2020, 1, 1),
+    summary: 'first version',
+    versionhistory: createSuccessfulRemoteDataObject$(versionHistory)
+  });
+  const latestVersion = Object.assign(new Version(), {
+    id: '2',
+    version: 2,
+    summary: 'latest version',
+    created: new Date(2020, 1, 2),
+    versionhistory: createSuccessfulRemoteDataObject$(versionHistory)
+  });
+  const versions = [latestVersion, firstVersion];
+  versionHistory.versions = createSuccessfulRemoteDataObject$(createPaginatedList(versions));
+  const firstItem = Object.assign(new Item(), {
+    id: 'first_item_id',
+    uuid: 'first_item_id',
+    handle: '123456789/1',
+    version: createSuccessfulRemoteDataObject$(firstVersion)
+  });
+  const latestItem = Object.assign(new Item(), {
+    id: 'latest_item_id',
+    uuid: 'latest_item_id',
+    handle: '123456789/2',
+    version: createSuccessfulRemoteDataObject$(latestVersion)
+  });
+  firstVersion.item = createSuccessfulRemoteDataObject$(firstItem);
+  latestVersion.item = createSuccessfulRemoteDataObject$(latestItem);
+  const versionHistoryService = jasmine.createSpyObj('versionHistoryService', {
+    getVersions: createSuccessfulRemoteDataObject$(createPaginatedList(versions))
+  });
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ItemVersionsNoticeComponent],
+      imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: VersionHistoryDataService, useValue: versionHistoryService }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  describe('when the item is the latest version', () => {
+    beforeEach(() => {
+      initComponentWithItem(latestItem);
+    });
+
+    it('should not display a notice', () => {
+      const alert = fixture.debugElement.query(By.css('ds-alert'));
+      expect(alert).toBeNull();
+    });
+  });
+
+  describe('when the item is not the latest version', () => {
+    beforeEach(() => {
+      initComponentWithItem(firstItem);
+    });
+
+    it('should display a notice', () => {
+      const alert = fixture.debugElement.query(By.css('ds-alert'));
+      expect(alert).not.toBeNull();
+    });
+  });
+
+  function initComponentWithItem(item: Item) {
+    fixture = TestBed.createComponent(ItemVersionsNoticeComponent);
+    component = fixture.componentInstance;
+    component.item = item;
+    fixture.detectChanges();
+  }
+});

--- a/src/app/shared/item/item-versions/notice/item-versions-notice.component.ts
+++ b/src/app/shared/item/item-versions/notice/item-versions-notice.component.ts
@@ -107,6 +107,8 @@ export class ItemVersionsNoticeComponent implements OnInit {
    * @param item The item for which the url is requested
    */
   getItemPage(item: Item): string {
-    return getItemPageRoute(item.id);
+    if (hasValue(item)) {
+      return getItemPageRoute(item.id);
+    }
   }
 }

--- a/src/app/shared/item/item-versions/notice/item-versions-notice.component.ts
+++ b/src/app/shared/item/item-versions/notice/item-versions-notice.component.ts
@@ -1,0 +1,112 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Item } from '../../../../core/shared/item.model';
+import { PaginationComponentOptions } from '../../../pagination/pagination-component-options.model';
+import { PaginatedSearchOptions } from '../../../search/paginated-search-options.model';
+import { Observable } from 'rxjs/internal/Observable';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { VersionHistory } from '../../../../core/shared/version-history.model';
+import { Version } from '../../../../core/shared/version.model';
+import { hasValue } from '../../../empty.util';
+import { getAllSucceededRemoteData, getRemoteDataPayload } from '../../../../core/shared/operators';
+import { filter, map, startWith, switchMap } from 'rxjs/operators';
+import { followLink } from '../../../utils/follow-link-config.model';
+import { VersionHistoryDataService } from '../../../../core/data/version-history-data.service';
+import { AlertType } from '../../../alert/aletr-type';
+import { combineLatest as observableCombineLatest } from 'rxjs';
+import { getItemPageRoute } from '../../../../+item-page/item-page-routing.module';
+
+@Component({
+  selector: 'ds-item-versions-notice',
+  templateUrl: './item-versions-notice.component.html'
+})
+/**
+ * Component for displaying a warning notice when the item is not the latest version within its version history
+ * The notice contains a link to the latest version's item page
+ */
+export class ItemVersionsNoticeComponent implements OnInit {
+  /**
+   * The item to display a version notice for
+   */
+  @Input() item: Item;
+
+  /**
+   * The item's version
+   */
+  versionRD$: Observable<RemoteData<Version>>;
+
+  /**
+   * The item's full version history
+   */
+  versionHistoryRD$: Observable<RemoteData<VersionHistory>>;
+
+  /**
+   * The latest version of the item's version history
+   */
+  latestVersion$: Observable<Version>;
+
+  /**
+   * Is the item's version equal to the latest version from the version history?
+   * This will determine whether or not to display a notice linking to the latest version
+   */
+  isLatestVersion$: Observable<boolean>;
+
+  /**
+   * Pagination options to fetch a single version on the first page (this is the latest version in the history)
+   */
+  latestVersionOptions = Object.assign(new PaginationComponentOptions(),{
+    id: 'item-newest-version-options',
+    currentPage: 1,
+    pageSize: 1
+  });
+
+  /**
+   * The AlertType enumeration
+   * @type {AlertType}
+   */
+  public AlertTypeEnum = AlertType;
+
+  constructor(private versionHistoryService: VersionHistoryDataService) {
+  }
+
+  /**
+   * Initialize the component's observables
+   */
+  ngOnInit(): void {
+    const latestVersionSearch = new PaginatedSearchOptions({pagination: this.latestVersionOptions});
+    if (hasValue(this.item.version)) {
+      this.versionRD$ = this.item.version;
+      this.versionHistoryRD$ = this.versionRD$.pipe(
+        getAllSucceededRemoteData(),
+        getRemoteDataPayload(),
+        switchMap((version: Version) => version.versionhistory)
+      );
+      const versionHistory$ = this.versionHistoryRD$.pipe(
+        getAllSucceededRemoteData(),
+        getRemoteDataPayload(),
+      );
+      this.latestVersion$ = versionHistory$.pipe(
+        switchMap((versionHistory: VersionHistory) =>
+          this.versionHistoryService.getVersions(versionHistory.id, latestVersionSearch, followLink('item'))),
+        getAllSucceededRemoteData(),
+        getRemoteDataPayload(),
+        filter((versions) => versions.page.length > 0),
+        map((versions) => versions.page[0])
+      );
+
+      this.isLatestVersion$ = observableCombineLatest(
+        this.versionRD$.pipe(getAllSucceededRemoteData(), getRemoteDataPayload()), this.latestVersion$
+      ).pipe(
+        map(([itemVersion, latestVersion]: [Version, Version]) => itemVersion.id === latestVersion.id),
+        startWith(true)
+      )
+    }
+  }
+
+  /**
+   * Get the item page url
+   * @param item The item for which the url is requested
+   */
+  getItemPage(item: Item): string {
+    return getItemPageRoute(item.id);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -179,6 +179,7 @@ import { ExistingMetadataListElementComponent } from './form/builder/ds-dynamic-
 import { ItemVersionsComponent } from './item/item-versions/item-versions.component';
 import { SortablejsModule } from 'ngx-sortablejs';
 import { MissingTranslationHelper } from './translate/missing-translation.helper';
+import { ItemVersionsNoticeComponent } from './item/item-versions/notice/item-versions-notice.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -347,6 +348,7 @@ const COMPONENTS = [
   ExistingMetadataListElementComponent,
   ItemVersionsComponent,
   PublicationSearchResultListElementComponent,
+  ItemVersionsNoticeComponent
 ];
 
 const ENTRY_COMPONENTS = [
@@ -411,6 +413,7 @@ const ENTRY_COMPONENTS = [
   DsDynamicLookupRelationExternalSourceTabComponent,
   ExternalSourceEntryImportModalComponent,
   ItemVersionsComponent,
+  ItemVersionsNoticeComponent
 ];
 
 const SHARED_ITEM_PAGE_COMPONENTS = [


### PR DESCRIPTION
This feature builds upon #585, as it makes use of the objects and services created there.
This PR adds a notice on top of simple and full item pages for items whose version history contains a newer version.

The notice is displayed in a non-dismissible warning alert and reads: “This is not the latest version of this item. The latest version can be found here.” with “here” as a link to the item page of the latest version, as seen in the screenshot below.

<img width="1130" alt="Screenshot 2020-02-27 at 10 17 34" src="https://user-images.githubusercontent.com/34308852/75429643-68449b00-594a-11ea-80b4-b86a7b751548.png">

Item pages of items that don’t contain any versioning, or are the latest item within their version history will not display any notice.