### PR TITLE
Re-enable automated CSRF Protection: Add custom XSRF interceptor which works with cross origin requests

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -145,6 +145,7 @@ import { ProcessFilesResponseParsingService } from './data/process-files-respons
 import { WorkflowActionDataService } from './data/workflow-action-data.service';
 import { WorkflowAction } from './tasks/models/workflow-action-object.model';
 import { LocaleInterceptor } from './locale/locale.interceptor';
+import { XsrfInterceptor } from './xsrf/xsrf.interceptor';
 import { ItemTemplateDataService } from './data/item-template-data.service';
 import { TemplateItem } from './shared/template-item.model';
 import { Feature } from './shared/feature.model';
@@ -299,6 +300,12 @@ const PROVIDERS = [
   {
     provide: HTTP_INTERCEPTORS,
     useClass: LocaleInterceptor,
+    multi: true
+  },
+  // register XsrfInterceptor as HttpInterceptor
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: XsrfInterceptor,
     multi: true
   },
   NotificationsService,

--- a/src/app/core/xsrf/xsrf.interceptor.spec.ts
+++ b/src/app/core/xsrf/xsrf.interceptor.spec.ts
@@ -44,9 +44,10 @@ describe(`XsrfInterceptor`, () => {
     httpMock = TestBed.get(HttpTestingController);
   });
 
