### PR TITLE
Upload bitstream bug-fix

### DIFF
--- a/src/app/+item-page/bitstreams/upload/upload-bitstream.component.spec.ts
+++ b/src/app/+item-page/bitstreams/upload/upload-bitstream.component.spec.ts
@@ -90,7 +90,7 @@ describe('UploadBistreamComponent', () => {
     buildAuthHeader: () => authToken
   });
   const notificationsServiceStub = new NotificationsServiceStub();
-  const uploaderComponent = jasmine.createSpyObj('uploaderComponent', ['ngOnInit']);
+  const uploaderComponent = jasmine.createSpyObj('uploaderComponent', ['ngOnInit', 'ngAfterViewInit']);
   const requestService = jasmine.createSpyObj('requestService', {
     removeByHrefSubstring: {}
   });

--- a/src/app/+item-page/bitstreams/upload/upload-bitstream.component.ts
+++ b/src/app/+item-page/bitstreams/upload/upload-bitstream.component.ts
@@ -154,6 +154,7 @@ export class UploadBitstreamComponent implements OnInit, OnDestroy {
       // Re-initialize the uploader component to ensure the latest changes to the options are applied
       if (this.uploaderComponent) {
         this.uploaderComponent.ngOnInit();
+        this.uploaderComponent.ngAfterViewInit();
       }
     });
   }


### PR DESCRIPTION
This PR fixes a bug present in the recently merged #577 explained in [this comment](https://github.com/DSpace/dspace-angular/pull/577#issuecomment-607928607).

**Technical details**
After the URL of the uploader changes (by either creating a new bundle, or selecting one from the dropdown), the uploader component is re-initialised to apply the changes to the uploader options by calling its `ngOnInit` method. However, this removes the callback methods from the uploader defined in `ngAfterViewInit`.
Simply calling `ngAfterViewInit` after `ngOnInit` fixes the issue.