### PR TITLE
Access Control - Group admin page

### DIFF
--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -188,7 +188,7 @@
 
   "admin.access-control.epeople.table.name": "Name",
 
-  "admin.access-control.epeople.table.email": "E-mail",
+  "admin.access-control.epeople.table.email": "E-mail (exact)",
 
   "admin.access-control.epeople.table.edit": "Edit",
 
@@ -287,7 +287,7 @@
 
   "admin.access-control.groups.form.members-list.search.scope.metadata": "Metadata",
 
-  "admin.access-control.groups.form.members-list.search.scope.email": "E-mail",
+  "admin.access-control.groups.form.members-list.search.scope.email": "E-mail (exact)",
 
   "admin.access-control.groups.form.members-list.search.button": "Search",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -290,6 +290,14 @@
 
   "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Remove member with name \"{{name}}\"",
 
+  "admin.access-control.groups.form.members-list.notification.success.addMember": "Successfully added member: \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.notification.failure.addMember": "Failed to add member: \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.notification.success.deleteMember": "Successfully deleted member: \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.notification.failure.deleteMember": "Failed to delete member: \"{{name}}\"",
+
   "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
 
   "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
@@ -315,6 +323,14 @@
   "admin.access-control.groups.form.subgroups-list.table.edit.buttons.remove": "Remove subgroup with name \"{{name}}\"",
 
   "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Add subgroup with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.notification.success.addSubgroup": "Successfully added subgroup: \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.notification.failure.addSubgroup": "Failed to add subgroup: \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.notification.success.deleteSubgroup": "Successfully deleted subgroup: \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.notification.failure.deleteSubgroup": "Failed to delete subgroup: \"{{name}}\"",
 
   "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -192,9 +192,9 @@
 
   "admin.access-control.epeople.table.edit": "Edit",
 
-  "item.access-control.epeople.table.edit.buttons.edit": "Edit",
+  "admin.access-control.epeople.table.edit.buttons.edit": "Edit",
 
-  "item.access-control.epeople.table.edit.buttons.remove": "Remove",
+  "admin.access-control.epeople.table.edit.buttons.remove": "Remove",
 
   "admin.access-control.epeople.no-items": "No EPeople to show.",
 
@@ -241,6 +241,7 @@
   "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
 
 
+
   "admin.access-control.groups.title": "DSpace Angular :: Groups",
 
   "admin.access-control.groups.head": "Groups",
@@ -275,8 +276,6 @@
   "admin.access-control.groups.form.groupName": "Group name",
 
   "admin.access-control.groups.form.groupDescription": "Description",
-
-  "admin.access-control.groups.form.button.return": "Return",
 
   "admin.access-control.groups.form.notification.created.success": "Successfully created group \"{{name}}\"",
 
@@ -350,7 +349,7 @@
 
   "admin.access-control.groups.form.subgroups-list.button.see-all": "Search all",
 
-  "admin.access-control.groups.form.return": "Return",
+  "admin.access-control.groups.form.return": "Return to groups",
 
 
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -277,9 +277,11 @@
 
   "admin.access-control.groups.form.groupDescription": "Description",
 
-  "admin.access-control.groups.form.notification.created.success": "Successfully created group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.created.success": "Successfully created Group \"{{name}}\"",
 
-  "admin.access-control.groups.form.notification.created.failure": "Failed to create group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.created.failure": "Failed to create Group \"{{name}}\"",
+
+  "admin.access-control.groups.form.notification.created.failure.groupNameInUse": "Failed to create Group with name: \"{{name}}\", make sure the name is not already in use.",
 
   "admin.access-control.groups.form.members-list.head": "Members",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -176,6 +176,8 @@
 
   "admin.access-control.epeople.search.head": "Search",
 
+  "admin.access-control.epeople.button.see-all": "Browse All",
+
   "admin.access-control.epeople.search.scope.metadata": "Metadata",
 
   "admin.access-control.epeople.search.scope.email": "E-mail (exact)",
@@ -192,9 +194,9 @@
 
   "admin.access-control.epeople.table.edit": "Edit",
 
-  "admin.access-control.epeople.table.edit.buttons.edit": "Edit",
+  "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",
 
-  "admin.access-control.epeople.table.edit.buttons.remove": "Remove",
+  "admin.access-control.epeople.table.edit.buttons.remove": "Delete \"{{name}}\"",
 
   "admin.access-control.epeople.no-items": "No EPeople to show.",
 
@@ -250,6 +252,8 @@
 
   "admin.access-control.groups.search.head": "Search groups",
 
+  "admin.access-control.groups.button.see-all": "Browse all",
+
   "admin.access-control.groups.search.button": "Search",
 
   "admin.access-control.groups.table.id": "ID",
@@ -261,6 +265,10 @@
   "admin.access-control.groups.table.comcol": "Community / Collection",
 
   "admin.access-control.groups.table.edit": "Edit",
+
+  "admin.access-control.groups.table.edit.buttons.edit": "Edit \"{{name}}\"",
+
+  "admin.access-control.groups.table.edit.buttons.remove": "Delete \"{{name}}\"",
 
   "admin.access-control.groups.no-items": "No groups found with this in their name or this as UUID",
 
@@ -283,9 +291,13 @@
 
   "admin.access-control.groups.form.notification.created.failure.groupNameInUse": "Failed to create Group with name: \"{{name}}\", make sure the name is not already in use.",
 
-  "admin.access-control.groups.form.members-list.head": "Members",
+  "admin.access-control.groups.form.members-list.head": "EPeople",
 
   "admin.access-control.groups.form.members-list.search.head": "Search EPeople",
+
+  "admin.access-control.groups.form.members-list.button.see-all": "Browse All",
+
+  "admin.access-control.groups.form.members-list.headMembers": "Browse Members",
 
   "admin.access-control.groups.form.members-list.search.scope.metadata": "Metadata",
 
@@ -315,13 +327,15 @@
 
   "admin.access-control.groups.form.members-list.no-members-yet": "No members in group yet, search and add.",
 
-  "admin.access-control.groups.form.members-list.button.see-all": "Search all",
-
   "admin.access-control.groups.form.members-list.no-items": "No EPeople found in that search",
 
-  "admin.access-control.groups.form.subgroups-list.head": "Subgroups",
+  "admin.access-control.groups.form.subgroups-list.head": "Groups",
 
   "admin.access-control.groups.form.subgroups-list.search.head": "Search Groups",
+
+  "admin.access-control.groups.form.subgroups-list.button.see-all": "Browse All",
+
+  "admin.access-control.groups.form.subgroups-list.headSubgroups": "Browse Subgroups",
 
   "admin.access-control.groups.form.subgroups-list.search.button": "Search",
 
@@ -347,9 +361,7 @@
 
   "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
 
-  "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet, search and add.",
-
-  "admin.access-control.groups.form.subgroups-list.button.see-all": "Search all",
+  "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet.",
 
   "admin.access-control.groups.form.return": "Return to groups",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -2274,6 +2274,9 @@
 
   "administrativeView.search.results.head": "Administrative Search",
 
+  "menu.section.admin_search": "Admin Search",
+
+
 
   "uploader.browse": "browse",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -349,6 +349,8 @@
 
   "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Add subgroup with name \"{{name}}\"",
 
+  "admin.access-control.groups.form.subgroups-list.table.edit.currentGroup": "Current group",
+
   "admin.access-control.groups.form.subgroups-list.notification.success.addSubgroup": "Successfully added subgroup: \"{{name}}\"",
 
   "admin.access-control.groups.form.subgroups-list.notification.failure.addSubgroup": "Failed to add subgroup: \"{{name}}\"",
@@ -358,6 +360,8 @@
   "admin.access-control.groups.form.subgroups-list.notification.failure.deleteSubgroup": "Failed to delete subgroup: \"{{name}}\"",
 
   "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
+
+  "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "This is the current group, can't be added.",
 
   "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -293,11 +293,11 @@
 
   "admin.access-control.groups.form.members-list.head": "EPeople",
 
-  "admin.access-control.groups.form.members-list.search.head": "Search EPeople",
+  "admin.access-control.groups.form.members-list.search.head": "Add EPeople",
 
   "admin.access-control.groups.form.members-list.button.see-all": "Browse All",
 
-  "admin.access-control.groups.form.members-list.headMembers": "Browse Members",
+  "admin.access-control.groups.form.members-list.headMembers": "Current Members",
 
   "admin.access-control.groups.form.members-list.search.scope.metadata": "Metadata",
 
@@ -331,11 +331,11 @@
 
   "admin.access-control.groups.form.subgroups-list.head": "Groups",
 
-  "admin.access-control.groups.form.subgroups-list.search.head": "Search Groups",
+  "admin.access-control.groups.form.subgroups-list.search.head": "Add Subgroup",
 
   "admin.access-control.groups.form.subgroups-list.button.see-all": "Browse All",
 
-  "admin.access-control.groups.form.subgroups-list.headSubgroups": "Browse Subgroups",
+  "admin.access-control.groups.form.subgroups-list.headSubgroups": "Current Subgroups",
 
   "admin.access-control.groups.form.subgroups-list.search.button": "Search",
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -176,11 +176,9 @@
 
   "admin.access-control.epeople.search.head": "Search",
 
-  "admin.access-control.epeople.search.scope.name": "Name",
+  "admin.access-control.epeople.search.scope.metadata": "Metadata",
 
   "admin.access-control.epeople.search.scope.email": "E-mail (exact)",
-
-  "admin.access-control.epeople.search.scope.metadata": "Metadata",
 
   "admin.access-control.epeople.search.button": "Search",
 
@@ -231,6 +229,96 @@
   "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
 
   "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
+
+
+  "admin.access-control.groups.title": "DSpace Angular :: Groups",
+
+  "admin.access-control.groups.head": "Groups",
+
+  "admin.access-control.groups.button.add": "Add group",
+
+  "admin.access-control.groups.search.head": "Search groups",
+
+  "admin.access-control.groups.search.button": "Search",
+
+  "admin.access-control.groups.table.id": "ID",
+
+  "admin.access-control.groups.table.name": "Name",
+
+  "admin.access-control.groups.table.members": "Members",
+
+  "admin.access-control.groups.table.comcol": "Community / Collection",
+
+  "admin.access-control.groups.table.edit": "Edit",
+
+  "admin.access-control.groups.no-items": "No groups found with this in their name or this as UUID",
+
+  "admin.access-control.groups.notification.deleted.success": "Successfully deleted group \"{{name}}\"",
+  // TODO
+  "admin.access-control.groups.notification.deleted.failure": "Failed to delete group \"{{name}}\" (Not yet implemented)",
+
+
+  "admin.access-control.groups.form.head.create": "Create group",
+
+  "admin.access-control.groups.form.head.edit": "Edit group",
+
+  "admin.access-control.groups.form.groupName": "Group name",
+
+  "admin.access-control.groups.form.button.return": "Return",
+
+  "admin.access-control.groups.form.notification.created.success": "Successfully created group \"{{name}}\"",
+
+  "admin.access-control.groups.form.notification.created.failure": "Failed to create group \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.head": "Members",
+
+  "admin.access-control.groups.form.members-list.search.head": "Search EPeople",
+
+  "admin.access-control.groups.form.members-list.search.scope.metadata": "Metadata",
+
+  "admin.access-control.groups.form.members-list.search.scope.email": "E-mail",
+
+  "admin.access-control.groups.form.members-list.search.button": "Search",
+
+  "admin.access-control.groups.form.members-list.table.id": "ID",
+
+  "admin.access-control.groups.form.members-list.table.name": "Name",
+
+  "admin.access-control.groups.form.members-list.table.edit": "Remove / Add",
+
+  "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Remove member with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.members-list.no-members-yet": "No members in group yet, search and add.",
+
+  "admin.access-control.groups.form.members-list.button.see-all": "Search all",
+
+  "admin.access-control.groups.form.members-list.no-items": "No EPeople found in that search",
+
+  "admin.access-control.groups.form.subgroups-list.head": "Subgroups",
+
+  "admin.access-control.groups.form.subgroups-list.search.head": "Search Groups",
+
+  "admin.access-control.groups.form.subgroups-list.search.button": "Search",
+
+  "admin.access-control.groups.form.subgroups-list.table.id": "ID",
+
+  "admin.access-control.groups.form.subgroups-list.table.name": "Name",
+
+  "admin.access-control.groups.form.subgroups-list.table.edit": "Remove / Add",
+
+  "admin.access-control.groups.form.subgroups-list.table.edit.buttons.remove": "Remove subgroup with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Add subgroup with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
+
+  "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet, search and add.",
+
+  "admin.access-control.groups.form.subgroups-list.button.see-all": "Search all",
+
+  "admin.access-control.groups.form.return": "Return",
 
 
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -226,6 +226,16 @@
 
   "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",
 
+  "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
+
+  "admin.access-control.epeople.form.table.id": "ID",
+
+  "admin.access-control.epeople.form.table.name": "Name",
+
+  "admin.access-control.epeople.form.memberOfNoGroups": "This EPerson is not a member of any groups",
+
+  "admin.access-control.epeople.form.goToGroups": "Add to groups",
+
   "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
 
   "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -254,8 +254,8 @@
   "admin.access-control.groups.no-items": "No groups found with this in their name or this as UUID",
 
   "admin.access-control.groups.notification.deleted.success": "Successfully deleted group \"{{name}}\"",
-  // TODO
-  "admin.access-control.groups.notification.deleted.failure": "Failed to delete group \"{{name}}\" (Not yet implemented)",
+
+  "admin.access-control.groups.notification.deleted.failure": "Failed to delete group \"{{name}}\"",
 
 
   "admin.access-control.groups.form.head.create": "Create group",
@@ -263,6 +263,8 @@
   "admin.access-control.groups.form.head.edit": "Edit group",
 
   "admin.access-control.groups.form.groupName": "Group name",
+
+  "admin.access-control.groups.form.groupDescription": "Description",
 
   "admin.access-control.groups.form.button.return": "Return",
 
@@ -290,6 +292,8 @@
 
   "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
 
+  "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
+
   "admin.access-control.groups.form.members-list.no-members-yet": "No members in group yet, search and add.",
 
   "admin.access-control.groups.form.members-list.button.see-all": "Search all",
@@ -311,6 +315,8 @@
   "admin.access-control.groups.form.subgroups-list.table.edit.buttons.remove": "Remove subgroup with name \"{{name}}\"",
 
   "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Add subgroup with name \"{{name}}\"",
+
+  "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
 
   "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
 

--- a/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
@@ -1,11 +1,24 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
+import { GroupFormComponent } from './group-registry/group-form/group-form.component';
+import { GroupsRegistryComponent } from './group-registry/groups-registry.component';
 
 @NgModule({
   imports: [
     RouterModule.forChild([
       { path: 'epeople', component: EPeopleRegistryComponent, data: { title: 'admin.access-control.epeople.title' } },
+      { path: 'groups', component: GroupsRegistryComponent, data: { title: 'admin.access-control.groups.title' } },
+      {
+        path: 'groups/:groupId',
+        component: GroupFormComponent,
+        data: {title: 'admin.registries.schema.title'}
+      },
+      {
+        path: 'groups/newGroup',
+        component: GroupFormComponent,
+        data: {title: 'admin.registries.schema.title'}
+      },
     ])
   ]
 })

--- a/src/app/+admin/admin-access-control/admin-access-control.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control.module.ts
@@ -6,6 +6,10 @@ import { SharedModule } from '../../shared/shared.module';
 import { AdminAccessControlRoutingModule } from './admin-access-control-routing.module';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
 import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-form.component';
+import { GroupFormComponent } from './group-registry/group-form/group-form.component';
+import { MembersListComponent } from './group-registry/group-form/members-list/members-list.component';
+import { SubgroupsListComponent } from './group-registry/group-form/subgroup-list/subgroups-list.component';
+import { GroupsRegistryComponent } from './group-registry/groups-registry.component';
 
 @NgModule({
   imports: [
@@ -17,7 +21,11 @@ import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-fo
   ],
   declarations: [
     EPeopleRegistryComponent,
-    EPersonFormComponent
+    EPersonFormComponent,
+    GroupsRegistryComponent,
+    GroupFormComponent,
+    SubgroupsListComponent,
+    MembersListComponent
   ],
   entryComponents: []
 })

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -15,7 +15,10 @@
         </button>
       </div>
 
-      <h3 id="search" class="border-bottom pb-2">{{labelPrefix + 'search.head' | translate}}</h3>
+      <h3 id="search" class="border-bottom pb-2">{{labelPrefix + 'search.head' | translate}}
+        <button (click)="clearFormAndResetResult();"
+                class="btn btn-primary float-right">{{labelPrefix + 'button.see-all' | translate}}</button>
+      </h3>
       <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
         <div class="col-12 col-sm-3">
           <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
@@ -64,12 +67,12 @@
                 <div class="btn-group edit-field">
                   <button (click)="toggleEditEPerson(eperson)"
                           class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.edit' | translate}}">
+                          title="{{labelPrefix + 'table.edit.buttons.edit' | translate: {name: eperson.name} }}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
                   <button (click)="deleteEPerson(eperson)"
                           class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate}}">
+                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: eperson.name} }}">
                     <i class="fas fa-trash-alt fa-fw"></i>
                   </button>
                 </div>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,3 +1,4 @@
+import { Router } from '@angular/router';
 import { of as observableOf } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -20,6 +21,7 @@ import { getMockTranslateService } from '../../../shared/mocks/mock-translate.se
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson-mock';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service-stub';
+import { RouterStub } from '../../../shared/testing/router-stub';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
 import { EPeopleRegistryComponent } from './epeople-registry.component';
 
