### PR TITLE
Authentication issue csr

### DIFF
--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -36,7 +36,7 @@ import { AppState, storeModuleConfig } from '../../app.reducer';
 import { StoreActionTypes } from '../../store.actions';
 import { isAuthenticated, isAuthenticatedLoaded } from './selectors';
 
-fdescribe('AuthEffects', () => {
+describe('AuthEffects', () => {
   let authEffects: AuthEffects;
   let actions: Observable<any>;
   let authServiceStub;

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -1,9 +1,9 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Store } from '@ngrx/store';
+import { Store, StoreModule } from '@ngrx/store';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { cold, hot } from 'jasmine-marbles';
-
 import { Observable, of as observableOf, throwError as observableThrow } from 'rxjs';
 
 import { AuthEffects } from './auth.effects';
@@ -29,41 +29,53 @@ import {
 } from './auth.actions';
 import { authMethodsMock, AuthServiceStub } from '../../shared/testing/auth-service.stub';
 import { AuthService } from './auth.service';
-import { AuthState } from './auth.reducer';
-
+import { authReducer } from './auth.reducer';
 import { AuthStatus } from './models/auth-status.model';
 import { EPersonMock } from '../../shared/testing/eperson.mock';
+import { AppState, storeModuleConfig } from '../../app.reducer';
+import { StoreActionTypes } from '../../store.actions';
+import { isAuthenticated, isAuthenticatedLoaded } from './selectors';
 
-describe('AuthEffects', () => {
+fdescribe('AuthEffects', () => {
   let authEffects: AuthEffects;
   let actions: Observable<any>;
   let authServiceStub;
-  const store: Store<AuthState> = jasmine.createSpyObj('store', {
-    /* tslint:disable:no-empty */
-    dispatch: {},
-    /* tslint:enable:no-empty */
-    select: observableOf(true)
-  });
+  let initialState;
   let token;
+  let store: MockStore<AppState>;
 
   function init() {
     authServiceStub = new AuthServiceStub();
     token = authServiceStub.getToken();
+    initialState = {
+      core: {
+        auth: {
+          authenticated: false,
+          loaded: false,
+          loading: false,
+          authMethods: []
+        }
+      }
+    };
   }
 
   beforeEach(() => {
     init();
     TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({ auth: authReducer }, storeModuleConfig)
+      ],
       providers: [
         AuthEffects,
+        provideMockStore({ initialState }),
         { provide: AuthService, useValue: authServiceStub },
-        { provide: Store, useValue: store },
         provideMockActions(() => actions),
         // other providers
       ],
     });
 
     authEffects = TestBed.get(AuthEffects);
+    store = TestBed.get(Store);
   });
 
   describe('authenticate$', () => {
@@ -361,5 +373,41 @@ describe('AuthEffects', () => {
         expect(authEffects.retrieveMethods$).toBeObservable(expected);
       });
     })
+  });
+
+  describe('clearInvalidTokenOnRehydrate$', () => {
+
+    beforeEach(() => {
+      store.overrideSelector(isAuthenticated, false);
+    });
+
+    describe('when auth loaded is false', () => {
+      it('should not call removeToken method', (done) => {
+        store.overrideSelector(isAuthenticatedLoaded, false);
+        actions = hot('--a-|', { a: { type: StoreActionTypes.REHYDRATE } });
+        spyOn(authServiceStub, 'removeToken');
+
+        authEffects.clearInvalidTokenOnRehydrate$.subscribe(() => {
+          expect(authServiceStub.removeToken).not.toHaveBeenCalled();
+
+        });
+
+        done();
+      });
+    });
+
+    describe('when auth loaded is true', () => {
+      it('should call removeToken method', fakeAsync(() => {
+        store.overrideSelector(isAuthenticatedLoaded, true);
+        actions = hot('--a-|', { a: { type: StoreActionTypes.REHYDRATE } });
+        spyOn(authServiceStub, 'removeToken');
+
+        authEffects.clearInvalidTokenOnRehydrate$.subscribe(() => {
+          expect(authServiceStub.removeToken).toHaveBeenCalled();
+          flush();
+        });
+
+      }));
+    });
   });
 });

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -1,20 +1,18 @@
-import { Observable, of as observableOf } from 'rxjs';
-
-import { catchError, debounceTime, filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 
+import { combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
+import { catchError, debounceTime, filter, map, switchMap, take, tap } from 'rxjs/operators';
 // import @ngrx
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Action, select, Store } from '@ngrx/store';
 
 // import services
 import { AuthService } from './auth.service';
-
 import { EPerson } from '../eperson/models/eperson.model';
 import { AuthStatus } from './models/auth-status.model';
 import { AuthTokenInfo } from './models/auth-token-info.model';
 import { AppState } from '../../app.reducer';
-import { isAuthenticated } from './selectors';
+import { isAuthenticated, isAuthenticatedLoaded } from './selectors';
 import { StoreActionTypes } from '../../store.actions';
 import { AuthMethod } from './models/auth.method';
 // import actions
@@ -187,10 +185,11 @@ export class AuthEffects {
   public clearInvalidTokenOnRehydrate$: Observable<any> = this.actions$.pipe(
     ofType(StoreActionTypes.REHYDRATE),
     switchMap(() => {
-      return this.store.pipe(
-        select(isAuthenticated),
+      const isLoaded$ = this.store.pipe(select(isAuthenticatedLoaded));
+      const authenticated$ = this.store.pipe(select(isAuthenticated));
+      return observableCombineLatest(isLoaded$, authenticated$).pipe(
         take(1),
-        filter((authenticated) => !authenticated),
+        filter(([loaded, authenticated]) => loaded && !authenticated),
         tap(() => this.authService.removeToken()),
         tap(() => this.authService.resetAuthenticationError())
       );

--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -1,4 +1,5 @@
-<form  (ngSubmit)="submit()"
+<form class="form-login"
+      (ngSubmit)="submit()"
       [formGroup]="form" novalidate>
   <label for="inputEmail" class="sr-only">{{"login.form.email" | translate}}</label>
   <input id="inputEmail"

--- a/src/app/shared/testing/auth-service.stub.ts
+++ b/src/app/shared/testing/auth-service.stub.ts
@@ -150,4 +150,8 @@ export class AuthServiceStub {
   getImpersonateID() {
     return this.impersonating;
   }
+
+  resetAuthenticationError() {
+    return;
+  }
 }


### PR DESCRIPTION
## References
https://github.com/DSpace/dspace-angular/issues/289

## Description
This resolve issue #289 with authentication that didn't work properly when SSR is disabled. The issue was due that JWT cookie was deleted, without checking if is valid, when authenticated status is false during store rehydration. This happened because it assumed checking of JWT had already been done on SSR.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
- Run application with `yarn start:dev`
- login 
- refresh the browser page 

with the previous code the session was lost now is maintained

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
