### PR TITLE
Fix all outdated references to environment.*.js. 

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@
   - Docker compose file that provides a DSpace CLI container to work with a running DSpace REST container.
 - cli.assetstore.yml
   - Docker compose file that will download and install data into a DSpace REST assetstore.  This script points to a default dataset that will be utilized for CI testing.
-- environment.dev.js
+- environment.dev.ts
   - Environment file for running DSpace Angular in Docker
 - local.cfg
   - Environment file for running the DSpace 7 REST API in Docker.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,4 +23,4 @@ services:
     stdin_open: true
     tty: true
     volumes:
-    - ./environment.dev.js:/app/src/environments/environment.dev.ts
+    - ./environment.dev.ts:/app/src/environments/environment.dev.ts

--- a/docker/environment.dev.ts
+++ b/docker/environment.dev.ts
@@ -1,13 +1,13 @@
-/*
+/**
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
  *
  * http://www.dspace.org/license/
  */
-import { GlobalConfig } from '../src/config/global-config.interface';
-
-export const environment: Partial<GlobalConfig> = {
+// This file is based on environment.template.ts provided by Angular UI
+export const environment = {
+  // Default to using the local REST API (running in Docker)
   rest: {
     ssl: false,
     host: 'localhost',

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,9 +1,9 @@
 # Configuration
 
-Default configuration file is located in `config/` folder. All configuration options should be listed in the default configuration file `config/environment.default.js`. Please do not change this file directly! To change the default configuration values, create local files that override the parameters you need to change:
+Default configuration file is located in `src/environments/` folder. All configuration options should be listed in the default configuration file `src/environments/environment.common.ts`. Please do not change this file directly! To change the default configuration values, create local files that override the parameters you need to change. You can use `environment.template.ts` as a starting point.
 
--	Create a new `environment.dev.js` file in `config/` for `devel` environment;
--	Create a new `environment.prod.js` file in `config/` for `production` environment;
+-	Create a new `environment.dev.ts` file in `src/environments/` for `development` environment;
+-	Create a new `environment.prod.ts` file in `src/environments/` for `production` environment;
 
 Some few configuration options can be overridden by setting environment variables. These and the variable names are listed below.
 
@@ -12,8 +12,8 @@ When you start dspace-angular on node, it spins up an http server on which it li
 
 To change this configuration, change the options `ui.host`, `ui.port` and `ui.ssl` in the appropriate configuration file (see above):
 ```
-module.exports = {
-  // Angular Universal server settings.
+export const environment = {
+  // Angular UI settings.
   ui: {
     ssl: false,
     host: 'localhost',
@@ -35,14 +35,14 @@ Alternately you can set the following environment variables. If any of these are
 dspace-angular connects to your DSpace installation by using its REST endpoint. To do so, you have to define the ip address, port and if ssl should be enabled. You can do this in a configuration file (see above) by adding the following options:
 
 ```
-module.exports = {
+export const environment = {
   // The REST API server settings.
   rest: {
     ssl: true,
-    host: 'dspace7.4science.it',
+    host: 'dspace7.4science.cloud',
     port: 443,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
-    nameSpace: '/dspace-spring-rest/api'
+    nameSpace: '/server/api'
   }
 };
 ```
@@ -50,9 +50,9 @@ module.exports = {
 Alternately you can set the following environment variables. If any of these are set, it will override all configuration files:
 ```
   DSPACE_REST_SSL=true
-  DSPACE_REST_HOST=localhost
-  DSPACE_REST_PORT=4000
-  DSPACE_REST_NAMESPACE=/
+  DSPACE_REST_HOST=dspace7.4science.cloud
+  DSPACE_REST_PORT=443
+  DSPACE_REST_NAMESPACE=/server/api
 ```
 
 ## Supporting analytics services other than Google Analytics


### PR DESCRIPTION
Today, while bug fixing https://github.com/DSpace/DSpace/pull/2772, I stumbled on a bunch of outdated references to `environment.*.js` configurations.

This PR cleans up those references, including:
* One typo in the default `docker-compose.yml` which causes the `environment.dev.ts` for Docker to not be loaded.
    * Also fixed a compilation bug in `environment.dev.ts` which was previously undiscovered as it wasn't being used/loaded by Docker. See https://github.com/DSpace/dspace-angular/pull/693/commits/b1d39feedad5b3d932eae4c61a8b64f249f33457
* Fixed several references to `environment.dev.js` in configuration docs & Docker README
* I also cleaned up our separate configuration Docs which had not been updated