### PR TITLE
Request by UUID issue

### DIFF
--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -162,7 +162,7 @@ describe('RequestService', () => {
       });
     });
 
-    describe('if the request with the specified UUID doesn\'t exist in the store', () => {
+    describe(`if the request with the specified UUID doesn't exist in the store `, () => {
       beforeEach(() => {
         selectSpy.and.callFake(() => {
           return () => {
@@ -171,10 +171,10 @@ describe('RequestService', () => {
         });
       });
 
-      it('should return an Observable of undefined', () => {
+      it(`it shouldn't return anything`, () => {
         const result = service.getByUUID(testUUID);
 
-        scheduler.expectObservable(result).toBe('b', { b: undefined });
+        scheduler.expectObservable(result).toBe('');
       });
     });
 

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -149,8 +149,7 @@ export class RequestService {
       mergeMap((uuid: string) => {
         if (isNotEmpty(uuid)) {
           return this.getByUUID(uuid);
-        }
-        else {
+        } else {
           return [undefined];
         }
       })


### PR DESCRIPTION
## Description
requestService.getUUID() didn't work for UUIDs of requests that aren't sent because they were already cached. 

## Instructions for Reviewers
The reason was that there was an observableRace to find which observable that returns first: the one in the cache or the one in the index that maps unsent UUIDs to the cached ones.

Because ngrx selectors return undefined immediately if they have no result, in practice the call that checked the requestcache always won the race because its undefined came before the result from the index.

The way to fix it was to add an hasValueOperator() to each of the race observables. That way they can only win if they return something.

I also optimized getByHref by ensuring it doesn't pass calls on to getByUUID if the UUID is empty

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
