### PR TITLE
Cache behavior for unknown type

### DIFF
--- a/src/app/core/data/base-response-parsing.service.spec.ts
+++ b/src/app/core/data/base-response-parsing.service.spec.ts
@@ -1,0 +1,104 @@
+import { BaseResponseParsingService } from './base-response-parsing.service';
+import { GlobalConfig } from '../../../config/global-config.interface';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { CacheableObject } from '../cache/object-cache.reducer';
+import { GetRequest, RestRequest } from './request.models';
+import { DSpaceObject } from '../shared/dspace-object.model';
+
+/* tslint:disable:max-classes-per-file */
+class TestService extends BaseResponseParsingService {
+  toCache = true;
+
+  constructor(protected EnvConfig: GlobalConfig,
+              protected objectCache: ObjectCacheService) {
+    super();
+  }
+
+  // Overwrite methods to make them public for testing
+  public process<ObjectDomain>(data: any, request: RestRequest): any {
+    super.process(data, request);
+  }
+
+  public cache<ObjectDomain>(obj, request: RestRequest, data: any) {
+    super.cache(obj, request, data);
+  }
+}
+
+describe('BaseResponseParsingService', () => {
+  let service: TestService;
+  let config: GlobalConfig;
+  let objectCache: ObjectCacheService;
+
+  const requestUUID = 'request-uuid';
+  const requestHref = 'request-href';
+  const request = new GetRequest(requestUUID, requestHref);
+
+  beforeEach(() => {
+    config = Object.assign({});
+    objectCache = jasmine.createSpyObj('objectCache', {
+      add: {}
+    });
+    service = new TestService(config, objectCache);
+  });
+
+  describe('cache', () => {
+    let obj: CacheableObject;
+
+    describe('when the object is undefined', () => {
+      it('should not throw an error', () => {
+        expect(() => { service.cache(obj, request, {}) }).not.toThrow();
+      });
+
+      it('should not call objectCache add', () => {
+        service.cache(obj, request, {});
+        expect(objectCache.add).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the object has a self link', () => {
+      beforeEach(() => {
+        obj = Object.assign(new DSpaceObject(), {
+          _links: {
+            self: { href: 'obj-selflink' }
+          }
+        });
+      });
+
+      it('should call objectCache add', () => {
+        service.cache(obj, request, {});
+        expect(objectCache.add).toHaveBeenCalledWith(obj, request.responseMsToLive, request.uuid);
+      });
+    });
+  });
+
+  describe('process', () => {
+    let data: any;
+    let result: any;
+
+    describe('when data is valid, but not a real type', () => {
+      beforeEach(() => {
+        data = {
+          type: 'NotARealType',
+          _links: {
+            self: { href: 'data-selflink' }
+          }
+        };
+      });
+
+      it('should not throw an error', () => {
+        expect(() => { result = service.process(data, request) }).not.toThrow();
+      });
+
+      it('should return undefined', () => {
+        result = service.process(data, request);
+        expect(result).toBeUndefined();
+      });
+
+      it('should not call objectCache add', () => {
+        result = service.process(data, request);
+        expect(objectCache.add).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+/* tslint:enable:max-classes-per-file */

--- a/src/app/core/data/base-response-parsing.service.ts
+++ b/src/app/core/data/base-response-parsing.service.ts
@@ -117,10 +117,12 @@ export abstract class BaseResponseParsingService {
         const serializer = new this.serializerConstructor(objConstructor);
         return serializer.deserialize(obj);
       } else {
+        console.warn('cannot deserialize type ' + type);
         return null;
       }
 
     } else {
+      console.warn('cannot deserialize type ' + type);
       return null;
     }
   }
@@ -142,7 +144,8 @@ export abstract class BaseResponseParsingService {
       } else {
         dataJSON = JSON.stringify(data);
       }
-      throw new Error(`Can't cache incomplete ${type}: ${JSON.stringify(co)}, parsed from (partial) response: ${dataJSON}`);
+      console.warn(`Can't cache incomplete ${type}: ${JSON.stringify(co)}, parsed from (partial) response: ${dataJSON}`);
+      return;
     }
     this.objectCache.add(co, hasValue(request.responseMsToLive) ? request.responseMsToLive : this.EnvConfig.cache.msToLive.default, request.uuid);
   }


### PR DESCRIPTION
We noticed while developing in REST, the Angular UI currently breaks if REST contains a type not (yet) known to Angular.

Each time a new REST type is implemented and somehow returned, an exception is thrown and the page rendering is aborted.

This change will avoid breaking the page, Angular will ignore any types it doesn't know (yet). It will display a warning though to ensure this is visible because it's not a typical use case for a production environment