### PR TITLE
Fix issue with repeatable scrollable dropdowns in the submission

### DIFF
--- a/src/app/shared/form/form.component.ts
+++ b/src/app/shared/form/form.component.ts
@@ -318,6 +318,12 @@ export class FormComponent implements OnDestroy, OnInit {
     const model = arrayContext.groups[arrayContext.groups.length - 1].group[0] as any;
     if (model.type === DYNAMIC_FORM_CONTROL_TYPE_SCROLLABLE_DROPDOWN) {
       model.value = Object.values(value)[0];
+      const ctrl = formArrayControl.controls[formArrayControl.length - 1];
+      const ctrlValue = ctrl.value;
+      const ctrlValueKey = Object.keys(ctrlValue)[0];
+      ctrl.setValue({
+        [ctrlValueKey]: model.value
+      });
     } else if (this.formBuilderService.isQualdropGroup(model)) {
       const ctrl = formArrayControl.controls[formArrayControl.length - 1];
       const ctrlKey = Object.keys(ctrl.value).find((key: string) => isNotEmpty(key.match(QUALDROP_GROUP_REGEX)));

--- a/src/app/submission/sections/form/section-form-operations.service.ts
+++ b/src/app/submission/sections/form/section-form-operations.service.ts
@@ -250,10 +250,7 @@ export class SectionFormOperationsService {
       fieldValue = new FormFieldMetadataValueObject(value);
     }
 
-    // make a copy of fieldvalue for returning,
-    // so any changes to it can't influence the original.
-    // fixes #817
-    return deepClone(fieldValue);
+    return fieldValue;
   }
 
   /**
@@ -314,7 +311,7 @@ export class SectionFormOperationsService {
     event: DynamicFormControlEvent
   ): void {
     const path = this.getFieldPathSegmentedFromChangeEvent(event);
-    const value = this.getFieldValueFromChangeEvent(event);
+    const value = deepClone(this.getFieldValueFromChangeEvent(event));
     if (isNotEmpty(value)) {
       value.place = this.getArrayIndexFromEvent(event);
       if (hasValue(event.group) && hasValue(event.group.value)) {

--- a/src/app/submission/sections/form/section-form-operations.service.ts
+++ b/src/app/submission/sections/form/section-form-operations.service.ts
@@ -28,6 +28,7 @@ import { FormBuilderService } from '../../../shared/form/builder/form-builder.se
 import { FormFieldMetadataValueObject } from '../../../shared/form/builder/models/form-field-metadata-value.model';
 import { DynamicQualdropModel } from '../../../shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-qualdrop.model';
 import { DynamicRelationGroupModel } from '../../../shared/form/builder/ds-dynamic-form-ui/models/relation-group/dynamic-relation-group.model';
+import { deepClone } from 'fast-json-patch';
 
 /**
  * The service handling all form section operations
@@ -249,7 +250,10 @@ export class SectionFormOperationsService {
       fieldValue = new FormFieldMetadataValueObject(value);
     }
 
-    return fieldValue;
+    // make a copy of fieldvalue for returning,
+    // so any changes to it can't influence the original.
+    // fixes #817
+    return deepClone(fieldValue);
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #817 

## Description
The reason for the error was that the value returned for scrollable dropdowns was bound to the field, and therefore readonly. So [cloning it before trying to modify it](https://github.com/DSpace/dspace-angular/pull/830/files#diff-69f602a806621adc6980f67794e68fd5R314) fixed the exception.

Afterwards I found another issue with scrollable dropdowns where if the field is empty, and you add multiple values before the first (auto)save, only the last would be saved. This was because when a field was added, the formControl wasn't updated like it was for other fields because the values had a different format compared to all the other fields. [I added a section to update the formcontrol value in the correct format](https://github.com/DSpace/dspace-angular/pull/830/files#diff-903cfa6a8163096b18bfd1797eb11099R321).

## Instructions for Reviewers
To test this PR verify that repeatable scrollable dropdowns work as they should, and that no new issues have been introduced.


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. 
    - Existing tests pass, but writing tests for these specific issues would be several orders of magnitude more complicated than the fix
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
