### PR TITLE
Edit collection - assign roles groups

### DIFF
--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -761,6 +761,12 @@
 
   "community.edit.tabs.roles.title": "Community Edit - Roles",
 
+  "community.edit.tabs.roles.none": "None",
+
+  "community.edit.tabs.roles.admin.name": "Administrators",
+
+  "community.edit.tabs.roles.admin.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
+
 
 
   "community.form.abstract": "Short Description",

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -803,17 +803,17 @@
 
   "comcol-role.edit.editor.name": "Editors",
 
-  "comcol-role.edit.editor.description": "Editors are able to accept or reject incoming submissions. However, they are not able to edit the submission's metadata.",
+  "comcol-role.edit.editor.description": "Editors are able to edit the metadata of incoming submissions, and then accept or reject them.",
 
 
   "comcol-role.edit.finaleditor.name": "Final editors",
 
-  "comcol-role.edit.finaleditor.description": "Final editors are able to edit the metadata of incoming submissions, and then accept or reject them.",
+  "comcol-role.edit.finaleditor.description": "Final editors are able to edit the metadata of incoming submissions, but will not be able to reject them.",
 
 
   "comcol-role.edit.reviewer.name": "Reviewers",
 
-  "comcol-role.edit.reviewer.description": "Reviewers are able to edit the metadata of incoming submissions, but will not be able to reject them.",
+  "comcol-role.edit.reviewer.description": "Reviewers are able to accept or reject incoming submissions. However, they are not able to edit the submission's metadata.",
 
 
 

--- a/resources/i18n/en.json5
+++ b/resources/i18n/en.json5
@@ -761,11 +761,59 @@
 
   "community.edit.tabs.roles.title": "Community Edit - Roles",
 
-  "community.edit.tabs.roles.none": "None",
 
-  "community.edit.tabs.roles.admin.name": "Administrators",
 
-  "community.edit.tabs.roles.admin.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
+  "comcol-role.edit.no-group": "None",
+
+  "comcol-role.edit.create": "Create",
+
+  "comcol-role.edit.restrict": "Restrict",
+
+  "comcol-role.edit.delete": "Delete",
+
+
+  "comcol-role.edit.community-admin.name": "Administrators",
+
+  "comcol-role.edit.collection-admin.name": "Administrators",
+
+
+  "comcol-role.edit.community-admin.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
+
+  "comcol-role.edit.collection-admin.description": "Collection administrators decide who can submit items to the collection, edit item metadata (after submission), and add (map) existing items from other collections to this collection (subject to authorization for that collection).",
+
+
+  "comcol-role.edit.submitters.name": "Submitters",
+
+  "comcol-role.edit.submitters.description": "The E-People and Groups that have permission to submit new items to this collection.",
+
+
+  "comcol-role.edit.item_read.name": "Default item read access",
+
+  "comcol-role.edit.item_read.description": "E-People and Groups that can read new items submitted to this collection. Changes to this role are not retroactive. Existing items in the system will still be viewable by those who had read access at the time of their addition.",
+
+  "comcol-role.edit.item_read.anonymous-group": "Default read for incoming items is currently set to Anonymous.",
+
+
+  "comcol-role.edit.bitstream_read.name": "Default bitstream read access",
+
+  "comcol-role.edit.bitstream_read.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
+
+  "comcol-role.edit.bitstream_read.anonymous-group": "Default read for incoming bitstreams is currently set to Anonymous.",
+
+
+  "comcol-role.edit.editor.name": "Editors",
+
+  "comcol-role.edit.editor.description": "Editors are able to accept or reject incoming submissions. However, they are not able to edit the submission's metadata.",
+
+
+  "comcol-role.edit.finaleditor.name": "Final editors",
+
+  "comcol-role.edit.finaleditor.description": "Final editors are able to edit the metadata of incoming submissions, and then accept or reject them.",
+
+
+  "comcol-role.edit.reviewer.name": "Reviewers",
+
+  "comcol-role.edit.reviewer.description": "Reviewers are able to edit the metadata of incoming submissions, but will not be able to reject them.",
 
 
 

--- a/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
+++ b/src/app/+admin/admin-access-control/admin-access-control-routing.module.ts
@@ -3,19 +3,27 @@ import { RouterModule } from '@angular/router';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
 import { GroupFormComponent } from './group-registry/group-form/group-form.component';
 import { GroupsRegistryComponent } from './group-registry/groups-registry.component';
