### PR TITLE
Hide EPerson search section in the edit mode

### DIFF
--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.html
@@ -7,87 +7,88 @@
       <ds-eperson-form *ngIf="isEPersonFormShown" (submitForm)="forceUpdateEPeople()"
                        (cancelForm)="isEPersonFormShown = false"></ds-eperson-form>
 
-      <div *ngIf="!isEPersonFormShown" class="button-row top d-flex pb-2">
-        <button class="mr-auto btn btn-success addEPerson-button"
-                (click)="isEPersonFormShown = true">
-          <i class="fas fa-plus"></i>
-          <span class="d-none d-sm-inline">{{labelPrefix + 'button.add' | translate}}</span>
-        </button>
-      </div>
-
-      <h3 id="search" class="border-bottom pb-2">{{labelPrefix + 'search.head' | translate}}
-        <button (click)="clearFormAndResetResult();"
-                class="btn btn-primary float-right">{{labelPrefix + 'button.see-all' | translate}}</button>
-      </h3>
-      <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
-        <div class="col-12 col-sm-3">
-          <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
-            <option value="metadata">{{labelPrefix + 'search.scope.metadata' | translate}}</option>
-            <option value="email">{{labelPrefix + 'search.scope.email' | translate}}</option>
-          </select>
+      <div *ngIf="!isEPersonFormShown">
+        <div class="button-row top d-flex pb-2">
+          <button class="mr-auto btn btn-success addEPerson-button"
+                  (click)="isEPersonFormShown = true">
+            <i class="fas fa-plus"></i>
+            <span class="d-none d-sm-inline">{{labelPrefix + 'button.add' | translate}}</span>
+          </button>
         </div>
-        <div class="col-sm-9 col-12">
-          <div class="form-group input-group">
-            <input type="text" name="query" id="query" formControlName="query"
-                   class="form-control" aria-label="Search input">
-            <span class="input-group-append">
-            <button type="submit"
-                    class="search-button btn btn-secondary">{{ labelPrefix + 'search.button' | translate }}</button>
-        </span>
+
+        <h3 id="search" class="border-bottom pb-2">{{labelPrefix + 'search.head' | translate}}
+          <button (click)="clearFormAndResetResult();"
+                  class="btn btn-primary float-right">{{labelPrefix + 'button.see-all' | translate}}</button>
+        </h3>
+        <form [formGroup]="searchForm" (ngSubmit)="search(searchForm.value)" class="row">
+          <div class="col-12 col-sm-3">
+            <select name="scope" id="scope" formControlName="scope" class="form-control" aria-label="Search scope">
+              <option value="metadata">{{labelPrefix + 'search.scope.metadata' | translate}}</option>
+              <option value="email">{{labelPrefix + 'search.scope.email' | translate}}</option>
+            </select>
           </div>
+          <div class="col-sm-9 col-12">
+            <div class="form-group input-group">
+              <input type="text" name="query" id="query" formControlName="query"
+                    class="form-control" aria-label="Search input">
+              <span class="input-group-append">
+              <button type="submit"
+                      class="search-button btn btn-secondary">{{ labelPrefix + 'search.button' | translate }}</button>
+          </span>
+            </div>
+          </div>
+        </form>
+
+        <ds-pagination
+          *ngIf="(ePeople | async)?.payload?.totalElements > 0"
+          [paginationOptions]="config"
+          [pageInfoState]="(ePeople | async)?.payload"
+          [collectionSize]="(ePeople | async)?.payload?.totalElements"
+          [hideGear]="true"
+          [hidePagerWhenSinglePage]="true"
+          (pageChange)="onPageChange($event)">
+
+          <div class="table-responsive">
+            <table id="epeople" class="table table-striped table-hover table-bordered">
+              <thead>
+              <tr>
+                <th scope="col">{{labelPrefix + 'table.id' | translate}}</th>
+                <th scope="col">{{labelPrefix + 'table.name' | translate}}</th>
+                <th scope="col">{{labelPrefix + 'table.email' | translate}}</th>
+                <th>{{labelPrefix + 'table.edit' | translate}}</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr *ngFor="let eperson of (ePeople | async)?.payload?.page"
+                  [ngClass]="{'table-primary' : isActive(eperson) | async}">
+                <td>{{eperson.id}}</td>
+                <td>{{eperson.name}}</td>
+                <td>{{eperson.email}}</td>
+                <td>
+                  <div class="btn-group edit-field">
+                    <button (click)="toggleEditEPerson(eperson)"
+                            class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
+                            title="{{labelPrefix + 'table.edit.buttons.edit' | translate: {name: eperson.name} }}">
+                      <i class="fas fa-edit fa-fw"></i>
+                    </button>
+                    <button (click)="deleteEPerson(eperson)"
+                            class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                            title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: eperson.name} }}">
+                      <i class="fas fa-trash-alt fa-fw"></i>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+
+        </ds-pagination>
+
+        <div *ngIf="(ePeople | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">
+          {{labelPrefix + 'no-items' | translate}}
         </div>