-  it('should add an X-XSRF-TOKEN header when we’re sending an HTTP POST request', () => {
+  it('should add an X-XSRF-TOKEN header when we are sending an HTTP POST request', (done) => {
     service.request(RestRequestMethod.POST, 'server/api/core/items', 'test').subscribe((response) => {
       expect(response).toBeTruthy();
+      done();
     });
 
     const httpRequest = httpMock.expectOne(`server/api/core/items`);
@@ -57,9 +58,10 @@ describe(`XsrfInterceptor`, () => {
     expect(token).toBe(testToken.toString());
   });
 
-  it('should NOT add an X-XSRF-TOKEN header when we’re sending an HTTP GET request', () => {
+  it('should NOT add an X-XSRF-TOKEN header when we are sending an HTTP GET request', (done) => {
     service.request(RestRequestMethod.GET, 'server/api/core/items').subscribe((response) => {
       expect(response).toBeTruthy();
+      done();
     });
 
     const httpRequest = httpMock.expectOne(`server/api/core/items`);
@@ -67,10 +69,11 @@ describe(`XsrfInterceptor`, () => {
     expect(!httpRequest.request.headers.has('X-XSRF-TOKEN'));
   });
 
-  it('should NOT add an X-XSRF-TOKEN header when we’re sending an HTTP POST to an untrusted URL', () => {
+  it('should NOT add an X-XSRF-TOKEN header when we are sending an HTTP POST to an untrusted URL', (done) => {
     // POST to a URL which is NOT our REST API
     service.request(RestRequestMethod.POST, 'https://untrusted.com', 'test').subscribe((response) => {
       expect(response).toBeTruthy();
+      done();
     });
 
     const httpRequest = httpMock.expectOne(`https://untrusted.com`);

--- a/src/app/core/xsrf/xsrf.interceptor.spec.ts
+++ b/src/app/core/xsrf/xsrf.interceptor.spec.ts
@@ -26,6 +26,14 @@ describe(`XsrfInterceptor`, () => {
   const testToken = 'test-token';
   const mockTokenExtractor = new MockTokenExtractor(testToken);
 
+  // Mock payload/statuses are dummy content as we are not testing the results
+  // of any below requests. We are only testing for X-XSRF-TOKEN header.
+  const mockPayload = {
+    id: 1
+  };
+  const mockStatusCode = 200;
+  const mockStatusText = 'SUCCESS';
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -52,10 +60,12 @@ describe(`XsrfInterceptor`, () => {
 
     const httpRequest = httpMock.expectOne(`server/api/core/items`);
 
-    expect(httpRequest.request.headers.has('X-XSRF-TOKEN'));
+    expect(httpRequest.request.headers.has('X-XSRF-TOKEN')).toBeTrue();
     const token = httpRequest.request.headers.get('X-XSRF-TOKEN');
     expect(token).toBeDefined();
     expect(token).toBe(testToken.toString());
+
+    httpRequest.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText });
   });
 
   it('should NOT add an X-XSRF-TOKEN header when we are sending an HTTP GET request', (done) => {
@@ -66,7 +76,9 @@ describe(`XsrfInterceptor`, () => {
 
     const httpRequest = httpMock.expectOne(`server/api/core/items`);
 
-    expect(!httpRequest.request.headers.has('X-XSRF-TOKEN'));
+    expect(httpRequest.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+
+    httpRequest.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText });
   });
 
   it('should NOT add an X-XSRF-TOKEN header when we are sending an HTTP POST to an untrusted URL', (done) => {
@@ -78,7 +90,9 @@ describe(`XsrfInterceptor`, () => {
 
     const httpRequest = httpMock.expectOne(`https://untrusted.com`);
 
-    expect(!httpRequest.request.headers.has('X-XSRF-TOKEN'));
+    expect(httpRequest.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+
+    httpRequest.flush(mockPayload, { status: mockStatusCode, statusText: mockStatusText });
   });
 
 });

--- a/src/app/core/xsrf/xsrf.interceptor.spec.ts
+++ b/src/app/core/xsrf/xsrf.interceptor.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS, HttpXsrfTokenExtractor } from '@angular/common/http';
+
+import { DSpaceRESTv2Service } from '../dspace-rest-v2/dspace-rest-v2.service';
+import { RestRequestMethod } from '../data/rest-request-method';
+import { XsrfInterceptor } from './xsrf.interceptor';
+
+/**
+ * A Mock TokenExtractor which just returns whatever token it is initialized with.
+ * This mock object is injected into our XsrfInterceptor, so that it always finds
+ * the same fake XSRF token.
+ */
+class MockTokenExtractor extends HttpXsrfTokenExtractor {
+  constructor(private token: string|null) { super(); }
+
+  getToken(): string|null { return this.token; }
+}
+
+describe(`XsrfInterceptor`, () => {
+  let service: DSpaceRESTv2Service;
+  let httpMock: HttpTestingController;
+
+  // Create a MockTokenExtractor which always returns "test-token". This will
+  // be used as the test HttpXsrfTokenExtractor, see below.
+  const testToken = 'test-token';
+  const mockTokenExtractor = new MockTokenExtractor(testToken);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DSpaceRESTv2Service,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: XsrfInterceptor,
+          multi: true,
+        },
+        { provide: HttpXsrfTokenExtractor, useValue: mockTokenExtractor },
+      ],
+    });
+
+    service = TestBed.get(DSpaceRESTv2Service);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should add an X-XSRF-TOKEN header when we’re sending an HTTP POST request', () => {
+    service.request(RestRequestMethod.POST, 'server/api/core/items', 'test').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+
+    const httpRequest = httpMock.expectOne(`server/api/core/items`);
+
+    expect(httpRequest.request.headers.has('X-XSRF-TOKEN'));
+    const token = httpRequest.request.headers.get('X-XSRF-TOKEN');
+    expect(token).toBeDefined();
+    expect(token).toBe(testToken.toString());
+  });
+
+  it('should NOT add an X-XSRF-TOKEN header when we’re sending an HTTP GET request', () => {
+    service.request(RestRequestMethod.GET, 'server/api/core/items').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+
+    const httpRequest = httpMock.expectOne(`server/api/core/items`);
+
+    expect(!httpRequest.request.headers.has('X-XSRF-TOKEN'));
+  });
+
+  it('should NOT add an X-XSRF-TOKEN header when we’re sending an HTTP POST to an untrusted URL', () => {
+    // POST to a URL which is NOT our REST API
+    service.request(RestRequestMethod.POST, 'https://untrusted.com', 'test').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+
+    const httpRequest = httpMock.expectOne(`https://untrusted.com`);
+
+    expect(!httpRequest.request.headers.has('X-XSRF-TOKEN'));
+  });
+
+});

--- a/src/app/core/xsrf/xsrf.interceptor.ts
+++ b/src/app/core/xsrf/xsrf.interceptor.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpXsrfTokenExtractor } from '@angular/common/http';
+import { Observable } from 'rxjs/internal/Observable';
+import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+
+/**
+ * Custom Http Interceptor intercepting Http Requests, adding the XSRF/CSRF
+ * token (if found in a cookie named XSRF-TOKEN) to their X-XSRF-TOKEN header.
+ *
+ * This custom interceptor is required as Angular's HttpXsrfInterceptor doesn't
+ * support absolute URLs, see: https://github.com/angular/angular/issues/1885
+ * Based on HttpXsrfInterceptor:
+ * https://github.com/angular/angular/blob/8.2.x/packages/common/http/src/xsrf.ts
+ *
+ * This custom interceptor accepts absolute URLs, but checks that the URL
+ * is trusted (i.e. it must be a request to our configured REST API).
+ */
+@Injectable()
+export class XsrfInterceptor implements HttpInterceptor {
+
+    constructor(private tokenExtractor: HttpXsrfTokenExtractor) {
+    }
+
+    /**
+     * Intercept http requests and add the XSRF/CSRF token to the X-Forwarded-For header
+     * @param httpRequest
+     * @param next
+     */
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        // Get request URL
+        const reqUrl = req.url.toLowerCase();
+
+        // Get root URL of configured REST API
+        const restUrl = new RESTURLCombiner('/').toString().toLowerCase();
+
+        // Skip any non-mutating request. This is because our REST API does NOT
+        // require CSRF verification for read-only requests.
+        // Also skip any request which is NOT to the configured REST API
+        if (req.method === 'GET' || req.method === 'HEAD' || !reqUrl.startsWith(restUrl)) {
+            return next.handle(req);
+        }
+
+        // Send request with credential options in order to be able to read cross-origin cookies
+        // Without this, Angular isn't able to read the XSRF-TOKEN cookie if it comes from
+        // a different origin. See https://stackoverflow.com/a/62364743
+        req = req.clone({ withCredentials: true });
+
+        // parse token from XSRF-TOKEN cookie sent by REST API
+        const token = this.tokenExtractor.getToken() as string;
+
+        // return token in request's X-XSRF-TOKEN header (anti-CSRF security)
+        const headerName = 'X-XSRF-TOKEN';
+        if (token !== null && !req.headers.has(headerName)) {
+            req = req.clone({ headers: req.headers.set(headerName, token) });
+        }
+        return next.handle(req);
+    }
+}


### PR DESCRIPTION
## References
* Should be tested with https://github.com/DSpace/DSpace/pull/2922 (Backend PR which re-enables CSRF protection in Server Webapp).  This PR will do nothing until the backend behavior is modified in 2922.

## Description
This PR creates a customized `XsrfInterceptor` which accepts XSRF/CSRF Cookies from different origins & responds with an X-XSRF-TOKEN header.  The default, Angular `HttpXsrfInterceptor` ONLY works if Angular and your backend are installed on the same origin/server.

## Instructions for Reviewers
* Install the backend PR locally: https://github.com/DSpace/DSpace/pull/2922   This PR must be tested with that Backend PR, as it otherwise does "nothing" (the new Interceptor will never find an `XSRF-TOKEN` Cookie and therefore never respond with an `X-XSRF-TOKEN` Header.
* Test this PR alongside that one to ensure the Angular UI still has the same behavior.  Especially test authentication and authorization (e.g. as an Admin, try to perform an Admin task).
* (Optionally) you may use Chrome Dev Tools (or similar) to verify that an X-XSRF-TOKEN header is sent on non-GET requests (e.g. login sends a POST to the /login endpoint & will include this header)


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
