### PR TITLE
File pagination simple and full item pages

### DIFF
--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.html
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.html
@@ -1,29 +1,87 @@
 <ds-metadata-field-wrapper [label]="label | translate">
-    <div class="file-section row" *ngFor="let file of (bitstreams$ | async); let last=last;">
-        <div class="col-3">
-            <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
-        </div>
-        <div class="col-7">
-            <dl class="row">
-                <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
-                <dd class="col-md-8">{{file.name}}</dd>
-
-                <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
-                <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
-
-
-                <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
-                <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
+    <div *ngVar="(originals$ | async)?.payload as originals">
+        <h5 class="simple-view-element-header">{{"item.page.filesection.original.bundle" | translate}}</h5>
+        <ds-pagination *ngIf="originals?.page?.length > 0"
+                       [hideGear]="true"
+                       [hidePagerWhenSinglePage]="true"
+                       [paginationOptions]="originalOptions"
+                       [pageInfoState]="originals"
+                       [collectionSize]="originals?.totalElements"
+                       [disableRouteParameterUpdate]="true"
+                       (pageChange)="switchOriginalPage($event)">
 
 
-                <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
-                <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
-            </dl>
-        </div>
-        <div class="col-2">
-            <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
-                {{"item.page.filesection.download" | translate}}
-            </ds-file-download-link>
-        </div>
+
+            <div class="file-section row" *ngFor="let file of originals?.page;">
+                <div class="col-3">
+                    <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                </div>
+                <div class="col-7">
+                    <dl class="row">
+                        <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
+                        <dd class="col-md-8">{{file.name}}</dd>
+
+                        <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
+                        <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
+
+
+                        <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
+                        <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
+
+
+                        <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
+                        <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
+                    </dl>
+                </div>
+                <div class="col-2">
+                    <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
+                        {{"item.page.filesection.download" | translate}}
+                    </ds-file-download-link>
+                </div>
+            </div>
+        </ds-pagination>
+    </div>
+
+    <div *ngVar="(licenses$ | async)?.payload as licenses">
+        <h5 class="simple-view-element-header">{{"item.page.filesection.license.bundle" | translate}}</h5>
+        <ds-pagination *ngIf="licenses?.page?.length > 0"
+                       [hideGear]="true"
+                       [hidePagerWhenSinglePage]="true"
+                       [paginationOptions]="licenseOptions"
+                       [pageInfoState]="licenses"
+                       [collectionSize]="licenses?.totalElements"
+                       [disableRouteParameterUpdate]="true"
+                       (pageChange)="switchLicensePage($event)">
+
+
+
+            <div class="file-section row" *ngFor="let file of licenses?.page;">
+                <div class="col-3">
+                    <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                </div>
+                <div class="col-7">
+                    <dl class="row">
+                        <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
+                        <dd class="col-md-8">{{file.name}}</dd>
+
+                        <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
+                        <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
+
+
+                        <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
+                        <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
+
+
+                        <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
+                        <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
+                    </dl>
+                </div>
+                <div class="col-2">
+                    <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
+                        {{"item.page.filesection.download" | translate}}
+                    </ds-file-download-link>
+                </div>
+            </div>
+        </ds-pagination>
     </div>
 </ds-metadata-field-wrapper>

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.spec.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.spec.ts
@@ -1,0 +1,117 @@
+import {FullFileSectionComponent} from './full-file-section.component';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {createSuccessfulRemoteDataObject$} from '../../../../shared/remote-data.utils';
+import {createPaginatedList} from '../../../../shared/testing/utils.test';
+import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
+import {TranslateLoaderMock} from '../../../../shared/mocks/translate-loader.mock';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {VarDirective} from '../../../../shared/utils/var.directive';
+import {FileSizePipe} from '../../../../shared/utils/file-size-pipe';
+import {MetadataFieldWrapperComponent} from '../../../field-components/metadata-field-wrapper/metadata-field-wrapper.component';
+import {BitstreamDataService} from '../../../../core/data/bitstream-data.service';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {Bitstream} from '../../../../core/shared/bitstream.model';
+import {of as observableOf} from 'rxjs';
+import {MockBitstreamFormat1} from '../../../../shared/mocks/item.mock';
+import {By} from '@angular/platform-browser';
+
+describe('FullFileSectionComponent', () => {
+    let comp: FullFileSectionComponent;
+    let fixture: ComponentFixture<FullFileSectionComponent>;
+
+    const mockBitstream: Bitstream = Object.assign(new Bitstream(),
+        {
+            sizeBytes: 10201,
+            content: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713/content',
+            format: observableOf(MockBitstreamFormat1),
+            bundleName: 'ORIGINAL',
+            _links: {
+                self: {
+                    href: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713'
+                },
+                content: {
+                    href: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713/content'
+                }
+            },
+            id: 'cf9b0c8e-a1eb-4b65-afd0-567366448713',
+            uuid: 'cf9b0c8e-a1eb-4b65-afd0-567366448713',
+            type: 'bitstream',
+            metadata: {
+                'dc.title': [
+                    {
+                        language: null,
+                        value: 'test_word.docx'
+                    }
+                ]
+            }
+        });
+
+    const bitstreamDataService = jasmine.createSpyObj('bitstreamDataService', {
+        findAllByItemAndBundleName: createSuccessfulRemoteDataObject$(createPaginatedList([mockBitstream, mockBitstream, mockBitstream]))
+    });
+
+    beforeEach(async(() => {
+
+        TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot({
+                loader: {
+                    provide: TranslateLoader,
+                    useClass: TranslateLoaderMock
+                }
+            }), BrowserAnimationsModule],
+            declarations: [FullFileSectionComponent, VarDirective, FileSizePipe, MetadataFieldWrapperComponent],
+            providers: [
+                {provide: BitstreamDataService, useValue: bitstreamDataService}
+            ],
+
+            schemas: [NO_ERRORS_SCHEMA]
+        }).compileComponents();
+    }));
+
+    beforeEach(async(() => {
+        fixture = TestBed.createComponent(FullFileSectionComponent);
+        comp = fixture.componentInstance;
+        fixture.detectChanges();
+    }));
+
+    describe('when the full file section gets loaded with bitstreams available', () => {
+        it ('should contain a list with bitstreams', () => {
+            const fileSection = fixture.debugElement.queryAll(By.css('.file-section'));
+            expect(fileSection.length).toEqual(6);
+        });
+
+        describe('when we press the pageChange button for original bundle', () => {
+            beforeEach(() => {
+                comp.switchOriginalPage(2);
+                fixture.detectChanges();
+            });
+
+            it ('should give the value to the currentpage', () => {
+                expect(comp.originalOptions.currentPage).toBe(2);
+            })
+            it ('should call the next function on the originalCurrentPage', (done) => {
+                comp.originalCurrentPage$.subscribe((event) => {
+                    expect(event).toEqual(2);
+                    done();
+                })
+            })
+        })
+
+        describe('when we press the pageChange button for license bundle', () => {
+            beforeEach(() => {
+                comp.switchLicensePage(2);
+                fixture.detectChanges();
+            });
+
+            it ('should give the value to the currentpage', () => {
+                expect(comp.licenseOptions.currentPage).toBe(2);
+            })
+            it ('should call the next function on the licenseCurrentPage', (done) => {
+                comp.licenseCurrentPage$.subscribe((event) => {
+                    expect(event).toEqual(2);
+                    done();
+                })
+            })
+        })
+    })
+})

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -29,7 +29,7 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   originals$: Observable<RemoteData<PaginatedList<Bitstream>>>;
   licenses$: Observable<RemoteData<PaginatedList<Bitstream>>>;
 
