### PR TITLE
[Quickfix] Fix IDE issues with spec files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
       "es2017"
     ],
     "types": [
-      "node"
+      "node",
+      "jasmine"
     ]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
All *.spec files showed errors in IDEs, even though they would compile.
This was caused by the fact that IDEs only recognize a single tsconfig.json file, even though we use a separate one for *.spec files.
Adding type "jasmine" to the root tsconfig.json file solves this issue.