### PR TITLE
Access-control - EPeople admin page

### DIFF
--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -222,6 +222,8 @@
 
   "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Failed to create EPerson \"{{name}}\", email \"{{email}}\" already in use.",
 
+  "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Failed to edit EPerson \"{{name}}\", email \"{{email}}\" already in use.",
+
   "admin.access-control.epeople.form.notification.edited.success": "Successfully edited EPerson \"{{name}}\"",
 
   "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -170,6 +170,66 @@
 
 
 
+  "admin.access-control.epeople.title": "DSpace Angular :: EPeople",
+
+  "admin.access-control.epeople.head": "EPeople",
+
+  "admin.access-control.epeople.search.head": "Search",
+
+  "admin.access-control.epeople.search.scope.name": "Name",
+
+  "admin.access-control.epeople.search.scope.email": "E-mail",
+
+  "admin.access-control.epeople.search.scope.metadata": "Metadata",
+
+  "admin.access-control.epeople.search.button": "Search",
+
+  "admin.access-control.epeople.button.add": "Add EPerson",
+
+  "admin.access-control.epeople.table.id": "ID",
+
+  "admin.access-control.epeople.table.name": "Name",
+
+  "admin.access-control.epeople.table.email": "E-mail",
+
+  "admin.access-control.epeople.table.edit": "Edit",
+
+  "item.access-control.epeople.table.edit.buttons.edit": "Edit",
+
+  "item.access-control.epeople.table.edit.buttons.remove": "Remove",
+
+  "admin.access-control.epeople.no-items": "No EPeople to show.",
+
+  "admin.access-control.epeople.form.create": "Create EPerson",
+
+  "admin.access-control.epeople.form.edit": "Edit EPerson",
+
+  "admin.access-control.epeople.form.firstName": "First name",
+
+  "admin.access-control.epeople.form.lastName": "Last name",
+
+  "admin.access-control.epeople.form.email": "E-mail",
+
+  "admin.access-control.epeople.form.emailHint": "Must be valid e-mail address",
+
+  "admin.access-control.epeople.form.canLogIn": "Can log in",
+
+  "admin.access-control.epeople.form.requireCertificate": "Requires certificate",
+
+  "admin.access-control.epeople.form.notification.created.success": "Successfully created EPerson \"{{name}}\"",
+
+  "admin.access-control.epeople.form.notification.created.failure": "Failed to create EPerson \"{{name}}\"",
+
+  "admin.access-control.epeople.form.notification.edited.success": "Successfully edited EPerson \"{{name}}\"",
+
+  "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",
+
+  "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
+
+  "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
+
+
+
   "admin.search.breadcrumbs": "Administrative Search",
 
   "admin.search.collection.edit": "Edit",
@@ -1500,7 +1560,7 @@
   "relationships.isSingleVolumeOf": "Journal Volume",
 
   "relationships.isVolumeOf": "Journal Volumes",
-  
+
   "relationships.isContributorOf": "Contributors",
 
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -178,7 +178,7 @@
 
   "admin.access-control.epeople.search.scope.name": "Name",
 
-  "admin.access-control.epeople.search.scope.email": "E-mail",
+  "admin.access-control.epeople.search.scope.email": "E-mail (exact)",
 
   "admin.access-control.epeople.search.scope.metadata": "Metadata",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -220,6 +220,8 @@
 
   "admin.access-control.epeople.form.notification.created.failure": "Failed to create EPerson \"{{name}}\"",
 
+  "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Failed to create EPerson \"{{name}}\", email \"{{email}}\" already in use.",
+
   "admin.access-control.epeople.form.notification.edited.success": "Successfully edited EPerson \"{{name}}\"",
 
   "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",

--- a/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      { path: 'epeople', component: EPeopleRegistryComponent, data: { title: 'admin.access-control.epeople.title' } },
+    ])
+  ]
+})
+export class AdminAccessControlRoutingModule {
+
+}

--- a/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
@@ -9,6 +9,9 @@ import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.co
     ])
   ]
 })
+/**
+ * Routing module for the AccessControl section of the admin sidebar
+ */
 export class AdminAccessControlRoutingModule {
 
 }

--- a/src/app/+admin/admin-access-control/admin-access-control.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control.module.ts
@@ -21,6 +21,9 @@ import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-fo
   ],
   entryComponents: []
 })
+/**
+ * This module handles all components related to the access control pages
+ */
 export class AdminAccessControlModule {
 
 }

--- a/src/app/+admin/admin-access-control/admin-access-control.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control.module.ts
@@ -1,0 +1,26 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { SharedModule } from '../../shared/shared.module';
+import { AdminAccessControlRoutingModule } from './admin-access-control-routing.module';
+import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
+import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-form.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SharedModule,
+    RouterModule,
+    TranslateModule,
+    AdminAccessControlRoutingModule
+  ],
+  declarations: [
+    EPeopleRegistryComponent,
+    EPersonFormComponent
+  ],
+  entryComponents: []
+})
+export class AdminAccessControlModule {
+
+}

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.actions.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.actions.ts
@@ -13,7 +13,7 @@ import { type } from '../../../shared/ngrx/type';
 export const EPeopleRegistryActionTypes = {
 
   EDIT_EPERSON: type('dspace/epeople-registry/EDIT_EPERSON'),
-  CANCEL_EDIT_EPERSON: type('dspace/epeople-registry/CANCEL_SCHEMA'),
+  CANCEL_EDIT_EPERSON: type('dspace/epeople-registry/CANCEL_EDIT_EPERSON'),
 };
 
 /* tslint:disable:max-classes-per-file */
@@ -25,8 +25,8 @@ export class EPeopleRegistryEditEPersonAction implements Action {
 
   eperson: EPerson;
 
-  constructor(registry: EPerson) {
-    this.eperson = registry;
+  constructor(eperson: EPerson) {
+    this.eperson = eperson;
   }
 }
 

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.actions.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.actions.ts
@@ -1,0 +1,49 @@
+import { Action } from '@ngrx/store';
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { type } from '../../../shared/ngrx/type';
+
+/**
+ * For each action type in an action group, make a simple
+ * enum object for all of this group's action types.
+ *
+ * The 'type' utility function coerces strings into string
+ * literal types and runs a simple check to guarantee all
+ * action types in the application are unique.
+ */
+export const EPeopleRegistryActionTypes = {
+
+  EDIT_EPERSON: type('dspace/epeople-registry/EDIT_EPERSON'),
+  CANCEL_EDIT_EPERSON: type('dspace/epeople-registry/CANCEL_SCHEMA'),
+};
+
+/* tslint:disable:max-classes-per-file */
+/**
+ * Used to edit an EPerson in the EPeople registry
+ */
+export class EPeopleRegistryEditEPersonAction implements Action {
+  type = EPeopleRegistryActionTypes.EDIT_EPERSON;
+
+  eperson: EPerson;
+
+  constructor(registry: EPerson) {
+    this.eperson = registry;
+  }
+}
+
+/**
+ * Used to cancel the editing of an EPerson in the EPeople registry
+ */
+export class EPeopleRegistryCancelEPersonAction implements Action {
+  type = EPeopleRegistryActionTypes.CANCEL_EDIT_EPERSON;
+}
+
+/* tslint:enable:max-classes-per-file */
+
+/**
+ * Export a type alias of all actions in this action group
+ * so that reducers can easily compose action types
+ * These are all the actions to perform on the EPeople registry state
+ */
+export type EPeopleRegistryAction
+  = EPeopleRegistryEditEPersonAction
+  | EPeopleRegistryCancelEPersonAction

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -8,10 +8,10 @@
                        (cancelForm)="isEPersonFormShown = false"></ds-eperson-form>
 
       <div *ngIf="!isEPersonFormShown" class="button-row top d-flex pb-2">
-        <button class="mr-auto btn btn-success"
+        <button class="mr-auto btn btn-success addEPerson-button"
                 (click)="isEPersonFormShown = true">
           <i class="fas fa-plus"></i>
-          <span class="d-none d-sm-inline">&nbsp;{{labelPrefix + 'button.add' | translate}}</span>
+          <span class="d-none d-sm-inline">{{labelPrefix + 'button.add' | translate}}</span>
         </button>
       </div>
 

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -1,0 +1,90 @@
+<div class="container">
+  <div class="epeople-registry row">
+    <div class="col-12">
+
+      <h2 id="header" class="border-bottom pb-2">{{labelPrefix + 'head' | translate}}</h2>
+
+      <ds-eperson-form *ngIf="isEPersonFormShown" (submitForm)="forceUpdateEPeople()"
+                       (cancelForm)="isEPersonFormShown = false"></ds-eperson-form>
+
+      <div class="button-row top d-flex">
+        <button class="mr-auto btn btn-success"
+                (click)="isEPersonFormShown = true">
+          <i class="fas fa-plus"></i>
+          <span class="d-none d-sm-inline">&nbsp;{{labelPrefix + 'button.add' | translate}}</span>
+        </button>
+      </div>
+
+      <h3 id="search" class="border-bottom pb-2">{{labelPrefix + 'search.head' | translate}}</h3>
+      <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
+        <div class="col-12 col-sm-3">
+          <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
+            <option value="name">{{labelPrefix + 'search.scope.name' | translate}}</option>
+            <option value="email">{{labelPrefix + 'search.scope.email' | translate}}</option>
+            <option value="metadata">{{labelPrefix + 'search.scope.metadata' | translate}}</option>
+          </select>
+        </div>
+        <div class="col-sm-9 col-12">
+          <div class="form-group input-group">
+            <input type="text" name="query" id="query" formControlName="query"
+                   class="form-control" aria-label="Search input">
+            <span class="input-group-append">
+            <button type="submit"
+                    class="search-button btn btn-secondary">{{ labelPrefix + 'search.button' | translate }}</button>
+        </span>
+          </div>
+        </div>
+      </form>
+
+      <ds-pagination
+        *ngIf="(ePeople | async)?.payload?.totalElements > 0"
+        [paginationOptions]="config"
+        [pageInfoState]="(ePeople | async)?.payload"
+        [collectionSize]="(ePeople | async)?.payload?.totalElements"
+        [hideGear]="true"
+        [hidePagerWhenSinglePage]="true"
+        (pageChange)="onPageChange($event)">
+
+        <div class="table-responsive">
+          <table id="epeople" class="table table-striped table-hover table-bordered">
+            <thead>
+            <tr>
+              <th scope="col">{{labelPrefix + 'table.id' | translate}}</th>
+              <th scope="col">{{labelPrefix + 'table.name' | translate}}</th>
+              <th scope="col">{{labelPrefix + 'table.email' | translate}}</th>
+              <th>{{labelPrefix + 'table.edit' | translate}}</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let eperson of (ePeople | async)?.payload?.page"
+                [ngClass]="{'table-primary' : isActive(eperson) | async}">
+              <td>{{eperson.id}}</td>
+              <td>{{eperson.name}}</td>
+              <td>{{eperson.email}}</td>
+              <td>
+                <div class="btn-group edit-field">
+                  <button (click)="editEPerson(eperson)" class="btn btn-outline-primary btn-sm"
+                          title="{{labelPrefix + 'table.edit.buttons.edit' | translate}}">
+                    <i class="fas fa-edit fa-fw"></i>
+                  </button>
+                  <button (click)="deleteEPerson(eperson)"
+                          class="btn btn-outline-danger btn-sm"
+                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate}}">
+                    <i class="fas fa-trash-alt fa-fw"></i>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+
+      </ds-pagination>
+
+      <div *ngIf="(ePeople | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">
+        {{labelPrefix + 'no-items' | translate}}
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -19,9 +19,8 @@
       <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
         <div class="col-12 col-sm-3">
           <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
-            <option value="name">{{labelPrefix + 'search.scope.name' | translate}}</option>
-            <option value="email">{{labelPrefix + 'search.scope.email' | translate}}</option>
             <option value="metadata">{{labelPrefix + 'search.scope.metadata' | translate}}</option>
+            <option value="email">{{labelPrefix + 'search.scope.email' | translate}}</option>
           </select>
         </div>
         <div class="col-sm-9 col-12">

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -7,7 +7,7 @@
       <ds-eperson-form *ngIf="isEPersonFormShown" (submitForm)="forceUpdateEPeople()"
                        (cancelForm)="isEPersonFormShown = false"></ds-eperson-form>
 
-      <div class="button-row top d-flex">
+      <div *ngIf="!isEPersonFormShown" class="button-row top d-flex pb-2">
         <button class="mr-auto btn btn-success"
                 (click)="isEPersonFormShown = true">
           <i class="fas fa-plus"></i>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -62,7 +62,8 @@
               <td>{{eperson.email}}</td>
               <td>
                 <div class="btn-group edit-field">