-  pageSize = 5;
+  pageSize = 2;
   originalOptions = Object.assign(new PaginationComponentOptions(),{
     id: 'original-bitstreams-options',
     currentPage: 1,

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -29,7 +29,7 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   originals$: Observable<RemoteData<PaginatedList<Bitstream>>>;
   licenses$: Observable<RemoteData<PaginatedList<Bitstream>>>;
 
-  pageSize = 2;
+  pageSize = 5;
   originalOptions = Object.assign(new PaginationComponentOptions(),{
     id: 'original-bitstreams-options',
     currentPage: 1,

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -1,14 +1,15 @@
 import { Component, Input, OnInit } from '@angular/core';
-import {BehaviorSubject, Observable} from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { BitstreamDataService } from '../../../../core/data/bitstream-data.service';
 
 import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { Item } from '../../../../core/shared/item.model';
 import { followLink } from '../../../../shared/utils/follow-link-config.model';
 import { FileSectionComponent } from '../../../simple/field-components/file-section/file-section.component';
-import {PaginationComponentOptions} from '../../../../shared/pagination/pagination-component-options.model';
-import {PaginatedList} from '../../../../core/data/paginated-list';
-import {RemoteData} from '../../../../core/data/remote-data';
+import { PaginationComponentOptions } from '../../../../shared/pagination/pagination-component-options.model';
+import { PaginatedList } from '../../../../core/data/paginated-list';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { switchMap } from "rxjs/operators";
 
 /**
  * This component renders the file section of the item
@@ -55,23 +56,23 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   }
 
   initialize(): void {
-    this.originalCurrentPage$.subscribe((value) => {
-      this.originals$ = this.bitstreamDataService.findAllByItemAndBundleName(
-          this.item,
-          'ORIGINAL',
-          { elementsPerPage: this.pageSize, currentPage: value },
-          followLink( 'format')
-      );
-    });
+    this.originals$ = this.originalCurrentPage$.pipe(
+        switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
+            this.item,
+            'ORIGINAL',
+            { elementsPerPage: this.pageSize, currentPage: pageNumber },
+            followLink( 'format')
+        ))
+    );
 
-    this.licenseCurrentPage$.subscribe((value) => {
-      this.licenses$ = this.bitstreamDataService.findAllByItemAndBundleName(
-          this.item,
-          'LICENSE',
-          { elementsPerPage: this.pageSize, currentPage: value },
-          followLink( 'format')
-      );
-    });
+    this.licenses$ = this.licenseCurrentPage$.pipe(
+        switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
+            this.item,
+            'LICENSE',
+            { elementsPerPage: this.pageSize, currentPage: pageNumber },
+            followLink( 'format')
+        ))
+    );
 
   }
 

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -1,13 +1,14 @@
-import { Component, Injector, Input, OnInit } from '@angular/core';
-import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
+import { Component, Input, OnInit } from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
 import { BitstreamDataService } from '../../../../core/data/bitstream-data.service';
 
 import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { Item } from '../../../../core/shared/item.model';
-import { getFirstSucceededRemoteListPayload } from '../../../../core/shared/operators';
 import { followLink } from '../../../../shared/utils/follow-link-config.model';
 import { FileSectionComponent } from '../../../simple/field-components/file-section/file-section.component';
+import {PaginationComponentOptions} from '../../../../shared/pagination/pagination-component-options.model';
+import {PaginatedList} from '../../../../core/data/paginated-list';
+import {RemoteData} from '../../../../core/data/remote-data';
 
 /**
  * This component renders the file section of the item
@@ -25,7 +26,23 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
 
   label: string;
 
-  bitstreams$: Observable<Bitstream[]>;
+  originals$: Observable<RemoteData<PaginatedList<Bitstream>>>;
+  licenses$: Observable<RemoteData<PaginatedList<Bitstream>>>;
+
+  pageSize = 5;
+  originalOptions = Object.assign(new PaginationComponentOptions(),{
+    id: 'original-bitstreams-options',
+    currentPage: 1,
+    pageSize: this.pageSize
+  });
+  originalCurrentPage$ = new BehaviorSubject<number>(1);
+
+  licenseOptions = Object.assign(new PaginationComponentOptions(),{
+    id: 'license-bitstreams-options',
+    currentPage: 1,
+    pageSize: this.pageSize
+  });
+  licenseCurrentPage$ = new BehaviorSubject<number>(1);
 
   constructor(
     bitstreamDataService: BitstreamDataService
@@ -34,40 +51,45 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   }
 
   ngOnInit(): void {
-    super.ngOnInit();
+    this.initialize();
   }
 
   initialize(): void {
-    // TODO pagination
-    const originals$ = this.bitstreamDataService.findAllByItemAndBundleName(
-      this.item,
-      'ORIGINAL',
-      { elementsPerPage: Number.MAX_SAFE_INTEGER },
-      followLink( 'format')
-    ).pipe(
-      getFirstSucceededRemoteListPayload(),
-      startWith([])
-    );
-    const licenses$ = this.bitstreamDataService.findAllByItemAndBundleName(
-      this.item,
-      'LICENSE',
-      { elementsPerPage: Number.MAX_SAFE_INTEGER },
-      followLink( 'format')
-    ).pipe(
-      getFirstSucceededRemoteListPayload(),
-      startWith([])
-    );
-    this.bitstreams$ = observableCombineLatest(originals$, licenses$).pipe(
-      map(([o, l]) => [...o, ...l]),
-      map((files: Bitstream[]) =>
-        files.map(
-          (original) => {
-            original.thumbnail = this.bitstreamDataService.getMatchingThumbnail(this.item, original);
-            return original;
-          }
-        )
-      )
-    );
+    this.originalCurrentPage$.subscribe((value) => {
+      this.originals$ = this.bitstreamDataService.findAllByItemAndBundleName(
+          this.item,
+          'ORIGINAL',
+          { elementsPerPage: this.pageSize, currentPage: value },
+          followLink( 'format')
+      );
+    });
+
+    this.licenseCurrentPage$.subscribe((value) => {
+      this.licenses$ = this.bitstreamDataService.findAllByItemAndBundleName(
+          this.item,
+          'LICENSE',
+          { elementsPerPage: this.pageSize, currentPage: value },
+          followLink( 'format')
+      );
+    });
+
   }
 
+  /**
+   * Update the current page for the original bundle bitstreams
+   * @param page
+   */
+  switchOriginalPage(page: number) {
+    this.originalOptions.currentPage = page;
+    this.originalCurrentPage$.next(page);
+  }
+
+  /**
+   * Update the current page for the license bundle bitstreams
+   * @param page
+   */
+  switchLicensePage(page: number) {
+    this.licenseOptions.currentPage = page;
+    this.licenseCurrentPage$.next(page);
+  }
 }

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.html
@@ -6,12 +6,12 @@
         <span>({{(file?.sizeBytes) | dsFileSize }})</span>
         <span *ngIf="!last" innerHTML="{{separator}}"></span>
       </ds-file-download-link>
-      <ds-loading *ngIf="isLoading" message="{{'loading.default' | translate}}"></ds-loading>
+      <ds-loading *ngIf="isLoading" message="{{'loading.default' | translate}}" [showMessage]="false"></ds-loading>
       <div *ngIf="!isLastPage" class="mt-1" id="view-more">
-        <a class="bitstream-view-more" [routerLink]="" (click)="getNextPage()">{{'item.page.bitstreams.view-more' | translate}}</a>
+        <a class="bitstream-view-more btn btn-outline-secondary btn-sm" [routerLink]="" (click)="getNextPage()">{{'item.page.bitstreams.view-more' | translate}}</a>
       </div>
       <div *ngIf="isLastPage && currentPage != 1" class="mt-1" id="view-less">
-        <a class="bitstream-view-less" [routerLink]="" (click)="currentPage = undefined; getNextPage();">{{'item.page.bitstreams.view-less' | translate}}</a>
+        <a class="bitstream-view-less btn btn-outline-secondary btn-sm" [routerLink]="" (click)="currentPage = undefined; getNextPage();">{{'item.page.bitstreams.view-less' | translate}}</a>
       </div>
     </div>
   </ds-metadata-field-wrapper>

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.html
@@ -6,6 +6,13 @@
         <span>({{(file?.sizeBytes) | dsFileSize }})</span>
         <span *ngIf="!last" innerHTML="{{separator}}"></span>
       </ds-file-download-link>
+      <ds-loading *ngIf="isLoading" message="{{'loading.default' | translate}}"></ds-loading>
+      <div *ngIf="!isLastPage" class="mt-1" id="view-more">
+        <a class="bitstream-view-more" [routerLink]="" (click)="getNextPage()">{{'item.page.bitstreams.view-more' | translate}}</a>
+      </div>
+      <div *ngIf="isLastPage && currentPage != 1" class="mt-1" id="view-less">
+        <a class="bitstream-view-less" [routerLink]="" (click)="currentPage = undefined; getNextPage();">{{'item.page.bitstreams.view-less' | translate}}</a>
+      </div>
     </div>
   </ds-metadata-field-wrapper>
 </ng-container>

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
@@ -1,0 +1,169 @@
+import {FileSectionComponent} from './file-section.component';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
+import {TranslateLoaderMock} from '../../../../shared/mocks/translate-loader.mock';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {VarDirective} from '../../../../shared/utils/var.directive';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {BitstreamDataService} from '../../../../core/data/bitstream-data.service';
+import {createSuccessfulRemoteDataObject$} from '../../../../shared/remote-data.utils';
+import {By} from '@angular/platform-browser';
+import {Bitstream} from '../../../../core/shared/bitstream.model';
+import {of as observableOf} from 'rxjs';
+import {MockBitstreamFormat1} from '../../../../shared/mocks/item.mock';
+import {FileSizePipe} from '../../../../shared/utils/file-size-pipe';
+import {PageInfo} from '../../../../core/shared/page-info.model';
+import {MetadataFieldWrapperComponent} from '../../../field-components/metadata-field-wrapper/metadata-field-wrapper.component';
+import {createPaginatedList} from '../../../../shared/testing/utils.test';
+
+describe('FileSectionComponent', () => {
+    let comp: FileSectionComponent;
+    let fixture: ComponentFixture<FileSectionComponent>;
+
+    const bitstreamDataService = jasmine.createSpyObj('bitstreamDataService', {
+        findAllByItemAndBundleName: createSuccessfulRemoteDataObject$(createPaginatedList([]))
+    });
+
+    const mockBitstream: Bitstream = Object.assign(new Bitstream(),
+        {
+            sizeBytes: 10201,
+            content: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713/content',
+            format: observableOf(MockBitstreamFormat1),
+            bundleName: 'ORIGINAL',
+            _links: {
+                self: {
+                    href: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713'
+                },
+                content: {
+                    href: 'https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/cf9b0c8e-a1eb-4b65-afd0-567366448713/content'
+                }
+            },
+            id: 'cf9b0c8e-a1eb-4b65-afd0-567366448713',
+            uuid: 'cf9b0c8e-a1eb-4b65-afd0-567366448713',
+            type: 'bitstream',
+            metadata: {
+                'dc.title': [
+                    {
+                        language: null,
+                        value: 'test_word.docx'
+                    }
+                ]
+            }
+        });
+
+    beforeEach(async(() => {
+
+        TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot({
+                loader: {
+                    provide: TranslateLoader,
+                    useClass: TranslateLoaderMock
+                }
+            }), BrowserAnimationsModule],
+            declarations: [FileSectionComponent, VarDirective, FileSizePipe, MetadataFieldWrapperComponent],
+            providers: [
+                {provide: BitstreamDataService, useValue: bitstreamDataService}
+            ],
+
+            schemas: [NO_ERRORS_SCHEMA]
+        }).compileComponents();
+    }));
+
+    beforeEach(async(() => {
+        fixture = TestBed.createComponent(FileSectionComponent);
+        comp = fixture.componentInstance;
+        fixture.detectChanges();
+    }));
+
+    describe('when the bitstreams are loading', () => {
+        beforeEach(() => {
+            comp.bitstreams$.next([mockBitstream]);
+            comp.isLoading = true;
+            fixture.detectChanges();
+        });
+
+        it('should display a loading component', () => {
+            const loading = fixture.debugElement.query(By.css('ds-loading'));
+            expect(loading.nativeElement).toBeDefined();
+        });
+    });
+
+    describe('when the "Show more" button is clicked', () => {
+
+        beforeEach(() => {
+            comp.bitstreams$.next([mockBitstream]);
+            comp.currentPage = 1;
+            comp.isLastPage = false;
+            fixture.detectChanges();
+        });
+
+        it('should call the service to retrieve more bitstreams', () => {
+            const viewMore = fixture.debugElement.query(By.css('.bitstream-view-more'));
+            viewMore.triggerEventHandler('click', null);
+            expect(bitstreamDataService.findAllByItemAndBundleName).toHaveBeenCalled()
+        })
+
+        it('one bitstream should be on the page', () => {
+            const viewMore = fixture.debugElement.query(By.css('.bitstream-view-more'));
+            viewMore.triggerEventHandler('click', null);
+            const fileDownloadLink = fixture.debugElement.queryAll(By.css('ds-file-download-link'));
+            expect(fileDownloadLink.length).toEqual(1);
+        })
+
+        describe('when it is then clicked again', () => {
+            beforeEach(() => {
+                bitstreamDataService.findAllByItemAndBundleName.and.returnValue(createSuccessfulRemoteDataObject$(createPaginatedList([mockBitstream])));
+                const viewMore = fixture.debugElement.query(By.css('.bitstream-view-more'));
+                viewMore.triggerEventHandler('click', null);
+                fixture.detectChanges();
+
+            })
+            it('should contain another bitstream', () => {
+                const fileDownloadLink = fixture.debugElement.queryAll(By.css('ds-file-download-link'));
+                expect(fileDownloadLink.length).toEqual(2);
+            })
+        })
+    });
+
+    describe('when its the last page of bitstreams', () => {
+        beforeEach(() => {
+            comp.bitstreams$.next([mockBitstream]);
+            comp.isLastPage = true;
+            comp.currentPage = 2;
+            fixture.detectChanges();
+        });
+
+        it('should not contain a view more link', () => {
+            const viewMore = fixture.debugElement.query(By.css('.bitstream-view-more'));
+            expect(viewMore).toBeFalsy();
+        })
+
+        it('should contain a view less link', () => {
+            const viewLess = fixture.debugElement.query(By.css('.bitstream-view-less'));
+            expect(viewLess).toBeTruthy();
+        })
+
+        it('clicking on the view less link should reset the pages and call getNextPage()', () => {
+            const pageInfo = Object.assign(new PageInfo(), {
+                elementsPerPage: 3,
+                totalElements: 5,
+                totalPages: 2,
+                currentPage: 1,
+                _links: {
+                    self: {href: 'https://rest.api/core/bitstreams/'},
+                    next: {href: 'https://rest.api/core/bitstreams?page=2'}
+                }
+            });
+            const PaginatedList = Object.assign(createPaginatedList([mockBitstream]), {
+                pageInfo: pageInfo
+            });
+            bitstreamDataService.findAllByItemAndBundleName.and.returnValue(createSuccessfulRemoteDataObject$(PaginatedList));
+            const viewLess = fixture.debugElement.query(By.css('.bitstream-view-less'));
+            viewLess.triggerEventHandler('click', null);
+            expect(bitstreamDataService.findAllByItemAndBundleName).toHaveBeenCalled();
+            expect(comp.currentPage).toBe(1);
+            expect(comp.isLastPage).toBeFalse();
+        })
+
+    })
+})

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
@@ -135,12 +135,12 @@ describe('FileSectionComponent', () => {
 
         it('should not contain a view more link', () => {
             const viewMore = fixture.debugElement.query(By.css('.bitstream-view-more'));
-            expect(viewMore).toBeFalsy();
+            expect(viewMore).toBeNull();
         })
 
         it('should contain a view less link', () => {
             const viewLess = fixture.debugElement.query(By.css('.bitstream-view-less'));
-            expect(viewLess).toBeTruthy();
+            expect(viewLess).toBeDefined();
         })
 
         it('clicking on the view less link should reset the pages and call getNextPage()', () => {

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -4,10 +4,10 @@ import { BitstreamDataService } from '../../../../core/data/bitstream-data.servi
 
 import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { Item } from '../../../../core/shared/item.model';
-import {filter, takeWhile} from 'rxjs/operators';
-import {RemoteData} from '../../../../core/data/remote-data';
-import {hasNoValue, hasValue} from '../../../../shared/empty.util';
-import {PaginatedList} from '../../../../core/data/paginated-list';
+import { filter, takeWhile } from 'rxjs/operators';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { hasNoValue, hasValue } from '../../../../shared/empty.util';
+import { PaginatedList } from '../../../../core/data/paginated-list';
 
 /**
  * This component renders the file section of the item
@@ -33,6 +33,8 @@ export class FileSectionComponent implements OnInit {
 
   isLastPage: boolean;
 
+  pageSize: number = 5;
+
   constructor(
     protected bitstreamDataService: BitstreamDataService
   ) {
@@ -56,7 +58,7 @@ export class FileSectionComponent implements OnInit {
     } else {
       this.currentPage++;
     }
-    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage }).pipe(
+    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage, elementsPerPage: this.pageSize }).pipe(
         filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
         takeWhile((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasNoValue(bitstreamsRD.payload) && hasNoValue(bitstreamsRD.error), true)
     ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -1,10 +1,13 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { BitstreamDataService } from '../../../../core/data/bitstream-data.service';
 
 import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { Item } from '../../../../core/shared/item.model';
-import { getFirstSucceededRemoteListPayload } from '../../../../core/shared/operators';
+import {filter, takeWhile} from 'rxjs/operators';
+import {RemoteData} from '../../../../core/data/remote-data';
+import {hasNoValue, hasValue} from '../../../../shared/empty.util';
+import {PaginatedList} from '../../../../core/data/paginated-list';
 
 /**
  * This component renders the file section of the item
@@ -22,7 +25,13 @@ export class FileSectionComponent implements OnInit {
 
   separator = '<br/>';
 
-  bitstreams$: Observable<Bitstream[]>;
+  bitstreams$: BehaviorSubject<Bitstream[]>;
+
+  currentPage: number;
+
+  isLoading: boolean;
+
+  isLastPage: boolean;
 
   constructor(
     protected bitstreamDataService: BitstreamDataService
@@ -30,13 +39,31 @@ export class FileSectionComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.initialize();
+    this.getNextPage();
   }
 
-  initialize(): void {
-    this.bitstreams$ = this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL').pipe(
-      getFirstSucceededRemoteListPayload()
-    );
+  /**
+   * This method will retrieve the next page of Bitstreams from the external BitstreamDataService call.
+   * It'll retrieve the currentPage from the class variables and it'll add the next page of bitstreams with the
+   * already existing one.
+   * If the currentPage variable is undefined, we'll set it to 1 and retrieve the first page of Bitstreams
+   */
+  getNextPage(): void {
+    this.isLoading = true;
+    if (this.currentPage === undefined) {
+      this.currentPage = 1;
+      this.bitstreams$ = new BehaviorSubject([]);
+    } else {
+      this.currentPage++;
+    }
+    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage }).pipe(
+        filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
+        takeWhile((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasNoValue(bitstreamsRD.payload) && hasNoValue(bitstreamsRD.error), true)
+    ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
+      const current: Bitstream[] = this.bitstreams$.getValue();
+      this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
+      this.isLoading = false;
+      this.isLastPage = hasNoValue(bitstreamsRD.payload.next);
+    });
   }
-
 }

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -56,7 +56,9 @@ export class FileSectionComponent implements OnInit {
     } else {
       this.currentPage++;
     }
-    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage }).pipe(
+    console.log(this.isLastPage);
+    console.log(this.currentPage);
+    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage, elementsPerPage: 1 }).pipe(
         filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
         takeWhile((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasNoValue(bitstreamsRD.payload) && hasNoValue(bitstreamsRD.error), true)
     ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
@@ -64,6 +66,8 @@ export class FileSectionComponent implements OnInit {
       this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
       this.isLoading = false;
       this.isLastPage = hasNoValue(bitstreamsRD.payload.next);
+      console.log("lel");
+      console.log(this.isLastPage);
     });
   }
 }

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -56,18 +56,14 @@ export class FileSectionComponent implements OnInit {
     } else {
       this.currentPage++;
     }
