### PR TITLE
Disregard embeds when checking request index

### DIFF
--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -1,4 +1,3 @@
-import { NgZone } from '@angular/core';
 import * as ngrx from '@ngrx/store';
 import { ActionsSubject, Store } from '@ngrx/store';
 import { cold, getTestScheduler, hot } from 'jasmine-marbles';
@@ -63,7 +62,6 @@ describe('RequestService', () => {
       objectCache,
       uuidService,
       store,
-      new NgZone({}),
       undefined
     );
     serviceAsAny = service as any;

--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -1,3 +1,4 @@
+import { NgZone } from '@angular/core';
 import * as ngrx from '@ngrx/store';
 import { ActionsSubject, Store } from '@ngrx/store';
 import { cold, getTestScheduler, hot } from 'jasmine-marbles';
@@ -62,6 +63,7 @@ describe('RequestService', () => {
       objectCache,
       uuidService,
       store,
+      new NgZone({}),
       undefined
     );
     serviceAsAny = service as any;

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpHeaders } from '@angular/common/http';
 
 import { createSelector, MemoizedSelector, select, Store } from '@ngrx/store';

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -148,6 +148,13 @@ export class RequestService {
    * @param {RestRequest} request The request to send out
    */
   configure<T extends CacheableObject>(request: RestRequest): void {
+    /**
+     * Since this method doesn't return anything, is used very often and has
+     * problems with actions being dispatched to the store but not reduced before
+     * that info is needed again, we may as well run it in a separate zone. That way
+     * it won't block the UI, and actions have a better chance of being already
+     * processed when the next isCachedOrPending call comes
+     */
     this.zone.runOutsideAngular(() => {
       const isGetRequest = request.method === RestRequestMethod.GET;
       if (!isGetRequest || request.forceBypassCache || !this.isCachedOrPending(request)) {

--- a/src/app/core/index/index.effects.ts
+++ b/src/app/core/index/index.effects.ts
@@ -12,6 +12,7 @@ import { AddToIndexAction, RemoveFromIndexByValueAction } from './index.actions'
 import { hasValue } from '../../shared/empty.util';
 import { IndexName } from './index.reducer';
 import { RestRequestMethod } from '../data/rest-request-method';
+import { getUrlWithoutEmbedParams } from './index.selectors';
 
 @Injectable()
 export class UUIDIndexEffects {
@@ -47,7 +48,7 @@ export class UUIDIndexEffects {
       map((action: RequestConfigureAction) => {
         return new AddToIndexAction(
           IndexName.REQUEST,
-          action.payload.href,
+          getUrlWithoutEmbedParams(action.payload.href),
           action.payload.uuid
         );
       })

--- a/src/app/core/index/index.selectors.spec.ts
+++ b/src/app/core/index/index.selectors.spec.ts
@@ -1,0 +1,32 @@
+import { getUrlWithoutEmbedParams } from './index.selectors';
+
+describe(`index selectors`, () => {
+
+  describe(`getUrlWithoutEmbedParams`, () => {
+
+    it(`should return a url without its embed params`, () => {
+      const source = 'https://rest.api/resource?a=1&embed=2&b=3&embed=4/5&c=6&embed=7/8/9';
+      const result = getUrlWithoutEmbedParams(source);
+      expect(result).toBe('https://rest.api/resource?a=1&b=3&c=6');
+    });
+
+    it(`should return a url without embed params unmodified`, () => {
+      const source = 'https://rest.api/resource?a=1&b=3&c=6';
+      const result = getUrlWithoutEmbedParams(source);
+      expect(result).toBe(source);
+    });
+
+    it(`should return a string that isn't a url unmodified`, () => {
+      const source = 'a=1&embed=2&b=3&embed=4/5&c=6&embed=7/8/9';
+      const result = getUrlWithoutEmbedParams(source);
+      expect(result).toBe(source);
+    });
+
+    it(`should return undefined or null unmodified`, () => {
+      expect(getUrlWithoutEmbedParams(undefined)).toBe(undefined);
+      expect(getUrlWithoutEmbedParams(null)).toBe(null);
+    });
+
+  });
+
+});

--- a/src/app/core/url-combiner/url-combiner.ts
+++ b/src/app/core/url-combiner/url-combiner.ts
@@ -41,8 +41,8 @@ export class URLCombiner {
       // remove consecutive slashes
       url = url.replace(/([^:\s])\/+/g, '$1/');
 
-      // remove trailing slash before parameters or hash
-      url = url.replace(/\/(\?|&|#[^!])/g, '$1');
+      // remove trailing slash
+      url = url.replace(/\/($|\?|&|#[^!])/g, '$1');
 
       // replace ? in parameters with &
       url = url.replace(/(\?.+)\?/g, '$1&');


### PR DESCRIPTION
Since #588 was merged we're getting more cache misses because the embed params are taken in to account when comparing request urls. They shouldn't. The embeds that were used don't influence the resource itself and should therefore be ignored when checking whether or not that resource is cached.

This PR filters out embed params when storing a request url in the index, and when searching that index later on.