### PR TITLE
Broken create community

### DIFF
--- a/src/app/+collection-page/collection-page-routing.module.ts
+++ b/src/app/+collection-page/collection-page-routing.module.ts
@@ -35,6 +35,11 @@ const COLLECTION_EDIT_PATH = 'edit';
   imports: [
     RouterModule.forChild([
       {
+        path: COLLECTION_CREATE_PATH,
+        component: CreateCollectionPageComponent,
+        canActivate: [AuthenticatedGuard, CreateCollectionPageGuard]
+      },
+      {
         path: ':id',
         resolve: {
           dso: CollectionPageResolver,
@@ -64,11 +69,6 @@ const COLLECTION_EDIT_PATH = 'edit';
             canActivate: [AuthenticatedGuard]
           }
         ]
-      },
-      {
-        path: COLLECTION_CREATE_PATH,
-        component: CreateCollectionPageComponent,
-        canActivate: [AuthenticatedGuard, CreateCollectionPageGuard]
       },
     ])
   ],

--- a/src/app/+community-page/community-page-routing.module.ts
+++ b/src/app/+community-page/community-page-routing.module.ts
@@ -34,6 +34,11 @@ const COMMUNITY_EDIT_PATH = 'edit';
   imports: [
     RouterModule.forChild([
       {
+        path: COMMUNITY_CREATE_PATH,
+        component: CreateCommunityPageComponent,
+        canActivate: [AuthenticatedGuard, CreateCommunityPageGuard]
+      },
+      {
         path: ':id',
         resolve: {
           dso: CommunityPageResolver,
@@ -57,11 +62,6 @@ const COMMUNITY_EDIT_PATH = 'edit';
             pathMatch: 'full',
           }
         ]
-      },
-      {
-        path: COMMUNITY_CREATE_PATH,
-        component: CreateCommunityPageComponent,
-        canActivate: [AuthenticatedGuard, CreateCommunityPageGuard]
       },
     ])
   ],

--- a/src/app/shared/comcol-forms/comcol-form/comcol-form.component.spec.ts
+++ b/src/app/shared/comcol-forms/comcol-form/comcol-form.component.spec.ts
@@ -137,7 +137,7 @@ describe('ComColFormComponent', () => {
                 type: Community.type
               },
             ),
-            uploader: {} as any,
+            uploader: undefined,
             deleteLogo: false
           }
         );

--- a/src/app/shared/comcol-forms/comcol-form/comcol-form.component.ts
+++ b/src/app/shared/comcol-forms/comcol-form/comcol-form.component.ts
@@ -39,7 +39,7 @@ export class ComColFormComponent<T extends DSpaceObject> implements OnInit, OnDe
   /**
    * The logo uploader component
    */
-  @ViewChild(UploaderComponent, {static: true}) uploaderComponent: UploaderComponent;
+  @ViewChild(UploaderComponent, {static: false}) uploaderComponent: UploaderComponent;
 
   /**
    * DSpaceObject that the form represents


### PR DESCRIPTION
## References
* https://github.com/DSpace/dspace-angular/issues/639

## Description
Create community and collection was broken, this has been resolved

## Instructions for Reviewers
This is just a bug fix to the create functions. Because they were at the end, the COLLECTION_CREATE_PATH was interpreted as a collection ID

## Checklist
- [X] My PR is small in size
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`