### PR TITLE
Fixed authentication issue with protected page on CSR

### DIFF
--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -150,7 +150,7 @@ describe('AuthEffects', () => {
 
   describe('authenticatedSuccess$', () => {
 
-    it('should not call removeToken method', (done) => {
+    it('should return a RETRIEVE_AUTHENTICATED_EPERSON action in response to a AUTHENTICATED_SUCCESS action', (done) => {
       spyOn((authEffects as any).authService, 'storeToken');
       actions = hot('--a-', {
         a: {

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -150,7 +150,8 @@ describe('AuthEffects', () => {
 
   describe('authenticatedSuccess$', () => {
 
-    it('should return a RETRIEVE_AUTHENTICATED_EPERSON action in response to a AUTHENTICATED_SUCCESS action', () => {
+    it('should not call removeToken method', (done) => {
+      spyOn((authEffects as any).authService, 'storeToken');
       actions = hot('--a-', {
         a: {
           type: AuthActionTypes.AUTHENTICATED_SUCCESS, payload: {
@@ -163,8 +164,14 @@ describe('AuthEffects', () => {
 
       const expected = cold('--b-', { b: new RetrieveAuthenticatedEpersonAction(EPersonMock._links.self.href) });
 
+      authEffects.authenticatedSuccess$.subscribe(() => {
+        expect(authServiceStub.storeToken).toHaveBeenCalledWith(token);
+      });
+
       expect(authEffects.authenticatedSuccess$).toBeObservable(expected);
+      done();
     });
+
   });
 
   describe('checkToken$', () => {

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -65,7 +65,6 @@ export class AuthEffects {
   @Effect()
   public authenticateSuccess$: Observable<Action> = this.actions$.pipe(
     ofType(AuthActionTypes.AUTHENTICATE_SUCCESS),
-    tap((action: AuthenticationSuccessAction) => this.authService.storeToken(action.payload)),
     map((action: AuthenticationSuccessAction) => new AuthenticatedAction(action.payload))
   );
 
@@ -82,6 +81,7 @@ export class AuthEffects {
   @Effect()
   public authenticatedSuccess$: Observable<Action> = this.actions$.pipe(
     ofType(AuthActionTypes.AUTHENTICATED_SUCCESS),
+    tap((action: AuthenticatedSuccessAction) => this.authService.storeToken(action.payload.authToken)),
     map((action: AuthenticatedSuccessAction) => new RetrieveAuthenticatedEpersonAction(action.payload.userHref))
   );
 


### PR DESCRIPTION
## Description
This PR fixed a small bug with authentication that occurred only when the current page has the AuthGuard enabled and the SSR is disabled. Indeed when you are on a protected page (i.e `/mydspace`) reloading the browser page works only once, the second time authentication is lost and you are redirect to login page

## Instructions for Reviewers

    - Run application with yarn start:dev
    - login
    - go to a protected page (i.e `/mydspace`)
    - refresh the browser page several times

with the previous code the session was lost after the first refresh now is maintained

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