+import { URLCombiner } from '../../core/url-combiner/url-combiner';
+import { getAccessControlModulePath } from '../admin-routing.module';
+
+const GROUP_EDIT_PATH = 'groups';
+
+export function getGroupEditPath(id: string) {
+  return new URLCombiner(getAccessControlModulePath(), GROUP_EDIT_PATH, id).toString();
+}
 
 @NgModule({
   imports: [
     RouterModule.forChild([
       { path: 'epeople', component: EPeopleRegistryComponent, data: { title: 'admin.access-control.epeople.title' } },
-      { path: 'groups', component: GroupsRegistryComponent, data: { title: 'admin.access-control.groups.title' } },
+      { path: GROUP_EDIT_PATH, component: GroupsRegistryComponent, data: { title: 'admin.access-control.groups.title' } },
       {
-        path: 'groups/:groupId',
+        path: `${GROUP_EDIT_PATH}/:groupId`,
         component: GroupFormComponent,
         data: {title: 'admin.registries.schema.title'}
       },
       {
-        path: 'groups/newGroup',
+        path: `${GROUP_EDIT_PATH}/newGroup`,
         component: GroupFormComponent,
         data: {title: 'admin.registries.schema.title'}
       },

--- a/src/app/+admin/admin-routing.module.ts
+++ b/src/app/+admin/admin-routing.module.ts
@@ -12,6 +12,10 @@ export function getRegistriesModulePath() {
   return new URLCombiner(getAdminModulePath(), REGISTRIES_MODULE_PATH).toString();
 }
 
+export function getAccessControlModulePath() {
+  return new URLCombiner(getAdminModulePath(), ACCESS_CONTROL_MODULE_PATH).toString();
+}
+
 @NgModule({
   imports: [
     RouterModule.forChild([

--- a/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.html
+++ b/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.html
@@ -1,0 +1,6 @@
+<ds-comcol-role
+  *ngFor="let comcolRole of getComcolRoles() | async"
+  [dso]="collection$ | async"
+  [comcolRole]="comcolRole"
+>
+</ds-comcol-role>

--- a/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
+++ b/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
@@ -10,6 +10,7 @@ import { Collection } from '../../../core/shared/collection.model';
 import { SharedModule } from '../../../shared/shared.module';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
 import { RequestService } from '../../../core/data/request.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CollectionRolesComponent', () => {
 
@@ -71,8 +72,9 @@ describe('CollectionRolesComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot(),
         SharedModule,
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot(),
       ],
       declarations: [
         CollectionRolesComponent,

--- a/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
+++ b/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed} from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { ActivatedRoute } from '@angular/router';
+import { of as observableOf } from 'rxjs/internal/observable/of';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { RemoteData } from '../../../core/data/remote-data';
+import { CollectionRolesComponent } from './collection-roles.component';
+import { Collection } from '../../../core/shared/collection.model';
+import { SharedModule } from '../../../shared/shared.module';
+import { GroupDataService } from '../../../core/eperson/group-data.service';
+import { RequestService } from '../../../core/data/request.service';
+
+describe('CollectionRolesComponent', () => {
+
+  let fixture: ComponentFixture<CollectionRolesComponent>;
+  let comp: CollectionRolesComponent;
+  let de: DebugElement;
+
+  beforeEach(() => {
+
+    const route = {
+      parent: {
+        data: observableOf({
+          dso: new RemoteData(
+            false,
+            false,
+            true,
+            undefined,
+            Object.assign(new Collection(), {
+              _links: {
+                'irrelevant': {
+                  href: 'irrelevant link',
+                },
+                'adminGroup': {
+                  href: 'adminGroup link',
+                },
+                'submittersGroup': {
+                  href: 'submittersGroup link',
+                },
+                'itemReadGroup': {
+                  href: 'itemReadGroup link',
+                },
+                'bitstreamReadGroup': {
+                  href: 'bitstreamReadGroup link',
+                },
+                'workflowGroups/test': {
+                  href: 'test workflow group link',
+                },
+              },
+            }),
+          ),
+        })
+      }
+    };
+
+    const requestService = {
+      hasByHrefObservable: () => observableOf(true),
+    };
+
+    const groupDataService = {
+      findByHref: () => observableOf(new RemoteData(
+        false,
+        false,
+        true,
+        undefined,
+        {},
+        200,
+      )),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        SharedModule,
+      ],
+      declarations: [
+        CollectionRolesComponent,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: route },
+        { provide: RequestService, useValue: requestService },
+        { provide: GroupDataService, useValue: groupDataService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CollectionRolesComponent);
+    comp = fixture.componentInstance;
+    de = fixture.debugElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should display a collection admin role component', () => {
+    expect(de.query(By.css('ds-comcol-role .collection-admin')))
+      .toBeTruthy();
+  });
+
+  it('should display a submitters role component', () => {
+    expect(de.query(By.css('ds-comcol-role .submitters')))
+      .toBeTruthy();
+  });
+
+  it('should display a default item read role component', () => {
+    expect(de.query(By.css('ds-comcol-role .item_read')))
+      .toBeTruthy();
+  });
+
+  it('should display a default bitstream read role component', () => {
+    expect(de.query(By.css('ds-comcol-role .bitstream_read')))
+      .toBeTruthy();
+  });
+
+  it('should display a test workflow role component', () => {
+    expect(de.query(By.css('ds-comcol-role .test')))
+      .toBeTruthy();
+  });
+});

--- a/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.ts
+++ b/src/app/+collection-page/edit-collection-page/collection-roles/collection-roles.component.ts
@@ -1,4 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { first, map } from 'rxjs/operators';
+import { RemoteData } from '../../../core/data/remote-data';
+import { Collection } from '../../../core/shared/collection.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../core/shared/operators';
+import { ComcolRole } from '../../../shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role';
 
 /**
  * Component for managing a collection's roles
@@ -7,6 +14,48 @@ import { Component } from '@angular/core';
   selector: 'ds-collection-roles',
   templateUrl: './collection-roles.component.html',
 })
-export class CollectionRolesComponent {
-  /* TODO: Implement Collection Edit - Roles */
+export class CollectionRolesComponent implements OnInit {
+
+  dsoRD$: Observable<RemoteData<Collection>>;
+
+  /**
+   * The collection to manage, as an observable.
+   */
+  get collection$(): Observable<Collection> {
+    return this.dsoRD$.pipe(
+      getSucceededRemoteData(),
+      getRemoteDataPayload(),
+    )
+  }
+
+  /**
+   * The different roles for the collection, as an observable.
+   */
+  getComcolRoles(): Observable<ComcolRole[]> {
+    return this.collection$.pipe(
+      map((collection) =>
+        [
+          ComcolRole.COLLECTION_ADMIN,
+          ComcolRole.SUBMITTERS,
+          ComcolRole.ITEM_READ,
+          ComcolRole.BITSTREAM_READ,
+          ...Object.keys(collection._links)
+            .filter((link) => link.startsWith('workflowGroups/'))
+            .map((link) => new ComcolRole(link.substr('workflowGroups/'.length), link)),
+        ]
+      ),
+    );
+  }
+
+  constructor(
+    protected route: ActivatedRoute,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.dsoRD$ = this.route.parent.data.pipe(
+      first(),
+      map((data) => data.dso),
+    );
+  }
 }

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.html
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.html
@@ -2,6 +2,5 @@
   *ngFor="let comcolRole of getComcolRoles()"
   [dso]="community$ | async"
   [comcolRole]="comcolRole"
-  class="card {{comcolRole.name}}"
 >
 </ds-comcol-role>

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.html
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.html
@@ -1,0 +1,7 @@
+<ds-comcol-role
+  *ngFor="let comcolRole of getComcolRoles()"
+  [dso]="community$ | async"
+  [comcolRole]="comcolRole"
+  class="card {{comcolRole.name}}"
+>
+</ds-comcol-role>

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { ActivatedRoute } from '@angular/router';
+import { of as observableOf } from 'rxjs/internal/observable/of';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { CommunityRolesComponent } from './community-roles.component';
+import { Community } from '../../../core/shared/community.model';
+import { By } from '@angular/platform-browser';
+import { RemoteData } from '../../../core/data/remote-data';
+
+describe('CommunityRolesComponent', () => {
+
+  let fixture: ComponentFixture<CommunityRolesComponent>;
+  let comp: CommunityRolesComponent;
+  let de: DebugElement;
+
+  beforeEach(() => {
+
+    const route = {
+      parent: {
+        data: observableOf({
+          dso: new RemoteData(
+            false,
+            false,
+            true,
+            undefined,
+            new Community(),
+          )
+        })
+      }
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+      ],
+      declarations: [
+        CommunityRolesComponent,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: route },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CommunityRolesComponent);
+    comp = fixture.componentInstance;
+    de = fixture.debugElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should display a community admin role component', () => {
+    expect(de.query(By.css('ds-comcol-role.admin'))).toBeDefined();
+  });
+});

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
@@ -7,6 +7,9 @@ import { CommunityRolesComponent } from './community-roles.component';
 import { Community } from '../../../core/shared/community.model';
 import { By } from '@angular/platform-browser';
 import { RemoteData } from '../../../core/data/remote-data';
+import { RequestService } from '../../../core/data/request.service';
+import { GroupDataService } from '../../../core/eperson/group-data.service';
+import { SharedModule } from '../../../shared/shared.module';
 
 describe('CommunityRolesComponent', () => {
 
@@ -24,21 +27,48 @@ describe('CommunityRolesComponent', () => {
             false,
             true,
             undefined,
-            new Community(),
-          )
+            Object.assign(new Community(), {
+              _links: {
+                irrelevant: {
+                  href: 'irrelevant link',
+                },
+                adminGroup: {
+                  href: 'adminGroup link',
+                },
+              },
+            }),
+          ),
         })
       }
+    };
+
+    const requestService = {
+      hasByHrefObservable: () => observableOf(true),
+    };
+
+    const groupDataService = {
+      findByHref: () => observableOf(new RemoteData(
+        false,
+        false,
+        true,
+        undefined,
+        {},
+        200,
+      )),
     };
 
     TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot(),
+        SharedModule,
       ],
       declarations: [
         CommunityRolesComponent,
       ],
       providers: [
         { provide: ActivatedRoute, useValue: route },
+        { provide: RequestService, useValue: requestService },
+        { provide: GroupDataService, useValue: groupDataService },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -51,6 +81,7 @@ describe('CommunityRolesComponent', () => {
   });
 
   it('should display a community admin role component', () => {
-    expect(de.query(By.css('ds-comcol-role.admin'))).toBeDefined();
+    expect(de.query(By.css('ds-comcol-role .community-admin')))
+      .toBeTruthy();
   });
 });

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.spec.ts
@@ -10,6 +10,7 @@ import { RemoteData } from '../../../core/data/remote-data';
 import { RequestService } from '../../../core/data/request.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CommunityRolesComponent', () => {
 
@@ -59,8 +60,9 @@ describe('CommunityRolesComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot(),
         SharedModule,
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot(),
       ],
       declarations: [
         CommunityRolesComponent,

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.ts
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.ts
@@ -33,7 +33,7 @@ export class CommunityRolesComponent implements OnInit {
    */
   getComcolRoles(): ComcolRole[] {
     return [
-      ComcolRole.ADMIN,
+      ComcolRole.COMMUNITY_ADMIN,
     ];
   }
 

--- a/src/app/+community-page/edit-community-page/community-roles/community-roles.component.ts
+++ b/src/app/+community-page/edit-community-page/community-roles/community-roles.component.ts
@@ -1,4 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs';
+import { first, map } from 'rxjs/operators';
+import { Community } from '../../../core/shared/community.model';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../core/shared/operators';
+import { ComcolRole } from '../../../shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role';
+import { RemoteData } from '../../../core/data/remote-data';
 
 /**
  * Component for managing a community's roles
@@ -7,6 +14,38 @@ import { Component } from '@angular/core';
   selector: 'ds-community-roles',
   templateUrl: './community-roles.component.html',
 })
-export class CommunityRolesComponent {
-  /* TODO: Implement Community Edit - Roles */
+export class CommunityRolesComponent implements OnInit {
+
+  dsoRD$: Observable<RemoteData<Community>>;
+
+  /**
+   * The community to manage, as an observable.
+   */
+  get community$(): Observable<Community> {
+    return this.dsoRD$.pipe(
+      getSucceededRemoteData(),
+      getRemoteDataPayload(),
+    )
+  }
+
+  /**
+   * The different roles for the community.
+   */
+  getComcolRoles(): ComcolRole[] {
+    return [
+      ComcolRole.ADMIN,
+    ];
+  }
+
+  constructor(
+    protected route: ActivatedRoute,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.dsoRD$ = this.route.parent.data.pipe(
+      first(),
+      map((data) => data.dso),
+    );
+  }
 }

--- a/src/app/core/eperson/group-data.service.spec.ts
+++ b/src/app/core/eperson/group-data.service.spec.ts
@@ -82,7 +82,8 @@ describe('GroupDataService', () => {
       rdbService,
       store,
       null,
-      halService
+      halService,
+      null,
     );
   };
 

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -15,6 +15,8 @@ import { RESOURCE_POLICY } from './resource-policy.resource-type';
 import { COMMUNITY } from './community.resource-type';
 import { Community } from './community.model';
 import { ChildHALResource } from './child-hal-resource.model';
+import { GROUP } from '../eperson/models/group.resource-type';
+import { Group } from '../eperson/models/group.model';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
@@ -69,6 +71,12 @@ export class Collection extends DSpaceObject implements ChildHALResource {
    */
   @link(COMMUNITY, false)
   parentCommunity?: Observable<RemoteData<Community>>;
+
+  /**
+   * The administrators group of this community.
+   */
+  @link(GROUP)
+  adminGroup?: Observable<RemoteData<Group>>;
 
   /**
    * The introductory text of this Collection

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -3,6 +3,8 @@ import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';
 import { RemoteData } from '../data/remote-data';
+import { Group } from '../eperson/models/group.model';
+import { GROUP } from '../eperson/models/group.resource-type';
 import { Bitstream } from './bitstream.model';
 import { BITSTREAM } from './bitstream.resource-type';
 import { Collection } from './collection.model';
@@ -32,6 +34,7 @@ export class Community extends DSpaceObject implements ChildHALResource {
     logo: HALLink;
     subcommunities: HALLink;
     parentCommunity: HALLink;
+    adminGroup: HALLink;
     self: HALLink;
   };
 
@@ -62,6 +65,12 @@ export class Community extends DSpaceObject implements ChildHALResource {
    */
   @link(COMMUNITY, false)
   parentCommunity?: Observable<RemoteData<Community>>;
+
+  /**
+   * The administrators group of this community.
+   */
+  @link(GROUP)
+  adminGroup?: Observable<RemoteData<Group>>;
 
   /**
    * The introductory text of this Community

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
@@ -1,40 +1,50 @@
-<div class="card p-2">
+<div class="card p-2 m-3 {{comcolRole.name}}">
 
-  <div class="card-body d-flex flex-column">
+  <div class="card-body d-flex flex-column"
+       *ngVar="group$ | async as group">
 
-    <div class="d-flex flex-row justify-content-between">
+    <div class="d-flex flex-md-row flex-column">
 
-      <div>
-        <p>{{'community.edit.tabs.roles.' + comcolRole.name + '.name' | translate}}</p>
+      <h5 class="w-100 ">
+        {{'comcol-role.edit.' + comcolRole.name + '.name' | translate}}
+      </h5>
+
+      <div class="w-100">
+        <ds-loading *ngIf="!(groupRD$ | async)"></ds-loading>
+        <div *ngIf="hasNoGroup$() | async">
+          {{'comcol-role.edit.no-group' | translate}}
+        </div>
+        <div *ngIf="hasAnonymousGroup$() | async">
+          {{'comcol-role.edit.' + comcolRole.name + '.anonymous-group' | translate}}
+        </div>
+        <a *ngIf="hasCustomGroup$() | async"
+           routerLink="{{editGroupLink$ | async}}">
+          {{group.name}}
+        </a>
       </div>
 
-      <ng-container *ngVar="group$ | async as group">
-
-          <div *ngIf="!group">
-            {{'community.edit.tabs.roles.none' | translate}}
-          </div>
-
-          <a *ngIf="group"
-             routerLink="{{editGroupLink$ | async}}">
-            {{group.name}}
-          </a>
-
-          <div *ngIf="!group"
-               class="btn btn-outline-dark create"
-               (click)="create()">create
-          </div>
-
-          <div *ngIf="group"
-               class="btn btn-outline-dark delete"
-               (click)="delete()">delete
-          </div>
-
-      </ng-container>
+      <div class="ml-md-auto pl-md-2 ml-0 pl-0 pt-2">
+        <div *ngIf="hasNoGroup$() | async"
+             class="btn btn-outline-dark create"
+             (click)="create()">
+          {{'comcol-role.edit.create' | translate}}
+        </div>
+        <div *ngIf="hasAnonymousGroup$() | async"
+             class="btn btn-outline-dark restrict"
+             (click)="create()">
+          {{'comcol-role.edit.restrict' | translate}}
+        </div>
+        <div *ngIf="hasCustomGroup$() | async"
+             class="btn btn-outline-dark delete"
+             (click)="delete()">
+          {{'comcol-role.edit.delete' | translate}}
+        </div>
+      </div>
 
     </div>
 
     <div class="mt-2">
-      {{'community.edit.tabs.roles.' + comcolRole.name + '.description' | translate}}
+      {{'comcol-role.edit.' + comcolRole.name + '.description' | translate}}
     </div>
 
   </div>

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
@@ -15,7 +15,7 @@
           </div>
 
           <a *ngIf="group"
-             href="{{editGroupLink$ | async}}">
+             routerLink="{{editGroupLink$ | async}}">
             {{group.name}}
           </a>
 

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
@@ -1,0 +1,42 @@
+<div class="card p-2">
+
+  <div class="card-body d-flex flex-column">
+
+    <div class="d-flex flex-row justify-content-between">
+
+      <div>
+        <p>{{'community.edit.tabs.roles.' + comcolRole.name + '.name' | translate}}</p>
+      </div>
+
+      <ng-container *ngVar="group$ | async as group">
+
+          <div *ngIf="!group">
+            {{'community.edit.tabs.roles.none' | translate}}
+          </div>
+
+          <a *ngIf="group"
+             href="{{editGroupLink$ | async}}">
+            {{group.name}}
+          </a>
+
+          <div *ngIf="!group"
+               class="btn btn-outline-dark create"
+               (click)="create()">create
+          </div>
+
+          <div *ngIf="group"
+               class="btn btn-outline-dark delete"
+               (click)="delete()">delete
+          </div>
+
+      </ng-container>
+
+    </div>
+
+    <div class="mt-2">
+      {{'community.edit.tabs.roles.' + comcolRole.name + '.description' | translate}}
+    </div>
+
+  </div>
+
+</div>

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -6,32 +6,46 @@ import { SharedModule } from '../../../shared.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { ChangeDetectorRef, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { RequestService } from '../../../../core/data/request.service';
-import { LinkService } from '../../../../core/cache/builders/link.service';
-import { Community } from '../../../../core/shared/community.model';
 import { ComcolRole } from './comcol-role';
 import { of as observableOf } from 'rxjs/internal/observable/of';
 import { RemoteData } from '../../../../core/data/remote-data';
-import { Group } from '../../../../core/eperson/models/group.model';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Collection } from '../../../../core/shared/collection.model';
 
 describe('ComcolRoleComponent', () => {
 
   let fixture: ComponentFixture<ComcolRoleComponent>;
   let comp: ComcolRoleComponent;
   let de: DebugElement;
+
+  let requestService;
   let groupService;
-  let linkService;
+
+  let group;
+  let statusCode;
 
   beforeEach(() => {
 
-    groupService = jasmine.createSpyObj('groupService', {
-      createComcolGroup: undefined,
-      deleteComcolGroup: undefined,
-    });
+    requestService = {hasByHrefObservable: () => observableOf(true)};
 
-    linkService = {
-      resolveLink: () => undefined,
+    groupService = {
+      findByHref: () => undefined,
+      createComcolGroup: jasmine.createSpy('createComcolGroup'),
+      deleteComcolGroup: jasmine.createSpy('deleteComcolGroup'),
     };
+
+    spyOn(groupService, 'findByHref').and.callFake((link) => {
+      if (link === 'test role link') {
+        return observableOf(new RemoteData(
+          false,
+          false,
+          true,
+          undefined,
+          group,
+          statusCode,
+        ));
+      }
+    });
 
     TestBed.configureTestingModule({
       imports: [
@@ -41,9 +55,8 @@ describe('ComcolRoleComponent', () => {
       ],
       providers: [
         { provide: GroupDataService, useValue: groupService },
-        { provide: LinkService, useValue: linkService },
         { provide: ChangeDetectorRef, useValue: {} },
-        { provide: RequestService, useValue: {} },
+        { provide: RequestService, useValue: requestService },
       ], schemas: [
         NO_ERRORS_SCHEMA
       ]
@@ -54,20 +67,38 @@ describe('ComcolRoleComponent', () => {
     de = fixture.debugElement;
 
     comp.comcolRole = new ComcolRole(
-      'test name',
-      'test link name',
+      'test role name',
+      'test role endpoint',
     );
 
-    comp.dso = new Community();
+    comp.dso = Object.assign(
+      new Collection(), {
+        _links: {
+          'test role endpoint': {
+            href: 'test role link',
+          }
+        }
+      }
+    );
 
     fixture.detectChanges();
   });
 
   describe('when there is no group yet', () => {
 
-    it('should have a create button but no delete button', () => {
-      expect(de.query(By.css('.btn.create'))).toBeDefined();
-      expect(de.query(By.css('.btn.delete'))).toBeNull();
+    beforeEach(() => {
+      group = null;
+      statusCode = 204;
+      fixture.detectChanges();
+    });
+
+    it('should have a create button but no restrict or delete button', () => {
+      expect(de.query(By.css('.btn.create')))
+        .toBeTruthy();
+      expect(de.query(By.css('.btn.restrict')))
+        .toBeNull();
+      expect(de.query(By.css('.btn.delete')))
+        .toBeNull();
     });
 
     describe('when the create button is pressed', () => {
@@ -82,25 +113,54 @@ describe('ComcolRoleComponent', () => {
     });
   });
 
-  describe('when there is a group yet', () => {
+  describe('when the related group is the Anonymous group', () => {
 
     beforeEach(() => {
-      Object.assign(comp.dso, {
-        'test link name': observableOf(new RemoteData(
-          false,
-          false,
-          true,
-          undefined,
-          new Group(),
-        )),
-      });
-
+      group = {
+        name: 'Anonymous'
+      };
+      statusCode = 200;
       fixture.detectChanges();
     });
 
-    it('should have a delete button but no create button', () => {
-      expect(de.query(By.css('.btn.delete'))).toBeDefined();
-      expect(de.query(By.css('.btn.create'))).toBeNull();
+    it('should have a restrict button but no create or delete button', () => {
+      expect(de.query(By.css('.btn.create')))
+        .toBeNull();
+      expect(de.query(By.css('.btn.restrict')))
+        .toBeTruthy();
+      expect(de.query(By.css('.btn.delete')))
+        .toBeNull();
+    });
+
+    describe('when the restrict button is pressed', () => {
+
+      beforeEach(() => {
+        de.query(By.css('.btn.restrict')).nativeElement.click();
+      });
+
+      it('should call the groupService create method', () => {
+        expect(groupService.createComcolGroup).toHaveBeenCalledWith(comp.dso, 'test role link');
+      });
+    });
+  });
+
+  describe('when the related group is a custom group', () => {
+
+    beforeEach(() => {
+      group = {
+        name: 'custom group name'
+      };
+      statusCode = 200;
+      fixture.detectChanges();
+    });
+
+    it('should have a delete button but no create or restrict button', () => {
+      expect(de.query(By.css('.btn.create')))
+        .toBeNull();
+      expect(de.query(By.css('.btn.restrict')))
+        .toBeNull();
+      expect(de.query(By.css('.btn.delete')))
+        .toBeTruthy();
     });
 
     describe('when the delete button is pressed', () => {

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -55,7 +55,6 @@ describe('ComcolRoleComponent', () => {
       ],
       providers: [
         { provide: GroupDataService, useValue: groupService },
-        { provide: ChangeDetectorRef, useValue: {} },
         { provide: RequestService, useValue: requestService },
       ], schemas: [
         NO_ERRORS_SCHEMA

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -1,0 +1,117 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComcolRoleComponent } from './comcol-role.component';
+import { GroupDataService } from '../../../../core/eperson/group-data.service';
+import { By } from '@angular/platform-browser';
+import { SharedModule } from '../../../shared.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { ChangeDetectorRef, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { RequestService } from '../../../../core/data/request.service';
+import { LinkService } from '../../../../core/cache/builders/link.service';
+import { Community } from '../../../../core/shared/community.model';
+import { ComcolRole } from './comcol-role';
+import { of as observableOf } from 'rxjs/internal/observable/of';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { Group } from '../../../../core/eperson/models/group.model';
+
+describe('ComcolRoleComponent', () => {
+
+  let fixture: ComponentFixture<ComcolRoleComponent>;
+  let comp: ComcolRoleComponent;
+  let de: DebugElement;
+  let groupService;
+  let linkService;
+
+  beforeEach(() => {
+
+    groupService = jasmine.createSpyObj('groupService', {
+      createComcolGroup: undefined,
+      deleteComcolGroup: undefined,
+    });
+
+    linkService = {
+      resolveLink: () => undefined,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        SharedModule,
+      ],
+      declarations: [
+      ],
+      providers: [
+        { provide: GroupDataService, useValue: groupService },
+        { provide: LinkService, useValue: linkService },
+        { provide: ChangeDetectorRef, useValue: {} },
+        { provide: RequestService, useValue: {} },
+      ], schemas: [
+        NO_ERRORS_SCHEMA
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ComcolRoleComponent);
+    comp = fixture.componentInstance;
+    de = fixture.debugElement;
+
+    comp.comcolRole = new ComcolRole(
+      'test name',
+      'test link name',
+    );
+
+    comp.dso = new Community();
+
+    fixture.detectChanges();
+  });
+
+  describe('when there is no group yet', () => {
+
+    it('should have a create button but no delete button', () => {
+      expect(de.query(By.css('.btn.create'))).toBeDefined();
+      expect(de.query(By.css('.btn.delete'))).toBeNull();
+    });
+
+    describe('when the create button is pressed', () => {
+
+      beforeEach(() => {
+        de.query(By.css('.btn.create')).nativeElement.click();
+      });
+
+      it('should call the groupService create method', () => {
+        expect(groupService.createComcolGroup).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when there is a group yet', () => {
+
+    beforeEach(() => {
+      Object.assign(comp.dso, {
+        'test link name': observableOf(new RemoteData(
+          false,
+          false,
+          true,
+          undefined,
+          new Group(),
+        )),
+      });
+
+      fixture.detectChanges();
+    });
+
+    it('should have a delete button but no create button', () => {
+      expect(de.query(By.css('.btn.delete'))).toBeDefined();
+      expect(de.query(By.css('.btn.create'))).toBeNull();
+    });
+
+    describe('when the delete button is pressed', () => {
+
+      beforeEach(() => {
+        de.query(By.css('.btn.delete')).nativeElement.click();
+      });
+
+      it('should call the groupService delete method', () => {
+        expect(groupService.deleteComcolGroup).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -12,6 +12,7 @@ import { ComcolRole } from './comcol-role';
 import { of as observableOf } from 'rxjs/internal/observable/of';
 import { RemoteData } from '../../../../core/data/remote-data';
 import { Group } from '../../../../core/eperson/models/group.model';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ComcolRoleComponent', () => {
 
@@ -34,10 +35,9 @@ describe('ComcolRoleComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot(),
         SharedModule,
-      ],
-      declarations: [
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot(),
       ],
       providers: [
         { provide: GroupDataService, useValue: groupService },

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
@@ -1,0 +1,94 @@
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { Group } from '../../../../core/eperson/models/group.model';
+import { Community } from '../../../../core/shared/community.model';
+import { EMPTY, Observable } from 'rxjs';
+import { getGroupEditPath } from '../../../../+admin/admin-access-control/admin-access-control-routing.module';
+import { GroupDataService } from '../../../../core/eperson/group-data.service';
+import { Collection } from '../../../../core/shared/collection.model';
+import { map } from 'rxjs/operators';
+import { followLink } from '../../../utils/follow-link-config.model';
+import { LinkService } from '../../../../core/cache/builders/link.service';
+import { getRemoteDataPayload, getSucceededRemoteData } from '../../../../core/shared/operators';
+import { ComcolRole } from './comcol-role';
+import { RequestService } from '../../../../core/data/request.service';
+
+/**
+ * Component for managing a community or collection role.
+ */
+@Component({
+  selector: 'ds-comcol-role',
+  styleUrls: ['./comcol-role.component.scss'],
+  templateUrl: './comcol-role.component.html'
+})
+export class ComcolRoleComponent implements OnInit {
+
+  /**
+   * The community or collection to manage.
+   */
+  @Input()
+  dso: Community|Collection;
+
+  /**
+   * The role to manage
+   */
+  @Input()
+  comcolRole: ComcolRole;
+
+  constructor(
+    protected groupService: GroupDataService,
+    protected linkService: LinkService,
+    protected cdr: ChangeDetectorRef,
+    protected requestService: RequestService,
+  ) {
+  }
+
+  /**
+   * The group for this role as an observable.
+   */
+  get group$(): Observable<Group> {
+
+    if (!this.dso[this.comcolRole.linkName]) {
+      return EMPTY;
+    }
+
+    return this.dso[this.comcolRole.linkName].pipe(
+      getSucceededRemoteData(),
+      getRemoteDataPayload(),
+    );
+  }
+
+  /**
+   * The link to the group edit page as an observable.
+   */
+  get editGroupLink$(): Observable<string> {
+    return this.group$.pipe(
+      map((group) => getGroupEditPath(group.id)),
+    );
+  }
+
+  /**
+   * Create a group for this community or collection role.
+   */
+  create() {
+
+    this.groupService.createComcolGroup(this.dso, this.comcolRole)
+      .subscribe(() => {
+        this.linkService.resolveLink(this.dso, followLink(this.comcolRole.linkName));
+        this.cdr.detectChanges();
+      });
+  }
+
+  /**
+   * Delete the group for this community or collection role.
+   */
+  delete() {
+    this.groupService.deleteComcolGroup(this.dso, this.comcolRole)
+      .subscribe(() => {
+        this.cdr.detectChanges();
+      })
+  }
+
+  ngOnInit(): void {
+    this.linkService.resolveLink(this.dso, followLink(this.comcolRole.linkName));
+  }
+}

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.ts
@@ -7,11 +7,43 @@ import { Collection } from '../../../../core/shared/collection.model';
 export class ComcolRole {
 
   /**
-   * The admin role.
+   * The community admin role.
    */
-  public static ADMIN = new ComcolRole(
-    'admin',
+  public static COMMUNITY_ADMIN = new ComcolRole(
+    'community-admin',
     'adminGroup',
+  );
+
+  /**
+   * The collection admin role.
+   */
+  public static COLLECTION_ADMIN = new ComcolRole(
+    'collection-admin',
+    'adminGroup',
+  );
+
+  /**
+   * The submitters role.
+   */
+  public static SUBMITTERS = new ComcolRole(
+    'submitters',
+    'submittersGroup',
+  );
+
+  /**
+   * The default item read role.
+   */
+  public static ITEM_READ = new ComcolRole(
+    'item_read',
+    'itemReadGroup',
+  );
+
+  /**
+   * The default bitstream read role.
+   */
+  public static BITSTREAM_READ = new ComcolRole(
+    'bitstream_read',
+    'bitstreamReadGroup',
   );
 
   /**

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-role/comcol-role.ts
@@ -1,0 +1,45 @@
+import { Community } from '../../../../core/shared/community.model';
+import { Collection } from '../../../../core/shared/collection.model';
+
+/**
+ * Class representing a community or collection role.
+ */
+export class ComcolRole {
+
+  /**
+   * The admin role.
+   */
+  public static ADMIN = new ComcolRole(
+    'admin',
+    'adminGroup',
+  );
+
+  /**
+   * @param name      The name for this community or collection role.
+   * @param linkName  The path linking to this community or collection role.
+   */
+  constructor(
+    public name,
+    public linkName,
+  ) {
+  }
+
+  /**
+   * Get the REST endpoint for managing this role for a given community or collection.
+   * @param dso
+   */
+  public getEndpoint(dso: Community | Collection) {
+
+    let linkPath;
+    switch (dso.type + '') {
+      case 'community':
+        linkPath = 'communities';
+        break;
+      case 'collection':
+        linkPath = 'collections';
+        break;
+    }
+
+    return `${linkPath}/${dso.uuid}/${this.linkName}`;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -9,6 +9,7 @@ import { NgbDatepickerModule, NgbModule, NgbTimepickerModule, NgbTypeaheadModule
 import { MissingTranslationHandler, TranslateModule } from '@ngx-translate/core';
 
 import { NgxPaginationModule } from 'ngx-pagination';
+import { ComcolRoleComponent } from './comcol-forms/edit-comcol-page/comcol-role/comcol-role.component';
 import { PublicationListElementComponent } from './object-list/item-list-element/item-types/publication/publication-list-element.component';
 
 import { FileUploadModule } from 'ng2-file-upload';
@@ -252,6 +253,7 @@ const COMPONENTS = [
   EditComColPageComponent,
   DeleteComColPageComponent,
   ComcolPageBrowseByComponent,
+  ComcolRoleComponent,
   DsDynamicFormComponent,
   DsDynamicFormControlContainerComponent,
   DsDynamicListComponent,


### PR DESCRIPTION
This PR adds functionality to create/delete an admin group for a collection.
This is added to the ‘Edit roles’ tab of the edit collection page by the CollectionRolesComponent.

New ComcolRole instances have been added, along with the relevant messages:

* 'collection_admin' (community admin role has been renamed to 'community_admin')
* 'submitters'
* 'item_read'
* 'bitstream_read'

The workflow roles are retrieved by the CollectionRolesComponent from the collection links starting with 'workflowGroups/'.

I couldn't find a way in the front-end to link the workflow steps to the workflow roles, so the page is a bit different from the DSpace 6 equivalent because it displays the workflow roles by the role rather than by the step.
For example:
* DSpace 6: 'Edit Metadata Step'
* DSpace 7: 'Reviewers'
The functionality doesn't change however.

The ComcolRoleComponent has been altered to support Anonymous groups.

This PR is dependent on
https://github.com/DSpace/dspace-angular/pull/632