### PR TITLE
Angular UI does not properly log out when clicking logout

### DIFF
--- a/src/app/core/auth/auth.interceptor.spec.ts
+++ b/src/app/core/auth/auth.interceptor.spec.ts
@@ -48,7 +48,7 @@ describe(`AuthInterceptor`, () => {
 
   describe('when has a valid token', () => {
 
-    it('should not add an Authorization header when we’re sending a HTTP request to \'authn\' endpoint', () => {
+    it('should not add an Authorization header when we’re sending a HTTP request to \'authn\' endpoint that is not the logout endpoint', () => {
       service.request(RestRequestMethod.POST, 'dspace-spring-rest/api/authn/login', 'password=password&user=user').subscribe((response) => {
         expect(response).toBeTruthy();
       });
@@ -58,8 +58,19 @@ describe(`AuthInterceptor`, () => {
       const token = httpRequest.request.headers.get('authorization');
       expect(token).toBeNull();
     });
+    it('should add an Authorization header when we’re sending a HTTP request to the\'authn/logout\' endpoint', () => {
+      service.request(RestRequestMethod.POST, 'dspace-spring-rest/api/authn/logout', 'test').subscribe((response) => {
+        expect(response).toBeTruthy();
+      });
 
-    it('should add an Authorization header when we’re sending a HTTP request to \'authn\' endpoint', () => {
+      const httpRequest = httpMock.expectOne(`dspace-spring-rest/api/authn/logout`);
+
+      expect(httpRequest.request.headers.has('authorization'));
+      const token = httpRequest.request.headers.get('authorization');
+      expect(token).toBe('Bearer token_test');
+    });
+
+    it('should add an Authorization header when we’re sending a HTTP request to a non-\'authn\' endpoint', () => {
       service.request(RestRequestMethod.POST, 'dspace-spring-rest/api/submission/workspaceitems', 'test').subscribe((response) => {
         expect(response).toBeTruthy();
       });

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -221,7 +221,7 @@ export class AuthInterceptor implements HttpInterceptor {
       // Redirect to the login route
       this.store.dispatch(new RedirectWhenTokenExpiredAction('auth.messages.expired'));
       return observableOf(null);
-    } else if (!this.isAuthRequest(req) && isNotEmpty(token)) {
+    } else if ((!this.isAuthRequest(req) || this.isLogoutResponse(req)) && isNotEmpty(token)) {
       // Intercept a request that is not to the authentication endpoint
       authService.isTokenExpiring().pipe(
         filter((isExpiring) => isExpiring))


### PR DESCRIPTION
## References
This PR is related to [Angular issue 678](https://github.com/DSpace/dspace-angular/issues/678)

## Description
This PR fixes the logout request to correctly send the token to be logged out to the server.

## Instructions for Reviewers
This PR ensures that the authorization token is sent with a logout request so the server knows which user to log out.

To verify the changes the following can be done
* Log in into the UI.
* Obtain the authorization token from a request in the request tab.
* Use the authorization token in a curl or postman to perform a GET request to the items endpoint (.../api/core/items).
* Verify that this gives a list of items.
* Log out in the UI.
* Use the same authorization token in a curl or postman to perform a GET request to the items endpoint.
* Verify that your request is unauthorized.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
