### PR TITLE
Cache behavior for unknown type

### DIFF
--- a/src/app/core/data/base-response-parsing.service.ts
+++ b/src/app/core/data/base-response-parsing.service.ts
@@ -51,7 +51,7 @@ export abstract class BaseResponseParsingService {
         return this.processArray(data, request);
       } else if (isRestDataObject(data)) {
         const object = this.deserialize(data);
-        if (isNotEmpty(data._embedded)) {
+        if (isNotEmpty(data._embedded) && hasValue(object)) {
           Object
             .keys(data._embedded)
             .filter((property) => data._embedded.hasOwnProperty(property))

--- a/src/app/core/data/base-response-parsing.service.ts
+++ b/src/app/core/data/base-response-parsing.service.ts
@@ -51,13 +51,13 @@ export abstract class BaseResponseParsingService {
         return this.processArray(data, request);
       } else if (isRestDataObject(data)) {
         const object = this.deserialize(data);
-        if (isNotEmpty(data._embedded) && hasValue(object)) {
+        if (isNotEmpty(data._embedded)) {
           Object
             .keys(data._embedded)
             .filter((property) => data._embedded.hasOwnProperty(property))
             .forEach((property) => {
               const parsedObj = this.process<ObjectDomain>(data._embedded[property], request);
-              if (this.shouldDirectlyAttachEmbeds && isNotEmpty(parsedObj)) {
+              if (hasValue(object) && this.shouldDirectlyAttachEmbeds && isNotEmpty(parsedObj)) {
                   if (isRestPaginatedList(data._embedded[property])) {
                     object[property] = parsedObj;
                     object[property].page = parsedObj.page.map((obj) => this.retrieveObjectOrUrl(obj));


### PR DESCRIPTION
This is a continuation of https://github.com/DSpace/dspace-angular/pull/611

We noticed the Angular UI currently also breaks in the BaseResponseParsingService.process() function if REST contains a type not (yet) known to Angular.

If the data is part of a type not yet known to Angular, the object is null
The null object causes an exception further down the road

The null objects will be ignored here since there's on use in caching them