-                  <button (click)="editEPerson(eperson)" class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
+                  <button (click)="toggleEditEPerson(eperson)"
+                          class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
                           title="{{labelPrefix + 'table.edit.buttons.edit' | translate}}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -62,12 +62,12 @@
               <td>{{eperson.email}}</td>
               <td>
                 <div class="btn-group edit-field">
-                  <button (click)="editEPerson(eperson)" class="btn btn-outline-primary btn-sm"
+                  <button (click)="editEPerson(eperson)" class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
                           title="{{labelPrefix + 'table.edit.buttons.edit' | translate}}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
                   <button (click)="deleteEPerson(eperson)"
-                          class="btn btn-outline-danger btn-sm"
+                          class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                           title="{{labelPrefix + 'table.edit.buttons.remove' | translate}}">
                     <i class="fas fa-trash-alt fa-fw"></i>
                   </button>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -22,9 +22,8 @@ import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson-mock'
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service-stub';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
 import { EPeopleRegistryComponent } from './epeople-registry.component';
-import { EPersonFormComponent } from './eperson-form/eperson-form.component';
 
-describe('EPeopleRegistryComponent', () => {
+fdescribe('EPeopleRegistryComponent', () => {
   let component: EPeopleRegistryComponent;
   let fixture: ComponentFixture<EPeopleRegistryComponent>;
   let translateService: TranslateService;
@@ -85,7 +84,7 @@ describe('EPeopleRegistryComponent', () => {
           }
         }),
       ],
-      declarations: [EPeopleRegistryComponent, EPersonFormComponent],
+      declarations: [EPeopleRegistryComponent],
       providers: [EPeopleRegistryComponent,
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
@@ -152,7 +151,7 @@ describe('EPeopleRegistryComponent', () => {
     });
   });
 
-  describe('editEPerson', () => {
+  describe('toggleEditEPerson', () => {
     describe('when you click on first edit eperson button', () => {
       beforeEach(fakeAsync(() => {
         const editButtons = fixture.debugElement.queryAll(By.css('.access-control-editEPersonButton'));
@@ -164,9 +163,16 @@ describe('EPeopleRegistryComponent', () => {
         fixture.detectChanges();
       }));
 
-      it('edit eperson form shows', () => {
-        const editFormTitle = fixture.debugElement.queryAll(By.css('ds-eperson-form h4'));
-        expect(editFormTitle[0]).toBeDefined();
+      it('editEPerson form is toggled', () => {
+        const ePeopleIds = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+        ePersonDataServiceStub.getActiveEPerson().subscribe((activeEPerson: EPerson) => {
+          if (activeEPerson === ePeopleIds[0].nativeElement.textContent) {
+            expect(component.isEPersonFormShown).toEqual(false);
+          } else {
+            expect(component.isEPersonFormShown).toEqual(true);
+          }
+
+        })
       });
     });
   });

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -23,7 +23,7 @@ import { NotificationsServiceStub } from '../../../shared/testing/notifications-
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
 import { EPeopleRegistryComponent } from './epeople-registry.component';
 
-fdescribe('EPeopleRegistryComponent', () => {
+describe('EPeopleRegistryComponent', () => {
   let component: EPeopleRegistryComponent;
   let fixture: ComponentFixture<EPeopleRegistryComponent>;
   let translateService: TranslateService;

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,0 +1,199 @@
+import { of as observableOf } from 'rxjs';
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { PaginatedList } from '../../../core/data/paginated-list';
+import { RemoteData } from '../../../core/data/remote-data';
+import { FindListOptions } from '../../../core/data/request.models';
+import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { PageInfo } from '../../../core/shared/page-info.model';
+import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
+import { getMockFormBuilderService } from '../../../shared/mocks/mock-form-builder-service';
+import { MockTranslateLoader } from '../../../shared/mocks/mock-translate-loader';
+import { getMockTranslateService } from '../../../shared/mocks/mock-translate.service';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson-mock';
+import { NotificationsServiceStub } from '../../../shared/testing/notifications-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
+import { EPeopleRegistryComponent } from './epeople-registry.component';
+import { EPersonFormComponent } from './eperson-form/eperson-form.component';
+
+describe('EPeopleRegistryComponent', () => {
+  let component: EPeopleRegistryComponent;
+  let fixture: ComponentFixture<EPeopleRegistryComponent>;
+  let translateService: TranslateService;
+  let builderService: FormBuilderService;
+
+  const mockEPeople = [EPersonMock, EPersonMock2];
+  let ePersonDataServiceStub: any;
+
+  beforeEach(async(() => {
+    ePersonDataServiceStub = {
+      activeEPerson: null,
+      allEpeople: mockEPeople,
+      getEPeople(): Observable<RemoteData<PaginatedList<EPerson>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+      },
+      getActiveEPerson(): Observable<EPerson> {
+        return observableOf(this.activeEPerson);
+      },
+      searchByScope(scope: string, query: string, options: FindListOptions = {}): Observable<RemoteData<PaginatedList<EPerson>>> {
+        if (scope === 'email') {
+          const result = this.allEpeople.find((ePerson: EPerson) => {
+            return ePerson.email === query
+          });
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
+        }
+        if (scope === 'metadata') {
+          const result = this.allEpeople.find((ePerson: EPerson) => {
+            return (ePerson.name.includes(query) || ePerson.email.includes(query))
+          });
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
+        }
+        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+      },
+      deleteEPerson(ePerson: EPerson): Observable<boolean> {
+        this.allEpeople = this.allEpeople.filter((ePerson2: EPerson) => {
+          return (ePerson2.uuid !== ePerson.uuid);
+        });
+        return observableOf(true);
+      },
+      editEPerson(ePerson: EPerson) {
+        this.activeEPerson = ePerson;
+      },
+      cancelEditEPerson() {
+        this.activeEPerson = null;
+      },
+      clearEPersonRequests(): void {
+        // empty
+      }
+    };
+    builderService = getMockFormBuilderService();
+    translateService = getMockTranslateService();
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [EPeopleRegistryComponent, EPersonFormComponent],
+      providers: [EPeopleRegistryComponent,
+        { provide: EPersonDataService, useValue: ePersonDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: FormBuilderService, useValue: builderService },
+        EPeopleRegistryComponent
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EPeopleRegistryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create EPeopleRegistryComponent', inject([EPeopleRegistryComponent], (comp: EPeopleRegistryComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  it('should display list of ePeople', () => {
+    const ePeopleIdsFound = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+    expect(ePeopleIdsFound.length).toEqual(2);
+    mockEPeople.map((ePerson: EPerson) => {
+      expect(ePeopleIdsFound.find((foundEl) => {
+        return (foundEl.nativeElement.textContent.trim() === ePerson.uuid);
+      })).toBeTruthy();
+    })
+  });
+
+  describe('search', () => {
+    describe('when searching with scope/query (scope metadata)', () => {
+      let ePeopleIdsFound;
+      beforeEach(fakeAsync(() => {
+        component.search({ scope: 'metadata', query: EPersonMock2.name });
+        tick();
+        fixture.detectChanges();
+        ePeopleIdsFound = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+      }));
+
+      it('should display search result', () => {
+        expect(ePeopleIdsFound.length).toEqual(1);
+        expect(ePeopleIdsFound.find((foundEl) => {
+          return (foundEl.nativeElement.textContent.trim() === EPersonMock2.uuid);
+        })).toBeTruthy();
+      });
+    });
+
+    describe('when searching with scope/query (scope email)', () => {
+      let ePeopleIdsFound;
+      beforeEach(fakeAsync(() => {
+        component.search({ scope: 'email', query: EPersonMock.email });
+        tick();
+        fixture.detectChanges();
+        ePeopleIdsFound = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+      }));
+
+      it('should display search result', () => {
+        expect(ePeopleIdsFound.length).toEqual(1);
+        expect(ePeopleIdsFound.find((foundEl) => {
+          return (foundEl.nativeElement.textContent.trim() === EPersonMock.uuid);
+        })).toBeTruthy();
+      });
+    });
+  });
+
+  describe('editEPerson', () => {
+    describe('when you click on first edit eperson button', () => {
+      beforeEach(fakeAsync(() => {
+        const editButtons = fixture.debugElement.queryAll(By.css('.access-control-editEPersonButton'));
+        editButtons[0].triggerEventHandler('click', {
+          preventDefault: () => {/**/
+          }
+        });
+        tick();
+        fixture.detectChanges();
+      }));
+
+      it('edit eperson form shows', () => {
+        const editFormTitle = fixture.debugElement.queryAll(By.css('ds-eperson-form h4'));
+        expect(editFormTitle[0]).toBeDefined();
+      });
+    });
+  });
+
+  describe('deleteEPerson', () => {
+    describe('when you click on first delete eperson button', () => {
+      let ePeopleIdsFoundBeforeDelete;
+      let ePeopleIdsFoundAfterDelete;
+      beforeEach(fakeAsync(() => {
+        ePeopleIdsFoundBeforeDelete = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+        const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+        deleteButtons[0].triggerEventHandler('click', {
+          preventDefault: () => {/**/
+          }
+        });
+        tick();
+        fixture.detectChanges();
+        ePeopleIdsFoundAfterDelete = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
+      }));
+
+      it('first ePerson is deleted', () => {
+        expect(ePeopleIdsFoundBeforeDelete.length === ePeopleIdsFoundAfterDelete + 1);
+        ePeopleIdsFoundAfterDelete.forEach((epersonElement) => {
+          expect(epersonElement.nativeElement.textContent !== ePeopleIdsFoundBeforeDelete[0].nativeElement.textContent).toBeTrue();
+        });
+      });
+    });
+  });
+
+});

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -190,7 +190,7 @@ describe('EPeopleRegistryComponent', () => {
       it('first ePerson is deleted', () => {
         expect(ePeopleIdsFoundBeforeDelete.length === ePeopleIdsFoundAfterDelete + 1);
         ePeopleIdsFoundAfterDelete.forEach((epersonElement) => {
-          expect(epersonElement.nativeElement.textContent !== ePeopleIdsFoundBeforeDelete[0].nativeElement.textContent).toBeTrue();
+          expect(epersonElement !== ePeopleIdsFoundBeforeDelete[0].nativeElement.textContent).toBeTrue();
         });
       });
     });

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -85,10 +85,7 @@ export class EPeopleRegistryComponent {
   public forceUpdateEPeople() {
     this.epersonService.clearEPersonRequests();
     this.isEPersonFormShown = false;
-    this.updateEPeople({
-      currentPage: 1,
-      elementsPerPage: this.config.pageSize
-    });
+    this.search({ query: '', scope: 'name' })
   }
 
   /**

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -55,7 +55,7 @@ export class EPeopleRegistryComponent {
     });
     this.isEPersonFormShown = false;
     this.searchForm = this.formBuilder.group(({
-      scope: 'name',
+      scope: 'metadata',
       query: '',
     }));
   }
@@ -85,42 +85,18 @@ export class EPeopleRegistryComponent {
   public forceUpdateEPeople() {
     this.epersonService.clearEPersonRequests();
     this.isEPersonFormShown = false;
-    this.search({ query: '', scope: 'name' })
+    this.search({ query: '', scope: 'metadata' })
   }
 
   /**
-   * Search in the EPeople by name, email or metadata
+   * Search in the EPeople by metadata (default) or email
    * @param data  Contains scope and query param
    */
   search(data: any) {
-    const query = data.query;
-    const scope = data.scope;
-    switch (scope) {
-      case 'name':
-        this.ePeople = this.epersonService.getEpeopleByName(query, {
-          currentPage: 1,
-          elementsPerPage: this.config.pageSize
-        });
-        break;
-      case 'email':
-        this.ePeople = this.epersonService.getEpeopleByEmail(query, {
-          currentPage: 1,
-          elementsPerPage: this.config.pageSize
-        });
-        break;
-      case 'metadata':
-        this.ePeople = this.epersonService.getEpeopleByMetadata(query, {
-          currentPage: 1,
-          elementsPerPage: this.config.pageSize
-        });
-        break;
-      default:
-        this.ePeople = this.epersonService.getEpeopleByEmail(query, {
-          currentPage: 1,
-          elementsPerPage: this.config.pageSize
-        });
-        break;
-    }
+    this.ePeople = this.epersonService.searchByScope(data.scope, data.query, {
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
   }
 
   /**
@@ -141,11 +117,11 @@ export class EPeopleRegistryComponent {
   }
 
   /**
-   * Start editing the selected metadata schema
-   * @param schema
+   * Start editing the selected EPerson
+   * @param ePerson
    */
   editEPerson(ePerson: EPerson) {
-    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson) => {
+    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
       if (ePerson === activeEPerson) {
         this.epersonService.cancelEditEPerson();
         this.isEPersonFormShown = false;
@@ -158,7 +134,7 @@ export class EPeopleRegistryComponent {
   }
 
   /**
-   * Delete EPerson
+   * Deletes EPerson, show notification on success/failure & updates EPeople list
    */
   deleteEPerson(ePerson: EPerson) {
     if (hasValue(ePerson.id)) {
@@ -167,7 +143,7 @@ export class EPeopleRegistryComponent {
           this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
           this.forceUpdateEPeople();
         } else {
-          this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
+          this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
         }
         this.epersonService.cancelEditEPerson();
         this.isEPersonFormShown = false;

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -1,0 +1,190 @@
+import { Component } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { PaginatedList } from '../../../core/data/paginated-list';
+import { RemoteData } from '../../../core/data/remote-data';
+import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { hasValue } from '../../../shared/empty.util';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../../shared/pagination/pagination-component-options.model';
+
+@Component({
+  selector: 'ds-epeople-registry',
+  templateUrl: './epeople-registry.component.html',
+})
+/**
+ * A component used for managing all existing epeople within the repository.
+ * The admin can create, edit or delete epeople here.
+ */
+export class EPeopleRegistryComponent {
+
+  labelPrefix = 'admin.access-control.epeople.';
+
+  /**
+   * A list of all the current EPeople within the repository or the result of the search
+   */
+  ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
+
+  /**
+   * Pagination config used to display the list of epeople
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'epeople-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  /**
+   * Whether or not to show the EPerson form
+   */
+  isEPersonFormShown: boolean;
+
+  // The search form
+  searchForm;
+
+  constructor(private epersonService: EPersonDataService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private formBuilder: FormBuilder) {
+    this.updateEPeople({
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
+    this.isEPersonFormShown = false;
+    this.searchForm = this.formBuilder.group(({
+      scope: 'name',
+      query: '',
+    }));
+  }
+
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateEPeople({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Update the list of EPeople by fetching it from the rest api or cache
+   */
+  private updateEPeople(options) {
+    this.ePeople = this.epersonService.getEPeople(options);
+  }
+
+  /**
+   * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
+   * a new REST call
+   */
+  public forceUpdateEPeople() {
+    this.epersonService.clearEPersonRequests();
+    this.isEPersonFormShown = false;
+    this.updateEPeople({
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Search in the EPeople by name, email or metadata
+   * @param data  Contains scope and query param
+   */
+  search(data: any) {
+    const query = data.query;
+    const scope = data.scope;
+    switch (scope) {
+      case 'name':
+        this.ePeople = this.epersonService.getEpeopleByName(query, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        });
+        break;
+      case 'email':
+        this.ePeople = this.epersonService.getEpeopleByEmail(query, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        });
+        break;
+      case 'metadata':
+        this.ePeople = this.epersonService.getEpeopleByMetadata(query, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        });
+        break;
+      default:
+        this.ePeople = this.epersonService.getEpeopleByEmail(query, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        });
+        break;
+    }
+  }
+
+  /**
+   * Checks whether the given EPerson is active (being edited)
+   * @param eperson
+   */
+  isActive(eperson: EPerson): Observable<boolean> {
+    return this.getActiveEPerson().pipe(
+      map((activeEPerson) => eperson === activeEPerson)
+    );
+  }
+
+  /**
+   * Gets the active eperson (being edited)
+   */
+  getActiveEPerson(): Observable<EPerson> {
+    return this.epersonService.getActiveEPerson();
+  }
+
+  /**
+   * Start editing the selected metadata schema
+   * @param schema
+   */
+  editEPerson(ePerson: EPerson) {
+    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson) => {
+      if (ePerson === activeEPerson) {
+        this.epersonService.cancelEditEPerson();
+        this.isEPersonFormShown = false;
+      } else {
+        this.epersonService.editEPerson(ePerson);
+        this.isEPersonFormShown = true;
+      }
+    });
+    this.scrollToTop()
+  }
+
+  /**
+   * Delete EPerson
+   */
+  deleteEPerson(ePerson: EPerson) {
+    if (hasValue(ePerson.id)) {
+      this.epersonService.deleteEPerson(ePerson).pipe(take(1)).subscribe((success: boolean) => {
+        if (success) {
+          this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
+          this.forceUpdateEPeople();
+        } else {
+          this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
+        }
+        this.epersonService.cancelEditEPerson();
+        this.isEPersonFormShown = false;
+      })
+    }
+  }
+
+  scrollToTop() {
+    (function smoothscroll() {
+      const currentScroll = document.documentElement.scrollTop || document.body.scrollTop;
+      if (currentScroll > 0) {
+        window.requestAnimationFrame(smoothscroll);
+        window.scrollTo(0, currentScroll - (currentScroll / 8));
+      }
+    })();
+  }
+}

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -12,8 +12,8 @@ import { NotificationsService } from '../../../shared/notifications/notification
 import { PaginationComponentOptions } from '../../../shared/pagination/pagination-component-options.model';
 
 @Component({
-  selector: 'ds-epeople-registry',
-  templateUrl: './epeople-registry.component.html',
+    selector: 'ds-epeople-registry',
+    templateUrl: './epeople-registry.component.html',
 })
 /**
  * A component used for managing all existing epeople within the repository.
@@ -21,143 +21,143 @@ import { PaginationComponentOptions } from '../../../shared/pagination/paginatio
  */
 export class EPeopleRegistryComponent {
 
-  labelPrefix = 'admin.access-control.epeople.';
+    labelPrefix = 'admin.access-control.epeople.';
 
-  /**
-   * A list of all the current EPeople within the repository or the result of the search
-   */
-  ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
+    /**
+     * A list of all the current EPeople within the repository or the result of the search
+     */
+    ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
 
-  /**
-   * Pagination config used to display the list of epeople
-   */
-  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
-    id: 'epeople-list-pagination',
-    pageSize: 5,
-    currentPage: 1
-  });
-
-  /**
-   * Whether or not to show the EPerson form
-   */
-  isEPersonFormShown: boolean;
-
-  // The search form
-  searchForm;
-
-  constructor(private epersonService: EPersonDataService,
-              private translateService: TranslateService,
-              private notificationsService: NotificationsService,
-              private formBuilder: FormBuilder) {
-    this.updateEPeople({
-      currentPage: 1,
-      elementsPerPage: this.config.pageSize
+    /**
+     * Pagination config used to display the list of epeople
+     */
+    config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+        id: 'epeople-list-pagination',
+        pageSize: 5,
+        currentPage: 1
     });
-    this.isEPersonFormShown = false;
-    this.searchForm = this.formBuilder.group(({
-      scope: 'metadata',
-      query: '',
-    }));
-  }
 
-  /**
-   * Event triggered when the user changes page
-   * @param event
-   */
-  onPageChange(event) {
-    this.updateEPeople({
-      currentPage: event,
-      elementsPerPage: this.config.pageSize
-    });
-  }
+    /**
+     * Whether or not to show the EPerson form
+     */
+    isEPersonFormShown: boolean;
 
-  /**
-   * Update the list of EPeople by fetching it from the rest api or cache
-   */
-  private updateEPeople(options) {
-    this.ePeople = this.epersonService.getEPeople(options);
-  }
+    // The search form
+    searchForm;
 
-  /**
-   * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
-   * a new REST call
-   */
-  public forceUpdateEPeople() {
-    this.epersonService.clearEPersonRequests();
-    this.isEPersonFormShown = false;
-    this.search({ query: '', scope: 'metadata' })
-  }
-
-  /**
-   * Search in the EPeople by metadata (default) or email
-   * @param data  Contains scope and query param
-   */
-  search(data: any) {
-    this.ePeople = this.epersonService.searchByScope(data.scope, data.query, {
-      currentPage: 1,
-      elementsPerPage: this.config.pageSize
-    });
-  }
-
-  /**
-   * Checks whether the given EPerson is active (being edited)
-   * @param eperson
-   */
-  isActive(eperson: EPerson): Observable<boolean> {
-    return this.getActiveEPerson().pipe(
-      map((activeEPerson) => eperson === activeEPerson)
-    );
-  }
-
-  /**
-   * Gets the active eperson (being edited)
-   */
-  getActiveEPerson(): Observable<EPerson> {
-    return this.epersonService.getActiveEPerson();
-  }
-
-  /**
-   * Start editing the selected EPerson
-   * @param ePerson
-   */
-  editEPerson(ePerson: EPerson) {
-    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
-      if (ePerson === activeEPerson) {
-        this.epersonService.cancelEditEPerson();
+    constructor(private epersonService: EPersonDataService,
+                private translateService: TranslateService,
+                private notificationsService: NotificationsService,
+                private formBuilder: FormBuilder) {
+        this.updateEPeople({
+            currentPage: 1,
+            elementsPerPage: this.config.pageSize
+        });
         this.isEPersonFormShown = false;
-      } else {
-        this.epersonService.editEPerson(ePerson);
-        this.isEPersonFormShown = true;
-      }
-    });
-    this.scrollToTop()
-  }
-
-  /**
-   * Deletes EPerson, show notification on success/failure & updates EPeople list
-   */
-  deleteEPerson(ePerson: EPerson) {
-    if (hasValue(ePerson.id)) {
-      this.epersonService.deleteEPerson(ePerson).pipe(take(1)).subscribe((success: boolean) => {
-        if (success) {
-          this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
-          this.forceUpdateEPeople();
-        } else {
-          this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
-        }
-        this.epersonService.cancelEditEPerson();
-        this.isEPersonFormShown = false;
-      })
+        this.searchForm = this.formBuilder.group(({
+            scope: 'metadata',
+            query: '',
+        }));
     }
-  }
 
-  scrollToTop() {
-    (function smoothscroll() {
-      const currentScroll = document.documentElement.scrollTop || document.body.scrollTop;
-      if (currentScroll > 0) {
-        window.requestAnimationFrame(smoothscroll);
-        window.scrollTo(0, currentScroll - (currentScroll / 8));
-      }
-    })();
-  }
+    /**
+     * Event triggered when the user changes page
+     * @param event
+     */
+    onPageChange(event) {
+        this.updateEPeople({
+            currentPage: event,
+            elementsPerPage: this.config.pageSize
+        });
+    }
+
+    /**
+     * Update the list of EPeople by fetching it from the rest api or cache
+     */
+    private updateEPeople(options) {
+        this.ePeople = this.epersonService.getEPeople(options);
+    }
+
+    /**
+     * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
+     * a new REST call
+     */
+    public forceUpdateEPeople() {
+        this.epersonService.clearEPersonRequests();
+        this.isEPersonFormShown = false;
+        this.search({ query: '', scope: 'metadata' })
+    }
+
+    /**
+     * Search in the EPeople by metadata (default) or email
+     * @param data  Contains scope and query param
+     */
+    search(data: any) {
+        this.ePeople = this.epersonService.searchByScope(data.scope, data.query, {
+            currentPage: 1,
+            elementsPerPage: this.config.pageSize
+        });
+    }
+
+    /**
+     * Checks whether the given EPerson is active (being edited)
+     * @param eperson
+     */
+    isActive(eperson: EPerson): Observable<boolean> {
+        return this.getActiveEPerson().pipe(
+            map((activeEPerson) => eperson === activeEPerson)
+        );
+    }
+
+    /**
+     * Gets the active eperson (being edited)
+     */
+    getActiveEPerson(): Observable<EPerson> {
+        return this.epersonService.getActiveEPerson();
+    }
+
+    /**
+     * Start editing the selected EPerson
+     * @param ePerson
+     */
+    toggleEditEPerson(ePerson: EPerson) {
+        this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
+            if (ePerson === activeEPerson) {
+                this.epersonService.cancelEditEPerson();
+                this.isEPersonFormShown = false;
+            } else {
+                this.epersonService.editEPerson(ePerson);
+                this.isEPersonFormShown = true;
+            }
+        });
+        this.scrollToTop()
+    }
+
+    /**
+     * Deletes EPerson, show notification on success/failure & updates EPeople list
+     */
+    deleteEPerson(ePerson: EPerson) {
+        if (hasValue(ePerson.id)) {
+            this.epersonService.deleteEPerson(ePerson).pipe(take(1)).subscribe((success: boolean) => {
+                if (success) {
+                    this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
+                    this.forceUpdateEPeople();
+                } else {
+                    this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
+                }
+                this.epersonService.cancelEditEPerson();
+                this.isEPersonFormShown = false;
+            })
+        }
+    }
+
+    scrollToTop() {
+        (function smoothscroll() {
+            const currentScroll = document.documentElement.scrollTop || document.body.scrollTop;
+            if (currentScroll > 0) {
+                window.requestAnimationFrame(smoothscroll);
+                window.scrollTo(0, currentScroll - (currentScroll / 8));
+            }
+        })();
+    }
 }

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.spec.ts
@@ -1,0 +1,54 @@
+import { EPersonMock } from '../../../shared/testing/eperson-mock';
+import { EPeopleRegistryCancelEPersonAction, EPeopleRegistryEditEPersonAction } from './epeople-registry.actions';
+import { ePeopleRegistryReducer, EPeopleRegistryState } from './epeople-registry.reducers';
+
+const initialState: EPeopleRegistryState = {
+  editEPerson: null,
+};
+
+const editState: EPeopleRegistryState = {
+  editEPerson: EPersonMock,
+};
+
+class NullAction extends EPeopleRegistryEditEPersonAction {
+  type = null;
+
+  constructor() {
+    super(undefined);
+  }
+}
+
+describe('epeopleRegistryReducer', () => {
+
+  it('should return the current state when no valid actions have been made', () => {
+    const state = initialState;
+    const action = new NullAction();
+    const newState = ePeopleRegistryReducer(state, action);
+
+    expect(newState).toEqual(state);
+  });
+
+  it('should start with an initial state', () => {
+    const state = initialState;
+    const action = new NullAction();
+    const initState = ePeopleRegistryReducer(undefined, action);
+
+    expect(initState).toEqual(state);
+  });
+
+  it('should update the current state to change the editEPerson to a new eperson when EPeopleRegistryEditEPersonAction is dispatched', () => {
+    const state = editState;
+    const action = new EPeopleRegistryEditEPersonAction(EPersonMock);
+    const newState = ePeopleRegistryReducer(state, action);
+
+    expect(newState.editEPerson).toEqual(EPersonMock);
+  });
+
+  it('should update the current state to remove the editEPerson from the state when EPeopleRegistryCancelEPersonAction is dispatched', () => {
+    const state = editState;
+    const action = new EPeopleRegistryCancelEPersonAction();
+    const newState = ePeopleRegistryReducer(state, action);
+
+    expect(newState.editEPerson).toEqual(null);
+  });
+});

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
@@ -6,7 +6,7 @@ import {
 } from './epeople-registry.actions';
 
 /**
- * The metadata registry state.
+ * The EPeople registry state.
  * @interface EPeopleRegistryState
  */
 export interface EPeopleRegistryState {

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
@@ -1,0 +1,49 @@
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import {
+  EPeopleRegistryAction,
+  EPeopleRegistryActionTypes,
+  EPeopleRegistryEditEPersonAction
+} from './epeople-registry.actions';
+
+/**
+ * The metadata registry state.
+ * @interface EPeopleRegistryState
+ */
+export interface EPeopleRegistryState {
+  editEPerson: EPerson;
+  selectedEPeople: EPerson[];
+}
+
+/**
+ * The initial state.
+ */
+const initialState: EPeopleRegistryState = {
+  editEPerson: null,
+  selectedEPeople: [],
+};
+
+/**
+ * Reducer that handles EPeopleRegistryActions to modify EPeople
+ * @param state   The current EPeopleRegistryState
+ * @param action  The EPeopleRegistryAction to perform on the state
+ */
+export function ePeopleRegistryReducer(state = initialState, action: EPeopleRegistryAction): EPeopleRegistryState {
+
+  switch (action.type) {
+
+    case EPeopleRegistryActionTypes.EDIT_EPERSON: {
+      return Object.assign({}, state, {
+        editEPerson: (action as EPeopleRegistryEditEPersonAction).eperson
+      });
+    }
+
+    case EPeopleRegistryActionTypes.CANCEL_EDIT_EPERSON: {
+      return Object.assign({}, state, {
+        editEPerson: null
+      });
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
@@ -11,7 +11,6 @@ import {
  */
 export interface EPeopleRegistryState {
   editEPerson: EPerson;
-  selectedEPeople: EPerson[];
 }
 
 /**
@@ -19,7 +18,6 @@ export interface EPeopleRegistryState {
  */
 const initialState: EPeopleRegistryState = {
   editEPerson: null,
-  selectedEPeople: [],
 };
 
 /**

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -1,0 +1,17 @@
+<div *ngIf="epersonService.getActiveEPerson() | async; then editheader; else createHeader"></div>
+
+<ng-template #createHeader>
+  <h4>{{messagePrefix + '.create' | translate}}</h4>
+</ng-template>
+
+<ng-template #editheader>
+  <h4>{{messagePrefix + '.edit' | translate}}</h4>
+</ng-template>
+
+<ds-form [formId]="formId"
+         [formModel]="formModel"
+         [formGroup]="formGroup"
+         [formLayout]="formLayout"
+         (cancel)="onCancel()"
+         (submitForm)="onSubmit()">
+</ds-form>

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -1,0 +1,206 @@
+import { of as observableOf } from 'rxjs';
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { RestResponse } from '../../../../core/cache/response.models';
+import { PaginatedList } from '../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { FindListOptions } from '../../../../core/data/request.models';
+import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
+import { EPerson } from '../../../../core/eperson/models/eperson.model';
+import { PageInfo } from '../../../../core/shared/page-info.model';
+import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
+import { getMockFormBuilderService } from '../../../../shared/mocks/mock-form-builder-service';
+import { getMockTranslateService } from '../../../../shared/mocks/mock-translate.service';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { EPersonMock, EPersonMock2 } from '../../../../shared/testing/eperson-mock';
+import { MockTranslateLoader } from '../../../../shared/testing/mock-translate-loader';
+import { NotificationsServiceStub } from '../../../../shared/testing/notifications-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../../../shared/testing/utils';
+import { EPeopleRegistryComponent } from '../epeople-registry.component';
+import { EPersonFormComponent } from './eperson-form.component';
+
+describe('EPersonFormComponent', () => {
+  let component: EPersonFormComponent;
+  let fixture: ComponentFixture<EPersonFormComponent>;
+  let translateService: TranslateService;
+  let builderService: FormBuilderService;
+
+  const mockEPeople = [EPersonMock, EPersonMock2];
+  let ePersonDataServiceStub: any;
+
+  beforeEach(async(() => {
+    ePersonDataServiceStub = {
+      activeEPerson: null,
+      allEpeople: mockEPeople,
+      getEPeople(): Observable<RemoteData<PaginatedList<EPerson>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+      },
+      getActiveEPerson(): Observable<EPerson> {
+        return observableOf(this.activeEPerson);
+      },
+      searchByScope(scope: string, query: string, options: FindListOptions = {}): Observable<RemoteData<PaginatedList<EPerson>>> {
+        if (scope === 'email') {
+          const result = this.allEpeople.find((ePerson: EPerson) => {
+            return ePerson.email === query
+          });
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
+        }
+        if (scope === 'metadata') {
+          const result = this.allEpeople.find((ePerson: EPerson) => {
+            return (ePerson.name.includes(query) || ePerson.email.includes(query))
+          });
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
+        }
+        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+      },
+      deleteEPerson(ePerson: EPerson): Observable<boolean> {
+        this.allEpeople = this.allEpeople.filter((ePerson2: EPerson) => {
+          return (ePerson2.uuid !== ePerson.uuid);
+        });
+        return observableOf(true);
+      },
+      create(ePerson: EPerson) {
+        this.allEpeople = [...this.allEpeople, ePerson]
+      },
+      editEPerson(ePerson: EPerson) {
+        this.activeEPerson = ePerson;
+      },
+      cancelEditEPerson() {
+        this.activeEPerson = null;
+      },
+      clearEPersonRequests(): void {
+        // empty
+      },
+      tryToCreate(ePerson: EPerson): Observable<RestResponse> {
+        this.allEpeople = [...this.allEpeople, ePerson]
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      },
+      updateEPerson(ePerson: EPerson): Observable<RestResponse> {
+        this.allEpeople.forEach((ePersonInList: EPerson, i: number) => {
+          if (ePersonInList.id === ePerson.id) {
+            this.allEpeople[i] = ePerson;
+          }
+        });
+        return observableOf(new RestResponse(true, 200, 'Success'));
+
+      }
+    };
+    builderService = getMockFormBuilderService();
+    translateService = getMockTranslateService();
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [EPeopleRegistryComponent, EPersonFormComponent],
+      providers: [EPersonFormComponent,
+        { provide: EPersonDataService, useValue: ePersonDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: FormBuilderService, useValue: builderService },
+        EPeopleRegistryComponent
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EPersonFormComponent);
+    component = fixture.componentInstance;
+    component.ngOnInit();
+    fixture.detectChanges();
+  });
+
+  it('should create EPersonFormComponent', inject([EPersonFormComponent], (comp: EPersonFormComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  describe('when submitting the form', () => {
+    const firstName = 'testName';
+    const lastName = 'testLastName';
+    const email = 'testEmail@test.com';
+    const canLogIn = false;
+    const requireCertificate = false;
+
+    const expected = Object.assign(new EPerson(), {
+      metadata: {
+        'eperson.firstname': [
+          {
+            value: firstName
+          }
+        ],
+        'eperson.lastname': [
+          {
+            value: lastName
+          },
+        ],
+      },
+      email: email,
+      canLogIn: canLogIn,
+      requireCertificate: requireCertificate,
+    });
+    beforeEach(() => {
+      spyOn(component.submitForm, 'emit');
+      component.firstName.value = firstName;
+      component.lastName.value = lastName;
+      component.email.value = email;
+      component.canLogIn.value = canLogIn;
+      component.requireCertificate.value = requireCertificate;
+    });
+    describe('without active EPerson', () => {
+      beforeEach(() => {
+        spyOn(ePersonDataServiceStub, 'getActiveEPerson').and.returnValue(observableOf(undefined));
+        component.onSubmit();
+        fixture.detectChanges();
+      });
+
+      it('should emit a new eperson using the correct values', async(() => {
+        fixture.whenStable().then(() => {
+          expect(component.submitForm.emit).toHaveBeenCalledWith(expected);
+        });
+      }));
+    });
+
+    describe('with an active eperson', () => {
+      const expectedWithId = Object.assign(new EPerson(), {
+        metadata: {
+          'eperson.firstname': [
+            {
+              value: firstName
+            }
+          ],
+          'eperson.lastname': [
+            {
+              value: lastName
+            },
+          ],
+        },
+        email: email,
+        canLogIn: canLogIn,
+        requireCertificate: requireCertificate,
+      });
+
+      beforeEach(() => {
+        spyOn(ePersonDataServiceStub, 'getActiveEPerson').and.returnValue(observableOf(expectedWithId));
+        component.onSubmit();
+        fixture.detectChanges();
+      });
+
+      it('should emit the existing eperson using the correct values', async(() => {
+        fixture.whenStable().then(() => {
+          expect(component.submitForm.emit).toHaveBeenCalledWith(expectedWithId);
+        });
+      }));
+    });
+  });
+
+});

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -106,10 +106,18 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    */
   subs: Subscription[] = [];
 
+  /**
+   * Try to retrieve initial active eperson, to fill in checkboxes at component creation
+   */
+  epersonInitial: EPerson;
+
   constructor(public epersonService: EPersonDataService,
               private formBuilderService: FormBuilderService,
               private translateService: TranslateService,
               private notificationsService: NotificationsService,) {
+    this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
+      this.epersonInitial = eperson;
+    }));
   }
 
   ngOnInit() {
@@ -155,12 +163,14 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           id: 'canLogIn',
           label: canLogIn,
           name: 'canLogIn',
+          value: (this.epersonInitial != null ? this.epersonInitial.canLogIn : true)
         });
       this.requireCertificate = new DynamicCheckboxModel(
         {
           id: 'requireCertificate',
           label: requireCertificate,
           name: 'requireCertificate',
+          value: (this.epersonInitial != null ? this.epersonInitial.requireCertificate : false)
         });
       this.formModel = [
         this.firstName,
@@ -175,10 +185,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',
           lastName: eperson != null ? eperson.firstMetadataValue('eperson.lastname') : '',
           email: eperson != null ? eperson.email : '',
-          canLogIn: eperson != null ? eperson.canLogIn : true,
-          requireCertificate: eperson != null ? eperson.requireCertificate : false,
-          selfRegistered: false,
         });
+        this.formGroup.get('canLogIn').patchValue((eperson != null ? eperson.canLogIn : true));
+        this.formGroup.get('requireCertificate').patchValue((eperson != null ? eperson.requireCertificate : false));
       }));
     });
   }
@@ -216,14 +225,12 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           email: this.email.value,
           canLogIn: this.canLogIn.value,
           requireCertificate: this.requireCertificate.value,
-          selfRegistered: false,
         };
         if (ePerson == null) {
           this.createNewEPerson(values);
         } else {
           this.editEPerson(ePerson, values);
         }
-        this.clearFields();
       }
     );
   }
@@ -270,7 +277,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       email: (hasValue(values.email) ? values.email : ePerson.email),
       canLogIn: (hasValue(values.canLogIn) ? values.canLogIn : ePerson.canLogIn),
       requireCertificate: (hasValue(values.requireCertificate) ? values.requireCertificate : ePerson.requireCertificate),
-      selfRegistered: false,
       _links: ePerson._links,
     });
 
@@ -320,7 +326,8 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       firstName: '',
       lastName: '',
       email: '',
-      canLogin: '',
+      canLogin: true,
+      requireCertificate: false
     });
   }
 

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -244,13 +244,13 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.created.failure', { name: ePersonToCreate.name }));
       }
     });
