### PR TITLE
Auto Assign new Pull Requests to "main" branch to the PR creator

### DIFF
--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -1,0 +1,24 @@
+# This workflow runs whenever a new pull request is created
+name: Pull Request opened
+
+# Only run for newly opened PRs against the "main" branch
+on: 
+  pull_request:
+    types: [opened]
+    branches: 
+      - main
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    steps:
+    # Assign the PR to whomever created it. This is useful for visualizing assignments on project boards
+    # See https://github.com/marketplace/actions/pull-request-assigner
+    - name: Assign PR to creator
+      uses: thomaseizinger/assign-pr-creator-action@v1.0.0
+      # Note, this authentication token is created automatically
+      # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # Ignore errors. It is possible the PR was created by someone who cannot be assigned
+      continue-on-error: true


### PR DESCRIPTION
(Copy of https://github.com/DSpace/DSpace/pull/2857 to this repository)

This creates a new "pull_request_opened.yml" workflow configuration which enables a [GitHub Action](https://docs.github.com/en/actions) for all newly created Pull Requests on the `main` branch.

More specifically, the [Pull Request Assigner](https://github.com/marketplace/actions/pull-request-assigner) action is run to auto-assign all Pull Requests to the creator of that PR.  While this sounds a bit strange, it's really useful for our new [Project Boards](https://github.com/orgs/DSpace/projects), as it makes it a ton easier to see who is working on each PR / issue by simply filtering on "assignee".

I'm creating this PR simply as documentation of this decision & to test the process in GitHub (to make sure it works as expected).  Additional GitHub actions may be forthcoming as well!