### PR TITLE
Fix delay in breadcrumb rendering

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,17 +1,20 @@
-<nav *ngIf="showBreadcrumbs" aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <ng-container *ngTemplateOutlet="breadcrumbs.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'Home', url: '/'}"></ng-container>
-        <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
-            <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
-        </ng-container>
-    </ol>
-</nav>
+<ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
+    <nav *ngIf="showBreadcrumbs" aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <ng-container
+                    *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'Home', url: '/'}"></ng-container>
+            <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
+                <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
+            </ng-container>
+        </ol>
+    </nav>
 
-<ng-template #breadcrumb let-text="text" let-url="url">
-    <li class="breadcrumb-item"><a [routerLink]="url">{{text | translate}}</a></li>
-</ng-template>
+    <ng-template #breadcrumb let-text="text" let-url="url">
+        <li class="breadcrumb-item"><a [routerLink]="url">{{text | translate}}</a></li>
+    </ng-template>
 
-<ng-template #activeBreadcrumb let-text="text" >
-    <li class="breadcrumb-item active" aria-current="page">{{text | translate}}</li>
-</ng-template>
+    <ng-template #activeBreadcrumb let-text="text">
+        <li class="breadcrumb-item active" aria-current="page">{{text | translate}}</li>
+    </ng-template>
+</ng-container>
 

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -9,6 +9,9 @@ import { TranslateLoaderMock } from '../shared/testing/translate-loader.mock';
 import { BreadcrumbConfig } from './breadcrumb/breadcrumb-config.model';
 import { BreadcrumbsService } from '../core/breadcrumbs/breadcrumbs.service';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { VarDirective } from '../shared/utils/var.directive';
 import { getTestScheduler } from 'jasmine-marbles';
 
 class TestBreadcrumbsService implements BreadcrumbsService<string> {
@@ -64,17 +67,16 @@ describe('BreadcrumbsComponent', () => {
   beforeEach(async(() => {
     init();
     TestBed.configureTestingModule({
-      declarations: [BreadcrumbsComponent],
+      declarations: [BreadcrumbsComponent, VarDirective],
       imports: [RouterTestingModule.withRoutes([]), TranslateModule.forRoot({
         loader: {
           provide: TranslateLoader,
           useClass: TranslateLoaderMock
         }
-      })],
+      }), NgbModule],
       providers: [
-        { provide: ActivatedRoute, useValue: route }
-
-      ]
+        {provide: ActivatedRoute, useValue: route}
+      ], schemas: [NO_ERRORS_SCHEMA]
     })
       .compileComponents();
   }));