@@ -51,6 +53,9 @@ describe('EPeopleRegistryComponent', () => {
           return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
         }
         if (scope === 'metadata') {
+          if (query === '') {
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+          }
           const result = this.allEpeople.find((ePerson: EPerson) => {
             return (ePerson.name.includes(query) || ePerson.email.includes(query))
           });
@@ -72,6 +77,9 @@ describe('EPeopleRegistryComponent', () => {
       },
       clearEPersonRequests(): void {
         // empty
+      },
+      getEPeoplePageRouterLink(): string {
+        return '/admin/access-control/epeople';
       }
     };
     builderService = getMockFormBuilderService();
@@ -89,7 +97,8 @@ describe('EPeopleRegistryComponent', () => {
       providers: [EPeopleRegistryComponent,
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
-        { provide: FormBuilderService, useValue: builderService }
+        { provide: FormBuilderService, useValue: builderService },
+        { provide: Router, useValue: new RouterStub() },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -89,8 +89,7 @@ describe('EPeopleRegistryComponent', () => {
       providers: [EPeopleRegistryComponent,
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
-        { provide: FormBuilderService, useValue: builderService },
-        EPeopleRegistryComponent
+        { provide: FormBuilderService, useValue: builderService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -29,10 +29,11 @@ describe('EPeopleRegistryComponent', () => {
   let translateService: TranslateService;
   let builderService: FormBuilderService;
 
-  const mockEPeople = [EPersonMock, EPersonMock2];
+  let mockEPeople;
   let ePersonDataServiceStub: any;
 
   beforeEach(async(() => {
+    mockEPeople = [EPersonMock, EPersonMock2];
     ePersonDataServiceStub = {
       activeEPerson: null,
       allEpeople: mockEPeople,

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -21,143 +21,143 @@ import { PaginationComponentOptions } from '../../../shared/pagination/paginatio
  */
 export class EPeopleRegistryComponent {
 
-    labelPrefix = 'admin.access-control.epeople.';
+  labelPrefix = 'admin.access-control.epeople.';
 
-    /**
-     * A list of all the current EPeople within the repository or the result of the search
-     */
-    ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
+  /**
+   * A list of all the current EPeople within the repository or the result of the search
+   */
+  ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
 
-    /**
-     * Pagination config used to display the list of epeople
-     */
-    config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
-        id: 'epeople-list-pagination',
-        pageSize: 5,
-        currentPage: 1
+  /**
+   * Pagination config used to display the list of epeople
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'epeople-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  /**
+   * Whether or not to show the EPerson form
+   */
+  isEPersonFormShown: boolean;
+
+  // The search form
+  searchForm;
+
+  constructor(private epersonService: EPersonDataService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private formBuilder: FormBuilder) {
+    this.updateEPeople({
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
     });
+    this.isEPersonFormShown = false;
+    this.searchForm = this.formBuilder.group(({
+      scope: 'metadata',
+      query: '',
+    }));
+  }
 
-    /**
-     * Whether or not to show the EPerson form
-     */
-    isEPersonFormShown: boolean;
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateEPeople({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
 
-    // The search form
-    searchForm;
+  /**
+   * Update the list of EPeople by fetching it from the rest api or cache
+   */
+  private updateEPeople(options) {
+    this.ePeople = this.epersonService.getEPeople(options);
+  }
 
-    constructor(private epersonService: EPersonDataService,
-                private translateService: TranslateService,
-                private notificationsService: NotificationsService,
-                private formBuilder: FormBuilder) {
-        this.updateEPeople({
-            currentPage: 1,
-            elementsPerPage: this.config.pageSize
-        });
+  /**
+   * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
+   * a new REST call
+   */
+  public forceUpdateEPeople() {
+    this.epersonService.clearEPersonRequests();
+    this.isEPersonFormShown = false;
+    this.search({ query: '', scope: 'metadata' })
+  }
+
+  /**
+   * Search in the EPeople by metadata (default) or email
+   * @param data  Contains scope and query param
+   */
+  search(data: any) {
+    this.ePeople = this.epersonService.searchByScope(data.scope, data.query, {
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Checks whether the given EPerson is active (being edited)
+   * @param eperson
+   */
+  isActive(eperson: EPerson): Observable<boolean> {
+    return this.getActiveEPerson().pipe(
+      map((activeEPerson) => eperson === activeEPerson)
+    );
+  }
+
+  /**
+   * Gets the active eperson (being edited)
+   */
+  getActiveEPerson(): Observable<EPerson> {
+    return this.epersonService.getActiveEPerson();
+  }
+
+  /**
+   * Start editing the selected EPerson
+   * @param ePerson
+   */
+  toggleEditEPerson(ePerson: EPerson) {
+    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
+      if (ePerson === activeEPerson) {
+        this.epersonService.cancelEditEPerson();
         this.isEPersonFormShown = false;
-        this.searchForm = this.formBuilder.group(({
-            scope: 'metadata',
-            query: '',
-        }));
-    }
+      } else {
+        this.epersonService.editEPerson(ePerson);
+        this.isEPersonFormShown = true;
+      }
+    });
+    this.scrollToTop()
+  }
 
-    /**
-     * Event triggered when the user changes page
-     * @param event
-     */
-    onPageChange(event) {
-        this.updateEPeople({
-            currentPage: event,
-            elementsPerPage: this.config.pageSize
-        });
-    }
-
-    /**
-     * Update the list of EPeople by fetching it from the rest api or cache
-     */
-    private updateEPeople(options) {
-        this.ePeople = this.epersonService.getEPeople(options);
-    }
-
-    /**
-     * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
-     * a new REST call
-     */
-    public forceUpdateEPeople() {
-        this.epersonService.clearEPersonRequests();
-        this.isEPersonFormShown = false;
-        this.search({ query: '', scope: 'metadata' })
-    }
-
-    /**
-     * Search in the EPeople by metadata (default) or email
-     * @param data  Contains scope and query param
-     */
-    search(data: any) {
-        this.ePeople = this.epersonService.searchByScope(data.scope, data.query, {
-            currentPage: 1,
-            elementsPerPage: this.config.pageSize
-        });
-    }
-
-    /**
-     * Checks whether the given EPerson is active (being edited)
-     * @param eperson
-     */
-    isActive(eperson: EPerson): Observable<boolean> {
-        return this.getActiveEPerson().pipe(
-            map((activeEPerson) => eperson === activeEPerson)
-        );
-    }
-
-    /**
-     * Gets the active eperson (being edited)
-     */
-    getActiveEPerson(): Observable<EPerson> {
-        return this.epersonService.getActiveEPerson();
-    }
-
-    /**
-     * Start editing the selected EPerson
-     * @param ePerson
-     */
-    toggleEditEPerson(ePerson: EPerson) {
-        this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
-            if (ePerson === activeEPerson) {
-                this.epersonService.cancelEditEPerson();
-                this.isEPersonFormShown = false;
-            } else {
-                this.epersonService.editEPerson(ePerson);
-                this.isEPersonFormShown = true;
-            }
-        });
-        this.scrollToTop()
-    }
-
-    /**
-     * Deletes EPerson, show notification on success/failure & updates EPeople list
-     */
-    deleteEPerson(ePerson: EPerson) {
-        if (hasValue(ePerson.id)) {
-            this.epersonService.deleteEPerson(ePerson).pipe(take(1)).subscribe((success: boolean) => {
-                if (success) {
-                    this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
-                    this.forceUpdateEPeople();
-                } else {
-                    this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
-                }
-                this.epersonService.cancelEditEPerson();
-                this.isEPersonFormShown = false;
-            })
+  /**
+   * Deletes EPerson, show notification on success/failure & updates EPeople list
+   */
+  deleteEPerson(ePerson: EPerson) {
+    if (hasValue(ePerson.id)) {
+      this.epersonService.deleteEPerson(ePerson).pipe(take(1)).subscribe((success: boolean) => {
+        if (success) {
+          this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: ePerson.name }));
+          this.forceUpdateEPeople();
+        } else {
+          this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', { name: ePerson.name }));
         }
+        this.epersonService.cancelEditEPerson();
+        this.isEPersonFormShown = false;
+      })
     }
+  }
 
-    scrollToTop() {
-        (function smoothscroll() {
-            const currentScroll = document.documentElement.scrollTop || document.body.scrollTop;
-            if (currentScroll > 0) {
-                window.requestAnimationFrame(smoothscroll);
-                window.scrollTo(0, currentScroll - (currentScroll / 8));
-            }
-        })();
-    }
+  scrollToTop() {
+    (function smoothscroll() {
+      const currentScroll = document.documentElement.scrollTop || document.body.scrollTop;
+      if (currentScroll > 0) {
+        window.requestAnimationFrame(smoothscroll);
+        window.scrollTo(0, currentScroll - (currentScroll / 8));
+      }
+    })();
+  }
 }

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.ts
@@ -12,8 +12,8 @@ import { NotificationsService } from '../../../shared/notifications/notification
 import { PaginationComponentOptions } from '../../../shared/pagination/pagination-component-options.model';
 
 @Component({
-    selector: 'ds-epeople-registry',
-    templateUrl: './epeople-registry.component.html',
+  selector: 'ds-epeople-registry',
+  templateUrl: './epeople-registry.component.html',
 })
 /**
  * A component used for managing all existing epeople within the repository.

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.reducers.ts
@@ -26,7 +26,6 @@ const initialState: EPeopleRegistryState = {
  * @param action  The EPeopleRegistryAction to perform on the state
  */
 export function ePeopleRegistryReducer(state = initialState, action: EPeopleRegistryAction): EPeopleRegistryState {
-
   switch (action.type) {
 
     case EPeopleRegistryActionTypes.EDIT_EPERSON: {

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -15,3 +15,43 @@
          (cancel)="onCancel()"
          (submitForm)="onSubmit()">
 </ds-form>
+
+<div *ngIf="epersonService.getActiveEPerson() | async">
+  <h5>{{messagePrefix + '.groupsEPersonIsMemberOf' | translate}}</h5>
+
+  <ds-pagination
+    *ngIf="(groups | async)?.payload?.totalElements > 0"
+    [paginationOptions]="config"
+    [pageInfoState]="(groups | async)?.payload"
+    [collectionSize]="(groups | async)?.payload?.totalElements"
+    [hideGear]="true"
+    [hidePagerWhenSinglePage]="true"
+    (pageChange)="onPageChange($event)">
+
+    <div class="table-responsive">
+      <table id="groups" class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+          <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
+          <th scope="col">{{messagePrefix + '.table.name' | translate}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let group of (groups | async)?.payload?.page">
+          <td>{{group.id}}</td>
+          <td><a [routerLink]="[groupsDataService.getGroupEditPageRouterLink(group.id)]">{{group.name}}</a></td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </ds-pagination>
+
+  <div *ngIf="(groups | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">
+    <div>{{messagePrefix + '.memberOfNoGroups' | translate}}</div>
+    <div>
+      <button [routerLink]="[groupsDataService.getGroupRegistryRouterLink()]"
+              class="btn btn-primary">{{messagePrefix + '.goToGroups' | translate}}</button>
+    </div>
+  </div>
+</div>

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -39,7 +39,8 @@
         <tbody>
         <tr *ngFor="let group of (groups | async)?.payload?.page">
           <td>{{group.id}}</td>
-          <td><a [routerLink]="[groupsDataService.getGroupEditPageRouterLink(group.id)]">{{group.name}}</a></td>
+          <td><a (click)="groupsDataService.startEditingNewGroup(group)"
+                 [routerLink]="[groupsDataService.getGroupEditPageRouterLink(group)]">{{group.name}}</a></td>
         </tr>
         </tbody>
       </table>

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -38,10 +38,11 @@ describe('EPersonFormComponent', () => {
   let translateService: TranslateService;
   let builderService: FormBuilderService;
 
-  const mockEPeople = [EPersonMock, EPersonMock2];
+  let mockEPeople;
   let ePersonDataServiceStub: any;
 
   beforeEach(async(() => {
+    mockEPeople = [EPersonMock, EPersonMock2];
     ePersonDataServiceStub = {
       activeEPerson: null,
       allEpeople: mockEPeople,

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -1,3 +1,5 @@
+import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngrx/store';
 import { of as observableOf } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -7,13 +9,18 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/internal/Observable';
+import { RemoteDataBuildService } from '../../../../core/cache/builders/remote-data-build.service';
+import { ObjectCacheService } from '../../../../core/cache/object-cache.service';
 import { RestResponse } from '../../../../core/cache/response.models';
+import { DSOChangeAnalyzer } from '../../../../core/data/dso-change-analyzer.service';
 import { PaginatedList } from '../../../../core/data/paginated-list';
 import { RemoteData } from '../../../../core/data/remote-data';
 import { FindListOptions } from '../../../../core/data/request.models';
 import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
 import { EPerson } from '../../../../core/eperson/models/eperson.model';
+import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { PageInfo } from '../../../../core/shared/page-info.model';
+import { UUIDService } from '../../../../core/shared/uuid.service';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
 import { getMockFormBuilderService } from '../../../../shared/mocks/mock-form-builder-service';
 import { getMockTranslateService } from '../../../../shared/mocks/mock-translate.service';
@@ -107,6 +114,13 @@ describe('EPersonFormComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: FormBuilderService, useValue: builderService },
+        { provide: DSOChangeAnalyzer, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: ObjectCacheService, useValue: {} },
+        { provide: UUIDService, useValue: {} },
+        { provide: Store, useValue: {} },
+        { provide: RemoteDataBuildService, useValue: {} },
+        { provide: HALEndpointService, useValue: {} },
         EPeopleRegistryComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -116,7 +130,6 @@ describe('EPersonFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EPersonFormComponent);
     component = fixture.componentInstance;
-    component.ngOnInit();
     fixture.detectChanges();
   });
 

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -139,30 +139,37 @@ describe('EPersonFormComponent', () => {
   }));
 
   describe('when submitting the form', () => {
-    const firstName = 'testName';
-    const lastName = 'testLastName';
-    const email = 'testEmail@test.com';
-    const canLogIn = false;
-    const requireCertificate = false;
+    let firstName;
+    let lastName;
+    let email;
+    let canLogIn;
+    let requireCertificate;
 
-    const expected = Object.assign(new EPerson(), {
-      metadata: {
-        'eperson.firstname': [
-          {
-            value: firstName
-          }
-        ],
-        'eperson.lastname': [
-          {
-            value: lastName
-          },
-        ],
-      },
-      email: email,
-      canLogIn: canLogIn,
-      requireCertificate: requireCertificate,
-    });
+    let expected;
     beforeEach(() => {
+      firstName = 'testName';
+      lastName = 'testLastName';
+      email = 'testEmail@test.com';
+      canLogIn = false;
+      requireCertificate = false;
+
+      expected = Object.assign(new EPerson(), {
+        metadata: {
+          'eperson.firstname': [
+            {
+              value: firstName
+            }
+          ],
+          'eperson.lastname': [
+            {
+              value: lastName
+            },
+          ],
+        },
+        email: email,
+        canLogIn: canLogIn,
+        requireCertificate: requireCertificate,
+      });
       spyOn(component.submitForm, 'emit');
       component.firstName.value = firstName;
       component.lastName.value = lastName;
@@ -185,25 +192,26 @@ describe('EPersonFormComponent', () => {
     });
 
     describe('with an active eperson', () => {
-      const expectedWithId = Object.assign(new EPerson(), {
-        metadata: {
-          'eperson.firstname': [
-            {
-              value: firstName
-            }
-          ],
-          'eperson.lastname': [
-            {
-              value: lastName
-            },
-          ],
-        },
-        email: email,
-        canLogIn: canLogIn,
-        requireCertificate: requireCertificate,
-      });
+      let expectedWithId;
 
       beforeEach(() => {
+        expectedWithId = Object.assign(new EPerson(), {
+          metadata: {
+            'eperson.firstname': [
+              {
+                value: firstName
+              }
+            ],
+            'eperson.lastname': [
+              {
+                value: lastName
+              },
+            ],
+          },
+          email: email,
+          canLogIn: canLogIn,
+          requireCertificate: requireCertificate,
+        });
         spyOn(ePersonDataServiceStub, 'getActiveEPerson').and.returnValue(observableOf(expectedWithId));
         component.onSubmit();
         fixture.detectChanges();

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -60,6 +60,9 @@ describe('EPersonFormComponent', () => {
           return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
         }
         if (scope === 'metadata') {
+          if (query === '') {
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allEpeople));
+          }
           const result = this.allEpeople.find((ePerson: EPerson) => {
             return (ePerson.name.includes(query) || ePerson.email.includes(query))
           });

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -200,10 +200,12 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       ];
       this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
       this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
-        this.groups = this.groupsDataService.findAllByHref(eperson._links.groups.href, {
-          currentPage: 1,
-          elementsPerPage: this.config.pageSize
-        });
+        if (eperson != null) {
+          this.groups = this.groupsDataService.findAllByHref(eperson._links.groups.href, {
+            currentPage: 1,
+            elementsPerPage: this.config.pageSize
+          });
+        }
         this.formGroup.patchValue({
           firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',
           lastName: eperson != null ? eperson.firstMetadataValue('eperson.lastname') : '',

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -241,7 +241,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    * @param values
    */
   createNewEPerson(values) {
-    console.log('createNewEPerson(values)', values)
     const ePersonToCreate = Object.assign(new EPerson(), values);
 
     const response = this.epersonService.tryToCreate(ePersonToCreate);

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -234,7 +234,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   onSubmit() {
     this.epersonService.getActiveEPerson().pipe(take(1)).subscribe(
       (ePerson: EPerson) => {
-        console.log('onsubmit ep', ePerson)
         const values = {
           metadata: {
             'eperson.firstname': [
@@ -343,19 +342,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           }));
         }
       }));
-  }
-
-  /**
-   * Reset all input-fields to be empty
-   */
-  clearFields() {
-    this.formGroup.patchValue({
-      firstName: '',
-      lastName: '',
-      email: '',
-      canLogin: true,
-      requireCertificate: false
-    });
   }
 
   /**

--- a/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -7,17 +7,21 @@ import {
   DynamicInputModel
 } from '@ng-dynamic-forms/core';
 import { TranslateService } from '@ngx-translate/core';
-import { combineLatest } from 'rxjs/internal/observable/combineLatest';
-import { Subscription } from 'rxjs/internal/Subscription';
+import { Subscription, combineLatest } from 'rxjs';
+import { Observable } from 'rxjs/internal/Observable';
 import { take } from 'rxjs/operators';
 import { RestResponse } from '../../../../core/cache/response.models';
 import { PaginatedList } from '../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../core/data/remote-data';
 import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../../core/eperson/group-data.service';
 import { EPerson } from '../../../../core/eperson/models/eperson.model';
+import { Group } from '../../../../core/eperson/models/group.model';
 import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../core/shared/operators';
 import { hasValue } from '../../../../shared/empty.util';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../../../shared/pagination/pagination-component-options.model';
 
 @Component({
   selector: 'ds-eperson-form',
@@ -107,11 +111,26 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   subs: Subscription[] = [];
 
   /**
+   * A list of all the groups this EPerson is a member of
+   */
+  groups: Observable<RemoteData<PaginatedList<Group>>>;
+
+  /**
+   * Pagination config used to display the list of groups
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'groups-ePersonMemberOf-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  /**
    * Try to retrieve initial active eperson, to fill in checkboxes at component creation
    */
   epersonInitial: EPerson;
 
   constructor(public epersonService: EPersonDataService,
+              public groupsDataService: GroupDataService,
               private formBuilderService: FormBuilderService,
               private translateService: TranslateService,
               private notificationsService: NotificationsService,) {
@@ -181,6 +200,10 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       ];
       this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
       this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
+        this.groups = this.groupsDataService.findAllByHref(eperson._links.groups.href, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        });
         this.formGroup.patchValue({
           firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',
           lastName: eperson != null ? eperson.firstMetadataValue('eperson.lastname') : '',
@@ -331,6 +354,26 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       canLogin: true,
       requireCertificate: false
     });
+  }
+
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateGroups({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Update the list of groups by fetching it from the rest api or cache
+   */
+  private updateGroups(options) {
+    this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
+      this.groups = this.groupsDataService.findAllByHref(eperson._links.groups.href, options);
+    }));
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
@@ -1,0 +1,32 @@
+<div class="container">
+  <div class="group-form row">
+    <div class="col-12">
+
+      <div *ngIf="groupDataService.getActiveGroup() | async; then editheader; else createHeader"></div>
+
+      <ng-template #createHeader>
+        <h2 class="border-bottom pb-2">{{messagePrefix + '.head.create' | translate}}</h2>
+      </ng-template>
+
+      <ng-template #editheader>
+        <h2 class="border-bottom pb-2">{{messagePrefix + '.head.edit' | translate}}</h2>
+      </ng-template>
+
+      <ds-form [formId]="formId"
+               [formModel]="formModel"
+               [formGroup]="formGroup"
+               [formLayout]="formLayout"
+               (cancel)="onCancel()"
+               (submitForm)="onSubmit()">
+      </ds-form>
+
+      <ds-subgroups-list [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
+      <ds-members-list [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
+
+      <div>
+        <button [routerLink]="['/admin/access-control/groups']" class="btn btn-primary">{{messagePrefix + '.return' | translate}}</button>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
@@ -24,7 +24,7 @@
       <ds-members-list [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
 
       <div>
-        <button [routerLink]="['/admin/access-control/groups']" class="btn btn-primary">{{messagePrefix + '.return' | translate}}</button>
+        <button [routerLink]="[this.groupDataService.getGroupRegistryRouterLink()]" class="btn btn-primary">{{messagePrefix + '.return' | translate}}</button>
       </div>
 
     </div>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
@@ -20,11 +20,12 @@
                (submitForm)="onSubmit()">
       </ds-form>
 
-      <ds-subgroups-list [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
       <ds-members-list [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
+      <ds-subgroups-list [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
 
       <div>
-        <button [routerLink]="[this.groupDataService.getGroupRegistryRouterLink()]" class="btn btn-primary">{{messagePrefix + '.return' | translate}}</button>
+        <button [routerLink]="[this.groupDataService.getGroupRegistryRouterLink()]"
+                class="btn btn-primary">{{messagePrefix + '.return' | translate}}</button>
       </div>
 
     </div>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.html
@@ -20,8 +20,8 @@
                (submitForm)="onSubmit()">
       </ds-form>
 
-      <ds-members-list [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
-      <ds-subgroups-list [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
+      <ds-members-list *ngIf="groupBeingEdited != null" [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
+      <ds-subgroups-list *ngIf="groupBeingEdited != null"  [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
 
       <div>
         <button [routerLink]="[this.groupDataService.getGroupRegistryRouterLink()]"

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.spec.ts
@@ -1,0 +1,153 @@
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { Store } from '@ngrx/store';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of as observableOf } from 'rxjs';
+import { Observable } from 'rxjs/internal/Observable';
+import { RemoteDataBuildService } from '../../../../core/cache/builders/remote-data-build.service';
+import { ObjectCacheService } from '../../../../core/cache/object-cache.service';
+import { RestResponse } from '../../../../core/cache/response.models';
+import { DSOChangeAnalyzer } from '../../../../core/data/dso-change-analyzer.service';
+import { PaginatedList } from '../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../../core/eperson/group-data.service';
+import { Group } from '../../../../core/eperson/models/group.model';
+import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
+import { PageInfo } from '../../../../core/shared/page-info.model';
+import { UUIDService } from '../../../../core/shared/uuid.service';
+import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
+import { getMockFormBuilderService } from '../../../../shared/mocks/mock-form-builder-service';
+import { MockRouter } from '../../../../shared/mocks/mock-router';
+import { getMockTranslateService } from '../../../../shared/mocks/mock-translate.service';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { GroupMock, GroupMock2 } from '../../../../shared/testing/group-mock';
+import { MockTranslateLoader } from '../../../../shared/testing/mock-translate-loader';
+import { NotificationsServiceStub } from '../../../../shared/testing/notifications-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../../../shared/testing/utils';
+import { GroupFormComponent } from './group-form.component';
+
+describe('GroupFormComponent', () => {
+  let component: GroupFormComponent;
+  let fixture: ComponentFixture<GroupFormComponent>;
+  let translateService: TranslateService;
+  let builderService: FormBuilderService;
+  let ePersonDataServiceStub: any;
+  let groupsDataServiceStub: any;
+  let router;
+
+  let groups;
+  let groupName;
+  let groupDescription;
+  let expected;
+
+  beforeEach(async(() => {
+    groups = [GroupMock, GroupMock2]
+    groupName = 'testGroupName';
+    groupDescription = 'testDescription';
+    expected = Object.assign(new Group(), {
+      name: groupName,
+      metadata: {
+        'dc.description': [
+          {
+            value: groupDescription
+          }
+        ],
+      },
+    });
+    ePersonDataServiceStub = {};
+    groupsDataServiceStub = {
+      allGroups: groups,
+      activeGroup: null,
+      getActiveGroup(): Observable<Group> {
+        return observableOf(this.activeGroup);
+      },
+      getGroupRegistryRouterLink(): string {
+        return '/admin/access-control/groups';
+      },
+      editGroup(group: Group) {
+        this.activeGroup = group
+      },
+      cancelEditGroup(): void {
+        this.activeGroup = null;
+      },
+      findById(id: string) {
+        return observableOf({ payload: null, hasSucceeded: true });
+      },
+      tryToCreate(group: Group): Observable<RestResponse> {
+        this.allGroups = [...this.allGroups, group]
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      },
+      searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
+      }
+    };
+    builderService = getMockFormBuilderService();
+    translateService = getMockTranslateService();
+    router = new MockRouter();
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [GroupFormComponent],
+      providers: [GroupFormComponent,
+        { provide: EPersonDataService, useValue: ePersonDataServiceStub },
+        { provide: GroupDataService, useValue: groupsDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: FormBuilderService, useValue: builderService },
+        { provide: DSOChangeAnalyzer, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: ObjectCacheService, useValue: {} },
+        { provide: UUIDService, useValue: {} },
+        { provide: Store, useValue: {} },
+        { provide: RemoteDataBuildService, useValue: {} },
+        { provide: HALEndpointService, useValue: {} },
+        { provide: ActivatedRoute, useValue: { data: observableOf({ dso: { payload: {} } }), params: observableOf({}) } },
+        { provide: Router, useValue: router },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create GroupFormComponent', inject([GroupFormComponent], (comp: GroupFormComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  describe('when submitting the form', () => {
+    beforeEach(() => {
+      spyOn(component.submitForm, 'emit');
+      component.groupName.value = groupName;
+      component.groupDescription.value = groupDescription;
+    });
+    describe('without active Group', () => {
+      beforeEach(() => {
+        component.onSubmit();
+        fixture.detectChanges();
+      });
+
+      it('should emit a new group using the correct values', async(() => {
+        fixture.whenStable().then(() => {
+          expect(component.submitForm.emit).toHaveBeenCalledWith(expected);
+        });
+      }));
+    });
+  });
+
+});

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -134,7 +134,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
   onCancel() {
     this.groupDataService.cancelEditGroup();
     this.cancelForm.emit();
-    this.router.navigate(['/admin/access-control/groups']);
+    this.router.navigate([this.groupDataService.getGroupRegistryRouterLink()]);
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -84,6 +84,11 @@ export class GroupFormComponent implements OnInit, OnDestroy {
    */
   subs: Subscription[] = [];
 
+  /**
+   * Group currently being edited
+   */
+  groupBeingEdited: Group;
+
   constructor(public groupDataService: GroupDataService,
               private ePersonDataService: EPersonDataService,
               private formBuilderService: FormBuilderService,
@@ -123,6 +128,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
       this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
       this.subs.push(this.groupDataService.getActiveGroup().subscribe((activeGroup: Group) => {
         if (activeGroup != null) {
+          this.groupBeingEdited = activeGroup;
           this.formGroup.patchValue({
             groupName: activeGroup != null ? activeGroup.name : '',
             groupDescription: activeGroup != null ? activeGroup.firstMetadataValue('dc.description') : '',
@@ -185,7 +191,9 @@ export class GroupFormComponent implements OnInit, OnDestroy {
         this.submitForm.emit(groupToCreate);
         const resp: any = restResponse;
         if (isNotEmpty(resp.resourceSelfLinks)) {
-          this.setActiveGroupWithLink(resp.resourceSelfLinks[0]);
+          const groupSelfLink = resp.resourceSelfLinks[0];
+          this.setActiveGroupWithLink(groupSelfLink);
+          this.router.navigateByUrl(this.groupDataService.getGroupEditPageRouterLinkWithID(this.groupDataService.getUUIDFromString(groupSelfLink)));
         }
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.created.failure', { name: groupToCreate.name }));

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -109,13 +109,14 @@ export class GroupFormComponent implements OnInit, OnDestroy {
         required: true,
       });
       this.groupDescription = new DynamicTextAreaModel({
-        id: 'description',
+        id: 'groupDescription',
         label: groupDescription,
-        name: 'dc.description',
+        name: 'groupDescription',
         required: false,
       });
       this.formModel = [
         this.groupName,
+        this.groupDescription
       ];
       this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
       this.subs.push(this.groupDataService.getActiveGroup().subscribe((group: Group) => {
@@ -160,7 +161,6 @@ export class GroupFormComponent implements OnInit, OnDestroy {
         } else {
           this.editGroup(group, values);
         }
-        this.clearFields();
       }
     );
   }
@@ -176,26 +176,20 @@ export class GroupFormComponent implements OnInit, OnDestroy {
         getRemoteDataPayload())
       .subscribe((group: Group) => {
         this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.created.success', { name: group.name }));
+        this.setActiveGroup(group.id);
         this.submitForm.emit(group);
       }));
   }
 
   /**
-   * //TODO
+   * // TODO
    * @param group
    * @param values
    */
   editGroup(group: Group, values) {
-    // TODO
-  }
-
-  /**
-   * Reset all input-fields to be empty
-   */
-  clearFields() {
-    this.formGroup.patchValue({
-      groupName: '',
-    });
+    // TODO (backend)
+    console.log('TODO implement editGroup', values);
+    this.notificationsService.error('TODO implement editGroup (not yet implemented in backend) ');
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
@@ -232,18 +232,14 @@ export class GroupFormComponent implements OnInit, OnDestroy {
    * @param groupId   ID of group to set as active
    */
   setActiveGroup(groupId: string) {
-    this.groupDataService.getActiveGroup().pipe(take(1)).subscribe((activeGroup: Group) => {
-      if (activeGroup === null) {
-        this.groupDataService.cancelEditGroup();
-        this.groupDataService.findById(groupId)
-          .pipe(
-            getSucceededRemoteData(),
-            getRemoteDataPayload())
-          .subscribe((group: Group) => {
-            this.groupDataService.editGroup(group);
-          })
-      }
-    });
+    this.groupDataService.cancelEditGroup();
+    this.groupDataService.findById(groupId)
+      .pipe(
+        getSucceededRemoteData(),
+        getRemoteDataPayload())
+      .subscribe((group: Group) => {
+        this.groupDataService.editGroup(group);
+      });
   }
 
   /**
@@ -268,6 +264,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
   /**
    * Cancel the current edit when component is destroyed & unsub all subscriptions
    */
+  @HostListener('window:beforeunload')
   ngOnDestroy(): void {
     this.onCancel();
     this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -1,0 +1,227 @@
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  DynamicFormControlModel,
+  DynamicFormLayout,
+  DynamicInputModel,
+  DynamicTextAreaModel
+} from '@ng-dynamic-forms/core';
+import { TranslateService } from '@ngx-translate/core';
+import { combineLatest } from 'rxjs/internal/observable/combineLatest';
+import { Subscription } from 'rxjs/internal/Subscription';
+import { take } from 'rxjs/operators';
+import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../../core/eperson/group-data.service';
+import { Group } from '../../../../core/eperson/models/group.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../core/shared/operators';
+import { hasValue } from '../../../../shared/empty.util';
+import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+
+@Component({
+  selector: 'ds-group-form',
+  templateUrl: './group-form.component.html'
+})
+/**
+ * A form used for creating and editing groups
+ */
+export class GroupFormComponent implements OnInit, OnDestroy {
+
+  messagePrefix = 'admin.access-control.groups.form';
+
+  /**
+   * A unique id used for ds-form
+   */
+  formId = 'group-form';
+
+  /**
+   * Dynamic models for the inputs of form
+   */
+  groupName: DynamicInputModel;
+  groupDescription: DynamicTextAreaModel;
+
+  /**
+   * A list of all dynamic input models
+   */
+  formModel: DynamicFormControlModel[];
+
+  /**
+   * Layout used for structuring the form inputs
+   */
+  formLayout: DynamicFormLayout = {
+    groupName: {
+      grid: {
+        host: 'row'
+      }
+    },
+    groupDescription: {
+      grid: {
+        host: 'row'
+      }
+    },
+  };
+
+  /**
+   * A FormGroup that combines all inputs
+   */
+  formGroup: FormGroup;
+
+  /**
+   * An EventEmitter that's fired whenever the form is being submitted
+   */
+  @Output() submitForm: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * An EventEmitter that's fired whenever the form is cancelled
+   */
+  @Output() cancelForm: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * List of subscriptions
+   */
+  subs: Subscription[] = [];
+
+  constructor(public groupDataService: GroupDataService,
+              private ePersonDataService: EPersonDataService,
+              private formBuilderService: FormBuilderService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private route: ActivatedRoute,
+              protected router: Router) {
+  }
+
+  ngOnInit() {
+    this.route.params.subscribe((params) => {
+      this.setActiveGroup(params.groupId)
+    });
+    combineLatest(
+      this.translateService.get(`${this.messagePrefix}.groupName`),
+      this.translateService.get(`${this.messagePrefix}.groupDescription`),
+    ).subscribe(([groupName, groupDescription]) => {
+      this.groupName = new DynamicInputModel({
+        id: 'groupName',
+        label: groupName,
+        name: 'groupName',
+        validators: {
+          required: null,
+        },
+        required: true,
+      });
+      this.groupDescription = new DynamicTextAreaModel({
+        id: 'description',
+        label: groupDescription,
+        name: 'dc.description',
+        required: false,
+      });
+      this.formModel = [
+        this.groupName,
+      ];
+      this.formGroup = this.formBuilderService.createFormGroup(this.formModel);
+      this.subs.push(this.groupDataService.getActiveGroup().subscribe((group: Group) => {
+        this.formGroup.patchValue({
+          groupName: group != null ? group.name : '',
+          groupDescription: group != null ? group.firstMetadataValue('dc.description') : '',
+        });
+      }));
+    });
+  }
+
+  /**
+   * Stop editing the currently selected group
+   */
+  onCancel() {
+    this.groupDataService.cancelEditGroup();
+    this.cancelForm.emit();
+    this.router.navigate(['/admin/access-control/groups']);
+  }
+
+  /**
+   * Submit the form
+   * When the eperson has an id attached -> Edit the eperson
+   * When the eperson has no id attached -> Create new eperson
+   * Emit the updated/created eperson using the EventEmitter submitForm
+   */
+  onSubmit() {
+    this.groupDataService.getActiveGroup().pipe(take(1)).subscribe(
+      (group: Group) => {
+        const values = {
+          name: this.groupName.value,
+          metadata: {
+            'dc.description': [
+              {
+                value: this.groupDescription.value
+              }
+            ],
+          },
+        };
+        if (group == null) {
+          this.createNewGroup(values);
+        } else {
+          this.editGroup(group, values);
+        }
+        this.clearFields();
+      }
+    );
+  }
+
+  /**
+   * Creates new Group based on given values from form
+   * @param values
+   */
+  createNewGroup(values) {
+    this.subs.push(this.groupDataService.createOrUpdateGroup(Object.assign(new Group(), values))
+      .pipe(
+        getSucceededRemoteData(),
+        getRemoteDataPayload())
+      .subscribe((group: Group) => {
+        this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.created.success', { name: group.name }));
+        this.submitForm.emit(group);
+      }));
+  }
+
+  /**
+   * //TODO
+   * @param group
+   * @param values
+   */
+  editGroup(group: Group, values) {
+    // TODO
+  }
+
+  /**
+   * Reset all input-fields to be empty
+   */
+  clearFields() {
+    this.formGroup.patchValue({
+      groupName: '',
+    });
+  }
+
+  /**
+   * Start editing the selected group
+   * @param group
+   */
+  setActiveGroup(groupId: string) {
+    this.groupDataService.getActiveGroup().pipe(take(1)).subscribe((activeGroup: Group) => {
+      if (activeGroup === null) {
+        this.groupDataService.cancelEditGroup();
+        this.groupDataService.findById(groupId)
+          .pipe(
+            getSucceededRemoteData(),
+            getRemoteDataPayload())
+          .subscribe((group: Group) => {
+            this.groupDataService.editGroup(group);
+          })
+      }
+    });
+  }
+
+  /**
+   * Cancel the current edit when component is destroyed & unsub all subscriptions
+   */
+  ngOnDestroy(): void {
+    this.onCancel();
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
+  }
+}

--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -134,7 +134,6 @@ export class GroupFormComponent implements OnInit, OnDestroy {
   onCancel() {
     this.groupDataService.cancelEditGroup();
     this.cancelForm.emit();
-    this.router.navigate([this.groupDataService.getGroupRegistryRouterLink()]);
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
@@ -22,12 +22,12 @@
   </form>
 
   <ds-pagination *ngIf="(ePeople | async)?.payload.totalElements > 0"
-    [paginationOptions]="config"
-    [pageInfoState]="(ePeople | async)?.payload"
-    [collectionSize]="(ePeople | async)?.payload?.totalElements"
-    [hideGear]="true"
-    [hidePagerWhenSinglePage]="true"
-    (pageChange)="onPageChange($event)">
+                 [paginationOptions]="config"
+                 [pageInfoState]="(ePeople | async)?.payload"
+                 [collectionSize]="(ePeople | async)?.payload?.totalElements"
+                 [hideGear]="true"
+                 [hidePagerWhenSinglePage]="true"
+                 (pageChange)="onPageChange($event)">
 
     <div class="table-responsive">
       <table id="groups" class="table table-striped table-hover table-bordered">
@@ -41,7 +41,8 @@
         <tbody>
         <tr *ngFor="let ePerson of (ePeople | async)?.payload?.page">
           <td>{{ePerson.id}}</td>
-          <td>{{ePerson.name}}</td>
+          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson)"
+                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.name}}</a></td>
           <td>
             <div class="btn-group edit-field">
               <button *ngIf="(isMemberOfGroup(ePerson) | async)"
@@ -66,12 +67,15 @@
 
   </ds-pagination>
 
-  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2" role="alert">
+  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2"
+       role="alert">
     {{messagePrefix + '.no-members-yet' | translate}}
-    <button (click)="search({query: ''})" class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
+    <button (click)="search({query: ''})"
+            class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
   </div>
 
-  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2" role="alert">
+  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2"
+       role="alert">
     {{messagePrefix + '.no-items' | translate}}
   </div>
 

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
@@ -1,7 +1,10 @@
 <ng-container>
   <h3 class="border-bottom pb-2">{{messagePrefix + '.head' | translate}}</h3>
 
-  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}</h4>
+  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}
+    <button (click)="clearFormAndResetResult();"
+            class="btn btn-primary float-right">{{messagePrefix + '.button.see-all' | translate}}</button>
+  </h4>
   <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
     <div class="col-12 col-sm-3">
       <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
@@ -21,16 +24,16 @@
     </div>
   </form>
 
-  <ds-pagination *ngIf="(ePeople | async)?.payload.totalElements > 0"
-                 [paginationOptions]="config"
-                 [pageInfoState]="(ePeople | async)?.payload"
-                 [collectionSize]="(ePeople | async)?.payload?.totalElements"
+  <ds-pagination *ngIf="(ePeopleSearch | async)?.payload.totalElements > 0"
+                 [paginationOptions]="configSearch"
+                 [pageInfoState]="(ePeopleSearch | async)?.payload"
+                 [collectionSize]="(ePeopleSearch | async)?.payload?.totalElements"
                  [hideGear]="true"
                  [hidePagerWhenSinglePage]="true"
-                 (pageChange)="onPageChange($event)">
+                 (pageChange)="onPageChangeSearch($event)">
 
     <div class="table-responsive">
-      <table id="epersons" class="table table-striped table-hover table-bordered">
+      <table id="epersonsSearch" class="table table-striped table-hover table-bordered">
         <thead>
         <tr>
           <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
@@ -39,7 +42,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let ePerson of (ePeople | async)?.payload?.page">
+        <tr *ngFor="let ePerson of (ePeopleSearch | async)?.payload?.page">
           <td>{{ePerson.id}}</td>
           <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson)"
                  [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.name}}</a></td>
@@ -67,16 +70,55 @@
 
   </ds-pagination>
 
-  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2"
-       role="alert">
-    {{messagePrefix + '.no-members-yet' | translate}}
-    <button (click)="search({query: ''})"
-            class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
-  </div>
-
-  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2"
+  <div *ngIf="(ePeopleSearch | async)?.payload.totalElements == 0 && searchDone"
+       class="alert alert-info w-100 mb-2"
        role="alert">
     {{messagePrefix + '.no-items' | translate}}
+  </div>
+
+  <h4>{{messagePrefix + '.headMembers' | translate}}</h4>
+
+  <ds-pagination *ngIf="(ePeopleMembersOfGroup | async)?.payload.totalElements > 0"
+                 [paginationOptions]="config"
+                 [pageInfoState]="(ePeopleMembersOfGroup | async)?.payload"
+                 [collectionSize]="(ePeopleMembersOfGroup | async)?.payload?.totalElements"
+                 [hideGear]="true"
+                 [hidePagerWhenSinglePage]="true"
+                 (pageChange)="onPageChange($event)">
+
+    <div class="table-responsive">
+      <table id="ePeopleMembersOfGroup" class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+          <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
+          <th scope="col">{{messagePrefix + '.table.name' | translate}}</th>
+          <th>{{messagePrefix + '.table.edit' | translate}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let ePerson of (ePeopleMembersOfGroup | async)?.payload?.page">
+          <td>{{ePerson.id}}</td>
+          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson)"
+                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.name}}</a></td>
+          <td>
+            <div class="btn-group edit-field">
+              <button (click)="deleteMemberFromGroup(ePerson)"
+                      class="btn btn-outline-danger btn-sm"
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.name} }}">
+                <i class="fas fa-trash-alt fa-fw"></i>
+              </button>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </ds-pagination>
+
+  <div *ngIf="(ePeopleMembersOfGroup | async)?.payload.totalElements == 0" class="alert alert-info w-100 mb-2"
+       role="alert">
+    {{messagePrefix + '.no-members-yet' | translate}}
   </div>
 
 </ng-container>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
@@ -1,0 +1,78 @@
+<ng-container>
+  <h3 class="border-bottom pb-2">{{messagePrefix + '.head' | translate}}</h3>
+
+  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}</h4>
+  <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
+    <div class="col-12 col-sm-3">
+      <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
+        <option value="metadata">{{messagePrefix + '.search.scope.metadata' | translate}}</option>
+        <option value="email">{{messagePrefix + '.search.scope.email' | translate}}</option>
+      </select>
+    </div>
+    <div class="col-sm-9 col-12">
+      <div class="form-group input-group">
+        <input type="text" name="query" id="query" formControlName="query"
+               class="form-control" aria-label="Search input">
+        <span class="input-group-append">
+            <button type="submit"
+                    class="search-button btn btn-secondary">{{ messagePrefix + '.search.button' | translate }}</button>
+        </span>
+      </div>
+    </div>
+  </form>
+
+  <ds-pagination *ngIf="(ePeople | async)?.payload.totalElements > 0"
+    [paginationOptions]="config"
+    [pageInfoState]="(ePeople | async)?.payload"
+    [collectionSize]="(ePeople | async)?.payload?.totalElements"
+    [hideGear]="true"
+    [hidePagerWhenSinglePage]="true"
+    (pageChange)="onPageChange($event)">
+
+    <div class="table-responsive">
+      <table id="groups" class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+          <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
+          <th scope="col">{{messagePrefix + '.table.name' | translate}}</th>
+          <th>{{messagePrefix + '.table.edit' | translate}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let ePerson of (ePeople | async)?.payload?.page">
+          <td>{{ePerson.id}}</td>
+          <td>{{ePerson.name}}</td>
+          <td>
+            <div class="btn-group edit-field">
+              <button *ngIf="(isMemberOfGroup(ePerson) | async)"
+                      (click)="deleteMemberFromGroup(ePerson)"
+                      class="btn btn-outline-danger btn-sm"
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.name} }}">
+                <i class="fas fa-trash-alt fa-fw"></i>
+              </button>
+
+              <button *ngIf="!(isMemberOfGroup(ePerson) | async)"
+                      (click)="addMemberToGroup(ePerson)"
+                      class="btn btn-outline-primary btn-sm"
+                      title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: ePerson.name} }}">
+                <i class="fas fa-plus fa-fw"></i>
+              </button>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </ds-pagination>
+
+  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2" role="alert">
+    {{messagePrefix + '.no-members-yet' | translate}}
+    <button (click)="search({query: ''})" class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
+  </div>
+
+  <div *ngIf="(ePeople | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2" role="alert">
+    {{messagePrefix + '.no-items' | translate}}
+  </div>
+
+</ng-container>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
@@ -30,7 +30,7 @@
                  (pageChange)="onPageChange($event)">
 
     <div class="table-responsive">
-      <table id="groups" class="table table-striped table-hover table-bordered">
+      <table id="epersons" class="table table-striped table-hover table-bordered">
         <thead>
         <tr>
           <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.spec.ts
@@ -1,0 +1,193 @@
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { RestResponse } from '../../../../../core/cache/response.models';
+import { PaginatedList } from '../../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../../core/data/remote-data';
+import { EPersonDataService } from '../../../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../../../core/eperson/group-data.service';
+import { EPerson } from '../../../../../core/eperson/models/eperson.model';
+import { Group } from '../../../../../core/eperson/models/group.model';
+import { PageInfo } from '../../../../../core/shared/page-info.model';
+import { FormBuilderService } from '../../../../../shared/form/builder/form-builder.service';
+import { getMockFormBuilderService } from '../../../../../shared/mocks/mock-form-builder-service';
+import { getMockTranslateService } from '../../../../../shared/mocks/mock-translate.service';
+import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
+import { EPersonMock, EPersonMock2 } from '../../../../../shared/testing/eperson-mock';
+import { GroupMock, GroupMock2 } from '../../../../../shared/testing/group-mock';
+import { MockTranslateLoader } from '../../../../../shared/testing/mock-translate-loader';
+import { NotificationsServiceStub } from '../../../../../shared/testing/notifications-service-stub';
+import { of as observableOf } from 'rxjs';
+import { createSuccessfulRemoteDataObject$ } from '../../../../../shared/testing/utils';
+import { MembersListComponent } from './members-list.component';
+
+describe('MembersListComponent', () => {
+  let component: MembersListComponent;
+  let fixture: ComponentFixture<MembersListComponent>;
+  let translateService: TranslateService;
+  let builderService: FormBuilderService;
+  let ePersonDataServiceStub: any;
+  let groupsDataServiceStub: any;
+  let activeGroup;
+  let allEPersons;
+  let allGroups;
+
+  beforeEach(async(() => {
+    activeGroup = GroupMock;
+    activeGroup.epersons = [EPersonMock2];
+    allEPersons = [EPersonMock, EPersonMock2];
+    allGroups = [GroupMock, GroupMock2]
+    ePersonDataServiceStub = {
+      findAllByHref(href: string): Observable<RemoteData<PaginatedList<EPerson>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList<EPerson>(new PageInfo(), activeGroup.epersons))
+      },
+      searchByScope(scope: string, query: string): Observable<RemoteData<PaginatedList<EPerson>>> {
+        if (query === '') {
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), allEPersons))
+        }
+        return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
+      },
+      clearEPersonRequests() {
+        // empty
+      },
+      getEPeoplePageRouterLink(): string {
+        return '/admin/access-control/epeople';
+      }
+    };
+    groupsDataServiceStub = {
+      getActiveGroup(): Observable<Group> {
+        return observableOf(activeGroup);
+      },
+      searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
+        if (query === '') {
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), allGroups))
+        }
+        return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
+      },
+      addMemberToGroup(parentGroup, eperson: EPerson): Observable<RestResponse> {
+        activeGroup.epersons = [...activeGroup.epersons, eperson];
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      },
+      clearGroupsRequests() {
+        // empty
+      },
+      deleteMemberFromGroup(parentGroup, epersonToDelete: EPerson): Observable<RestResponse> {
+        activeGroup.epersons = activeGroup.epersons.find((eperson: EPerson) => {
+          if (eperson.id !== epersonToDelete.id) {
+            return eperson;
+          }
+        });
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      }
+    };
+    builderService = getMockFormBuilderService();
+    translateService = getMockTranslateService();
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [MembersListComponent],
+      providers: [MembersListComponent,
+        { provide: EPersonDataService, useValue: ePersonDataServiceStub },
+        { provide: GroupDataService, useValue: groupsDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: FormBuilderService, useValue: builderService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MembersListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create MembersListComponent', inject([MembersListComponent], (comp: MembersListComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  it('should show list of eperson members of current active group', () => {
+    const epersonIdsFound = fixture.debugElement.queryAll(By.css('#epersons tr td:first-child'));
+    expect(epersonIdsFound.length).toEqual(1);
+    activeGroup.epersons.map((eperson: EPerson) => {
+      expect(epersonIdsFound.find((foundEl) => {
+        return (foundEl.nativeElement.textContent.trim() === eperson.uuid);
+      })).toBeTruthy();
+    });
+  });
+
+  describe('search', () => {
+    describe('when searching without query', () => {
+      let epersonsFound;
+      beforeEach(fakeAsync(() => {
+        component.search({ scope: 'metadata', query: '' });
+        tick();
+        fixture.detectChanges();
+        epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
+      }));
+
+      it('should display all epersons', () => {
+        expect(epersonsFound.length).toEqual(2);
+      });
+
+      describe('if eperson is already a subeperson', () => {
+        it('should have delete button, else it should have add button', () => {
+          activeGroup.epersons.map((eperson: EPerson) => {
+            epersonsFound.map((foundEPersonRowElement) => {
+              if (foundEPersonRowElement.debugElement !== undefined) {
+                const epersonId = foundEPersonRowElement.debugElement.query(By.css('td:first-child'));
+                const addButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-plus'));
+                const deleteButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-trash-alt'));
+                if (epersonId.nativeElement.textContent === eperson.id) {
+                  expect(addButton).toBeUndefined();
+                  expect(deleteButton).toBeDefined();
+                } else {
+                  expect(deleteButton).toBeUndefined();
+                  expect(addButton).toBeDefined();
+                }
+              }
+            })
+          })
+        });
+      });
+
+      describe('if first add button is pressed', () => {
+        beforeEach(fakeAsync(() => {
+          const addButton = fixture.debugElement.query(By.css('#epersons tbody .fa-plus'));
+          addButton.nativeElement.click();
+          tick();
+          fixture.detectChanges();
+        }));
+        it('one more subeperson in list (from 1 to 2 total epersons)', () => {
+          epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
+          expect(epersonsFound.length).toEqual(2);
+        });
+      });
+
+      describe('if first delete button is pressed', () => {
+        beforeEach(fakeAsync(() => {
+          const addButton = fixture.debugElement.query(By.css('#epersons tbody .fa-trash-alt'));
+          addButton.nativeElement.click();
+          tick();
+          fixture.detectChanges();
+        }));
+        it('one less subeperson in list from 1 to 0 (of 2 total epersons)', () => {
+          epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
+          expect(epersonsFound.length).toEqual(0);
+        });
+      });
+    });
+  });
+
+});

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.spec.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/internal/Observable';
@@ -16,6 +17,7 @@ import { Group } from '../../../../../core/eperson/models/group.model';
 import { PageInfo } from '../../../../../core/shared/page-info.model';
 import { FormBuilderService } from '../../../../../shared/form/builder/form-builder.service';
 import { getMockFormBuilderService } from '../../../../../shared/mocks/mock-form-builder-service';
+import { MockRouter } from '../../../../../shared/mocks/mock-router';
 import { getMockTranslateService } from '../../../../../shared/mocks/mock-translate.service';
 import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
 import { EPersonMock, EPersonMock2 } from '../../../../../shared/testing/eperson-mock';
@@ -36,15 +38,21 @@ describe('MembersListComponent', () => {
   let activeGroup;
   let allEPersons;
   let allGroups;
+  let epersonMembers;
+  let subgroupMembers;
 
   beforeEach(async(() => {
     activeGroup = GroupMock;
-    activeGroup.epersons = [EPersonMock2];
+    epersonMembers = [EPersonMock2];
+    subgroupMembers = [GroupMock2];
     allEPersons = [EPersonMock, EPersonMock2];
-    allGroups = [GroupMock, GroupMock2]
+    allGroups = [GroupMock, GroupMock2];
     ePersonDataServiceStub = {
+      activeGroup: activeGroup,
+      epersonMembers: epersonMembers,
+      subgroupMembers: subgroupMembers,
       findAllByHref(href: string): Observable<RemoteData<PaginatedList<EPerson>>> {
-        return createSuccessfulRemoteDataObject$(new PaginatedList<EPerson>(new PageInfo(), activeGroup.epersons))
+        return createSuccessfulRemoteDataObject$(new PaginatedList<EPerson>(new PageInfo(), groupsDataServiceStub.getEPersonMembers()))
       },
       searchByScope(scope: string, query: string): Observable<RemoteData<PaginatedList<EPerson>>> {
         if (query === '') {
@@ -55,33 +63,52 @@ describe('MembersListComponent', () => {
       clearEPersonRequests() {
         // empty
       },
+      clearLinkRequests() {
+        // empty
+      },
       getEPeoplePageRouterLink(): string {
         return '/admin/access-control/epeople';
       }
     };
     groupsDataServiceStub = {
+      activeGroup: activeGroup,
+      epersonMembers: epersonMembers,
+      subgroupMembers: subgroupMembers,
+      allGroups: allGroups,
       getActiveGroup(): Observable<Group> {
         return observableOf(activeGroup);
       },
+      getEPersonMembers() {
+        return this.epersonMembers;
+      },
       searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
         if (query === '') {
-          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), allGroups))
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), this.allGroups))
         }
         return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
       },
       addMemberToGroup(parentGroup, eperson: EPerson): Observable<RestResponse> {
-        activeGroup.epersons = [...activeGroup.epersons, eperson];
+        this.epersonMembers = [...this.epersonMembers, eperson];
         return observableOf(new RestResponse(true, 200, 'Success'));
       },
       clearGroupsRequests() {
         // empty
       },
+      clearGroupLinkRequests() {
+        // empty
+      },
+      getGroupEditPageRouterLink(group: Group): string {
+        return '/admin/access-control/groups/' + group.id;
+      },
       deleteMemberFromGroup(parentGroup, epersonToDelete: EPerson): Observable<RestResponse> {
-        activeGroup.epersons = activeGroup.epersons.find((eperson: EPerson) => {
+        this.epersonMembers = this.epersonMembers.find((eperson: EPerson) => {
           if (eperson.id !== epersonToDelete.id) {
             return eperson;
           }
         });
+        if (this.epersonMembers === undefined) {
+          this.epersonMembers = []
+        }
         return observableOf(new RestResponse(true, 200, 'Success'));
       }
     };
@@ -102,6 +129,7 @@ describe('MembersListComponent', () => {
         { provide: GroupDataService, useValue: groupsDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: FormBuilderService, useValue: builderService },
+        { provide: Router, useValue: new MockRouter() },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -112,15 +140,20 @@ describe('MembersListComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+  afterEach(fakeAsync(() => {
+    fixture.destroy();
+    flush();
+    component = null;
+  }));
 
   it('should create MembersListComponent', inject([MembersListComponent], (comp: MembersListComponent) => {
     expect(comp).toBeDefined();
   }));
 
   it('should show list of eperson members of current active group', () => {
-    const epersonIdsFound = fixture.debugElement.queryAll(By.css('#epersons tr td:first-child'));
+    const epersonIdsFound = fixture.debugElement.queryAll(By.css('#ePeopleMembersOfGroup tr td:first-child'));
     expect(epersonIdsFound.length).toEqual(1);
-    activeGroup.epersons.map((eperson: EPerson) => {
+    epersonMembers.map((eperson: EPerson) => {
       expect(epersonIdsFound.find((foundEl) => {
         return (foundEl.nativeElement.textContent.trim() === eperson.uuid);
       })).toBeTruthy();
@@ -134,14 +167,14 @@ describe('MembersListComponent', () => {
         component.search({ scope: 'metadata', query: '' });
         tick();
         fixture.detectChanges();
-        epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
+        epersonsFound = fixture.debugElement.queryAll(By.css('#epersonsSearch tbody tr'));
       }));
 
       it('should display all epersons', () => {
         expect(epersonsFound.length).toEqual(2);
       });
 
-      describe('if eperson is already a subeperson', () => {
+      describe('if eperson is already a eperson', () => {
         it('should have delete button, else it should have add button', () => {
           activeGroup.epersons.map((eperson: EPerson) => {
             epersonsFound.map((foundEPersonRowElement) => {
@@ -164,27 +197,42 @@ describe('MembersListComponent', () => {
 
       describe('if first add button is pressed', () => {
         beforeEach(fakeAsync(() => {
-          const addButton = fixture.debugElement.query(By.css('#epersons tbody .fa-plus'));
+          const addButton = fixture.debugElement.query(By.css('#epersonsSearch tbody .fa-plus'));
           addButton.nativeElement.click();
           tick();
           fixture.detectChanges();
         }));
-        it('one more subeperson in list (from 1 to 2 total epersons)', () => {
-          epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
+        it('all groups in search member of selected group', () => {
+          epersonsFound = fixture.debugElement.queryAll(By.css('#epersonsSearch tbody tr'));
           expect(epersonsFound.length).toEqual(2);
+          epersonsFound.map((foundEPersonRowElement) => {
+            if (foundEPersonRowElement.debugElement !== undefined) {
+              const addButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-plus'));
+              const deleteButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-trash-alt'));
+              expect(addButton).toBeUndefined();
+              expect(deleteButton).toBeDefined();
+            }
+          })
         });
       });
 
       describe('if first delete button is pressed', () => {
         beforeEach(fakeAsync(() => {
-          const addButton = fixture.debugElement.query(By.css('#epersons tbody .fa-trash-alt'));
+          const addButton = fixture.debugElement.query(By.css('#epersonsSearch tbody .fa-trash-alt'));
           addButton.nativeElement.click();
           tick();
           fixture.detectChanges();
         }));
-        it('one less subeperson in list from 1 to 0 (of 2 total epersons)', () => {
-          epersonsFound = fixture.debugElement.queryAll(By.css('#epersons tbody tr'));
-          expect(epersonsFound.length).toEqual(0);
+        it('first eperson in search delete button, because now member', () => {
+          epersonsFound = fixture.debugElement.queryAll(By.css('#epersonsSearch tbody tr'));
+          epersonsFound.map((foundEPersonRowElement) => {
+            if (foundEPersonRowElement.debugElement !== undefined) {
+              const addButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-plus'));
+              const deleteButton = foundEPersonRowElement.debugElement.query(By.css('td:last-child .fa-trash-alt'));
+              expect(deleteButton).toBeUndefined();
+              expect(addButton).toBeDefined();
+            }
+          })
         });
       });
     });

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -55,7 +55,7 @@ export class MembersListComponent implements OnInit, OnDestroy {
   searchDone: boolean;
 
   constructor(private groupDataService: GroupDataService,
-              private ePersonDataService: EPersonDataService,
+              public ePersonDataService: EPersonDataService,
               private translateService: TranslateService,
               private notificationsService: NotificationsService,
               private formBuilder: FormBuilder) {

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -1,0 +1,152 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable, of as observableOf, Subscription } from 'rxjs';
+import { map, mergeMap, take } from 'rxjs/operators';
+import { PaginatedList } from '../../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../../core/data/remote-data';
+import { EPersonDataService } from '../../../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../../../core/eperson/group-data.service';
+import { EPerson } from '../../../../../core/eperson/models/eperson.model';
+import { Group } from '../../../../../core/eperson/models/group.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../../core/shared/operators';
+import { hasValue } from '../../../../../shared/empty.util';
+import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../../../../shared/pagination/pagination-component-options.model';
+
+@Component({
+  selector: 'ds-members-list',
+  templateUrl: './members-list.component.html'
+})
+/**
+ * The list of members in the edit group page
+ */
+export class MembersListComponent implements OnInit, OnDestroy {
+
+  @Input()
+  messagePrefix: string;
+
+  ePeople: Observable<RemoteData<PaginatedList<EPerson>>>;
+
+  /**
+   * Pagination config used to display the list of EPeople
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'members-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  /**
+   * List of subscriptions
+   */
+  subs: Subscription[] = [];
+
+  // The search form
+  searchForm;
+
+  /**
+   * Whether or not user has done a search yet
+   */
+  searchDone: boolean;
+
+  constructor(private groupDataService: GroupDataService,
+              private ePersonDataService: EPersonDataService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private formBuilder: FormBuilder) {
+  }
+
+  ngOnInit() {
+    this.subs.push(this.groupDataService.getActiveGroup().subscribe((group: Group) => {
+      if (group != null) {
+        this.ePeople = this.ePersonDataService.findAllByHref(group._links.epersons.href, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        })
+      }
+    }));
+    this.searchForm = this.formBuilder.group(({
+      scope: 'metadata',
+      query: '',
+    }));
+    this.searchDone = false;
+  }
+
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateMembers({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Update the list of members by fetching it from the rest api or cache
+   */
+  private updateMembers(options) {
+    this.ePeople = this.ePersonDataService.getEPeople(options);
+  }
+
+  deleteMemberFromGroup(ePerson: EPerson) {
+    // TODO
+    console.log('deleteMember TODO', ePerson);
+    // this.forceUpdateEPeople();
+  }
+
+  addMemberToGroup(ePerson: EPerson) {
+    // TODO
+    console.log('addMember TODO', ePerson);
+    // this.forceUpdateEPeople();
+  }
+
+  isMemberOfGroup(ePerson: EPerson): Observable<boolean> {
+    return this.groupDataService.getActiveGroup().pipe(take(1),
+      mergeMap((group: Group) => {
+        if (group != null) {
+          return this.groupDataService.findAllByHref(ePerson._links.groups.href, {
+            currentPage: 0,
+            elementsPerPage: Number.MAX_SAFE_INTEGER
+          })
+            .pipe(
+              getSucceededRemoteData(),
+              getRemoteDataPayload(),
+              map((listTotalGroups: PaginatedList<Group>) => listTotalGroups.page.filter((groupInList: Group) => groupInList.id === group.id)),
+              map((groups: Group[]) => groups.length > 0))
+        } else {
+          return observableOf(false);
+        }
+      }))
+  }
+
+  /**
+   * Search in the EPeople by name, email or metadata
+   * @param data  Contains scope and query param
+   */
+  search(data: any) {
+    this.searchDone = true;
+    this.ePeople = this.ePersonDataService.searchByScope(data.scope, data.query, {
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Force-update the list of EPeople by first clearing the cache related to EPeople, then performing
+   * a new REST call
+   */
+  public forceUpdateEPeople() {
+    this.ePersonDataService.clearEPersonRequests();
+    this.search({ query: '', scope: 'metadata' })
+  }
+
+  /**
+   * unsub all subscriptions
+   */
+  ngOnDestroy(): void {
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
+  }
+}

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -140,11 +140,11 @@ export class MembersListComponent implements OnInit, OnDestroy {
       if (activeGroup != null) {
         const response = this.groupDataService.addMemberToGroup(activeGroup, ePerson);
         this.showNotifications('addMember', response, ePerson.name, activeGroup);
-        this.forceUpdateEPeople(activeGroup, ePerson);
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.noActiveGroup'));
       }
     });
+    this.forceUpdateEPeople(this.groupBeingEdited, ePerson);
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
@@ -1,7 +1,10 @@
 <ng-container>
   <h3 class="border-bottom pb-2">{{messagePrefix + '.head' | translate}}</h3>
 
-  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}</h4>
+  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}
+    <button (click)="clearFormAndResetResult();"
+            class="btn btn-primary float-right">{{messagePrefix + '.button.see-all' | translate}}</button>
+  </h4>
   <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
     <div class="col-12">
       <div class="form-group input-group">
@@ -15,16 +18,16 @@
     </div>
   </form>
 
-  <ds-pagination *ngIf="(groups | async)?.payload.totalElements > 0"
-                 [paginationOptions]="config"
-                 [pageInfoState]="(groups | async)?.payload"
-                 [collectionSize]="(groups | async)?.payload?.totalElements"
+  <ds-pagination *ngIf="(groupsSearch | async)?.payload.totalElements > 0"
+                 [paginationOptions]="configSearch"
+                 [pageInfoState]="(groupsSearch | async)?.payload"
+                 [collectionSize]="(groupsSearch | async)?.payload?.totalElements"
                  [hideGear]="true"
                  [hidePagerWhenSinglePage]="true"
-                 (pageChange)="onPageChange($event)">
+                 (pageChange)="onPageChangeSearch($event)">
 
     <div class="table-responsive">
-      <table id="groups" class="table table-striped table-hover table-bordered">
+      <table id="groupsSearch" class="table table-striped table-hover table-bordered">
         <thead>
         <tr>
           <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
@@ -33,7 +36,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let group of (groups | async)?.payload?.page">
+        <tr *ngFor="let group of (groupsSearch | async)?.payload?.page">
           <td>{{group.id}}</td>
           <td><a (click)="groupDataService.startEditingNewGroup(group)"
                  [routerLink]="[groupDataService.getGroupEditPageRouterLink(group)]">{{group.name}}</a></td>
@@ -41,14 +44,14 @@
             <div class="btn-group edit-field">
               <button *ngIf="(isSubgroupOfGroup(group) | async)"
                       (click)="deleteSubgroupFromGroup(group)"
-                      class="btn btn-outline-danger btn-sm"
+                      class="btn btn-outline-danger btn-sm deleteButton"
                       title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: group.name} }}">
                 <i class="fas fa-trash-alt fa-fw"></i>
               </button>
 
               <button *ngIf="!(isSubgroupOfGroup(group) | async)"
                       (click)="addSubgroupToGroup(group)"
-                      class="btn btn-outline-primary btn-sm"
+                      class="btn btn-outline-primary btn-sm addButton"
                       title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: group.name} }}">
                 <i class="fas fa-plus fa-fw"></i>
               </button>
@@ -58,19 +61,55 @@
         </tbody>
       </table>
     </div>
-
   </ds-pagination>
 
-  <div *ngIf="(groups | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2"
-       role="alert">
-    {{messagePrefix + '.no-subgroups-yet' | translate}}
-    <button (click)="search({query: ''})"
-            class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
-  </div>
-
-  <div *ngIf="(groups | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2"
+  <div *ngIf="(groupsSearch | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2"
        role="alert">
     {{messagePrefix + '.no-items' | translate}}
+  </div>
+
+  <h4>{{messagePrefix + '.headSubgroups' | translate}}</h4>
+
+  <ds-pagination *ngIf="(subgroupsOfGroup | async)?.payload.totalElements > 0"
+                 [paginationOptions]="config"
+                 [pageInfoState]="(subgroupsOfGroup | async)?.payload"
+                 [collectionSize]="(subgroupsOfGroup | async)?.payload?.totalElements"
+                 [hideGear]="true"
+                 [hidePagerWhenSinglePage]="true"
+                 (pageChange)="onPageChange($event)">
+
+    <div class="table-responsive">
+      <table id="subgroupsOfGroup" class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+          <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
+          <th scope="col">{{messagePrefix + '.table.name' | translate}}</th>
+          <th>{{messagePrefix + '.table.edit' | translate}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let group of (subgroupsOfGroup | async)?.payload?.page">
+          <td>{{group.id}}</td>
+          <td><a (click)="groupDataService.startEditingNewGroup(group)"
+                 [routerLink]="[groupDataService.getGroupEditPageRouterLink(group)]">{{group.name}}</a></td>
+          <td>
+            <div class="btn-group edit-field">
+              <button (click)="deleteSubgroupFromGroup(group)"
+                      class="btn btn-outline-danger btn-sm deleteButton"
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: group.name} }}">
+                <i class="fas fa-trash-alt fa-fw"></i>
+              </button>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </ds-pagination>
+
+  <div *ngIf="(subgroupsOfGroup | async)?.payload.totalElements == 0" class="alert alert-info w-100 mb-2"
+       role="alert">
+    {{messagePrefix + '.no-subgroups-yet' | translate}}
   </div>
 
 </ng-container>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
@@ -1,0 +1,72 @@
+<ng-container>
+  <h3 class="border-bottom pb-2">{{messagePrefix + '.head' | translate}}</h3>
+
+  <h4 id="search" class="border-bottom pb-2">{{messagePrefix + '.search.head' | translate}}</h4>
+  <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
+    <div class="col-12">
+      <div class="form-group input-group">
+        <input type="text" name="query" id="query" formControlName="query"
+               class="form-control" aria-label="Search input">
+        <span class="input-group-append">
+            <button type="submit"
+                    class="search-button btn btn-secondary">{{ messagePrefix + '.search.button' | translate }}</button>
+        </span>
+      </div>
+    </div>
+  </form>
+
+  <ds-pagination *ngIf="(groups | async)?.payload.totalElements > 0"
+    [paginationOptions]="config"
+    [pageInfoState]="(groups | async)?.payload"
+    [collectionSize]="(groups | async)?.payload?.totalElements"
+    [hideGear]="true"
+    [hidePagerWhenSinglePage]="true"
+    (pageChange)="onPageChange($event)">
+
+    <div class="table-responsive">
+      <table id="groups" class="table table-striped table-hover table-bordered">
+        <thead>
+        <tr>
+          <th scope="col">{{messagePrefix + '.table.id' | translate}}</th>
+          <th scope="col">{{messagePrefix + '.table.name' | translate}}</th>
+          <th>{{messagePrefix + '.table.edit' | translate}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let group of (groups | async)?.payload?.page">
+          <td>{{group.id}}</td>
+          <td>{{group.name}}</td>
+          <td>
+            <div class="btn-group edit-field">
+              <button *ngIf="(isSubgroupOfGroup(group) | async)"
+                      (click)="deleteSubgroupFromGroup(group)"
+                      class="btn btn-outline-danger btn-sm"
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: group.name} }}">
+                <i class="fas fa-trash-alt fa-fw"></i>
+              </button>
+
+              <button *ngIf="!(isSubgroupOfGroup(group) | async)"
+                      (click)="addSubgroupToGroup(group)"
+                      class="btn btn-outline-primary btn-sm"
+                      title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: group.name} }}">
+                <i class="fas fa-plus fa-fw"></i>
+              </button>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </ds-pagination>
+
+  <div *ngIf="(groups | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2" role="alert">
+    {{messagePrefix + '.no-subgroups-yet' | translate}}
+    <button (click)="search({query: ''})" class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
+  </div>
+
+  <div *ngIf="(groups | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2" role="alert">
+    {{messagePrefix + '.no-items' | translate}}
+  </div>
+
+</ng-container>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
@@ -16,12 +16,12 @@
   </form>
 
   <ds-pagination *ngIf="(groups | async)?.payload.totalElements > 0"
-    [paginationOptions]="config"
-    [pageInfoState]="(groups | async)?.payload"
-    [collectionSize]="(groups | async)?.payload?.totalElements"
-    [hideGear]="true"
-    [hidePagerWhenSinglePage]="true"
-    (pageChange)="onPageChange($event)">
+                 [paginationOptions]="config"
+                 [pageInfoState]="(groups | async)?.payload"
+                 [collectionSize]="(groups | async)?.payload?.totalElements"
+                 [hideGear]="true"
+                 [hidePagerWhenSinglePage]="true"
+                 (pageChange)="onPageChange($event)">
 
     <div class="table-responsive">
       <table id="groups" class="table table-striped table-hover table-bordered">
@@ -35,7 +35,8 @@
         <tbody>
         <tr *ngFor="let group of (groups | async)?.payload?.page">
           <td>{{group.id}}</td>
-          <td>{{group.name}}</td>
+          <td><a (click)="groupDataService.startEditingNewGroup(group)"
+                 [routerLink]="[groupDataService.getGroupEditPageRouterLink(group)]">{{group.name}}</a></td>
           <td>
             <div class="btn-group edit-field">
               <button *ngIf="(isSubgroupOfGroup(group) | async)"
@@ -60,12 +61,15 @@
 
   </ds-pagination>
 
-  <div *ngIf="(groups | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2" role="alert">
+  <div *ngIf="(groups | async)?.payload.totalElements == 0 && !searchDone" class="alert alert-info w-100 mb-2"
+       role="alert">
     {{messagePrefix + '.no-subgroups-yet' | translate}}
-    <button (click)="search({query: ''})" class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
+    <button (click)="search({query: ''})"
+            class="btn btn-primary">{{messagePrefix + '.button.see-all' | translate}}</button>
   </div>
 
-  <div *ngIf="(groups | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2" role="alert">
+  <div *ngIf="(groups | async)?.payload.totalElements == 0 && searchDone" class="alert alert-info w-100 mb-2"
+       role="alert">
     {{messagePrefix + '.no-items' | translate}}
   </div>
 

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
@@ -42,14 +42,16 @@
                  [routerLink]="[groupDataService.getGroupEditPageRouterLink(group)]">{{group.name}}</a></td>
           <td>
             <div class="btn-group edit-field">
-              <button *ngIf="(isSubgroupOfGroup(group) | async)"
+              <button *ngIf="(isSubgroupOfGroup(group) | async) && !(isActiveGroup(group) | async)"
                       (click)="deleteSubgroupFromGroup(group)"
                       class="btn btn-outline-danger btn-sm deleteButton"
                       title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: group.name} }}">
                 <i class="fas fa-trash-alt fa-fw"></i>
               </button>
 
-              <button *ngIf="!(isSubgroupOfGroup(group) | async)"
+              <p *ngIf="(isActiveGroup(group) | async)">{{ messagePrefix + '.table.edit.currentGroup' | translate }}</p>
+
+              <button *ngIf="!(isSubgroupOfGroup(group) | async) && !(isActiveGroup(group) | async)"
                       (click)="addSubgroupToGroup(group)"
                       class="btn btn-outline-primary btn-sm addButton"
                       title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: group.name} }}">

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.spec.ts
@@ -1,0 +1,177 @@
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { RestResponse } from '../../../../../core/cache/response.models';
+import { PaginatedList } from '../../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../../core/data/remote-data';
+import { GroupDataService } from '../../../../../core/eperson/group-data.service';
+import { Group } from '../../../../../core/eperson/models/group.model';
+import { PageInfo } from '../../../../../core/shared/page-info.model';
+import { FormBuilderService } from '../../../../../shared/form/builder/form-builder.service';
+import { getMockFormBuilderService } from '../../../../../shared/mocks/mock-form-builder-service';
+import { getMockTranslateService } from '../../../../../shared/mocks/mock-translate.service';
+import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
+import { GroupMock, GroupMock2 } from '../../../../../shared/testing/group-mock';
+import { MockTranslateLoader } from '../../../../../shared/testing/mock-translate-loader';
+import { NotificationsServiceStub } from '../../../../../shared/testing/notifications-service-stub';
+import { of as observableOf } from 'rxjs';
+import { createSuccessfulRemoteDataObject$ } from '../../../../../shared/testing/utils';
+import { SubgroupsListComponent } from './subgroups-list.component';
+
+describe('SubgroupsListComponent', () => {
+  let component: SubgroupsListComponent;
+  let fixture: ComponentFixture<SubgroupsListComponent>;
+  let translateService: TranslateService;
+  let builderService: FormBuilderService;
+  let ePersonDataServiceStub: any;
+  let groupsDataServiceStub: any;
+  let activeGroup;
+  let allGroups;
+
+  beforeEach(async(() => {
+    activeGroup = GroupMock;
+    allGroups = [GroupMock, GroupMock2]
+    ePersonDataServiceStub = {};
+    groupsDataServiceStub = {
+      activeGroup: activeGroup,
+      getActiveGroup(): Observable<Group> {
+        return observableOf(this.activeGroup);
+      },
+      findAllByHref(href: string): Observable<RemoteData<PaginatedList<Group>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList<Group>(new PageInfo(), this.activeGroup.subgroups))
+      },
+      getGroupEditPageRouterLink(group: Group): string {
+        return '/admin/access-control/groups/' + group.id;
+      },
+      searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
+        if (query === '') {
+          return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), allGroups))
+        }
+        return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), []))
+      },
+      addSubGroupToGroup(parentGroup, subgroup: Group): Observable<RestResponse> {
+        this.activeGroup.subgroups = [...this.activeGroup.subgroups, subgroup];
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      },
+      clearGroupsRequests() {
+        // empty
+      },
+      deleteSubGroupFromGroup(parentGroup, subgroup: Group): Observable<RestResponse>  {
+        this.activeGroup.subgroups = this.activeGroup.subgroups.find((group: Group) => {
+          if (group.id !== subgroup.id) {
+            return group;
+          }
+        });
+        return observableOf(new RestResponse(true, 200, 'Success'));
+      }
+    };
+    builderService = getMockFormBuilderService();
+    translateService = getMockTranslateService();
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [SubgroupsListComponent],
+      providers: [SubgroupsListComponent,
+        { provide: GroupDataService, useValue: groupsDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: FormBuilderService, useValue: builderService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubgroupsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create SubgroupsListComponent', inject([SubgroupsListComponent], (comp: SubgroupsListComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  it('should show list of subgroups of current active group', () => {
+    const groupIdsFound = fixture.debugElement.queryAll(By.css('#groups tr td:first-child'));
+    expect(groupIdsFound.length).toEqual(1);
+    activeGroup.subgroups.map((group: Group) => {
+      expect(groupIdsFound.find((foundEl) => {
+        return (foundEl.nativeElement.textContent.trim() === group.uuid);
+      })).toBeTruthy();
+    })
+  });
+
+  describe('search', () => {
+    describe('when searching without query', () => {
+      let groupsFound;
+      beforeEach(fakeAsync(() => {
+        component.search({ query: '' });
+        tick();
+        fixture.detectChanges();
+        groupsFound = fixture.debugElement.queryAll(By.css('#groups tbody tr'));
+      }));
+
+      it('should display all groups', () => {
+        expect(groupsFound.length).toEqual(2);
+      });
+
+      describe('if group is already a subgroup', () => {
+        it('should have delete button, else it should have add button', () => {
+          activeGroup.subgroups.map((group: Group) => {
+            groupsFound.map((foundGroupRowElement) => {
+              if (foundGroupRowElement.debugElement !== undefined) {
+                const groupId = foundGroupRowElement.debugElement.query(By.css('td:first-child'));
+                const addButton = foundGroupRowElement.debugElement.query(By.css('td:last-child .fa-plus'));
+                const deleteButton = foundGroupRowElement.debugElement.query(By.css('td:last-child .fa-trash-alt'));
+                if (groupId.nativeElement.textContent === group.id) {
+                  expect(addButton).toBeUndefined();
+                  expect(deleteButton).toBeDefined();
+                } else {
+                  expect(deleteButton).toBeUndefined();
+                  expect(addButton).toBeDefined();
+                }
+              }
+            })
+          })
+        });
+      });
+
+      describe('if first add button is pressed', () => {
+        beforeEach(fakeAsync(() => {
+          const addButton = fixture.debugElement.query(By.css('#groups tbody .fa-plus'));
+          addButton.nativeElement.click();
+          tick();
+          fixture.detectChanges();
+        }));
+        it('one more subgroup in list (from 1 to 2 total groups)', () => {
+          groupsFound = fixture.debugElement.queryAll(By.css('#groups tbody tr'));
+          expect(groupsFound.length).toEqual(2);
+        });
+      });
+
+      describe('if first delete button is pressed', () => {
+        beforeEach(fakeAsync(() => {
+          const addButton = fixture.debugElement.query(By.css('#groups tbody .fa-trash-alt'));
+          addButton.nativeElement.click();
+          tick();
+          fixture.detectChanges();
+        }));
+        it('one less subgroup in list from 1 to 0 (of 2 total groups)', () => {
+          groupsFound = fixture.debugElement.queryAll(By.css('#groups tbody tr'));
+          expect(groupsFound.length).toEqual(0);
+        });
+      });
+    });
+  });
+
+});

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -123,7 +123,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     this.groupDataService.getActiveGroup().pipe(take(1)).subscribe((activeGroup: Group) => {
       if (activeGroup != null) {
         const response = this.groupDataService.deleteSubGroupFromGroup(activeGroup, subgroup);
-        this.showNotifications('addSubgroup', response, subgroup.name, activeGroup);
+        this.showNotifications('deleteSubgroup', response, subgroup.name, activeGroup);
         this.forceUpdateGroups(activeGroup);
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.noActiveGroup'));
@@ -139,7 +139,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     this.groupDataService.getActiveGroup().pipe(take(1)).subscribe((activeGroup: Group) => {
       if (activeGroup != null) {
         const response = this.groupDataService.addSubGroupToGroup(activeGroup, subgroup);
-        this.showNotifications('deleteSubgroup', response, subgroup.name, activeGroup);
+        this.showNotifications('addSubgroup', response, subgroup.name, activeGroup);
         this.forceUpdateGroups(activeGroup);
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.noActiveGroup'));

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -62,7 +62,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subs.push(this.groupDataService.getActiveGroup().subscribe((group: Group) => {
       if (group != null) {
-        this.groups = this.groupDataService.findAllByHref(group._links.groups.href, {
+        this.groups = this.groupDataService.findAllByHref(group._links.subgroups.href, {
           currentPage: 1,
           elementsPerPage: this.config.pageSize
         })
@@ -100,7 +100,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     return this.groupDataService.getActiveGroup().pipe(take(1),
       mergeMap((group: Group) => {
         if (group != null) {
-          return this.groupDataService.findAllByHref(group._links.groups.href, {
+          return this.groupDataService.findAllByHref(group._links.subgroups.href, {
             currentPage: 0,
             elementsPerPage: Number.MAX_SAFE_INTEGER
           })
@@ -157,7 +157,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     this.groups = this.groupDataService.searchGroups(query.trim(), {
       currentPage: 1,
       elementsPerPage: this.config.pageSize
-    }, followLink('epersons'));
+    });
   }
 
   /**
@@ -166,7 +166,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
    */
   public forceUpdateGroups(activeGroup: Group) {
     this.groupDataService.clearGroupsRequests();
-    this.groups = this.groupDataService.findAllByHref(activeGroup._links.groups.href, {
+    this.groups = this.groupDataService.findAllByHref(activeGroup._links.subgroups.href, {
       currentPage: 1,
       elementsPerPage: this.config.pageSize
     })

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -130,7 +130,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
                 map((listTotalGroups: PaginatedList<Group>) => listTotalGroups.page.filter((groupInList: Group) => groupInList.id === possibleSubgroup.id)),
                 map((groups: Group[]) => groups.length > 0))
           }
-        } else  {
+        } else {
           return observableOf(false);
         }
       }));
@@ -144,7 +144,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     return this.groupDataService.getActiveGroup().pipe(take(1),
       mergeMap((activeGroup: Group) => {
         if (activeGroup != null && activeGroup.uuid === group.uuid) {
-            return observableOf(true);
+          return observableOf(true);
         }
         return observableOf(false);
       }));
@@ -176,7 +176,6 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
         if (activeGroup.uuid !== subgroup.uuid) {
           const response = this.groupDataService.addSubGroupToGroup(activeGroup, subgroup);
           this.showNotifications('addSubgroup', response, subgroup.name, activeGroup);
-          this.forceUpdateGroups(activeGroup);
         } else {
           this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.subgroupToAddIsActiveGroup'));
         }
@@ -184,6 +183,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.noActiveGroup'));
       }
     });
+    this.forceUpdateGroups(this.groupBeingEdited);
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -169,7 +169,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
     this.groups = this.groupDataService.findAllByHref(activeGroup._links.subgroups.href, {
       currentPage: 1,
       elementsPerPage: this.config.pageSize
-    })
+    });
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -1,0 +1,149 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable, of as observableOf, Subscription } from 'rxjs';
+import { map, mergeMap, take } from 'rxjs/operators';
+import { PaginatedList } from '../../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../../core/data/remote-data';
+import { GroupDataService } from '../../../../../core/eperson/group-data.service';
+import { Group } from '../../../../../core/eperson/models/group.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../../core/shared/operators';
+import { hasValue } from '../../../../../shared/empty.util';
+import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../../../../shared/pagination/pagination-component-options.model';
+import { followLink } from '../../../../../shared/utils/follow-link-config.model';
+
+@Component({
+  selector: 'ds-subgroups-list',
+  templateUrl: './subgroups-list.component.html'
+})
+/**
+ * The list of subgroups in the edit group page
+ */
+export class SubgroupsListComponent implements OnInit, OnDestroy {
+
+  @Input()
+  messagePrefix: string;
+
+  groups: Observable<RemoteData<PaginatedList<Group>>>;
+
+  /**
+   * List of subscriptions
+   */
+  subs: Subscription[] = [];
+
+  /**
+   * Pagination config used to display the list of subgroups
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'subgroups-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  // The search form
+  searchForm;
+
+  /**
+   * Whether or not user has done a search yet
+   */
+  searchDone: boolean;
+
+  constructor(public groupDataService: GroupDataService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private formBuilder: FormBuilder) {
+  }
+
+  ngOnInit() {
+    this.subs.push(this.groupDataService.getActiveGroup().subscribe((group: Group) => {
+      if (group != null) {
+        this.groups = this.groupDataService.findAllByHref(group._links.groups.href, {
+          currentPage: 1,
+          elementsPerPage: this.config.pageSize
+        })
+      }
+    }));
+    this.searchForm = this.formBuilder.group(({
+      query: '',
+    }));
+    this.searchDone = false;
+  }
+
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateSubgroups({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Update the list of subgroups by fetching it from the rest api or cache
+   */
+  private updateSubgroups(options) {
+    this.groups = this.groupDataService.getGroups(options);
+  }
+
+  isSubgroupOfGroup(possibleSubgroup: Group): Observable<boolean> {
+    return this.groupDataService.getActiveGroup().pipe(take(1),
+      mergeMap((group: Group) => {
+        if (group != null) {
+          return this.groupDataService.findAllByHref(group._links.groups.href, {
+            currentPage: 0,
+            elementsPerPage: Number.MAX_SAFE_INTEGER
+          })
+            .pipe(
+              getSucceededRemoteData(),
+              getRemoteDataPayload(),
+              map((listTotalGroups: PaginatedList<Group>) => listTotalGroups.page.filter((groupInList: Group) => groupInList.id === possibleSubgroup.id)),
+              map((groups: Group[]) => groups.length > 0))
+        } else {
+          return observableOf(false);
+        }
+      }))
+  }
+
+  deleteSubgroupFromGroup(group: Group) {
+    // TODO
+    console.log('deleteSubgroup TODO', group);
+    // this.forceUpdateGroup();
+  }
+
+  addSubgroupToGroup(group: Group) {
+    // TODO
+    console.log('addSubgroup TODO', group);
+    // this.forceUpdateGroup();
+  }
+
+  /**
+   * Search in the groups (searches by group name and by uuid exact match)
+   * @param data  Contains query param
+   */
+  search(data: any) {
+    this.searchDone = true;
+    const query: string = data.query;
+    this.groups = this.groupDataService.searchGroups(query.trim(), {
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    }, followLink('epersons'));
+  }
+
+  /**
+   * Force-update the list of groups by first clearing the cache related to groups, then performing a new REST call
+   */
+  public forceUpdateGroup() {
+    this.groupDataService.clearGroupsRequests();
+    this.search({ query: '' })
+  }
+
+  /**
+   * unsub all subscriptions
+   */
+  ngOnDestroy(): void {
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
+  }
+}

--- a/src/app/+admin/admin-access-control/group-registry/group-registry.actions.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-registry.actions.ts
@@ -1,0 +1,49 @@
+import { Action } from '@ngrx/store';
+import { Group } from '../../../core/eperson/models/group.model';
+import { type } from '../../../shared/ngrx/type';
+
+/**
+ * For each action type in an action group, make a simple
+ * enum object for all of this group's action types.
+ *
+ * The 'type' utility function coerces strings into string
+ * literal types and runs a simple check to guarantee all
+ * action types in the application are unique.
+ */
+export const GroupRegistryActionTypes = {
+
+  EDIT_GROUP: type('dspace/epeople-registry/EDIT_GROUP'),
+  CANCEL_EDIT_GROUP: type('dspace/epeople-registry/CANCEL_EDIT_GROUP'),
+};
+
+/* tslint:disable:max-classes-per-file */
+/**
+ * Used to edit a Group in the Group registry
+ */
+export class GroupRegistryEditGroupAction implements Action {
+  type = GroupRegistryActionTypes.EDIT_GROUP;
+
+  group: Group;
+
+  constructor(group: Group) {
+    this.group = group;
+  }
+}
+
+/**
+ * Used to cancel the editing of a Group in the Group registry
+ */
+export class GroupRegistryCancelGroupAction implements Action {
+  type = GroupRegistryActionTypes.CANCEL_EDIT_GROUP;
+}
+
+/* tslint:enable:max-classes-per-file */
+
+/**
+ * Export a type alias of all actions in this action group
+ * so that reducers can easily compose action types
+ * These are all the actions to perform on the EPeople registry state
+ */
+export type GroupRegistryAction
+  = GroupRegistryEditGroupAction
+  | GroupRegistryCancelGroupAction

--- a/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.spec.ts
@@ -1,0 +1,54 @@
+import { GroupMock } from '../../../shared/testing/group-mock';
+import { GroupRegistryCancelGroupAction, GroupRegistryEditGroupAction } from './group-registry.actions';
+import { groupRegistryReducer, GroupRegistryState } from './group-registry.reducers';
+
+const initialState: GroupRegistryState = {
+  editGroup: null,
+};
+
+const editState: GroupRegistryState = {
+  editGroup: GroupMock,
+};
+
+class NullAction extends GroupRegistryEditGroupAction {
+  type = null;
+
+  constructor() {
+    super(undefined);
+  }
+}
+
+describe('groupRegistryReducer', () => {
+
+  it('should return the current state when no valid actions have been made', () => {
+    const state = initialState;
+    const action = new NullAction();
+    const newState = groupRegistryReducer(state, action);
+
+    expect(newState).toEqual(state);
+  });
+
+  it('should start with an initial state', () => {
+    const state = initialState;
+    const action = new NullAction();
+    const initState = groupRegistryReducer(undefined, action);
+
+    expect(initState).toEqual(state);
+  });
+
+  it('should update the current state to change the editGroup to a new group when GroupRegistryEditGroupAction is dispatched', () => {
+    const state = editState;
+    const action = new GroupRegistryEditGroupAction(GroupMock);
+    const newState = groupRegistryReducer(state, action);
+
+    expect(newState.editGroup).toEqual(GroupMock);
+  });
+
+  it('should update the current state to remove the editGroup from the state when GroupRegistryCancelGroupAction is dispatched', () => {
+    const state = editState;
+    const action = new GroupRegistryCancelGroupAction();
+    const newState = groupRegistryReducer(state, action);
+
+    expect(newState.editGroup).toEqual(null);
+  });
+});

--- a/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.ts
@@ -1,0 +1,45 @@
+import { Group } from '../../../core/eperson/models/group.model';
+import { GroupRegistryAction, GroupRegistryActionTypes, GroupRegistryEditGroupAction } from './group-registry.actions';
+
+/**
+ * The metadata registry state.
+ * @interface GroupRegistryState
+ */
+export interface GroupRegistryState {
+  editGroup: Group;
+  selectedGroup: Group[];
+}
+
+/**
+ * The initial state.
+ */
+const initialState: GroupRegistryState = {
+  editGroup: null,
+  selectedGroup: [],
+};
+
+/**
+ * Reducer that handles GroupRegistryActions to modify Groups
+ * @param state   The current GroupRegistryState
+ * @param action  The GroupRegistryAction to perform on the state
+ */
+export function groupRegistryReducer(state = initialState, action: GroupRegistryAction): GroupRegistryState {
+
+  switch (action.type) {
+
+    case GroupRegistryActionTypes.EDIT_GROUP: {
+      return Object.assign({}, state, {
+        editGroup: (action as GroupRegistryEditGroupAction).group
+      });
+    }
+
+    case GroupRegistryActionTypes.CANCEL_EDIT_GROUP: {
+      return Object.assign({}, state, {
+        editGroup: null
+      });
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-registry.reducers.ts
@@ -7,7 +7,6 @@ import { GroupRegistryAction, GroupRegistryActionTypes, GroupRegistryEditGroupAc
  */
 export interface GroupRegistryState {
   editGroup: Group;
-  selectedGroup: Group[];
 }
 
 /**
@@ -15,7 +14,6 @@ export interface GroupRegistryState {
  */
 const initialState: GroupRegistryState = {
   editGroup: null,
-  selectedGroup: [],
 };
 
 /**

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
@@ -50,7 +50,7 @@
             <tr *ngFor="let group of (groups | async)?.payload?.page">
               <td>{{group.id}}</td>
               <td>{{group.name}}</td>
-              <td>{{(getMembers(group) | async)?.payload?.totalElements}}</td>
+              <td>{{(getMembers(group) | async)?.payload?.totalElements + (getSubgroups(group) | async)?.payload?.totalElements}}</td>
 <!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
               <td>
                 <div class="btn-group edit-field">

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
@@ -12,7 +12,10 @@
         </button>
       </div>
 
-      <h3 id="search" class="border-bottom pb-2">{{messagePrefix + 'search.head' | translate}}</h3>
+      <h3 id="search" class="border-bottom pb-2">{{messagePrefix + 'search.head' | translate}}
+        <button (click)="clearFormAndResetResult();"
+                class="btn btn-primary float-right">{{messagePrefix + 'button.see-all' | translate}}</button>
+      </h3>
       <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
         <div class="col-12">
           <div class="form-group input-group">
@@ -42,7 +45,7 @@
               <th scope="col">{{messagePrefix + 'table.id' | translate}}</th>
               <th scope="col">{{messagePrefix + 'table.name' | translate}}</th>
               <th scope="col">{{messagePrefix + 'table.members' | translate}}</th>
-<!--              <th scope="col">{{messagePrefix + 'table.comcol' | translate}}</th>-->
+              <!--              <th scope="col">{{messagePrefix + 'table.comcol' | translate}}</th>-->
               <th>{{messagePrefix + 'table.edit' | translate}}</th>
             </tr>
             </thead>
@@ -51,16 +54,17 @@
               <td>{{group.id}}</td>
               <td>{{group.name}}</td>
               <td>{{(getMembers(group) | async)?.payload?.totalElements + (getSubgroups(group) | async)?.payload?.totalElements}}</td>
-<!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
+              <!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
               <td>
                 <div class="btn-group edit-field">
-                  <button [routerLink]="groupService.getGroupEditPageRouterLink(group)" class="btn btn-outline-primary btn-sm"
-                          title="{{messagePrefix + 'table.edit.buttons.edit' | translate}}">
+                  <button [routerLink]="groupService.getGroupEditPageRouterLink(group)"
+                          class="btn btn-outline-primary btn-sm"
+                          title="{{messagePrefix + 'table.edit.buttons.edit' | translate: {name: group.name} }}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
-                  <button (click)="deleteGroup(group)"
+                  <button *ngIf="!group?.permanent" (click)="deleteGroup(group)"
                           class="btn btn-outline-danger btn-sm"
-                          title="{{messagePrefix + 'table.edit.buttons.remove' | translate}}">
+                          title="{{messagePrefix + 'table.edit.buttons.remove' | translate: {name: group.name} }}">
                     <i class="fas fa-trash-alt fa-fw"></i>
                   </button>
                 </div>
@@ -69,7 +73,6 @@
             </tbody>
           </table>
         </div>
-
       </ds-pagination>
 
       <div *ngIf="(groups | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
@@ -1,0 +1,81 @@
+<div class="container">
+  <div class="groups-registry row">
+    <div class="col-12">
+
+      <h2 id="header" class="border-bottom pb-2">{{messagePrefix + 'head' | translate}}</h2>
+
+      <div class="button-row top d-flex pb-2">
+        <button class="mr-auto btn btn-success"
+                [routerLink]="['newGroup']">
+          <i class="fas fa-plus"></i>
+          <span class="d-none d-sm-inline">&nbsp;{{messagePrefix + 'button.add' | translate}}</span>
+        </button>
+      </div>
+
+      <h3 id="search" class="border-bottom pb-2">{{messagePrefix + 'search.head' | translate}}</h3>
+      <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
+        <div class="col-12">
+          <div class="form-group input-group">
+            <input type="text" name="query" id="query" formControlName="query"
+                   class="form-control" aria-label="Search input">
+            <span class="input-group-append">
+            <button type="submit"
+                    class="search-button btn btn-secondary">{{ messagePrefix + 'search.button' | translate }}</button>
+        </span>
+          </div>
+        </div>
+      </form>
+
+      <ds-pagination
+        *ngIf="(groups | async)?.payload?.totalElements > 0"
+        [paginationOptions]="config"
+        [pageInfoState]="(groups | async)?.payload"
+        [collectionSize]="(groups | async)?.payload?.totalElements"
+        [hideGear]="true"
+        [hidePagerWhenSinglePage]="true"
+        (pageChange)="onPageChange($event)">
+
+        <div class="table-responsive">
+          <table id="groups" class="table table-striped table-hover table-bordered">
+            <thead>
+            <tr>
+              <th scope="col">{{messagePrefix + 'table.id' | translate}}</th>
+              <th scope="col">{{messagePrefix + 'table.name' | translate}}</th>
+              <th scope="col">{{messagePrefix + 'table.members' | translate}}</th>
+<!--              <th scope="col">{{messagePrefix + 'table.comcol' | translate}}</th>-->
+              <th>{{messagePrefix + 'table.edit' | translate}}</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let group of (groups | async)?.payload?.page">
+              <td>{{group.id}}</td>
+              <td>{{group.name}}</td>
+              <td>{{(getMembers(group) | async)?.payload?.totalElements}}</td>
+<!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
+              <td>
+                <div class="btn-group edit-field">
+                  <button [routerLink]="[group.id]" class="btn btn-outline-primary btn-sm"
+                          title="{{messagePrefix + 'table.edit.buttons.edit' | translate}}">
+                    <i class="fas fa-edit fa-fw"></i>
+                  </button>
+                  <button (click)="deleteGroup(group)"
+                          class="btn btn-outline-danger btn-sm"
+                          title="{{messagePrefix + 'table.edit.buttons.remove' | translate}}">
+                    <i class="fas fa-trash-alt fa-fw"></i>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+
+      </ds-pagination>
+
+      <div *ngIf="(groups | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">
+        {{messagePrefix + 'no-items' | translate}}
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
@@ -54,7 +54,7 @@
 <!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
               <td>
                 <div class="btn-group edit-field">
-                  <button [routerLink]="[group.id]" class="btn btn-outline-primary btn-sm"
+                  <button [routerLink]="groupService.getGroupEditPageRouterLink(group)" class="btn btn-outline-primary btn-sm"
                           title="{{messagePrefix + 'table.edit.buttons.edit' | translate}}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.spec.ts
@@ -3,6 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs/internal/Observable';
@@ -12,12 +13,15 @@ import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
 import { Group } from '../../../core/eperson/models/group.model';
+import { RouteService } from '../../../core/services/route.service';
 import { PageInfo } from '../../../core/shared/page-info.model';
+import { MockRouter } from '../../../shared/mocks/mock-router';
 import { MockTranslateLoader } from '../../../shared/mocks/mock-translate-loader';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson-mock';
 import { GroupMock, GroupMock2 } from '../../../shared/testing/group-mock';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service-stub';
+import { routeServiceStub } from '../../../shared/testing/route-service-stub';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
 import { GroupsRegistryComponent } from './groups-registry.component';
 
@@ -47,9 +51,6 @@ describe('GroupRegistryComponent', () => {
     };
     groupsDataServiceStub = {
       allGroups: mockGroups,
-      getGroups(): Observable<RemoteData<PaginatedList<Group>>> {
-        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allGroups));
-      },
       findAllByHref(href: string): Observable<RemoteData<PaginatedList<Group>>> {
         switch (href) {
           case 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/groups':
@@ -63,7 +64,13 @@ describe('GroupRegistryComponent', () => {
       getGroupEditPageRouterLink(group: Group): string {
         return '/admin/access-control/groups/' + group.id;
       },
+      getGroupRegistryRouterLink(): string {
+        return '/admin/access-control/groups';
+      },
       searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
+        if (query === '') {
+          return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allGroups));
+        }
         const result = this.allGroups.find((group: Group) => {
           return (group.id.includes(query))
         });
@@ -84,6 +91,8 @@ describe('GroupRegistryComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: GroupDataService, useValue: groupsDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: RouteService, useValue: routeServiceStub },
+        { provide: Router, useValue: new MockRouter() },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.spec.ts
@@ -1,0 +1,130 @@
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule, By } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { PaginatedList } from '../../../core/data/paginated-list';
+import { RemoteData } from '../../../core/data/remote-data';
+import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../core/eperson/group-data.service';
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { Group } from '../../../core/eperson/models/group.model';
+import { PageInfo } from '../../../core/shared/page-info.model';
+import { MockTranslateLoader } from '../../../shared/mocks/mock-translate-loader';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson-mock';
+import { GroupMock, GroupMock2 } from '../../../shared/testing/group-mock';
+import { NotificationsServiceStub } from '../../../shared/testing/notifications-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../../shared/testing/utils';
+import { GroupsRegistryComponent } from './groups-registry.component';
+
+describe('GroupRegistryComponent', () => {
+  let component: GroupsRegistryComponent;
+  let fixture: ComponentFixture<GroupsRegistryComponent>;
+  let ePersonDataServiceStub: any;
+  let groupsDataServiceStub: any;
+
+  let mockGroups;
+  let mockEPeople;
+
+  beforeEach(async(() => {
+    mockGroups = [GroupMock, GroupMock2];
+    mockEPeople = [EPersonMock, EPersonMock2];
+    ePersonDataServiceStub = {
+      findAllByHref(href: string): Observable<RemoteData<PaginatedList<EPerson>>> {
+        switch (href) {
+          case 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/epersons':
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, []));
+          case 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/epersons':
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, [EPersonMock]));
+          default:
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, []));
+        }
+      }
+    };
+    groupsDataServiceStub = {
+      allGroups: mockGroups,
+      getGroups(): Observable<RemoteData<PaginatedList<Group>>> {
+        return createSuccessfulRemoteDataObject$(new PaginatedList(null, this.allGroups));
+      },
+      findAllByHref(href: string): Observable<RemoteData<PaginatedList<Group>>> {
+        switch (href) {
+          case 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/groups':
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, []));
+          case 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/groups':
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, [GroupMock2]));
+          default:
+            return createSuccessfulRemoteDataObject$(new PaginatedList(null, []));
+        }
+      },
+      getGroupEditPageRouterLink(group: Group): string {
+        return '/admin/access-control/groups/' + group.id;
+      },
+      searchGroups(query: string): Observable<RemoteData<PaginatedList<Group>>> {
+        const result = this.allGroups.find((group: Group) => {
+          return (group.id.includes(query))
+        });
+        return createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [result]));
+      }
+    };
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [GroupsRegistryComponent],
+      providers: [GroupsRegistryComponent,
+        { provide: EPersonDataService, useValue: ePersonDataServiceStub },
+        { provide: GroupDataService, useValue: groupsDataServiceStub },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupsRegistryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create GroupRegistryComponent', inject([GroupsRegistryComponent], (comp: GroupsRegistryComponent) => {
+    expect(comp).toBeDefined();
+  }));
+
+  it('should display list of groups', () => {
+    const groupIdsFound = fixture.debugElement.queryAll(By.css('#groups tr td:first-child'));
+    expect(groupIdsFound.length).toEqual(2);
+    mockGroups.map((group: Group) => {
+      expect(groupIdsFound.find((foundEl) => {
+        return (foundEl.nativeElement.textContent.trim() === group.uuid);
+      })).toBeTruthy();
+    })
+  });
+
+  describe('search', () => {
+    describe('when searching with query', () => {
+      let groupIdsFound;
+      beforeEach(fakeAsync(() => {
+        component.search({ query: GroupMock2.id });
+        tick();
+        fixture.detectChanges();
+        groupIdsFound = fixture.debugElement.queryAll(By.css('#groups tr td:first-child'));
+      }));
+
+      it('should display search result', () => {
+        expect(groupIdsFound.length).toEqual(1);
+        expect(groupIdsFound.find((foundEl) => {
+          return (foundEl.nativeElement.textContent.trim() === GroupMock2.uuid);
+        })).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -1,0 +1,135 @@
+import { Component } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { PaginatedList } from '../../../core/data/paginated-list';
+import { RemoteData } from '../../../core/data/remote-data';
+import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../../core/eperson/group-data.service';
+import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { Group } from '../../../core/eperson/models/group.model';
+import { hasValue } from '../../../shared/empty.util';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../../shared/pagination/pagination-component-options.model';
+import { followLink } from '../../../shared/utils/follow-link-config.model';
+
+@Component({
+  selector: 'ds-groups-registry',
+  templateUrl: './groups-registry.component.html',
+})
+/**
+ * A component used for managing all existing groups within the repository.
+ * The admin can create, edit or delete groups here.
+ */
+export class GroupsRegistryComponent {
+
+  messagePrefix = 'admin.access-control.groups.';
+
+  /**
+   * Pagination config used to display the list of groups
+   */
+  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'groups-list-pagination',
+    pageSize: 5,
+    currentPage: 1
+  });
+
+  /**
+   * A list of all the current groups within the repository or the result of the search
+   */
+  groups: Observable<RemoteData<PaginatedList<Group>>>;
+
+  // The search form
+  searchForm;
+
+  constructor(private groupService: GroupDataService,
+              private ePersonDataService: EPersonDataService,
+              private translateService: TranslateService,
+              private notificationsService: NotificationsService,
+              private formBuilder: FormBuilder) {
+    this.updateGroups({
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    });
+    this.searchForm = this.formBuilder.group(({
+      query: '',
+    }));
+  }
+
+  /**
+   * Event triggered when the user changes page
+   * @param event
+   */
+  onPageChange(event) {
+    this.updateGroups({
+      currentPage: event,
+      elementsPerPage: this.config.pageSize
+    });
+  }
+
+  /**
+   * Update the list of groups by fetching it from the rest api or cache
+   */
+  private updateGroups(options) {
+    this.groups = this.groupService.getGroups(options, followLink('epersons'));
+  }
+
+  /**
+   * Search in the groups (searches by group name and by uuid exact match)
+   * @param data  Contains query param
+   */
+  search(data: any) {
+    const query: string = data.query;
+    this.groups = this.groupService.searchGroups(query.trim(), {
+      currentPage: 1,
+      elementsPerPage: this.config.pageSize
+    }, followLink('epersons'));
+  }
+
+  /**
+   * Delete Group
+   */
+  deleteGroup(group: Group) {
+    if (hasValue(group.id)) {
+      this.groupService.deleteGroup(group).pipe(take(1)).subscribe((success: boolean) => {
+        if (success) {
+          this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: group.name }));
+          this.forceUpdateGroup();
+        } else {
+          this.notificationsService.error(this.translateService.get(this.messagePrefix + 'notification.deleted.failure', { name: group.name }));
+        }
+      })
+    }
+  }
+
+  /**
+   * Force-update the list of groups by first clearing the cache related to groups, then performing a new REST call
+   */
+  public forceUpdateGroup() {
+    this.groupService.clearGroupsRequests();
+    this.search({ query: '' })
+  }
+
+  /**
+   * Get the amount of members (epersons embedded value of a group) //TODO
+   * @param group
+   */
+  getMembers(group: Group): Observable<RemoteData<PaginatedList<EPerson>>> {
+    return this.ePersonDataService.findAllByHref(group._links.epersons.href);
+  }
+
+  /**
+   * Extract optional UUID from a group name => To be resolved to community or collection with link
+   * (Or will be resolved in backend and added to group object, tbd) //TODO
+   * @param groupName
+   */
+  getOptionalComColFromName(groupName: string): string {
+    let optionalComColName = '';
+    const uuidMatches = groupName.match(/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g);
+    if (uuidMatches != null) {
+      optionalComColName = uuidMatches[0];
+    }
+    return optionalComColName;
+  }
+}

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -149,11 +149,6 @@ export class GroupsRegistryComponent implements OnInit {
    * @param groupName
    */
   getOptionalComColFromName(groupName: string): string {
-    let optionalComColName = '';
-    const uuidMatches = groupName.match(/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g);
-    if (uuidMatches != null) {
-      optionalComColName = uuidMatches[0];
-    }
-    return optionalComColName;
+    return this.groupService.getUUIDFromString(groupName);
   }
 }

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -91,6 +91,9 @@ export class GroupsRegistryComponent {
    * Delete Group
    */
   deleteGroup(group: Group) {
+    // TODO (backend)
+    console.log('TODO implement editGroup', group);
+    this.notificationsService.error('TODO implement deleteGroup (not yet implemented in backend)');
     if (hasValue(group.id)) {
       this.groupService.deleteGroup(group).pipe(take(1)).subscribe((success: boolean) => {
         if (success) {
@@ -112,7 +115,7 @@ export class GroupsRegistryComponent {
   }
 
   /**
-   * Get the amount of members (epersons embedded value of a group) //TODO
+   * Get the amount of members (epersons embedded value of a group)
    * @param group
    */
   getMembers(group: Group): Observable<RemoteData<PaginatedList<EPerson>>> {

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -22,7 +22,7 @@ import { followLink } from '../../../shared/utils/follow-link-config.model';
  * A component used for managing all existing groups within the repository.
  * The admin can create, edit or delete groups here.
  */
-export class GroupsRegistryComponent {
+export class GroupsRegistryComponent implements OnInit {
 
   messagePrefix = 'admin.access-control.groups.';
 
@@ -48,13 +48,16 @@ export class GroupsRegistryComponent {
               private translateService: TranslateService,
               private notificationsService: NotificationsService,
               private formBuilder: FormBuilder) {
+    this.searchForm = this.formBuilder.group(({
+      query: '',
+    }));
+  }
+
+  ngOnInit() {
     this.updateGroups({
       currentPage: 1,
       elementsPerPage: this.config.pageSize
     });
-    this.searchForm = this.formBuilder.group(({
-      query: '',
-    }));
   }
 
   /**
@@ -72,7 +75,7 @@ export class GroupsRegistryComponent {
    * Update the list of groups by fetching it from the rest api or cache
    */
   private updateGroups(options) {
-    this.groups = this.groupService.getGroups(options, followLink('epersons'));
+    this.groups = this.groupService.getGroups(options, followLink('epersons'), followLink('groups'));
   }
 
   /**
@@ -115,11 +118,19 @@ export class GroupsRegistryComponent {
   }
 
   /**
-   * Get the amount of members (epersons embedded value of a group)
+   * Get the members (epersons embedded value of a group)
    * @param group
    */
   getMembers(group: Group): Observable<RemoteData<PaginatedList<EPerson>>> {
     return this.ePersonDataService.findAllByHref(group._links.epersons.href);
+  }
+
+  /**
+   * Get the subgroups (groups embedded value of a group)
+   * @param group
+   */
+  getSubgroups(group: Group): Observable<RemoteData<PaginatedList<Group>>> {
+    return this.groupService.findAllByHref(group._links.groups.href);
   }
 
   /**

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -75,7 +75,7 @@ export class GroupsRegistryComponent implements OnInit {
    * Update the list of groups by fetching it from the rest api or cache
    */
   private updateGroups(options) {
-    this.groups = this.groupService.getGroups(options, followLink('epersons'), followLink('groups'));
+    this.groups = this.groupService.getGroups(options, followLink('epersons'), followLink('subgroups'));
   }
 
   /**
@@ -87,7 +87,7 @@ export class GroupsRegistryComponent implements OnInit {
     this.groups = this.groupService.searchGroups(query.trim(), {
       currentPage: 1,
       elementsPerPage: this.config.pageSize
-    }, followLink('epersons'));
+    });
   }
 
   /**
@@ -130,7 +130,7 @@ export class GroupsRegistryComponent implements OnInit {
    * @param group
    */
   getSubgroups(group: Group): Observable<RemoteData<PaginatedList<Group>>> {
-    return this.groupService.findAllByHref(group._links.groups.href);
+    return this.groupService.findAllByHref(group._links.subgroups.href);
   }
 
   /**

--- a/src/app/+admin/admin-routing.module.ts
+++ b/src/app/+admin/admin-routing.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { getAdminModulePath } from '../app-routing.module';
-import { URLCombiner } from '../core/url-combiner/url-combiner';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
+import { URLCombiner } from '../core/url-combiner/url-combiner';
 
 const REGISTRIES_MODULE_PATH = 'registries';
 const ACCESS_CONTROL_MODULE_PATH = 'access-control';

--- a/src/app/+admin/admin-routing.module.ts
+++ b/src/app/+admin/admin-routing.module.ts
@@ -1,7 +1,7 @@
-import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
-import { URLCombiner } from '../core/url-combiner/url-combiner';
+import { RouterModule } from '@angular/router';
 import { getAdminModulePath } from '../app-routing.module';
+import { URLCombiner } from '../core/url-combiner/url-combiner';
 import { AdminSearchPageComponent } from './admin-search-page/admin-search-page.component';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 
@@ -28,8 +28,8 @@ export function getRegistriesModulePath() {
         resolve: { breadcrumb: I18nBreadcrumbResolver },
         component: AdminSearchPageComponent,
         data: { title: 'admin.search.title', breadcrumbKey: 'admin.search' }
-      },
-    ])
+      }
+    ]),
   ]
 })
 export class AdminRoutingModule {

--- a/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
@@ -336,7 +336,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         model: {
           type: MenuItemType.LINK,
           text: 'menu.section.access_control_groups',
-          link: ''
+          link: '/admin/access-control/groups'
         } as LinkMenuItemModel,
       },
       {

--- a/src/app/app.reducer.ts
+++ b/src/app/app.reducer.ts
@@ -5,6 +5,10 @@ import {
   EPeopleRegistryState
 } from './+admin/admin-access-control/epeople-registry/epeople-registry.reducers';
 import {
+  groupRegistryReducer,
+  GroupRegistryState
+} from './+admin/admin-access-control/group-registry/group-registry.reducers';
+import {
   metadataRegistryReducer,
   MetadataRegistryState
 } from './+admin/admin-registries/metadata-registry/metadata-registry.reducers';
@@ -47,6 +51,7 @@ export interface AppState {
   relationshipLists: NameVariantListsState;
   communityList: CommunityListState;
   epeopleRegistry: EPeopleRegistryState;
+  groupRegistry: GroupRegistryState;
 }
 
 export const appReducers: ActionReducerMap<AppState> = {
@@ -66,6 +71,7 @@ export const appReducers: ActionReducerMap<AppState> = {
   relationshipLists: nameVariantReducer,
   communityList: CommunityListReducer,
   epeopleRegistry: ePeopleRegistryReducer,
+  groupRegistry: groupRegistryReducer,
 };
 
 export const routerStateSelector = (state: AppState) => state.router;

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -276,6 +276,8 @@ export class ObjectCacheService {
    *     list of operations to perform
    */
   public addPatch(selfLink: string, patch: Operation[]) {
+    console.log('selfLink addPatch', selfLink)
+    console.log('patch addPatch', patch)
     this.store.dispatch(new AddPatchObjectCacheAction(selfLink, patch));
     this.store.dispatch(new AddToSSBAction(selfLink, RestRequestMethod.PATCH));
   }

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -276,8 +276,6 @@ export class ObjectCacheService {
    *     list of operations to perform
    */
   public addPatch(selfLink: string, patch: Operation[]) {
-    console.log('selfLink addPatch', selfLink)
-    console.log('patch addPatch', patch)
     this.store.dispatch(new AddPatchObjectCacheAction(selfLink, patch));
     this.store.dispatch(new AddToSSBAction(selfLink, RestRequestMethod.PATCH));
   }

--- a/src/app/core/data/data.service.spec.ts
+++ b/src/app/core/data/data.service.spec.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { Store } from '@ngrx/store';
 import { compare, Operation } from 'fast-json-patch';
 import { Observable, of as observableOf } from 'rxjs';
-import * as uuidv4 from 'uuid/v4';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';

--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -19,7 +19,6 @@ import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson-mock';
 import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service-stub';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
 import { SearchParam } from '../cache/models/search-param.model';
-import { ObjectCacheService } from '../cache/object-cache.service';
 import { CoreState } from '../core.reducers';
 import { ChangeAnalyzer } from '../data/change-analyzer';
 import { PaginatedList } from '../data/paginated-list';
@@ -39,43 +38,15 @@ describe('EPersonDataService', () => {
   let requestService: RequestService;
   let scheduler: TestScheduler;
 
-  const epeople = [EPersonMock, EPersonMock2];
+  let epeople;
 
-  const restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
-  const epersonsEndpoint = `${restEndpointURL}/epersons`;
-  let halService: any = new HALEndpointServiceStub(restEndpointURL);
-  const epeople$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [epeople]));
-  const rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons': epeople$ });
-  const objectCache = Object.assign({
-    /* tslint:disable:no-empty */
-    remove: () => {
-    },
-    hasBySelfLinkObservable: () => observableOf(false)
-    /* tslint:enable:no-empty */
-  }) as ObjectCacheService;
+  let restEndpointURL;
+  let epersonsEndpoint;
+  let halService: any;
+  let epeople$;
+  let rdbService;
 
-  TestBed.configureTestingModule({
-    imports: [
-      CommonModule,
-      StoreModule.forRoot({}),
-      TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: MockTranslateLoader
-        }
-      }),
-    ],
-    declarations: [],
-    providers: [],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
-  });
-
-  const getRequestEntry$ = (successful: boolean) => {
-    return observableOf({
-      completed: true,
-      response: { isSuccessful: successful, payload: epeople } as any
-    } as RequestEntry)
-  };
+  let getRequestEntry$;
 
   function initTestService() {
     return new EPersonDataService(
@@ -90,7 +61,39 @@ describe('EPersonDataService', () => {
     );
   }
 
+  function init() {
+    getRequestEntry$ = (successful: boolean) => {
+      return observableOf({
+        completed: true,
+        response: { isSuccessful: successful, payload: epeople } as any
+      } as RequestEntry)
+    };
+    restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
+    epersonsEndpoint = `${restEndpointURL}/epersons`;
+    epeople = [EPersonMock, EPersonMock2];
+    epeople$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), [epeople]));
+    rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/epersons': epeople$ });
+    halService = new HALEndpointServiceStub(restEndpointURL);
+
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        StoreModule.forRoot({}),
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [],
+      providers: [],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+  }
+
   beforeEach(() => {
+    init();
     requestService = getMockRequestService(getRequestEntry$(true));
     store = new Store<CoreState>(undefined, undefined, undefined);
     service = initTestService();

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -181,12 +181,19 @@ export class EPersonDataService extends DataService<EPerson> {
   }
 
   /**
-   * Method that clears a cached EPerson request and returns its REST url
+   * Method that clears a cached EPerson request
    */
   public clearEPersonRequests(): void {
     this.getBrowseEndpoint().pipe(take(1)).subscribe((link: string) => {
       this.requestService.removeByHrefSubstring(link);
     });
+  }
+
+  /**
+   * Method that clears a link's requests in cache
+   */
+  public clearLinkRequests(href: string): void {
+    this.requestService.removeByHrefSubstring(href);
   }
 
   /**

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -219,4 +219,27 @@ export class EPersonDataService extends DataService<EPerson> {
     return this.delete(ePerson.id);
   }
 
+  /**
+   * Change which ePerson is being edited and return the link for EPeople edit page
+   * @param ePerson New EPerson to edit
+   */
+  public startEditingNewEPerson(ePerson: EPerson): string {
+    this.getActiveEPerson().pipe(take(1)).subscribe((activeEPerson: EPerson) => {
+      if (ePerson === activeEPerson) {
+        this.cancelEditEPerson();
+      } else {
+        this.editEPerson(ePerson);
+      }
+    });
+    return '/admin/access-control/epeople';
+  }
+
+  /**
+   * Get EPeople admin page
+   * @param ePerson New EPerson to edit
+   */
+  public getEPeoplePageRouterLink(): string {
+    return '/admin/access-control/epeople';
+  }
+
 }

--- a/src/app/core/eperson/group-data.service.spec.ts
+++ b/src/app/core/eperson/group-data.service.spec.ts
@@ -1,0 +1,187 @@
+import { CommonModule } from '@angular/common';
+import { HttpHeaders } from '@angular/common/http';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store, StoreModule } from '@ngrx/store';
+import { of as observableOf } from 'rxjs';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { compare, Operation } from 'fast-json-patch';
+import {
+  GroupRegistryCancelGroupAction,
+  GroupRegistryEditGroupAction
+} from '../../+admin/admin-access-control/group-registry/group-registry.actions';
+import { getMockRemoteDataBuildServiceHrefMap } from '../../shared/mocks/mock-remote-data-build.service';
+import { getMockRequestService } from '../../shared/mocks/mock-request.service';
+import { MockTranslateLoader } from '../../shared/mocks/mock-translate-loader';
+import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson-mock';
+import { GroupMock, GroupMock2 } from '../../shared/testing/group-mock';
+import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service-stub';
+import { createSuccessfulRemoteDataObject$ } from '../../shared/testing/utils';
+import { SearchParam } from '../cache/models/search-param.model';
+import { CoreState } from '../core.reducers';
+import { ChangeAnalyzer } from '../data/change-analyzer';
+import { PaginatedList } from '../data/paginated-list';
+import { DeleteByIDRequest, DeleteRequest, FindListOptions, PostRequest } from '../data/request.models';
+import { RequestEntry } from '../data/request.reducer';
+import { RequestService } from '../data/request.service';
+import { HttpOptions } from '../dspace-rest-v2/dspace-rest-v2.service';
+import { Item } from '../shared/item.model';
+import { PageInfo } from '../shared/page-info.model';
+import { GroupDataService } from './group-data.service';
+
+describe('GroupDataService', () => {
+  let service: GroupDataService;
+  let store: Store<CoreState>;
+  let requestService: RequestService;
+
+  const restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
+  const groupsEndpoint = `${restEndpointURL}/groups`;
+  const groups = [GroupMock, GroupMock2];
+  const groups$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), groups));
+  const halService: any = new HALEndpointServiceStub(restEndpointURL);
+  const rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups': groups$ });
+
+  TestBed.configureTestingModule({
+    imports: [
+      CommonModule,
+      StoreModule.forRoot({}),
+      TranslateModule.forRoot({
+        loader: {
+          provide: TranslateLoader,
+          useClass: MockTranslateLoader
+        }
+      }),
+    ],
+    declarations: [],
+    providers: [],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  });
+
+  const getRequestEntry$ = (successful: boolean) => {
+    return observableOf({
+      completed: true,
+      response: { isSuccessful: successful, payload: groups } as any
+    } as RequestEntry)
+  };
+
+  function initTestService() {
+    return new GroupDataService(
+      new DummyChangeAnalyzer() as any,
+      null,
+      null,
+      requestService,
+      rdbService,
+      store,
+      null,
+      halService
+    );
+  };
+
+  beforeEach(() => {
+    requestService = getMockRequestService(getRequestEntry$(true));
+    store = new Store<CoreState>(undefined, undefined, undefined);
+    service = initTestService();
+    spyOn(store, 'dispatch');
+  });
+
+  describe('searchGroups', () => {
+    beforeEach(() => {
+      spyOn(service, 'searchBy');
+    });
+
+    it('search with empty query', () => {
+      service.searchGroups('');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('query', ''))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options);
+    });
+
+    it('search with query', () => {
+      service.searchGroups('test');
+      const options = Object.assign(new FindListOptions(), {
+        searchParams: [Object.assign(new SearchParam('query', 'test'))]
+      });
+      expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options);
+    });
+  });
+
+  describe('deleteGroup', () => {
+    beforeEach(() => {
+      service.deleteGroup(GroupMock2).subscribe();
+    });
+
+    it('should send DeleteRequest', () => {
+      const expected = new DeleteByIDRequest(requestService.generateRequestId(), groupsEndpoint + '/' + GroupMock2.uuid, GroupMock2.uuid);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('addSubGroupToGroup', () => {
+    beforeEach(() => {
+      service.addSubGroupToGroup(GroupMock, GroupMock2).subscribe();
+    });
+    it('should send PostRequest to eperson/groups/group-id/subgroups endpoint with new subgroup link in body', () => {
+      let headers = new HttpHeaders();
+      const options: HttpOptions = Object.create({});
+      headers = headers.append('Content-Type', 'text/uri-list');
+      options.headers = headers;
+      const expected = new PostRequest(requestService.generateRequestId(), GroupMock.self + '/' + service.subgroupsEndpoint, GroupMock2.self, options);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('deleteSubGroupFromGroup', () => {
+    beforeEach(() => {
+      service.deleteSubGroupFromGroup(GroupMock, GroupMock2).subscribe();
+    });
+    it('should send DeleteRequest to eperson/groups/group-id/subgroups/group-id endpoint', () => {
+      const expected = new DeleteRequest(requestService.generateRequestId(), GroupMock.self + '/' + service.subgroupsEndpoint + '/' + GroupMock2.id);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('addMemberToGroup', () => {
+    beforeEach(() => {
+      service.addMemberToGroup(GroupMock, EPersonMock2).subscribe();
+    });
+    it('should send PostRequest to eperson/groups/group-id/epersons endpoint with new eperson member in body', () => {
+      let headers = new HttpHeaders();
+      const options: HttpOptions = Object.create({});
+      headers = headers.append('Content-Type', 'text/uri-list');
+      options.headers = headers;
+      const expected = new PostRequest(requestService.generateRequestId(), GroupMock.self + '/' + service.ePersonsEndpoint, EPersonMock2.self, options);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('deleteMemberFromGroup', () => {
+    beforeEach(() => {
+      service.deleteMemberFromGroup(GroupMock, EPersonMock).subscribe();
+    });
+    it('should send DeleteRequest to eperson/groups/group-id/epersons/eperson-id endpoint', () => {
+      const expected = new DeleteRequest(requestService.generateRequestId(), GroupMock.self + '/' + service.ePersonsEndpoint + '/' + EPersonMock.id);
+      expect(requestService.configure).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('editGroup', () => {
+    it('should dispatch a EDIT_GROUP action with the groupp to start editing', () => {
+      service.editGroup(GroupMock);
+      expect(store.dispatch).toHaveBeenCalledWith(new GroupRegistryEditGroupAction(GroupMock));
+    });
+  });
+
+  describe('cancelEditGroup', () => {
+    it('should dispatch a CANCEL_EDIT_GROUP action', () => {
+      service.cancelEditGroup();
+      expect(store.dispatch).toHaveBeenCalledWith(new GroupRegistryCancelGroupAction());
+    });
+  });
+});
+
+class DummyChangeAnalyzer implements ChangeAnalyzer<Item> {
+  diff(object1: Item, object2: Item): Operation[] {
+    return compare((object1 as any).metadata, (object2 as any).metadata);
+  }
+}

--- a/src/app/core/eperson/group-data.service.spec.ts
+++ b/src/app/core/eperson/group-data.service.spec.ts
@@ -34,35 +34,44 @@ describe('GroupDataService', () => {
   let store: Store<CoreState>;
   let requestService: RequestService;
 
-  const restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
-  const groupsEndpoint = `${restEndpointURL}/groups`;
-  const groups = [GroupMock, GroupMock2];
-  const groups$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), groups));
-  const halService: any = new HALEndpointServiceStub(restEndpointURL);
-  const rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups': groups$ });
+  let restEndpointURL;
+  let groupsEndpoint;
+  let groups;
+  let groups$;
+  let halService;
+  let rdbService;
 
-  TestBed.configureTestingModule({
-    imports: [
-      CommonModule,
-      StoreModule.forRoot({}),
-      TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: MockTranslateLoader
-        }
-      }),
-    ],
-    declarations: [],
-    providers: [],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
-  });
+  let getRequestEntry$;
 
-  const getRequestEntry$ = (successful: boolean) => {
-    return observableOf({
-      completed: true,
-      response: { isSuccessful: successful, payload: groups } as any
-    } as RequestEntry)
-  };
+  function init() {
+    getRequestEntry$ = (successful: boolean) => {
+      return observableOf({
+        completed: true,
+        response: { isSuccessful: successful, payload: groups } as any
+      } as RequestEntry)
+    };
+    restEndpointURL = 'https://dspace.4science.it/dspace-spring-rest/api/eperson';
+    groupsEndpoint = `${restEndpointURL}/groups`;
+    groups = [GroupMock, GroupMock2];
+    groups$ = createSuccessfulRemoteDataObject$(new PaginatedList(new PageInfo(), groups));
+    rdbService = getMockRemoteDataBuildServiceHrefMap(undefined, { 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups': groups$ });
+    halService = new HALEndpointServiceStub(restEndpointURL);
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        StoreModule.forRoot({}),
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader
+          }
+        }),
+      ],
+      declarations: [],
+      providers: [],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+  }
 
   function initTestService() {
     return new GroupDataService(
@@ -78,6 +87,7 @@ describe('GroupDataService', () => {
   };
 
   beforeEach(() => {
+    init();
     requestService = getMockRequestService(getRequestEntry$(true));
     store = new Store<CoreState>(undefined, undefined, undefined);
     service = initTestService();

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -277,7 +277,7 @@ export class GroupDataService extends DataService<Group> {
         this.editGroup(newGroup)
       }
     });
-    return '/admin/access-control/groups/' + newGroup.id;
+    return this.getGroupEditPageRouterLinkWithID(newGroup.id)
   }
 
   /**
@@ -285,7 +285,28 @@ export class GroupDataService extends DataService<Group> {
    * @param group Group we want edit page for
    */
   public getGroupEditPageRouterLink(group: Group): string {
-    return '/admin/access-control/groups/' + group.id;
+    return this.getGroupEditPageRouterLinkWithID(group.id);
+  }
+
+  /**
+   * Get Edit page of group
+   * @param groupID Group ID we want edit page for
+   */
+  public getGroupEditPageRouterLinkWithID(groupId: string): string {
+    return '/admin/access-control/groups/' + groupId;
+  }
+
+  /**
+   * Extract optional UUID from a string
+   * @param stringWithUUID  String with possible UUID
+   */
+  public getUUIDFromString(stringWithUUID: string): string {
+    let foundUUID = '';
+    const uuidMatches = stringWithUUID.match(/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/g);
+    if (uuidMatches != null) {
+      foundUUID = uuidMatches[0];
+    }
+    return foundUUID;
   }
 
 }

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -1,28 +1,38 @@
-import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 
-import { Store } from '@ngrx/store';
+import { createSelector, select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
+import {
+  GroupRegistryCancelGroupAction,
+  GroupRegistryEditGroupAction
+} from '../../+admin/admin-access-control/group-registry/group-registry.actions';
+import { GroupRegistryState } from '../../+admin/admin-access-control/group-registry/group-registry.reducers';
+import { AppState } from '../../app.reducer';
+import { hasValue } from '../../shared/empty.util';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
+import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { SearchParam } from '../cache/models/search-param.model';
+import { ObjectCacheService } from '../cache/object-cache.service';
 import { DataService } from '../data/data.service';
+import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
+import { PaginatedList } from '../data/paginated-list';
+import { RemoteData } from '../data/remote-data';
+import { FindListOptions, FindListRequest } from '../data/request.models';
 
 import { RequestService } from '../data/request.service';
-import { FindListOptions } from '../data/request.models';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { Group } from './models/group.model';
-import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
-import { CoreState } from '../core.reducers';
-import { ObjectCacheService } from '../cache/object-cache.service';
-import { SearchParam } from '../cache/models/search-param.model';
-import { RemoteData } from '../data/remote-data';
-import { PaginatedList } from '../data/paginated-list';
-import { NotificationsService } from '../../shared/notifications/notifications.service';
-import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
 import { dataService } from '../cache/builders/build-decorators';
 import { GROUP } from './models/group.resource-type';
 
+const groupRegistryStateSelector = (state: AppState) => state.groupRegistry;
+const editGroupSelector = createSelector(groupRegistryStateSelector, (groupRegistryState: GroupRegistryState) => groupRegistryState.editGroup);
+
 /**
- * Provides methods to retrieve eperson group resources.
+ * Provides methods to retrieve eperson group resources from the REST API & Group related CRUD actions.
  */
 @Injectable({
   providedIn: 'root'
@@ -38,11 +48,49 @@ export class GroupDataService extends DataService<Group> {
     protected notificationsService: NotificationsService,
     protected requestService: RequestService,
     protected rdbService: RemoteDataBuildService,
-    protected store: Store<CoreState>,
+    protected store: Store<any>,
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService
   ) {
     super();
+  }
+
+  /**
+   * Retrieves all groups
+   * @param pagination The pagination info used to retrieve the groups
+   */
+  public getGroups(options: FindListOptions = {}, ...linksToFollow: Array<FollowLinkConfig<Group>>): Observable<RemoteData<PaginatedList<Group>>> {
+    const hrefObs = this.getFindAllHref(options, this.linkPath, ...linksToFollow);
+    hrefObs.pipe(
+      filter((href: string) => hasValue(href)),
+      take(1))
+      .subscribe((href: string) => {
+        const request = new FindListRequest(this.requestService.generateRequestId(), href, options);
+        this.requestService.configure(request);
+      });
+
+    return this.rdbService.buildList<Group>(hrefObs) as Observable<RemoteData<PaginatedList<Group>>>;
+  }
+
+  /**
+   * Returns a search result list of groups, with certain query (searches in group name and by exact uuid)
+   * Endpoint used: /eperson/groups/search/byMetadata?query=<:name>
+   * @param query     search query param
+   * @param options
+   * @param linksToFollow
+   */
+  public searchGroups(query: string, options?: FindListOptions, ...linksToFollow: Array<FollowLinkConfig<Group>>): Observable<RemoteData<PaginatedList<Group>>> {
+    const searchParams = [new SearchParam('query', query)];
+    let findListOptions = new FindListOptions();
+    if (options) {
+      findListOptions = Object.assign(new FindListOptions(), options);
+    }
+    if (findListOptions.searchParams) {
+      findListOptions.searchParams = [...findListOptions.searchParams, ...searchParams];
+    } else {
+      findListOptions.searchParams = searchParams;
+    }
+    return this.searchBy('byMetadata', findListOptions, ...linksToFollow);
   }
 
   /**
@@ -59,10 +107,74 @@ export class GroupDataService extends DataService<Group> {
     options.searchParams = [new SearchParam('groupName', groupName)];
 
     return this.searchBy(searchHref, options).pipe(
-        filter((groups: RemoteData<PaginatedList<Group>>) => !groups.isResponsePending),
-        take(1),
-        map((groups: RemoteData<PaginatedList<Group>>) => groups.payload.totalElements > 0)
-      );
+      filter((groups: RemoteData<PaginatedList<Group>>) => !groups.isResponsePending),
+      take(1),
+      map((groups: RemoteData<PaginatedList<Group>>) => groups.payload.totalElements > 0)
+    );
+  }
+
+  /**
+   * Method to delete a group
+   * @param id The group id to delete
+   */
+  public deleteGroup(group: Group): Observable<boolean> {
+    return this.delete(group);
+  }
+
+  /**
+   * Create or Update a group
+   *  If the group contains an id, it is assumed the eperson already exists and is updated instead
+   *  //TODO
+   * @param group    The group to create or update
+   */
+  public createOrUpdateGroup(group: Group): Observable<RemoteData<Group>> {
+    const isUpdate = hasValue(group.id);
+    if (isUpdate) {
+      return this.updateGroup(group);
+    } else {
+      console.log('group create', group)
+      return this.create(group, null);
+    }
+  }
+
+  /**
+   * // TODO
+   * @param {DSpaceObject} ePerson The given object
+   */
+  updateGroup(group: Group): Observable<RemoteData<Group>> {
+      // TODO
+    return null;
+  }
+
+  /**
+   * Method to retrieve the group that is currently being edited
+   */
+  public getActiveGroup(): Observable<Group> {
+    return this.store.pipe(select(editGroupSelector))
+  }
+
+  /**
+   * Method to cancel editing a group, dispatches a cancel group action
+   */
+  public cancelEditGroup() {
+    this.store.dispatch(new GroupRegistryCancelGroupAction());
+  }
+
+  /**
+   * Method to set the group being edited, dispatches an edit group action
+   * @param group The group to edit
+   */
+  public editGroup(group: Group) {
+    this.store.dispatch(new GroupRegistryEditGroupAction(group));
+  }
+
+  /**
+   * Method that clears a cached groups request and returns its REST url
+   */
+  public clearGroupsRequests(): void {
+    this.getBrowseEndpoint().pipe(take(1)).subscribe((link: string) => {
+      this.requestService.removeByHrefSubstring(link);
+    });
   }
 
 }

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -246,12 +246,19 @@ export class GroupDataService extends DataService<Group> {
   }
 
   /**
-   * Method that clears a cached groups request and returns its REST url
+   * Method that clears a cached groups request
    */
   public clearGroupsRequests(): void {
     this.getBrowseEndpoint().pipe(take(1)).subscribe((link: string) => {
       this.requestService.removeByHrefSubstring(link);
     });
+  }
+
+  /**
+   * Method that clears a cached get subgroups of certain group request
+   */
+  public clearGroupLinkRequests(href: string): void {
+    this.requestService.removeByHrefSubstring(href);
   }
 
   public getGroupRegistryRouterLink(): string {

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -255,4 +255,12 @@ export class GroupDataService extends DataService<Group> {
     });
   }
 
+  public getGroupRegistryRouterLink(): string {
+    return '/admin/access-control/groups';
+  }
+
+  public getGroupEditPageRouterLink(groupId: string): string {
+    return '/admin/access-control/groups/' + groupId;
+  }
+
 }

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -124,7 +124,7 @@ export class GroupDataService extends DataService<Group> {
    * @param id The group id to delete
    */
   public deleteGroup(group: Group): Observable<boolean> {
-    return this.delete(group);
+    return this.delete(group.id);
   }
 
   /**

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -259,8 +259,27 @@ export class GroupDataService extends DataService<Group> {
     return '/admin/access-control/groups';
   }
 
-  public getGroupEditPageRouterLink(groupId: string): string {
-    return '/admin/access-control/groups/' + groupId;
+  /**
+   * Change which group is being edited and return the link for the edit page of the new group being edited
+   * @param newGroup New group to edit
+   */
+  public startEditingNewGroup(newGroup: Group): string {
+    this.getActiveGroup().pipe(take(1)).subscribe((activeGroup: Group) => {
+      if (newGroup === activeGroup) {
+        this.cancelEditGroup()
+      } else {
+        this.editGroup(newGroup)
+      }
+    });
+    return '/admin/access-control/groups/' + newGroup.id;
+  }
+
+  /**
+   * Get Edit page of group
+   * @param group Group we want edit page for
+   */
+  public getGroupEditPageRouterLink(group: Group): string {
+    return '/admin/access-control/groups/' + group.id;
   }
 
 }

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -45,8 +45,8 @@ const editGroupSelector = createSelector(groupRegistryStateSelector, (groupRegis
 export class GroupDataService extends DataService<Group> {
   protected linkPath = 'groups';
   protected browseEndpoint = '';
-  protected ePersonsEndpoint = 'epersons';
-  protected subgroupsEndpoint = 'subgroups';
+  public ePersonsEndpoint = 'epersons';
+  public subgroupsEndpoint = 'subgroups';
 
   constructor(
     protected comparator: DSOChangeAnalyzer<Group>,
@@ -130,7 +130,6 @@ export class GroupDataService extends DataService<Group> {
   /**
    * Create or Update a group
    *  If the group contains an id, it is assumed the eperson already exists and is updated instead
-   *  //TODO
    * @param group    The group to create or update
    */
   public createOrUpdateGroup(group: Group): Observable<RemoteData<Group>> {

--- a/src/app/core/eperson/models/group.model.ts
+++ b/src/app/core/eperson/models/group.model.ts
@@ -39,7 +39,7 @@ export class Group extends DSpaceObject {
   @deserialize
   _links: {
     self: HALLink;
-    groups: HALLink;
+    subgroups: HALLink;
     epersons: HALLink;
   };
 
@@ -48,7 +48,7 @@ export class Group extends DSpaceObject {
    * Will be undefined unless the groups {@link HALLink} has been resolved.
    */
   @link(GROUP, true)
-  public groups?: Observable<RemoteData<PaginatedList<Group>>>;
+  public subgroups?: Observable<RemoteData<PaginatedList<Group>>>;
 
   /**
    * The list of EPeople in this group

--- a/src/app/core/eperson/models/group.model.ts
+++ b/src/app/core/eperson/models/group.model.ts
@@ -6,12 +6,20 @@ import { RemoteData } from '../../data/remote-data';
 
 import { DSpaceObject } from '../../shared/dspace-object.model';
 import { HALLink } from '../../shared/hal-link.model';
+import { EPerson } from './eperson.model';
+import { EPERSON } from './eperson.resource-type';
 import { GROUP } from './group.resource-type';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Group extends DSpaceObject {
   static type = GROUP;
+
+  /**
+   * A string representing the unique name of this Group
+   */
+  @autoserialize
+  public name: string;
 
   /**
    * A string representing the unique handle of this Group
@@ -32,6 +40,7 @@ export class Group extends DSpaceObject {
   _links: {
     self: HALLink;
     groups: HALLink;
+    epersons: HALLink;
   };
 
   /**
@@ -40,5 +49,12 @@ export class Group extends DSpaceObject {
    */
   @link(GROUP, true)
   public groups?: Observable<RemoteData<PaginatedList<Group>>>;
+
+  /**
+   * The list of EPeople in this group
+   * Will be undefined unless the epersons {@link HALLink} has been resolved.
+   */
+  @link(EPERSON, true)
+  public epersons?: Observable<RemoteData<PaginatedList<EPerson>>>;
 
 }

--- a/src/app/shared/testing/eperson-mock.ts
+++ b/src/app/shared/testing/eperson-mock.ts
@@ -3,7 +3,7 @@ import { GroupMock } from './group-mock';
 
 export const EPersonMock: EPerson = Object.assign(new EPerson(), {
   handle: null,
-  groups: [],
+  groups: [GroupMock],
   netid: 'test@test.com',
   lastActive: '2018-05-14T12:25:42.411+0000',
   canLogIn: true,
@@ -49,7 +49,7 @@ export const EPersonMock: EPerson = Object.assign(new EPerson(), {
 
 export const EPersonMock2: EPerson = Object.assign(new EPerson(), {
   handle: null,
-  groups: [GroupMock],
+  groups: [],
   netid: 'test2@test.com',
   lastActive: '2019-05-14T12:25:42.411+0000',
   canLogIn: false,

--- a/src/app/shared/testing/group-mock.ts
+++ b/src/app/shared/testing/group-mock.ts
@@ -1,14 +1,34 @@
 import { Group } from '../../core/eperson/models/group.model';
+import { EPersonMock } from './eperson-mock';
+
+export const GroupMock2: Group = Object.assign(new Group(), {
+  handle: null,
+  groups: [],
+  epersons: [],
+  selfRegistered: false,
+  _links: {
+    self: {
+      href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2',
+    },
+    subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/subgroups' },
+    epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/epersons' }
+  },
+  id: 'testgroupid2',
+  uuid: 'testgroupid2',
+  type: 'group',
+});
 
 export const GroupMock: Group = Object.assign(new Group(), {
   handle: null,
-  groups: [],
+  groups: [GroupMock2],
+  epersons: [EPersonMock],
   selfRegistered: false,
   _links: {
     self: {
       href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid',
     },
-    groups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/groups' }
+    subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/subgroups' },
+    epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/epersons' }
   },
   id: 'testgroupid',
   uuid: 'testgroupid',

--- a/src/app/shared/testing/group-mock.ts
+++ b/src/app/shared/testing/group-mock.ts
@@ -3,7 +3,7 @@ import { EPersonMock } from './eperson-mock';
 
 export const GroupMock2: Group = Object.assign(new Group(), {
   handle: null,
-  groups: [],
+  subgroups: [],
   epersons: [],
   selfRegistered: false,
   _links: {
@@ -20,7 +20,7 @@ export const GroupMock2: Group = Object.assign(new Group(), {
 
 export const GroupMock: Group = Object.assign(new Group(), {
   handle: null,
-  groups: [GroupMock2],
+  subgroups: [GroupMock2],
   epersons: [EPersonMock],
   selfRegistered: false,
   _links: {

--- a/src/app/shared/testing/group-mock.ts
+++ b/src/app/shared/testing/group-mock.ts
@@ -2,35 +2,37 @@ import { Group } from '../../core/eperson/models/group.model';
 import { EPersonMock } from './eperson-mock';
 
 export const GroupMock2: Group = Object.assign(new Group(), {
-  handle: null,
-  subgroups: [],
-  epersons: [],
-  selfRegistered: false,
-  _links: {
-    self: {
-      href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2',
+    handle: null,
+    subgroups: [],
+    epersons: [],
+    permanent: true,
+    selfRegistered: false,
+    _links: {
+        self: {
+            href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2',
+        },
+        subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/subgroups' },
+        epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/epersons' }
     },
-    subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/subgroups' },
-    epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid2/epersons' }
-  },
-  id: 'testgroupid2',
-  uuid: 'testgroupid2',
-  type: 'group',
+    id: 'testgroupid2',
+    uuid: 'testgroupid2',
+    type: 'group',
 });
 
 export const GroupMock: Group = Object.assign(new Group(), {
-  handle: null,
-  subgroups: [GroupMock2],
-  epersons: [EPersonMock],
-  selfRegistered: false,
-  _links: {
-    self: {
-      href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid',
+    handle: null,
+    subgroups: [GroupMock2],
+    epersons: [EPersonMock],
+    selfRegistered: false,
+    permanent: false,
+    _links: {
+        self: {
+            href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid',
+        },
+        subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/subgroups' },
+        epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/epersons' }
     },
-    subgroups: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/subgroups' },
-    epersons: { href: 'https://dspace.4science.it/dspace-spring-rest/api/eperson/groups/testgroupid/epersons' }
-  },
-  id: 'testgroupid',
-  uuid: 'testgroupid',
-  type: 'group',
+    id: 'testgroupid',
+    uuid: 'testgroupid',
+    type: 'group',
 });

--- a/src/app/submission/sections/upload/section-upload.component.ts
+++ b/src/app/submission/sections/upload/section-upload.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectorRef, Component, Inject } from '@angular/core';
 
 import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, Subscription} from 'rxjs';
 import { distinctUntilChanged, filter, find, flatMap, map, reduce, take, tap } from 'rxjs/operators';
-import { followLink } from '../../../shared/utils/follow-link-config.model';
 
 import { SectionModelComponent } from '../models/section.model';
 import { hasValue, isNotEmpty, isNotUndefined, isUndefined } from '../../../shared/empty.util';
@@ -23,7 +22,6 @@ import { Group } from '../../../core/eperson/models/group.model';
 import { SectionsService } from '../sections.service';
 import { SubmissionService } from '../../submission.service';
 import { Collection } from '../../../core/shared/collection.model';
-import { ResourcePolicy } from '../../../core/shared/resource-policy.model';
 import { AccessConditionOption } from '../../../core/config/models/config-access-condition-option.model';
 import { PaginatedList } from '../../../core/data/paginated-list';
 
@@ -205,7 +203,7 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
                 mapGroups$.push(
                   this.groupService.findById(accessCondition.selectGroupUUID).pipe(
                     find((rd: RemoteData<Group>) => !rd.isResponsePending && rd.hasSucceeded),
-                    flatMap((group: RemoteData<Group>) => group.payload.groups),
+                    flatMap((group: RemoteData<Group>) => group.payload.subgroups),
                     find((rd: RemoteData<PaginatedList<Group>>) => !rd.isResponsePending && rd.hasSucceeded),
                     map((rd: RemoteData<PaginatedList<Group>>) => ({
                       accessCondition: accessCondition.name,


### PR DESCRIPTION
This PR adds the admin access control page for Groups.

Functionalities:

- (Read) Initial page load gives you a pageable list of all Groups. This list is searchable. Per Group ID, Name, #Members (epersons and subgroups) is shown.
- (Create) A new Group can be created, the name (and optional description) must first be submitted before subgroups/epeople can be added.
- (Delete) The delete of a group is not yet implemented in the backend, so this button currently just shows a notification
- (Update) Changing a group’s name / description is not yet implemented in the backend, so submitting the edit form just shows a notification
- (Update Members): Members (people and groups) can be added/deleted. For this there is a searchable list of both on the edit group page. The edit group page is accessible via the access-control group list, or via the url containing the group’s uuid (/admin/access-control/groups/). Initially at edit group page load the list of subgroups and epersons that group has, is shown, but again a search is possible.

This is dependent on backend PR: https://github.com/DSpace/DSpace/pull/2686 and frontend PR for the EPeople access control admin page: https://github.com/DSpace/dspace-angular/pull/609 