### PR TITLE
DS-4467 Impl multi field sorting capcity

### DIFF
--- a/src/app/shared/object-collection/object-collection.component.html
+++ b/src/app/shared/object-collection/object-collection.component.html
@@ -13,6 +13,7 @@
                 (deselectObject)="deselectObject.emit($event)"
                 (selectObject)="selectObject.emit($event)"
                 (sortFieldChange)="onSortFieldChange($event)"
+                [sortOptionsMulti]="sortOptionsMulti"
                 [selectable]="selectable"
                 [selectionConfig]="selectionConfig"
                 [importable]="importable"

--- a/src/app/shared/object-collection/object-collection.component.ts
+++ b/src/app/shared/object-collection/object-collection.component.ts
@@ -40,6 +40,11 @@ export class ObjectCollectionComponent implements OnInit {
   @Input() sortConfig: SortOptions;
 
   /**
+   * Optional array of SortOptions to support field selection from the pagination gear
+   */
+  @Input() sortOptionsMulti: SortOptions[];
+
+  /**
    * Whether or not the list elements have a border or not
    */
   @Input() hasBorder = false;

--- a/src/app/shared/object-list/object-list.component.html
+++ b/src/app/shared/object-list/object-list.component.html
@@ -3,6 +3,7 @@
         [pageInfoState]="objects?.payload"
         [collectionSize]="objects?.payload?.totalElements"
         [sortOptions]="sortConfig"
+        [sortOptionsMulti]="sortOptionsMulti"
         [hideGear]="hideGear"
         [hidePagerWhenSinglePage]="hidePagerWhenSinglePage"
         [hidePaginationDetail]="hidePaginationDetail"

--- a/src/app/shared/object-list/object-list.component.ts
+++ b/src/app/shared/object-list/object-list.component.ts
@@ -35,6 +35,11 @@ export class ObjectListComponent {
   @Input() sortConfig: SortOptions;
 
   /**
+   * Optional array of SortOptions to support field selection from the pagination gear
+   */
+  @Input() sortOptionsMulti: SortOptions[];
+
+  /**
    * Whether or not the list elements have a border
    */
   @Input() hasBorder = false;

--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -13,6 +13,10 @@
             <button class="dropdown-item" *ngFor="let item of pageSizeOptions" (click)="doPageSizeChange(item)"><i [ngClass]="{'invisible': item != pageSize}" class="fas fa-check" aria-hidden="true"></i> {{item}} </button>
             <h6 class="dropdown-header">{{ 'pagination.sort-direction' | translate}}</h6>
             <button class="dropdown-item" *ngFor="let direction of (sortDirections | dsKeys)" (click)="doSortDirectionChange(direction.value)"><i [ngClass]="{'invisible': direction.value !== sortDirection}" class="fas fa-check" aria-hidden="true"></i> {{'sorting.' + direction.key | translate}} </button>
+            <div *ngIf="sortOptionsMulti != null">
+              <h6 class="dropdown-header">{{ 'pagination.sort-field' | translate}}</h6>
+              <button class="dropdown-item" *ngFor="let field of (sortOptionsMulti)" (click)="doSortFieldChange(field.field)"><i [ngClass]="{'invisible': field.field !== sortField}" class="fas fa-check" aria-hidden="true"></i> {{'sorting.' + field.field }} </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -55,6 +55,11 @@ export class PaginationComponent implements OnDestroy, OnInit {
   @Input() sortOptions: SortOptions;
 
   /**
+   * Optional array of SortOptions to support field selection from the pagination gear
+   */
+  @Input() sortOptionsMulti: SortOptions[];
+
+  /**
    * An event fired when the page is changed.
    * Event's payload equals to the newly selected page.
    */


### PR DESCRIPTION
See: https://jira.lyrasis.org/browse/DS-4467
Fixes #1303 

In previous versions of DSpace there was the capacity to select what field to sort against in a set of data from the gear icon E.G (https://imgur.com/a/HhuSKZ1) . I've added a small and nullable `input` of `SortOptions[]` into the`ds-viewable-collection -> ds-pagination` sequence that allows devs to configure multi field sorting for this feature.

Would love to get some feedback on this, as well as I'd love to see something like this implemented for every listable DSO }}that makes use of the `object-collection.componen.ts` ({{ds-viewable-collection) feature.