-    console.log(this.isLastPage);
-    console.log(this.currentPage);
-    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage, elementsPerPage: 1 }).pipe(
+    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage }).pipe(
         filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
         takeWhile((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasNoValue(bitstreamsRD.payload) && hasNoValue(bitstreamsRD.error), true)
     ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
       const current: Bitstream[] = this.bitstreams$.getValue();
       this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
       this.isLoading = false;
-      this.isLastPage = hasNoValue(bitstreamsRD.payload.next);
-      console.log("lel");
-      console.log(this.isLastPage);
+      this.isLastPage = this.currentPage === bitstreamsRD.payload.totalPages;
     });
   }
 }

--- a/src/app/core/cache/builders/remote-data-build.service.ts
+++ b/src/app/core/cache/builders/remote-data-build.service.ts
@@ -139,8 +139,8 @@ export class RemoteDataBuildService {
     const pageInfo$ = requestEntry$.pipe(
       filterSuccessfulResponses(),
       map((response: DSOSuccessResponse) => {
-        if (hasValue((response as DSOSuccessResponse).pageInfo)) {
-          return (response as DSOSuccessResponse).pageInfo;
+        if (hasValue(response.pageInfo)) {
+          return Object.assign(new PageInfo(), response.pageInfo);
         }
       })
     );

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1524,6 +1524,13 @@
 
   "item.page.uri": "URI",
 
+  "item.page.bitstreams.view-more": "Show more",
+
+  "item.page.bitstreams.view-less": "Show less",
+
+  "item.page.filesection.original.bundle" : "Original bundle",
+
+  "item.page.filesection.license.bundle" : "License bundle",
 
 
   "item.select.confirm": "Confirm selected",


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/dspace-angular/issues/759

## Description
This PR will ensure that the Pagination for files attached to an Item on the simple and full item pages will be fixed and working. The page size is currently set to 5 as a default.

## Instructions for Reviewers

List of changes in this PR:
* The file section on the simple item page will now have pagination.
* The file section on the full item page will now have pagination as well.
* Tests have been included for both cases

These changes can be reviewed by visiting an item with more than 5 Bitstreams. You'll now be able to access its Bitstreams on the simple item page through pagination with the 'view more' and 'view less' buttons. It'll also be possible to view the pagination on the full item page through a complete pagination component including page numbers, size and total results.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