-    this.showNotificationIfEmailInUse(ePersonToCreate);
+    this.showNotificationIfEmailInUse(ePersonToCreate, 'created');
   }
 
   /**
    * Edits existing EPerson based on given values from form and old EPerson
-   * @param ePerson
-   * @param values
+   * @param ePerson   ePerson to edit
+   * @param values    new ePerson values (of form)
    */
   editEPerson(ePerson: EPerson, values) {
     const editedEperson = Object.assign(new EPerson(), {
@@ -280,24 +280,33 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.edited.success', { name: editedEperson.name }));
         this.submitForm.emit(editedEperson);
       } else {
-        this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.created.failure', { name: editedEperson.name }));
+        this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.edited.failure', { name: editedEperson.name }));
       }
     });
-    this.showNotificationIfEmailInUse(editedEperson);
+
+    if (values.email != null && values.email !== ePerson.email) {
+      this.showNotificationIfEmailInUse(editedEperson, 'edited');
+    }
   }
 
-  private showNotificationIfEmailInUse(ePersonToCreate: EPerson) {
+  /**
+   * Checks for the given ePerson if there is already an ePerson in the system with that email
+   * and shows notification if this is the case
+   * @param ePerson               ePerson values to check
+   * @param notificationSection   whether in create or edit
+   */
+  private showNotificationIfEmailInUse(ePerson: EPerson, notificationSection: string) {
     // Relevant message for email in use
     // TODO: should be changed to email scope, but byEmail currently not in backend
-    this.subs.push(this.epersonService.searchByScope(null, ePersonToCreate.email, {
+    this.subs.push(this.epersonService.searchByScope(null, ePerson.email, {
       currentPage: 1,
       elementsPerPage: 0
     }).pipe(getSucceededRemoteData(), getRemoteDataPayload())
       .subscribe((list: PaginatedList<EPerson>) => {
         if (list.totalElements > 0) {
-          this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.created.failure.emailInUse', {
-            name: ePersonToCreate.name,
-            email: ePersonToCreate.email
+          this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.' + notificationSection + '.failure.emailInUse', {
+            name: ePerson.name,
+            email: ePerson.email
           }));
         }
       }));

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -98,7 +98,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    */
   @Output() cancelForm: EventEmitter<any> = new EventEmitter();
 
-  constructor(private epersonService: EPersonDataService,
+  constructor(public epersonService: EPersonDataService,
               private formBuilderService: FormBuilderService,
               private translateService: TranslateService,
               private notificationsService: NotificationsService,) {

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -185,9 +185,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',
           lastName: eperson != null ? eperson.firstMetadataValue('eperson.lastname') : '',
           email: eperson != null ? eperson.email : '',
+          canLogIn: eperson != null ? eperson.canLogIn : true,
+          requireCertificate: eperson != null ? eperson.requireCertificate : false
         });
-        this.formGroup.get('canLogIn').patchValue((eperson != null ? eperson.canLogIn : true));
-        this.formGroup.get('requireCertificate').patchValue((eperson != null ? eperson.requireCertificate : false));
       }));
     });
   }