@@ -92,14 +94,16 @@ describe('BreadcrumbsComponent', () => {
 
   describe('ngOnInit', () => {
     beforeEach(() => {
-      spyOn(component, 'resolveBreadcrumbs').and.returnValue(observableOf([]))
+      spyOn(component, 'resolveBreadcrumbs').and.returnValue(observableOf([]));
     });
 
     it('should call resolveBreadcrumb on init', () => {
       router.events = observableOf(new NavigationEnd(0, '', ''));
       component.ngOnInit();
+      fixture.detectChanges();
+
       expect(component.resolveBreadcrumbs).toHaveBeenCalledWith(route.root);
-    })
+    });
   });
 
   describe('resolveBreadcrumbs', () => {

--- a/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
-import { hasNoValue, hasValue, isNotUndefined, isUndefined } from '../shared/empty.util';
+import { hasNoValue, hasValue, isUndefined } from '../shared/empty.util';
 import { filter, map, switchMap, tap } from 'rxjs/operators';
-import { combineLatest, Observable, Subscription, of as observableOf } from 'rxjs';
+import { combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
 
 /**
  * Component representing the breadcrumbs of a page
@@ -13,21 +13,16 @@ import { combineLatest, Observable, Subscription, of as observableOf } from 'rxj
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss']
 })
-export class BreadcrumbsComponent implements OnInit, OnDestroy {
+export class BreadcrumbsComponent implements OnInit {
   /**
-   * List of breadcrumbs for this page
+   * Observable of the list of breadcrumbs for this page
    */
-  breadcrumbs: Breadcrumb[];
+  breadcrumbs$: Observable<Breadcrumb[]>;
 
   /**
    * Whether or not to show breadcrumbs on this page
    */
   showBreadcrumbs: boolean;
-
-  /**
-   * Subscription to unsubscribe from on destroy
-   */
-  subscription: Subscription;
 
   constructor(
     private route: ActivatedRoute,
@@ -39,14 +34,11 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
    * Sets the breadcrumbs on init for this page
    */
   ngOnInit(): void {
-    this.subscription = this.router.events.pipe(
+    this.breadcrumbs$ = this.router.events.pipe(
       filter((e): e is NavigationEnd => e instanceof NavigationEnd),
       tap(() => this.reset()),
-      switchMap(() => this.resolveBreadcrumbs(this.route.root))
-    ).subscribe((breadcrumbs) => {
-        this.breadcrumbs = breadcrumbs;
-      }
-    )
+      switchMap(() => this.resolveBreadcrumbs(this.route.root)),
+    );
   }
 
   /**
@@ -82,19 +74,9 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Unsubscribe from subscription
-   */
-  ngOnDestroy(): void {
-    if (hasValue(this.subscription)) {
-      this.subscription.unsubscribe();
-    }
-  }
-
-  /**
    * Resets the state of the breadcrumbs
    */
   reset() {
-    this.breadcrumbs = [];
     this.showBreadcrumbs = true;
   }
 }

--- a/src/app/core/breadcrumbs/collection-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/collection-breadcrumb.resolver.ts
@@ -8,7 +8,9 @@ import { followLink, FollowLinkConfig } from '../../shared/utils/follow-link-con
 /**
  * The class that resolves the BreadcrumbConfig object for a Collection
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class CollectionBreadcrumbResolver extends DSOBreadcrumbResolver<Collection> {
   constructor(protected breadcrumbService: DSOBreadcrumbsService, protected dataService: CollectionDataService) {
     super(breadcrumbService, dataService);

--- a/src/app/core/breadcrumbs/community-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/community-breadcrumb.resolver.ts
@@ -8,7 +8,9 @@ import { followLink, FollowLinkConfig } from '../../shared/utils/follow-link-con
 /**
  * The class that resolves the BreadcrumbConfig object for a Community
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class CommunityBreadcrumbResolver extends DSOBreadcrumbResolver<Community> {
   constructor(protected breadcrumbService: DSOBreadcrumbsService, protected dataService: CommunityDataService) {
     super(breadcrumbService, dataService);

--- a/src/app/core/breadcrumbs/dso-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/dso-breadcrumb.resolver.ts
@@ -13,7 +13,9 @@ import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 /**
  * The class that resolves the BreadcrumbConfig object for a DSpaceObject
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export abstract class DSOBreadcrumbResolver<T extends ChildHALResource & DSpaceObject> implements Resolve<BreadcrumbConfig<T>> {
   constructor(protected breadcrumbService: DSOBreadcrumbsService, protected dataService: DataService<T>) {
   }

--- a/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
+++ b/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
@@ -15,7 +15,9 @@ import { Injectable } from '@angular/core';
 /**
  * Service to calculate DSpaceObject breadcrumbs for a single part of the route
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class DSOBreadcrumbsService implements BreadcrumbsService<ChildHALResource & DSpaceObject> {
   constructor(
     private linkService: LinkService,

--- a/src/app/core/breadcrumbs/i18n-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/i18n-breadcrumb.resolver.ts
@@ -7,7 +7,9 @@ import { hasNoValue } from '../../shared/empty.util';
 /**
  * The class that resolves a BreadcrumbConfig object with an i18n key string for a route
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class I18nBreadcrumbResolver implements Resolve<BreadcrumbConfig<string>> {
   constructor(protected breadcrumbService: I18nBreadcrumbsService) {
   }

--- a/src/app/core/breadcrumbs/i18n-breadcrumbs.service.ts
+++ b/src/app/core/breadcrumbs/i18n-breadcrumbs.service.ts
@@ -11,7 +11,9 @@ export const BREADCRUMB_MESSAGE_POSTFIX = '.breadcrumbs';
 /**
  * Service to calculate i18n breadcrumbs for a single part of the route
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class I18nBreadcrumbsService implements BreadcrumbsService<string> {
 
   /**

--- a/src/app/core/breadcrumbs/item-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/item-breadcrumb.resolver.ts
@@ -8,7 +8,9 @@ import { followLink, FollowLinkConfig } from '../../shared/utils/follow-link-con
 /**
  * The class that resolves the BreadcrumbConfig object for an Item
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ItemBreadcrumbResolver extends DSOBreadcrumbResolver<Item> {
   constructor(protected breadcrumbService: DSOBreadcrumbsService, protected dataService: ItemDataService) {
     super(breadcrumbService, dataService);


### PR DESCRIPTION
## References
The issue was mentioned in an [Angular issue comment](https://github.com/DSpace/dspace-angular/pull/645#issuecomment-624645477)
> > I also noticed, but it seems an issue with breadcrumbs change detection because after the first triggered change detection the right trail appears
>
>You're right. I see why as well. I'll create a small PR to fix it.
​
## Description
Fix to correctly update the breadcrumb when navigating directly to a DSpace page.
​
## Instructions for Reviewers
There was an issue with the breadcrumb not updating automatically when using the browser to directly go to a DSpace page.
This fix solves that issue.
​
To verify the fix:
* Open the homepage of the repository.
* Navigate to an item page. Verify that the breadcrumb updates upon navigation.
* Hard refresh your browser on the item page. Verify that the breadcrumb corresponds to the current item page breadcrumb
​
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_
​
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.