-      </form>
-
-      <ds-pagination
-        *ngIf="(ePeople | async)?.payload?.totalElements > 0"
-        [paginationOptions]="config"
-        [pageInfoState]="(ePeople | async)?.payload"
-        [collectionSize]="(ePeople | async)?.payload?.totalElements"
-        [hideGear]="true"
-        [hidePagerWhenSinglePage]="true"
-        (pageChange)="onPageChange($event)">
-
-        <div class="table-responsive">
-          <table id="epeople" class="table table-striped table-hover table-bordered">
-            <thead>
-            <tr>
-              <th scope="col">{{labelPrefix + 'table.id' | translate}}</th>
-              <th scope="col">{{labelPrefix + 'table.name' | translate}}</th>
-              <th scope="col">{{labelPrefix + 'table.email' | translate}}</th>
-              <th>{{labelPrefix + 'table.edit' | translate}}</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr *ngFor="let eperson of (ePeople | async)?.payload?.page"
-                [ngClass]="{'table-primary' : isActive(eperson) | async}">
-              <td>{{eperson.id}}</td>
-              <td>{{eperson.name}}</td>
-              <td>{{eperson.email}}</td>
-              <td>
-                <div class="btn-group edit-field">
-                  <button (click)="toggleEditEPerson(eperson)"
-                          class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.edit' | translate: {name: eperson.name} }}">
-                    <i class="fas fa-edit fa-fw"></i>
-                  </button>
-                  <button (click)="deleteEPerson(eperson)"
-                          class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: eperson.name} }}">
-                    <i class="fas fa-trash-alt fa-fw"></i>
-                  </button>
-                </div>
-              </td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-
-      </ds-pagination>
-
-      <div *ngIf="(ePeople | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2" role="alert">
-        {{labelPrefix + 'no-items' | translate}}
       </div>
-
     </div>
   </div>
 </div>

--- a/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/+admin/admin-access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -175,13 +175,17 @@ describe('EPeopleRegistryComponent', () => {
       it('editEPerson form is toggled', () => {
         const ePeopleIds = fixture.debugElement.queryAll(By.css('#epeople tr td:first-child'));
         ePersonDataServiceStub.getActiveEPerson().subscribe((activeEPerson: EPerson) => {
-          if (activeEPerson === ePeopleIds[0].nativeElement.textContent) {
+          if (ePeopleIds[0] && activeEPerson === ePeopleIds[0].nativeElement.textContent) {
             expect(component.isEPersonFormShown).toEqual(false);
           } else {
             expect(component.isEPersonFormShown).toEqual(true);
           }
 
         })
+      });
+
+      it('EPerson search section is hidden', () => {
+        expect(fixture.debugElement.query(By.css('#search'))).toBeNull();
       });
     });
   });


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/840

## Description
I added a div in the epeople-registry.component.html page that included the whole search section in order to hide it with a *ngIf

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
