### PR TITLE
Misc edit community and collection fixes

### DIFF
--- a/src/app/shared/comcol-forms/comcol-form/comcol-form.component.spec.ts
+++ b/src/app/shared/comcol-forms/comcol-form/comcol-form.component.spec.ts
@@ -22,6 +22,7 @@ import { NotificationsService } from '../../notifications/notifications.service'
 import { NotificationsServiceStub } from '../../testing/notifications-service.stub';
 import { VarDirective } from '../../utils/var.directive';
 import { ComColFormComponent } from './comcol-form.component';
+import { Operation } from 'fast-json-patch';
 
 describe('ComColFormComponent', () => {
   let comp: ComColFormComponent<DSpaceObject>;
@@ -40,11 +41,8 @@ describe('ComColFormComponent', () => {
     }
   };
   const dcTitle = 'dc.title';
-  const dcRandom = 'dc.random';
   const dcAbstract = 'dc.description.abstract';
 
-  const titleMD = { [dcTitle]: [{ value: 'Community Title', language: null }] };
-  const randomMD = { [dcRandom]: [{ value: 'Random metadata excluded from form', language: null }] };
   const abstractMD = { [dcAbstract]: [{ value: 'Community description', language: null }] };
   const newTitleMD = { [dcTitle]: [{ value: 'New Community Title', language: null }] };
   const formModel = [
@@ -112,33 +110,47 @@ describe('ComColFormComponent', () => {
       });
 
       it('should emit the new version of the community', () => {
-        comp.dso = Object.assign(
-          new Community(),
-          {
-            metadata: {
-              ...titleMD,
-              ...randomMD
-            }
-          }
-        );
+        comp.dso = new Community();
         comp.onSubmit();
+
+        const operations: Operation[] = [
+          {
+            op: 'replace',
+            path: '/metadata/dc.title',
+            value: {
+              value: 'New Community Title',
+              language: null,
+            },
+          },
+          {
+            op: 'replace',
+            path: '/metadata/dc.description.abstract',
+            value: {
+              value: 'Community description',
+              language: null,
+            },
+          },
+        ];
 
         expect(comp.submitForm.emit).toHaveBeenCalledWith(
           {
-            dso: Object.assign(
-              {},
-              new Community(),
-              {
+            dso: Object.assign({}, comp.dso, {
                 metadata: {
-                  ...newTitleMD,
-                  ...randomMD,
-                  ...abstractMD
+                  'dc.title': [{
+                    value: 'New Community Title',
+                    language: null,
+                  }],
+                  'dc.description.abstract': [{
+                    value: 'Community description',
+                    language: null,
+                  }],
                 },
-                type: Community.type
-              },
+                type: Community.type,
+              }
             ),
             uploader: undefined,
-            deleteLogo: false
+            deleteLogo: false,
+            operations: operations,
           }
         );
       })
@@ -163,11 +175,6 @@ describe('ComColFormComponent', () => {
 
       it('should emit finish', () => {
         expect(comp.finish.emit).toHaveBeenCalled();
-      });
-
-      it('should remove the object\'s cache', () => {
-        expect(requestServiceStub.removeByHrefSubstring).toHaveBeenCalled();
-        expect(objectCacheStub.remove).toHaveBeenCalled();
       });
     });
 
@@ -238,6 +245,11 @@ describe('ComColFormComponent', () => {
 
           it('should display a success notification', () => {
             expect(notificationsService.success).toHaveBeenCalled();
+          });
+
+          it('should remove the object\'s cache', () => {
+            expect(requestServiceStub.removeByHrefSubstring).toHaveBeenCalled();
+            expect(objectCacheStub.remove).toHaveBeenCalled();
           });
         });
 

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -77,7 +77,8 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
     const uploader = event.uploader;
 
     this.parentUUID$.pipe(take(1)).subscribe((uuid: string) => {
-      this.dsoDataService.create(dso, new RequestParam('parent', uuid))
+      const params = uuid ? [new RequestParam('parent', uuid)] : [];
+      this.dsoDataService.create(dso, ...params)
         .pipe(getSucceededRemoteData())
         .subscribe((dsoRD: RemoteData<TDomain>) => {
           if (isNotUndefined(dsoRD)) {

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-metadata/comcol-metadata.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-metadata/comcol-metadata.component.spec.ts
@@ -13,13 +13,13 @@ import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { SharedModule } from '../../../shared.module';
 import { NotificationsServiceStub } from '../../../testing/notifications-service.stub';
-import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../../remote-data.utils';
+import { createSuccessfulRemoteDataObject$ } from '../../../remote-data.utils';
 import { ComcolMetadataComponent } from './comcol-metadata.component';
 
 describe('ComColMetadataComponent', () => {
   let comp: ComcolMetadataComponent<DSpaceObject>;
   let fixture: ComponentFixture<ComcolMetadataComponent<DSpaceObject>>;
-  let dsoDataService: CommunityDataService;
+  let dsoDataService;
   let router: Router;
 
   let community;
@@ -27,7 +27,6 @@ describe('ComColMetadataComponent', () => {
   let communityDataServiceStub;
   let routerStub;
   let routeStub;
-  let isSuccessful = true;
 
   const logoEndpoint = 'rest/api/logo/endpoint';
 
@@ -50,11 +49,7 @@ describe('ComColMetadataComponent', () => {
 
     communityDataServiceStub = {
       update: (com, uuid?) => createSuccessfulRemoteDataObject$(newCommunity),
-      patch: () => {
-        return observableOf({
-          isSuccessful,
-        })
-      },
+      patch: () => null,
       getLogoEndpoint: () => observableOf(logoEndpoint)
     };
 
@@ -123,22 +118,38 @@ describe('ComColMetadataComponent', () => {
             /* tslint:enable:no-empty */
           },
           deleteLogo: false,
-        }
+        };
+        spyOn(router, 'navigate');
       });
 
-      it('should navigate when successful', () => {
-        spyOn(router, 'navigate');
-        comp.onSubmit(data);
-        fixture.detectChanges();
-        expect(router.navigate).toHaveBeenCalled();
+      describe('when successful', () => {
+
+        beforeEach(() => {
+          spyOn(dsoDataService, 'patch').and.returnValue(observableOf({
+              isSuccessful: true,
+          }));
+        });
+
+        it('should navigate', () => {
+          comp.onSubmit(data);
+          fixture.detectChanges();
+          expect(router.navigate).toHaveBeenCalled();
+        });
       });
 
-      it('should not navigate on failure', () => {
-        isSuccessful = false;
-        spyOn(router, 'navigate');
-        comp.onSubmit(data);
-        fixture.detectChanges();
-        expect(router.navigate).not.toHaveBeenCalled();
+      describe('on failure', () => {
+
+        beforeEach(() => {
+          spyOn(dsoDataService, 'patch').and.returnValue(observableOf({
+              isSuccessful: false,
+            }));
+        });
+
+        it('should not navigate', () => {
+          comp.onSubmit(data);
+          fixture.detectChanges();
+          expect(router.navigate).not.toHaveBeenCalled();
+        });
       });
     });
 

--- a/src/app/shared/comcol-forms/edit-comcol-page/comcol-metadata/comcol-metadata.component.spec.ts
+++ b/src/app/shared/comcol-forms/edit-comcol-page/comcol-metadata/comcol-metadata.component.spec.ts
@@ -27,6 +27,7 @@ describe('ComColMetadataComponent', () => {
   let communityDataServiceStub;
   let routerStub;
   let routeStub;
+  let isSuccessful = true;
 
   const logoEndpoint = 'rest/api/logo/endpoint';
 
@@ -49,6 +50,11 @@ describe('ComColMetadataComponent', () => {
 
     communityDataServiceStub = {
       update: (com, uuid?) => createSuccessfulRemoteDataObject$(newCommunity),
+      patch: () => {
+        return observableOf({
+          isSuccessful,
+        })
+      },
       getLogoEndpoint: () => observableOf(logoEndpoint)
     };
 
@@ -95,21 +101,28 @@ describe('ComColMetadataComponent', () => {
     describe('with an empty queue in the uploader', () => {
       beforeEach(() => {
         data = {
-          dso: Object.assign(new Community(), {
-            metadata: [{
-              key: 'dc.title',
-              value: 'test'
-            }]
-          }),
+          operations: [
+            {
+              op: 'replace',
+              path: '/metadata/dc.title',
+              value: {
+                value: 'test',
+                language: null,
+              },
+            },
+          ],
+          dso: new Community(),
           uploader: {
             options: {
               url: ''
             },
             queue: [],
             /* tslint:disable:no-empty */
-            uploadAll: () => {}
+            uploadAll: () => {
+            }
             /* tslint:enable:no-empty */
-          }
+          },
+          deleteLogo: false,
         }
       });
 
@@ -121,8 +134,8 @@ describe('ComColMetadataComponent', () => {
       });
 
       it('should not navigate on failure', () => {
+        isSuccessful = false;
         spyOn(router, 'navigate');
-        spyOn(dsoDataService, 'update').and.returnValue(createFailedRemoteDataObject$(newCommunity));
         comp.onSubmit(data);
         fixture.detectChanges();
         expect(router.navigate).not.toHaveBeenCalled();

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.spec.ts
@@ -39,7 +39,15 @@ describe('CreateCollectionParentSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ community: communityRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: communityRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -14,6 +14,6 @@
         </h3>
 
         <h5 class="px-2">{{'dso-selector.create.community.sub-level' | translate}}</h5>
-        <ds-dso-selector [currentDSOId]="(dsoRD$ | async)?.payload.uuid" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
+        <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
     </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
@@ -33,7 +33,15 @@ describe('CreateCommunityParentSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ community: communityRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: communityRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.spec.ts
@@ -32,7 +32,15 @@ describe('CreateItemParentSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ collection: collectionRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: collectionRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
@@ -5,6 +5,6 @@
     </button>
   </div>
   <div class="modal-body">
-    <ds-dso-selector [currentDSOId]="(dsoRD$ | async)?.payload.uuid ? 'search.resourceid:' + (dsoRD$ | async)?.payload.uuid : null" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
+    <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
   </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
@@ -63,7 +63,7 @@ describe('DSOSelectorModalWrapperComponent', () => {
   });
 
   it('should initially set the DSO to the activated route\'s item/collection/community', () => {
-    component.dsoRD$
+    component.dsoRD
       .pipe(first())
       .subscribe((a) => {
         expect(a).toEqual(itemRD);

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
@@ -63,11 +63,7 @@ describe('DSOSelectorModalWrapperComponent', () => {
   });
 
   it('should initially set the DSO to the activated route\'s item/collection/community', () => {
-    component.dsoRD
-      .pipe(first())
-      .subscribe((a) => {
-        expect(a).toEqual(itemRD);
-      })
+    expect(component.dsoRD).toEqual(itemRD);
   });
 
   describe('selectObject', () => {

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
@@ -41,8 +41,16 @@ describe('DSOSelectorModalWrapperComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ item: itemRD }) } } } }
-        }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: itemRD,
+                },
+              },
+            }
+          }
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.spec.ts
@@ -33,7 +33,15 @@ describe('EditCollectionSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ collection: collectionRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: collectionRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.spec.ts
@@ -33,7 +33,15 @@ describe('EditCommunitySelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ community: communityRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: communityRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.spec.ts
@@ -33,7 +33,15 @@ describe('EditItemSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         {
           provide: ActivatedRoute,
-          useValue: { root: { firstChild: { firstChild: { data: observableOf({ item: itemRD }) } } } }
+          useValue: {
+            root: {
+              snapshot: {
+                data: {
+                  dso: itemRD,
+                },
+              },
+            }
+          },
         },
         {
           provide: Router, useValue: router

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -767,6 +767,10 @@
 
   "community.edit.notifications.success": "Successfully edited the Community",
 
+  "community.edit.notifications.unauthorized": "You do not have privileges to make this change",
+
+  "community.edit.notifications.error": "An error occured while editing the Community",
+
   "community.edit.return": "Return",
 
 


### PR DESCRIPTION
## References

https://github.com/DSpace/dspace-angular/issues/665
https://github.com/DSpace/dspace-angular/issues/666

## Description

This PR addresses some issues with the Community & Collection edit pages.

## Instructions for Reviewers

List of changes in this PR:
* (DSOSelectorModalWrapperComponent): the mechanism to automatically select the current Community/Collection in the new/edit menu has been fixed
* (ComcolMetadataComponent): the request method used by the edit Community/Collection page has been changed from PUT to PATCH to repair the edit functionality
* (ComcolMetadataComponent): an appropriate error message is shown when the user doesn't have sufficient edit rights. I didn't add error message for other cases, because I don't think a 'Bad Request' or an 'Internal Server Error' message would have an added value to most end users.
* (ComcolMetadataComponent): I've split up the logo <> metadata logic, to make sure both can happen at the same time

I've tested the following cases, both for communities and collections:
* creating a new community/collection with metadata and with a logo
* creating a new community/collection with metadata and without a logo
* adding a community/collection logo without editing the metadata
* deleting a community/collection logo without editing the metadata
* adding a community/collection logo while editing the metadata
* deleting a community/collection logo while editing the metadata
* editing community/collection metadata without changing the logo
* trying one of the above as a user without permission, to verify the error message (I used a local REST server to test this, to be able to easily deny the permission)