### PR TITLE
Automatically add new Issues to "DSpace Backlog" project board

### DIFF
--- a/.github/workflows/issue_opened.yml
+++ b/.github/workflows/issue_opened.yml
@@ -1,0 +1,29 @@
+# This workflow runs whenever a new issue is created
+name: Issue opened
+
+on: 
+  issues:
+    types: [opened]
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    steps:
+    # Add the new issue to a project board, if it needs triage
+    # See https://github.com/marketplace/actions/create-project-card-action
+    - name: Add issue to project board
+      # Only add to project board if issue is flagged as "needs triage" or has no labels
+      # NOTE: By default we flag new issues as "needs triage" in our issue template
+      if: (contains(github.event.issue.labels.*.name, 'needs triage') || join(github.event.issue.labels.*.name) == '')
+      uses: technote-space/create-project-card-action@v1
+      # Note, the authentication token below is an ORG level Secret. 
+      # It must be created/recreated manually via a personal access token with "public_repo" and "admin:org" permissions
+      # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token
+      # This is necessary because the "DSpace Backlog" project is an org level project (i.e. not repo specific)
+      with:
+        GITHUB_TOKEN: ${{ secrets.ORG_PROJECT_TOKEN }}
+        PROJECT: DSpace Backlog
+        COLUMN: Triage
+        CHECK_ORG_PROJECT: true
+      # Ignore errors
+      continue-on-error: true


### PR DESCRIPTION
(Copy of DSpace/DSpace#2861 to this repository)

This creates a new "issue_opened.yml" workflow configuration which enables a [GitHub Action](https://docs.github.com/en/actions) for all newly created Issues which are either _unlabeled_ or labeled with `needs triage`.

More specifically, the [Create Project Card action](https://github.com/marketplace/actions/create-project-card-action) is run to check for new issues to add to the [DSpace Backlog project board](https://github.com/orgs/DSpace/projects/10).  The purpose of this Board is to capture incoming issues that need triaging/scheduling for a specific release...although there's also an "Unscheduled backlog" column on that board for anything that is currently unscheduled.

At this time, only issues flagged as `needs triage` (which will be added by default) or unlabeled will go on this board.  Other issues will be assumed to have already been triaged to a specific release board (e.g. the DSpace 7.1 board or similar).

I'm creating this PR simply as documentation of this decision & to test the process in GitHub (to make sure it works as expected). Additional GitHub actions may be forthcoming as well!