### PR TITLE
Quick fix to Travis e2e testing issues (running against a Docker backend)

### DIFF
--- a/docker/local.cfg
+++ b/docker/local.cfg
@@ -1,5 +1,6 @@
 dspace.dir=/dspace
 db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.server.url=http://localhost:8080/server
+dspace.ui.url=http://localhost:4000
 dspace.name=DSpace Started with Docker Compose
 solr.server=http://dspacesolr:8983/solr


### PR DESCRIPTION
Recently, all PRs began failing e2e tests (which run against a Docker-based REST API in Travis).  See for example the latest `master` build: https://travis-ci.com/github/dspace/dspace-angular/builds/167632878

This began when https://github.com/DSpace/DSpace/pull/2735 was merged, and I've tracked it down to a configuration problem for the Docker REST API backend.  Simply put, in https://github.com/DSpace/DSpace/pull/2735, the REST API CORS headers were updated to limit access to only URLs defined in `rest.cors.allowed-origins`, which only includes `dspace.ui.url` by default.

Unfortunately, in the REST API, currently `dspace.ui.url` still defaults to http://localhost:3000, while the frontend now defaults to port 4000 (as of #625)

So, this PR simply changes our Travis Docker REST API configuration to set `dspace.ui.url=http://localhost:4000`, which ensures the front end in Travis CI (running on port 4000) is allowed to access the backend running in Docker.

I'll be submitting a separate PR to the REST API to correct this port in the default `dspace.cfg` (_now submitted, see https://github.com/DSpace/DSpace/pull/2772_).  But this PR fixes the Travis build errors for the front end and ensures the `dspace.ui.url` is explicitly defined (rather than relying on defaults).

**This PR only affects Travis CI and therefore will be merged immediately if Travis CI succeeds.**