@@ -198,7 +198,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   onCancel() {
     this.epersonService.cancelEditEPerson();
     this.cancelForm.emit();
-    this.clearFields();
   }
 
   /**
@@ -210,6 +209,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   onSubmit() {
     this.epersonService.getActiveEPerson().pipe(take(1)).subscribe(
       (ePerson: EPerson) => {
+        console.log('onsubmit ep', ePerson)
         const values = {
           metadata: {
             'eperson.firstname': [
@@ -241,6 +241,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    * @param values
    */
   createNewEPerson(values) {
+    console.log('createNewEPerson(values)', values)
     const ePersonToCreate = Object.assign(new EPerson(), values);
 
     const response = this.epersonService.tryToCreate(ePersonToCreate);

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -198,6 +198,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   onCancel() {
     this.epersonService.cancelEditEPerson();
     this.cancelForm.emit();
+    this.clearFields();
   }
 
   /**
@@ -249,6 +250,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         this.submitForm.emit(ePersonToCreate);
       } else {
         this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.created.failure', { name: ePersonToCreate.name }));
+        this.cancelForm.emit();
       }
     });
     this.showNotificationIfEmailInUse(ePersonToCreate, 'created');
@@ -287,6 +289,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         this.submitForm.emit(editedEperson);
       } else {
         this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.edited.failure', { name: editedEperson.name }));
+        this.cancelForm.emit();
       }
     });
 
@@ -303,8 +306,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    */
   private showNotificationIfEmailInUse(ePerson: EPerson, notificationSection: string) {
     // Relevant message for email in use
-    // TODO: should be changed to email scope, but byEmail currently not in backend
-    this.subs.push(this.epersonService.searchByScope(null, ePerson.email, {
+    this.subs.push(this.epersonService.searchByScope('email', ePerson.email, {
       currentPage: 1,
       elementsPerPage: 0
     }).pipe(getSucceededRemoteData(), getRemoteDataPayload())

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -1,0 +1,291 @@
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import {
+  DynamicCheckboxModel,
+  DynamicFormControlModel,
+  DynamicFormLayout,
+  DynamicInputModel
+} from '@ng-dynamic-forms/core';
+import { TranslateService } from '@ngx-translate/core';
+import { combineLatest } from 'rxjs/internal/observable/combineLatest';
+import { take } from 'rxjs/operators';
+import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
+import { EPerson } from '../../../../core/eperson/models/eperson.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../core/shared/operators';
+import { hasValue } from '../../../../shared/empty.util';
+import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+
+@Component({
+  selector: 'ds-eperson-form',
+  templateUrl: './eperson-form.component.html'
+})
+/**
+ * A form used for creating and editing EPeople
+ */
+export class EPersonFormComponent implements OnInit, OnDestroy {
+
+  labelPrefix = 'admin.access-control.epeople.form.';
+
+  /**
+   * A unique id used for ds-form
+   */
+  formId = 'eperson-form';
+
+  /**
+   * The labelPrefix for all messages related to this form
+   */
+  messagePrefix = 'admin.access-control.epeople.form';
+
+  /**
+   * Dynamic input models for the inputs of form
+   */
+  firstName: DynamicInputModel;
+  lastName: DynamicInputModel;
+  email: DynamicInputModel;
+  // booleans
+  canLogIn: DynamicCheckboxModel;
+  requireCertificate: DynamicCheckboxModel;
+
+  /**
+   * A list of all dynamic input models
+   */
+  formModel: DynamicFormControlModel[];
+
+  /**
+   * Layout used for structuring the form inputs
+   */
+  formLayout: DynamicFormLayout = {
+    firstName: {
+      grid: {
+        host: 'row'
+      }
+    },
+    lastName: {
+      grid: {
+        host: 'row'
+      }
+    },
+    email: {
+      grid: {
+        host: 'row'
+      }
+    },
+    canLogIn: {
+      grid: {
+        host: 'col col-sm-6 d-inline-block'
+      }
+    },
+    requireCertificate: {
+      grid: {
+        host: 'col col-sm-6 d-inline-block'
+      }
+    },
+  };
+
+  /**
+   * A FormGroup that combines all inputs
+   */
+  formGroup: FormGroup;
+
+  /**
+   * An EventEmitter that's fired whenever the form is being submitted
+   */
+  @Output() submitForm: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * An EventEmitter that's fired whenever the form is cancelled
+   */
+  @Output() cancelForm: EventEmitter<any> = new EventEmitter();
+
+  constructor(private epersonService: EPersonDataService,
+              private formBuilderService: FormBuilderService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,) {
+  }
+
+  ngOnInit() {
+    combineLatest(
+      this.translateService.get(`${this.messagePrefix}.firstName`),
+      this.translateService.get(`${this.messagePrefix}.lastName`),
+      this.translateService.get(`${this.messagePrefix}.email`),
+      this.translateService.get(`${this.messagePrefix}.canLogIn`),
+      this.translateService.get(`${this.messagePrefix}.requireCertificate`),
+      this.translateService.get(`${this.messagePrefix}.emailHint`),
+    ).subscribe(([firstName, lastName, email, canLogIn, requireCertificate, emailHint]) => {
+      this.firstName = new DynamicInputModel({
+        id: 'firstName',
+        label: firstName,
+        name: 'firstName',
+        validators: {
+          required: null,
+        },
+        required: true,
+      });
+      this.lastName = new DynamicInputModel({
+        id: 'lastName',
+        label: lastName,
+        name: 'lastName',
+        validators: {
+          required: null,
+        },
+        required: true,
+      });
+      this.email = new DynamicInputModel({
+        id: 'email',
+        label: email,
+        name: 'email',
+        validators: {
+          required: null,
+          pattern: '^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$'
+        },
+        required: true,
+        hint: emailHint
+      });
+      this.canLogIn = new DynamicCheckboxModel(
+        {
+          id: 'canLogIn',
+          label: canLogIn,
+          name: 'canLogIn',
+        });
+      this.requireCertificate = new DynamicCheckboxModel(
+        {
+          id: 'requireCertificate',
+          label: requireCertificate,
+          name: 'requireCertificate',
+        });
+      this.formModel = [
+        this.firstName,
+        this.lastName,
+        this.email,
+        this.canLogIn,
+        this.requireCertificate,
+      ];
+      this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
+      this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
+        this.formGroup.patchValue({
+          firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',
+          lastName: eperson != null ? eperson.firstMetadataValue('eperson.lastname') : '',
+          email: eperson != null ? eperson.email : '',
+          canLogIn: eperson != null ? eperson.canLogIn : true,
+          requireCertificate: eperson != null ? eperson.requireCertificate : false,
+          selfRegistered: false,
+        });
+      });
+    });
+  }
+
+  /**
+   * Stop editing the currently selected eperson
+   */
+  onCancel() {
+    this.epersonService.cancelEditEPerson();
+    this.cancelForm.emit();
+  }
+
+  /**
+   * Submit the form
+   * When the eperson has an id attached -> Edit the eperson
+   * When the eperson has no id attached -> Create new eperson
+   * Emit the updated/created eperson using the EventEmitter submitForm
+   */
+  onSubmit() {
+    this.epersonService.getActiveEPerson().pipe(take(1)).subscribe(
+      (ePerson: EPerson) => {
+        const values = {
+          metadata: {
+            'eperson.firstname': [
+              {
+                value: this.firstName.value
+              }
+            ],
+            'eperson.lastname': [
+              {
+                value: this.lastName.value
+              },
+            ],
+          },
+          email: this.email.value,
+          canLogIn: this.canLogIn.value,
+          requireCertificate: this.requireCertificate.value,
+          selfRegistered: false,
+        };
+        if (ePerson == null) {
+          this.createNewEPerson(values);
+        } else {
+          this.editEPerson(ePerson, values);
+        }
+        this.clearFields();
+      }
+    );
+  }
+
+  /**
+   * Creates new EPerson based on given values from form
+   * @param values
+   */
+  createNewEPerson(values) {
+    this.epersonService.createOrUpdateEPerson(Object.assign(new EPerson(), values))
+      .pipe(
+        getSucceededRemoteData(),
+        getRemoteDataPayload())
+      .subscribe((newEPerson: EPerson) => {
+        this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.created.success', { name: newEPerson.name }));
+        this.submitForm.emit(newEPerson);
+      });
+  }
+
+  /**
+   * Edits existing EPerson based on given values from form and old EPerson
+   * @param ePerson
+   * @param values
+   */
+  editEPerson(ePerson: EPerson, values) {
+    this.epersonService.createOrUpdateEPerson(Object.assign(new EPerson(), {
+      id: ePerson.id,
+      metadata: {
+        'eperson.firstname': [
+          {
+            value: (this.firstName.value ? this.firstName.value : ePerson.firstMetadataValue('eperson.firstname'))
+          }
+        ],
+        'eperson.lastname': [
+          {
+            value: (this.lastName.value ? this.lastName.value : ePerson.firstMetadataValue('eperson.lastname'))
+          },
+        ],
+      },
+      email: (hasValue(values.email) ? values.email : ePerson.email),
+      canLogIn: (hasValue(values.canLogIn) ? values.canLogIn : ePerson.canLogIn),
+      requireCertificate: (hasValue(values.requireCertificate) ? values.requireCertificate : ePerson.requireCertificate),
+      selfRegistered: false,
+      _links: ePerson._links,
+    }))
+      .pipe(
+        getSucceededRemoteData(),
+        getRemoteDataPayload())
+      .subscribe((updatedEPerson: EPerson) => {
+        this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.edited.success', { name: updatedEPerson.name }));
+        this.submitForm.emit(updatedEPerson);
+      });
+  }
+
+  /**
+   * Reset all input-fields to be empty
+   */
+  clearFields() {
+    this.formGroup.patchValue({
+      firstName: '',
+      lastName: '',
+      email: '',
+      canLogin: '',
+    });
+  }
+
+  /**
+   * Cancel the current edit when component is destroyed
+   */
+  ngOnDestroy(): void {
+    this.onCancel();
+  }
+}

--- a/src/app/+admin/admin-routing.module.ts
+++ b/src/app/+admin/admin-routing.module.ts
@@ -1,11 +1,12 @@
-import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
-import { URLCombiner } from '../core/url-combiner/url-combiner';
+import { RouterModule } from '@angular/router';
 import { getAdminModulePath } from '../app-routing.module';
+import { URLCombiner } from '../core/url-combiner/url-combiner';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 
 const REGISTRIES_MODULE_PATH = 'registries';
+const ACCESS_CONTROL_MODULE_PATH = 'access-control';
 
 export function getRegistriesModulePath() {
   return new URLCombiner(getAdminModulePath(), REGISTRIES_MODULE_PATH).toString();
@@ -17,6 +18,10 @@ export function getRegistriesModulePath() {
       {
         path: REGISTRIES_MODULE_PATH,
         loadChildren: './admin-registries/admin-registries.module#AdminRegistriesModule'
+      },
+      {
+        path: ACCESS_CONTROL_MODULE_PATH,
+        loadChildren: './admin-access-control/admin-access-control.module#AdminAccessControlModule'
       },
       {
         path: 'search',

--- a/src/app/+admin/admin-routing.module.ts
+++ b/src/app/+admin/admin-routing.module.ts
@@ -1,7 +1,7 @@
-import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { getAdminModulePath } from '../app-routing.module';
+import { NgModule } from '@angular/core';
 import { URLCombiner } from '../core/url-combiner/url-combiner';
+import { getAdminModulePath } from '../app-routing.module';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 

--- a/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
@@ -1,23 +1,23 @@
 import { Component, Injector, OnInit } from '@angular/core';
-import { Observable } from 'rxjs/internal/Observable';
-import { slideHorizontal, slideSidebar } from '../../shared/animations/slide';
-import { CSSVariableService } from '../../shared/sass-helper/sass-helper.service';
-import { MenuService } from '../../shared/menu/menu.service';
-import { MenuID, MenuItemType } from '../../shared/menu/initial-menus-state';
-import { MenuComponent } from '../../shared/menu/menu.component';
-import { TextMenuItemModel } from '../../shared/menu/menu-item/models/text.model';
-import { LinkMenuItemModel } from '../../shared/menu/menu-item/models/link.model';
-import { AuthService } from '../../core/auth/auth.service';
-import { first, map } from 'rxjs/operators';
-import { combineLatest as combineLatestObservable } from 'rxjs';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { OnClickMenuItemModel } from '../../shared/menu/menu-item/models/onclick.model';
-import { CreateCommunityParentSelectorComponent } from '../../shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component';
+import { combineLatest as combineLatestObservable } from 'rxjs';
+import { Observable } from 'rxjs/internal/Observable';
+import { first, map } from 'rxjs/operators';
+import { AuthService } from '../../core/auth/auth.service';
+import { slideHorizontal, slideSidebar } from '../../shared/animations/slide';
 import { CreateCollectionParentSelectorComponent } from '../../shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component';
-import { EditItemSelectorComponent } from '../../shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component';
-import { EditCommunitySelectorComponent } from '../../shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component';
+import { CreateCommunityParentSelectorComponent } from '../../shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component';
+import { CreateItemParentSelectorComponent } from '../../shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component';
 import { EditCollectionSelectorComponent } from '../../shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component';
-import {CreateItemParentSelectorComponent} from '../../shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component';
+import { EditCommunitySelectorComponent } from '../../shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component';
+import { EditItemSelectorComponent } from '../../shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component';
+import { MenuID, MenuItemType } from '../../shared/menu/initial-menus-state';
+import { LinkMenuItemModel } from '../../shared/menu/menu-item/models/link.model';
+import { OnClickMenuItemModel } from '../../shared/menu/menu-item/models/onclick.model';
+import { TextMenuItemModel } from '../../shared/menu/menu-item/models/text.model';
+import { MenuComponent } from '../../shared/menu/menu.component';
+import { MenuService } from '../../shared/menu/menu.service';
+import { CSSVariableService } from '../../shared/sass-helper/sass-helper.service';
 
 /**
  * Component representing the admin sidebar
@@ -325,7 +325,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         model: {
           type: MenuItemType.LINK,
           text: 'menu.section.access_control_people',
-          link: ''
+          link: '/admin/access-control/epeople'
         } as LinkMenuItemModel,
       },
       {

--- a/src/app/+admin/admin.module.ts
+++ b/src/app/+admin/admin.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
-import { AdminRegistriesModule } from './admin-registries/admin-registries.module';
-import { AdminRoutingModule } from './admin-routing.module';
 import { SharedModule } from '../shared/shared.module';
+import { AdminAccessControlModule } from './admin-access-control/admin-access-control.module';
+import { AdminRegistriesModule } from './admin-registries/admin-registries.module';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { SearchPageModule } from '../+search-page/search-page.module';
 import { ItemAdminSearchResultListElementComponent } from './admin-search-page/admin-search-results/admin-search-result-list-element/item-search-result/item-admin-search-result-list-element.component';
@@ -15,7 +15,7 @@ import { ItemAdminSearchResultActionsComponent } from './admin-search-page/admin
 @NgModule({
   imports: [
     AdminRegistriesModule,
-    AdminRoutingModule,
+    AdminAccessControlModule,
     SharedModule,
     SearchPageModule
   ],

--- a/src/app/+admin/admin.module.ts
+++ b/src/app/+admin/admin.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared/shared.module';
 import { AdminAccessControlModule } from './admin-access-control/admin-access-control.module';
 import { AdminRegistriesModule } from './admin-registries/admin-registries.module';
+import { AdminRoutingModule } from './admin-routing.module';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { SearchPageModule } from '../+search-page/search-page.module';
 import { ItemAdminSearchResultListElementComponent } from './admin-search-page/admin-search-results/admin-search-result-list-element/item-search-result/item-admin-search-result-list-element.component';
@@ -14,6 +15,7 @@ import { ItemAdminSearchResultActionsComponent } from './admin-search-page/admin
 
 @NgModule({
   imports: [
+    AdminRoutingModule,
     AdminRegistriesModule,
     AdminAccessControlModule,
     SharedModule,

--- a/src/app/app.reducer.ts
+++ b/src/app/app.reducer.ts
@@ -1,30 +1,34 @@
-import { ActionReducerMap, createSelector, MemoizedSelector } from '@ngrx/store';
 import * as fromRouter from '@ngrx/router-store';
-
-import { hostWindowReducer, HostWindowState } from './shared/search/host-window.reducer';
-import { CommunityListReducer, CommunityListState } from './community-list-page/community-list.reducer';
-import { formReducer, FormState } from './shared/form/form.reducer';
-import { sidebarReducer, SidebarState } from './shared/sidebar/sidebar.reducer';
-import { sidebarFilterReducer, SidebarFiltersState } from './shared/sidebar/filter/sidebar-filter.reducer';
-import { filterReducer, SearchFiltersState } from './shared/search/search-filters/search-filter/search-filter.reducer';
-import { notificationsReducer, NotificationsState } from './shared/notifications/notifications.reducers';
-import { truncatableReducer, TruncatablesState } from './shared/truncatable/truncatable.reducer';
+import { ActionReducerMap, createSelector, MemoizedSelector } from '@ngrx/store';
+import {
+  ePeopleRegistryReducer,
+  EPeopleRegistryState
+} from './+admin/admin-access-control/epeople-registry/epeople-registry.reducers';
 import {
   metadataRegistryReducer,
   MetadataRegistryState
 } from './+admin/admin-registries/metadata-registry/metadata-registry.reducers';
+import { CommunityListReducer, CommunityListState } from './community-list-page/community-list.reducer';
 import { hasValue } from './shared/empty.util';
-import { cssVariablesReducer, CSSVariablesState } from './shared/sass-helper/sass-helper.reducer';
+import {
+  NameVariantListsState,
+  nameVariantReducer
+} from './shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/name-variant.reducer';
+import { formReducer, FormState } from './shared/form/form.reducer';
 import { menusReducer, MenusState } from './shared/menu/menu.reducer';
+import { notificationsReducer, NotificationsState } from './shared/notifications/notifications.reducers';
 import {
   selectableListReducer,
   SelectableListsState
 } from './shared/object-list/selectable-list/selectable-list.reducer';
 import { ObjectSelectionListState, objectSelectionReducer } from './shared/object-select/object-select.reducer';
-import {
-  NameVariantListsState,
-  nameVariantReducer
-} from './shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/name-variant.reducer';
+import { cssVariablesReducer, CSSVariablesState } from './shared/sass-helper/sass-helper.reducer';
+
+import { hostWindowReducer, HostWindowState } from './shared/search/host-window.reducer';
+import { filterReducer, SearchFiltersState } from './shared/search/search-filters/search-filter/search-filter.reducer';
+import { sidebarFilterReducer, SidebarFiltersState } from './shared/sidebar/filter/sidebar-filter.reducer';
+import { sidebarReducer, SidebarState } from './shared/sidebar/sidebar.reducer';
+import { truncatableReducer, TruncatablesState } from './shared/truncatable/truncatable.reducer';
 
 export interface AppState {
   router: fromRouter.RouterReducerState;
@@ -42,6 +46,7 @@ export interface AppState {
   selectableLists: SelectableListsState;
   relationshipLists: NameVariantListsState;
   communityList: CommunityListState;
+  epeopleRegistry: EPeopleRegistryState;
 }
 
 export const appReducers: ActionReducerMap<AppState> = {
@@ -60,6 +65,7 @@ export const appReducers: ActionReducerMap<AppState> = {
   selectableLists: selectableListReducer,
   relationshipLists: nameVariantReducer,
   communityList: CommunityListReducer,
+  epeopleRegistry: ePeopleRegistryReducer,
 };
 
 export const routerStateSelector = (state: AppState) => state.router;

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -10,6 +10,7 @@ import { coreSelector } from '../core.selectors';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { selfLinkFromUuidSelector } from '../index/index.selectors';
 import { GenericConstructor } from '../shared/generic-constructor';
+import { getClassForType } from './builders/build-decorators';
 import { LinkService } from './builders/link.service';
 import {
   AddPatchObjectCacheAction,
@@ -20,7 +21,6 @@ import {
 
 import { CacheableObject, ObjectCacheEntry, ObjectCacheState } from './object-cache.reducer';
 import { AddToSSBAction } from './server-sync-buffer.actions';
-import { getClassForType } from './builders/build-decorators';
 
 /**
  * The base selector function to select the object cache in the store
@@ -48,7 +48,7 @@ export class ObjectCacheService {
   constructor(
     private store: Store<CoreState>,
     private linkService: LinkService
-    ) {
+  ) {
   }
 
   /**
@@ -276,6 +276,8 @@ export class ObjectCacheService {
    *     list of operations to perform
    */
   public addPatch(selfLink: string, patch: Operation[]) {
+    console.log('selfLink addPatch', selfLink)
+    console.log('patch addPatch', patch)
     this.store.dispatch(new AddPatchObjectCacheAction(selfLink, patch));
     this.store.dispatch(new AddToSSBAction(selfLink, RestRequestMethod.PATCH));
   }

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -276,8 +276,6 @@ export class ObjectCacheService {
    *     list of operations to perform
    */
   public addPatch(selfLink: string, patch: Operation[]) {
-    console.log('selfLink addPatch', selfLink)
-    console.log('patch addPatch', patch)
     this.store.dispatch(new AddPatchObjectCacheAction(selfLink, patch));
     this.store.dispatch(new AddToSSBAction(selfLink, RestRequestMethod.PATCH));
   }

--- a/src/app/core/data/data.service.ts
+++ b/src/app/core/data/data.service.ts
@@ -306,7 +306,7 @@ export abstract class DataService<T extends CacheableObject> {
    * @return {Observable<RemoteData<PaginatedList<T>>}
    *    Return an observable that emits response from the server
    */
-  protected searchBy(searchMethod: string, options: FindListOptions = {}, ...linksToFollow: Array<FollowLinkConfig<T>>): Observable<RemoteData<PaginatedList<T>>> {
+  searchBy(searchMethod: string, options: FindListOptions = {}, ...linksToFollow: Array<FollowLinkConfig<T>>): Observable<RemoteData<PaginatedList<T>>> {
 
     const hrefObs = this.getSearchByHref(searchMethod, options, ...linksToFollow);
 

--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -20,7 +20,6 @@ import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-servic
 import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
 import { SearchParam } from '../cache/models/search-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
-import { RestResponse } from '../cache/response.models';
 import { CoreState } from '../core.reducers';
 import { ChangeAnalyzer } from '../data/change-analyzer';
 import { PaginatedList } from '../data/paginated-list';
@@ -39,10 +38,6 @@ describe('EPersonDataService', () => {
   let store: Store<CoreState>;
   let requestService: RequestService;
   let scheduler: TestScheduler;
-
-  const responseCacheEntry = new RequestEntry();
-  responseCacheEntry.response = new RestResponse(true, 200, 'Success');
-  responseCacheEntry.completed = true;
 
   const epeople = [EPersonMock, EPersonMock2];
 
@@ -77,6 +72,7 @@ describe('EPersonDataService', () => {
 
   const getRequestEntry$ = (successful: boolean) => {
     return observableOf({
+      completed: true,
       response: { isSuccessful: successful, payload: epeople } as any
     } as RequestEntry)
   };

--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -1,0 +1,308 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
+import { Store, StoreModule } from '@ngrx/store';
+import { compare, Operation } from 'fast-json-patch';
+import { getTestScheduler } from 'jasmine-marbles';
+import { of as observableOf } from 'rxjs';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { TestScheduler } from 'rxjs/testing';
+import {
+  EPeopleRegistryCancelEPersonAction,
+  EPeopleRegistryEditEPersonAction
+} from '../../+admin/admin-access-control/epeople-registry/epeople-registry.actions';
+import { getMockRemoteDataBuildServiceHrefMap } from '../../shared/mocks/mock-remote-data-build.service';
+import { getMockRequestService } from '../../shared/mocks/mock-request.service';
+import { MockTranslateLoader } from '../../shared/mocks/mock-translate-loader';
+import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson-mock';
+import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
+import { SearchParam } from '../cache/models/search-param.model';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { RestResponse } from '../cache/response.models';
+import { CoreState } from '../core.reducers';
+import { ChangeAnalyzer } from '../data/change-analyzer';
+import { PaginatedList } from '../data/paginated-list';
+import { RemoteData } from '../data/remote-data';
+import { DeleteByIDRequest, FindListOptions, PatchRequest } from '../data/request.models';
+import { RequestEntry } from '../data/request.reducer';
+import { RequestService } from '../data/request.service';
+import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { Item } from '../shared/item.model';
+import { PageInfo } from '../shared/page-info.model';
+import { EPersonDataService } from './eperson-data.service';
+import { EPerson } from './models/eperson.model';
+
+describe('EPersonDataService', () => {
+  let service: EPersonDataService;
+  let store: Store<CoreState>;
+  let requestService: RequestService;
+  let scheduler: TestScheduler;
+
+  const responseCacheEntry = new RequestEntry();
+  responseCacheEntry.response = new RestResponse(true, 200, 'Success');
+  responseCacheEntry.completed = true;
+
+  const epeople = [EPersonMock, EPersonMock2];
+
+  const restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
+  const epersonsEndpoint = `${restEndpointURL}/epersons`;
+  let halService: any = new HALEndpointServiceStub(restEndpointURL);
+  const epeople$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [epeople]));
+  const rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons': epeople$ });
+  const objectCache = Object.assign({
+    /* tslint:disable:no-empty */
+    remove: () => {
+    },
+    hasBySelfLinkObservable: () => observableOf(false)
+    /* tslint:enable:no-empty */
+  }) as ObjectCacheService;
+
+  TestBed.configureTestingModule({
+    imports: [
+      CommonModule,
+      StoreModule.forRoot({}),
+      TranslateModule.forRoot({
+        loader: {
+          provide: TranslateLoader,
+          useClass: MockTranslateLoader
+        }
+      }),
+    ],
+    declarations: [],
+    providers: [],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
+
+  const getRequestEntry$ = (successful: boolean) => {
+    return observableOf({
+      response: { isSuccessful: successful, payload: epeople } as any
+    } as RequestEntry)
+  };
+
+  function initTestService() {
+    return new EPersonDataService(
+      requestService,
+      rdbService,
+      store,
+      null,
+      halService,
+      null,
+      null,
+      new DummyChangeAnalyzer() as any
+    );
+  }
+
+  beforeEach(() => {
+    requestService = getMockRequestService(getRequestEntry$(true));
+    store = new Store<CoreState>(undefined, undefined, undefined);
+    service = initTestService();
+    spyOn(store, 'dispatch');
+  });
+
+  describe('searchByScope', () => {
+    beforeEach(() => {
+      spyOn(service, 'searchBy');
+    });
+
+    it('search by default scope (byMetadata) and no query', () => {
+      service.searchByScope(null, '');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('query', ''))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options);
+    });
+
+    it('search metadata scope and no query', () => {
+      service.searchByScope('metadata', '');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('query', ''))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options);
+    });
+
+    it('search metadata scope and with query', () => {
+      service.searchByScope('metadata', 'test');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('query', 'test'))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options);
+    });
+
+    it('search email scope and no query', () => {
+      service.searchByScope('email', '');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('email', ''))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byEmail', options);
+    });
+  });
+
+  describe('updateEPerson', () => {
+    beforeEach(() => {
+      spyOn(service, 'findByHref').and.returnValue(createSuccessfulRemoteDataObject$(EPersonMock));
+    });
+
+    describe('change Email', () => {
+      const newEmail = 'changedemail@test.com';
+      beforeEach(() => {
+        const changedEPerson = Object.assign(new EPerson(), {
+          id: EPersonMock.id,
+          metadata: EPersonMock.metadata,
+          email: newEmail,
+          canLogIn: EPersonMock.canLogIn,
+          requireCertificate: EPersonMock.requireCertificate,
+          _links: EPersonMock._links,
+        });
+        service.updateEPerson(changedEPerson).subscribe();
+      });
+      it('should send PatchRequest with replace email operation', () => {
+        const operations = [{ op: 'replace', path: '/email', value: newEmail }];
+        const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
+        expect(requestService.configure).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe('change certificate', () => {
+      beforeEach(() => {
+        const changedEPerson = Object.assign(new EPerson(), {
+          id: EPersonMock.id,
+          metadata: EPersonMock.metadata,
+          email: EPersonMock.email,
+          canLogIn: EPersonMock.canLogIn,
+          requireCertificate: !EPersonMock.requireCertificate,
+          _links: EPersonMock._links,
+        });
+        service.updateEPerson(changedEPerson).subscribe();
+      });
+      it('should send PatchRequest with replace certificate operation', () => {
+        const operations = [{ op: 'replace', path: '/certificate', value: !EPersonMock.requireCertificate }];
+        const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
+        expect(requestService.configure).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe('change canLogin', () => {
+      beforeEach(() => {
+        const changedEPerson = Object.assign(new EPerson(), {
+          id: EPersonMock.id,
+          metadata: EPersonMock.metadata,
+          email: EPersonMock.email,
+          canLogIn: !EPersonMock.canLogIn,
+          requireCertificate: EPersonMock.requireCertificate,
+          _links: EPersonMock._links,
+        });
+        service.updateEPerson(changedEPerson).subscribe();
+      });
+      it('should send PatchRequest with replace canLogIn operation', () => {
+        const operations = [{ op: 'replace', path: '/canLogIn', value: !EPersonMock.canLogIn }];
+        const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
+        expect(requestService.configure).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe('change name', () => {
+      const newFirstName = 'changedFirst';
+      const newLastName = 'changedLast';
+      beforeEach(() => {
+        const changedEPerson = Object.assign(new EPerson(), {
+          id: EPersonMock.id,
+          metadata: {
+            'eperson.firstname': [
+              {
+                value: newFirstName,
+              }
+            ],
+            'eperson.lastname': [
+              {
+                value: newLastName,
+              },
+            ],
+          },
+          email: EPersonMock.email,
+          canLogIn: EPersonMock.canLogIn,
+          requireCertificate: EPersonMock.requireCertificate,
+          _links: EPersonMock._links,
+        });
+        service.updateEPerson(changedEPerson).subscribe();
+      });
+      it('should send PatchRequest with replace name metadata operations', () => {
+        const operations = [
+          { op: 'replace', path: '/eperson.lastname/0/value', value: newLastName },
+          { op: 'replace', path: '/eperson.firstname/0/value', value: newFirstName }];
+        const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
+        expect(requestService.configure).toHaveBeenCalledWith(expected);
+      });
+    });
+  });
+
+  describe('clearEPersonRequests', () => {
+    beforeEach(async(() => {
+      scheduler = getTestScheduler();
+      halService = {
+        getEndpoint(linkPath: string): Observable<string> {
+          return observableOf(restEndpointURL + '/' + linkPath);
+        }
+      } as HALEndpointService;
+      initTestService();
+      service.clearEPersonRequests();
+    }));
+    it('should remove the eperson hrefs in the request service', () => {
+      expect(requestService.removeByHrefSubstring).toHaveBeenCalledWith(epersonsEndpoint);
+    });
+  });
+
+  describe('getActiveEPerson', () => {
+    it('should retrieve the ePerson currently getting edited, if any', () => {
+      service.editEPerson(EPersonMock);
+
+      service.getActiveEPerson().subscribe((activeEPerson: EPerson) => {
+        expect(activeEPerson).toEqual(EPersonMock);
+      })
+    });
+
+    it('should retrieve the ePerson currently getting edited, null if none being edited', () => {
+      service.getActiveEPerson().subscribe((activeEPerson: EPerson) => {
+        expect(activeEPerson).toEqual(null);
+      })
+    })
+  });
+
+  describe('cancelEditEPerson', () => {
+    it('should dispatch a CANCEL_EDIT_EPERSON action', () => {
+      service.cancelEditEPerson();
+      expect(store.dispatch).toHaveBeenCalledWith(new EPeopleRegistryCancelEPersonAction());
+    });
+  });
+
+  describe('editEPerson', () => {
+    it('should dispatch a EDIT_EPERSON action with the EPerson to start editing', () => {
+      service.editEPerson(EPersonMock);
+      expect(store.dispatch).toHaveBeenCalledWith(new EPeopleRegistryEditEPersonAction(EPersonMock));
+    });
+  });
+
+  describe('deleteEPerson', () => {
+    beforeEach(() => {
+      spyOn(service, 'findById').and.returnValue(getRemotedataObservable(EPersonMock));
+      service.deleteEPerson(EPersonMock).subscribe();
+    });
+
+    it('should send DeleteRequest', () => {
+      const expected = new DeleteByIDRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, EPersonMock.uuid);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+});
+
+function getRemotedataObservable(obj: any): Observable<RemoteData<any>> {
+  return observableOf(new RemoteData(false, false, true, undefined, obj));
+}
+
+class DummyChangeAnalyzer implements ChangeAnalyzer<Item> {
+  diff(object1: Item, object2: Item): Operation[] {
+    return compare((object1 as any).metadata, (object2 as any).metadata);
+  }
+}

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -146,9 +146,10 @@ export class EPersonDataService extends DataService<EPerson> {
       map((oldEPerson: EPerson) => {
         const operations = this.generateOperations(oldEPerson, ePerson);
         const patchRequest = new PatchRequest(requestId, ePerson._links.self.href, operations);
-        this.requestService.configure(patchRequest);
+        return this.requestService.configure(patchRequest);
       }),
-    );
+      take(1)
+    ).subscribe();
 
     return this.fetchResponse(requestId);
   }

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -78,7 +78,7 @@ export class EPersonDataService extends DataService<EPerson> {
    * @param query   Query of search
    * @param options Options of search request
    */
-  public searchByScope(scope: string, query: string, options: FindListOptions = {}) {
+  public searchByScope(scope: string, query: string, options: FindListOptions = {}): Observable<RemoteData<PaginatedList<EPerson>>> {
     switch (scope) {
       case 'metadata':
         return this.getEpeopleByMetadata(query.trim(), options);
@@ -95,7 +95,7 @@ export class EPersonDataService extends DataService<EPerson> {
    * @param options
    * @param linksToFollow
    */
-  public getEpeopleByEmail(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+  private getEpeopleByEmail(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
     const searchParams = [new SearchParam('email', query)];
     return this.getEPeopleBy(searchParams, this.searchByEmailPath, options, ...linksToFollow);
   }
@@ -106,7 +106,7 @@ export class EPersonDataService extends DataService<EPerson> {
    * @param options
    * @param linksToFollow
    */
-  public getEpeopleByMetadata(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+  private getEpeopleByMetadata(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
     const searchParams = [new SearchParam('query', query)];
     return this.getEPeopleBy(searchParams, this.searchByMetadataPath, options, ...linksToFollow);
   }
@@ -171,11 +171,6 @@ export class EPersonDataService extends DataService<EPerson> {
     if (hasValue(oldEPerson.canLogIn) && oldEPerson.canLogIn !== newEPerson.canLogIn) {
       operations = [...operations, {
         op: 'replace', path: '/canLogIn', value: newEPerson.canLogIn
-      }]
-    }
-    if (hasValue(oldEPerson.netid) && oldEPerson.netid !== newEPerson.netid) {
-      operations = [...operations, {
-        op: 'replace', path: '/netid', value: newEPerson.netid
       }]
     }
     return operations;

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -1,31 +1,52 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { createSelector, select, Store } from '@ngrx/store';
+import { Operation } from 'fast-json-patch/lib/core';
+import { Observable } from 'rxjs';
+import { filter, mergeMap, take } from 'rxjs/operators';
+import {
+  EPeopleRegistryCancelEPersonAction,
+  EPeopleRegistryEditEPersonAction
+} from '../../+admin/admin-access-control/epeople-registry/epeople-registry.actions';
+import { EPeopleRegistryState } from '../../+admin/admin-access-control/epeople-registry/epeople-registry.reducers';
+import { AppState } from '../../app.reducer';
+import { hasValue } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { dataService } from '../cache/builders/build-decorators';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { SearchParam } from '../cache/models/search-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
-import { CoreState } from '../core.reducers';
 import { DataService } from '../data/data.service';
 import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
+import { PaginatedList } from '../data/paginated-list';
+import { RemoteData } from '../data/remote-data';
+import { FindListOptions, FindListRequest, PatchRequest, } from '../data/request.models';
 import { RequestService } from '../data/request.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../shared/operators';
 import { EPerson } from './models/eperson.model';
 import { EPERSON } from './models/eperson.resource-type';
 
+const ePeopleRegistryStateSelector = (state: AppState) => state.epeopleRegistry;
+const editEPersonSelector = createSelector(ePeopleRegistryStateSelector, (ePeopleRegistryState: EPeopleRegistryState) => ePeopleRegistryState.editEPerson);
+
 /**
- * A service to retrieve {@link EPerson}s from the REST API
+ * A service to retrieve {@link EPerson}s from the REST API & EPerson related CRUD actions
  */
 @Injectable()
 @dataService(EPERSON)
 export class EPersonDataService extends DataService<EPerson> {
 
-  protected linkPath: 'epersons';
+  protected linkPath = 'epersons';
+  protected searchByNamePath = 'byName';
+  protected searchByEmailPath = 'byEmail';
+  protected searchByMetadataPath = 'byMetadata';
 
   constructor(
     protected requestService: RequestService,
     protected rdbService: RemoteDataBuildService,
-    protected store: Store<CoreState>,
+    protected store: Store<any>,
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
     protected notificationsService: NotificationsService,
@@ -33,6 +54,179 @@ export class EPersonDataService extends DataService<EPerson> {
     protected comparator: DSOChangeAnalyzer<EPerson>
   ) {
     super();
+  }
+
+  /**
+   * Retrieves all EPeople
+   * @param pagination The pagination info used to retrieve the EPeople
+   */
+  public getEPeople(options: FindListOptions = {}): Observable<RemoteData<PaginatedList<EPerson>>> {
+    const hrefObs = this.getFindAllHref(options, this.linkPath);
+    hrefObs.pipe(
+      filter((href: string) => hasValue(href)),
+      take(1))
+      .subscribe((href: string) => {
+        const request = new FindListRequest(this.requestService.generateRequestId(), href, options);
+        this.requestService.configure(request);
+      });
+
+    return this.rdbService.buildList<EPerson>(hrefObs) as Observable<RemoteData<PaginatedList<EPerson>>>;
+  }
+
+  /**
+   * Returns a search result list of EPeople, by name query (/eperson/epersons/search/{@link searchByNamePath}?q=<>)
+   * @param query     name query
+   * @param options
+   * @param linksToFollow
+   */
+  public getEpeopleByName(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+    const searchParams = [new SearchParam('q', query)];
+    return this.getEPeopleBy(searchParams, this.searchByNamePath, options, ...linksToFollow);
+  }
+
+  /**
+   * Returns a search result list of EPeople, by email query (/eperson/epersons/search/{@link searchByEmailPath}?email=<>)
+   * @param query     email query
+   * @param options
+   * @param linksToFollow
+   */
+  public getEpeopleByEmail(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+    const searchParams = [new SearchParam('email', query)];
+    return this.getEPeopleBy(searchParams, this.searchByEmailPath, options, ...linksToFollow);
+  }
+
+  /**
+   * Returns a search result list of EPeople, by metadata query (/eperson/epersons/search/{@link searchByMetadataPath}?query=<>)
+   * @param query     metadata query
+   * @param options
+   * @param linksToFollow
+   */
+  public getEpeopleByMetadata(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+    const searchParams = [new SearchParam('query', query)];
+    return this.getEPeopleBy(searchParams, this.searchByMetadataPath, options, ...linksToFollow);
+  }
+
+  /**
+   * Returns a search result list of EPeople in a given searchMethod, with given searchParams
+   * @param searchParams    query parameters in the search
+   * @param searchMethod    searchBy path
+   * @param options
+   * @param linksToFollow
+   */
+  private getEPeopleBy(searchParams: SearchParam[], searchMethod: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<EPerson>>): Observable<RemoteData<PaginatedList<EPerson>>> {
+    let findListOptions = new FindListOptions();
+    if (options) {
+      findListOptions = Object.assign(new FindListOptions(), options);
+    }
+    if (findListOptions.searchParams) {
+      findListOptions.searchParams = [...findListOptions.searchParams, ...searchParams];
+    } else {
+      findListOptions.searchParams = searchParams;
+    }
+    return this.searchBy(searchMethod, findListOptions, ...linksToFollow);
+  }
+
+  /**
+   * Create or Update an EPerson
+   *  If the EPerson contains an id, it is assumed the eperson already exists and is updated instead
+   * @param ePerson    The EPerson to create or update
+   */
+  public createOrUpdateEPerson(ePerson: EPerson): Observable<RemoteData<EPerson>> {
+    const isUpdate = hasValue(ePerson.id);
+    if (isUpdate) {
+      return this.updateEPerson(ePerson);
+    } else {
+      return this.create(ePerson, null);
+    }
+  }
+
+  /**
+   * Add a new patch to the object cache
+   * The patch is derived from the differences between the given object and its version in the object cache
+   * @param {DSpaceObject} ePerson The given object
+   */
+  updateEPerson(ePerson: EPerson): Observable<RemoteData<EPerson>> {
+    const oldVersion$ = this.findByHref(ePerson._links.self.href);
+    return oldVersion$.pipe(
+      getSucceededRemoteData(),
+      getRemoteDataPayload(),
+      mergeMap((oldEPerson: EPerson) => {
+        const operations = this.generateOperations(oldEPerson, ePerson);
+        const patchRequest = new PatchRequest(this.requestService.generateRequestId(), ePerson._links.self.href, operations);
+        this.requestService.configure(patchRequest);
+        return this.findByHref(ePerson._links.self.href);
+      }),
+    );
+  }
+
+  /**
+   * Metadata operations are generated by the difference between old and new EPerson
+   * Custom replace operations for the other EPerson values
+   * @param oldEPerson
+   * @param newEPerson
+   */
+  generateOperations(oldEPerson: EPerson, newEPerson: EPerson): Operation[] {
+    let operations = this.comparator.diff(oldEPerson, newEPerson).filter((operation: Operation) => operation.op === 'replace');
+    if (hasValue(oldEPerson.email) && oldEPerson.email !== newEPerson.email) {
+      operations = [...operations, {
+        op: 'replace', path: '/email', value: newEPerson.email
+      }]
+    }
+    if (hasValue(oldEPerson.requireCertificate) && oldEPerson.requireCertificate !== newEPerson.requireCertificate) {
+      operations = [...operations, {
+        op: 'replace', path: '/certificate', value: newEPerson.requireCertificate
+      }]
+    }
+    if (hasValue(oldEPerson.canLogIn) && oldEPerson.canLogIn !== newEPerson.canLogIn) {
+      operations = [...operations, {
+        op: 'replace', path: '/canLogIn', value: newEPerson.canLogIn
+      }]
+    }
+    if (hasValue(oldEPerson.netid) && oldEPerson.netid !== newEPerson.netid) {
+      operations = [...operations, {
+        op: 'replace', path: '/netid', value: newEPerson.netid
+      }]
+    }
+    return operations;
+  }
+
+  /**
+   * Method that clears a cached EPerson request and returns its REST url
+   */
+  public clearEPersonRequests(): void {
+    this.getBrowseEndpoint().pipe(take(1)).subscribe((link: string) => {
+      this.requestService.removeByHrefSubstring(link);
+    });
+  }
+
+  /**
+   * Method to retrieve the eperson that is currently being edited
+   */
+  public getActiveEPerson(): Observable<EPerson> {
+    return this.store.pipe(select(editEPersonSelector))
+  }
+
+  /**
+   * Method to cancel editing an EPerson, dispatches a cancel EPerson action
+   */
+  public cancelEditEPerson() {
+    this.store.dispatch(new EPeopleRegistryCancelEPersonAction());
+  }
+
+  /**
+   * Method to set the EPerson being edited, dispatches an edit EPerson action
+   * @param ePerson The EPerson to edit
+   */
+  public editEPerson(ePerson: EPerson) {
+    this.store.dispatch(new EPeopleRegistryEditEPersonAction(ePerson));
+  }
+
+  /**
+   * Method to delete an EPerson
+   * @param id The EPerson to delete
+   */
+  public deleteEPerson(ePerson: EPerson): Observable<boolean> {
+    return this.delete(ePerson);
   }
 
 }

--- a/src/app/shared/testing/eperson-mock.ts
+++ b/src/app/shared/testing/eperson-mock.ts
@@ -1,6 +1,7 @@
 import { EPerson } from '../../core/eperson/models/eperson.model';
+import { GroupMock } from './group-mock';
 
-export const EPersonMock: EPerson = Object.assign(new EPerson(),{
+export const EPersonMock: EPerson = Object.assign(new EPerson(), {
   handle: null,
   groups: [],
   netid: 'test@test.com',
@@ -12,7 +13,8 @@ export const EPersonMock: EPerson = Object.assign(new EPerson(),{
   _links: {
     self: {
       href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons/testid',
-    }
+    },
+    groups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons/testid/groups' }
   },
   id: 'testid',
   uuid: 'testid',
@@ -40,6 +42,52 @@ export const EPersonMock: EPerson = Object.assign(new EPerson(),{
       {
         language: null,
         value: 'en'
+      },
+    ]
+  }
+});
+
+export const EPersonMock2: EPerson = Object.assign(new EPerson(), {
+  handle: null,
+  groups: [GroupMock],
+  netid: 'test2@test.com',
+  lastActive: '2019-05-14T12:25:42.411+0000',
+  canLogIn: false,
+  email: 'test2@test.com',
+  requireCertificate: false,
+  selfRegistered: true,
+  _links: {
+    self: {
+      href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons/testid2',
+    },
+    groups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons/testid2/groups' }
+  },
+  id: 'testid2',
+  uuid: 'testid2',
+  type: 'eperson',
+  metadata: {
+    'dc.title': [
+      {
+        language: null,
+        value: 'User Test 2'
+      }
+    ],
+    'eperson.firstname': [
+      {
+        language: null,
+        value: 'User2'
+      }
+    ],
+    'eperson.lastname': [
+      {
+        language: null,
+        value: 'Test2'
+      },
+    ],
+    'eperson.language': [
+      {
+        language: null,
+        value: 'fr'
       },
     ]
   }

--- a/src/app/shared/testing/eperson-mock.ts
+++ b/src/app/shared/testing/eperson-mock.ts
@@ -81,7 +81,7 @@ export const EPersonMock2: EPerson = Object.assign(new EPerson(), {
     'eperson.lastname': [
       {
         language: null,
-        value: 'Test2'
+        value: 'MeepMeep'
       },
     ],
     'eperson.language': [

--- a/src/app/shared/testing/group-mock.ts
+++ b/src/app/shared/testing/group-mock.ts
@@ -1,0 +1,16 @@
+import { Group } from '../../core/eperson/models/group.model';
+
+export const GroupMock: Group = Object.assign(new Group(), {
+  handle: null,
+  groups: [],
+  selfRegistered: false,
+  _links: {
+    self: {
+      href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid',
+    },
+    groups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/groups' }
+  },
+  id: 'testgroupid',
+  uuid: 'testgroupid',
+  type: 'group',
+});


### PR DESCRIPTION
This PR adds the admin access control pages for EPeople.

Functionalities:
- (Read) Initial page load gives you a pageable list of all EPeople. This list is searchable by scope, the default scope is byMetadata; byEmail is also selectable. Per EPerson ID, Name and Email is shown.
- (Create) EPerson form to create new EPerson
- (Delete) EPerson can be deleted
- (Update) EPerson form to edit their info (happens via patches to the backend)

This is dependent on backend PR: https://github.com/DSpace/DSpace/pull/2686. The Groups admin page will be coming in an upcoming PR.