### PR TITLE
Support multiple dso type values in discovery

### DIFF
--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
@@ -133,7 +133,7 @@ export class CollectionItemMapperComponent implements OnInit {
             return this.searchService.search(Object.assign(new PaginatedSearchOptions(options), {
               query: this.buildQuery(collectionRD.payload.id, options.query),
               scope: undefined,
-              dsoType: DSpaceObjectType.ITEM,
+              dsoTypes: [DSpaceObjectType.ITEM],
               sort: this.defaultSortOptions
             }), 10000).pipe(
               toDSpaceObjectListRD(),

--- a/src/app/+collection-page/collection-page.component.ts
+++ b/src/app/+collection-page/collection-page.component.ts
@@ -87,7 +87,7 @@ export class CollectionPageComponent implements OnInit {
                 scope: id,
                 pagination: dto.paginationConfig,
                 sort: dto.sortConfig,
-                dsoType: DSpaceObjectType.ITEM
+                dsoTypes: [DSpaceObjectType.ITEM]
               })).pipe(toDSpaceObjectListRD()) as Observable<RemoteData<PaginatedList<Item>>>
         }),
         startWith(undefined) // Make sure switching pages shows loading component

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
@@ -125,7 +125,7 @@ export class ItemCollectionMapperComponent implements OnInit {
       switchMap(([itemCollectionsRD, owningCollectionRD, searchOptions]) => {
         return this.searchService.search(Object.assign(new PaginatedSearchOptions(searchOptions), {
           query: this.buildQuery([...itemCollectionsRD.payload.page, owningCollectionRD.payload], searchOptions.query),
-          dsoType: DSpaceObjectType.COLLECTION
+          dsoTypes: [DSpaceObjectType.COLLECTION]
         }), 10000).pipe(
           toDSpaceObjectListRD(),
           startWith(undefined)

--- a/src/app/+item-page/edit-item-page/item-move/item-move.component.ts
+++ b/src/app/+item-page/edit-item-page/item-move/item-move.component.ts
@@ -79,7 +79,7 @@ export class ItemMoveComponent implements OnInit {
   loadSuggestions(query): void {
     this.collectionSearchResults = this.searchService.search(new PaginatedSearchOptions({
       pagination: this.pagination,
-      dsoType: DSpaceObjectType.COLLECTION,
+      dsoTypes: [DSpaceObjectType.COLLECTION],
       query: query
     })).pipe(
       first(),

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -2,14 +2,14 @@
     <input type="search"
            class="form-control"
            (click)="$event.stopPropagation();"
-           placeholder="{{'dso-selector.placeholder' | translate: { type: type.toString().toLowerCase() } }}"
+           placeholder="{{'dso-selector.placeholder' | translate: { type: typesString } }}"
            [formControl]="input" dsAutoFocus (keyup.enter)="selectSingleResult()">
 </div>
 <div class="dropdown-divider"></div>
 <div class="scrollable-menu list-group">
     <button class="list-group-item list-group-item-action border-0 disabled"
             *ngIf="(listEntries$ | async)?.payload.page.length == 0">
-        {{'dso-selector.no-results' | translate: { type: type.toString().toLowerCase() } }}
+        {{'dso-selector.no-results' | translate: { type: typesString } }}
     </button>
     <button *ngFor="let listEntry of (listEntries$ | async)?.payload.page"
             class="list-group-item list-group-item-action border-0 list-entry"

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -49,7 +49,7 @@ describe('DSOSelectorComponent', () => {
     component = fixture.componentInstance;
     debugElement = fixture.debugElement;
     component.currentDSOId = currentDSOId;
-    component.type = type;
+    component.types = [type];
 
     fixture.detectChanges();
   });
@@ -61,7 +61,7 @@ describe('DSOSelectorComponent', () => {
   it('should initially call the search method on the SearchService with the given DSO uuid', () => {
     const searchOptions = new PaginatedSearchOptions({
       query: currentDSOId,
-      dsoType: type,
+      dsoTypes: [type],
       pagination: (component as any).defaultPagination
     });
 

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -43,9 +43,12 @@ export class DSOSelectorComponent implements OnInit {
   @Input() currentDSOId: string;
 
   /**
-   * The type of DSpace objects this components shows a list of
+   * The types of DSpace objects this components shows a list of
    */
-  @Input() type: DSpaceObjectType;
+  @Input() types: DSpaceObjectType[];
+
+  // list of allowed selectable dsoTypes
+  typesString: string;
 
   /**
    * Emits the selected Object when a user selects it in the list
@@ -91,6 +94,7 @@ export class DSOSelectorComponent implements OnInit {
    */
   ngOnInit(): void {
     this.input.setValue(this.currentDSOId);
+    this.typesString = this.types.map((type: string) => type.toString().toLowerCase()).join(', ');
     this.listEntries$ = this.input.valueChanges
       .pipe(
         debounceTime(this.debounceTime),
@@ -99,7 +103,7 @@ export class DSOSelectorComponent implements OnInit {
             return this.searchService.search(
               new PaginatedSearchOptions({
                 query: query,
-                dsoType: this.type !== DSpaceObjectType.DSPACEOBJECT ? this.type : null,
+                dsoTypes: this.types,
                 pagination: this.defaultPagination
               })
             )

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
@@ -20,7 +20,7 @@ import { DSOSelectorModalWrapperComponent, SelectorActionType } from '../dso-sel
 })
 export class CreateCollectionParentSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.COLLECTION;
-  selectorType = DSpaceObjectType.COMMUNITY;
+  selectorTypes = [DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.CREATE;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -14,6 +14,6 @@
         </h3>
 
         <h5 class="px-2">{{'dso-selector.create.community.sub-level' | translate}}</h5>
-        <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
+        <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="[selectorType]" (onSelect)="selectObject($event)"></ds-dso-selector>
     </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -14,6 +14,6 @@
         </h3>
 
         <h5 class="px-2">{{'dso-selector.create.community.sub-level' | translate}}</h5>
-        <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="[selectorType]" (onSelect)="selectObject($event)"></ds-dso-selector>
+        <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-dso-selector>
     </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
@@ -27,7 +27,7 @@ import {
 })
 export class CreateCommunityParentSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.COMMUNITY;
-  selectorType = DSpaceObjectType.COMMUNITY;
+  selectorTypes = [DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.CREATE;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.ts
@@ -18,7 +18,7 @@ import { DSOSelectorModalWrapperComponent, SelectorActionType } from '../dso-sel
 })
 export class CreateItemParentSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.ITEM;
-  selectorType = DSpaceObjectType.COLLECTION;
+  selectorTypes = [DSpaceObjectType.COLLECTION];
   action = SelectorActionType.CREATE;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
@@ -5,6 +5,6 @@
     </button>
   </div>
   <div class="modal-body">
-    <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [type]="selectorType" (onSelect)="selectObject($event)"></ds-dso-selector>
+    <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-dso-selector>
   </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.spec.ts
@@ -124,7 +124,7 @@ describe('DSOSelectorModalWrapperComponent', () => {
 })
 class TestComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.ITEM;
-  selectorType = DSpaceObjectType.ITEM;
+  selectorTypes = [DSpaceObjectType.ITEM];
   action = SelectorActionType.EDIT;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute) {

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
@@ -29,9 +29,9 @@ export abstract class DSOSelectorModalWrapperComponent implements OnInit {
   objectType: DSpaceObjectType;
 
   /**
-   * The type of DSO that can be selected from this list
+   * The types of DSO that can be selected from this list
    */
-  selectorType: DSpaceObjectType;
+  selectorTypes: DSpaceObjectType[];
 
   /**
    * The type of action to perform

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.ts
@@ -20,7 +20,7 @@ import {
 })
 export class EditCollectionSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.COLLECTION;
-  selectorType = DSpaceObjectType.COLLECTION;
+  selectorTypes = [DSpaceObjectType.COLLECTION];
   action = SelectorActionType.EDIT;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.ts
@@ -21,7 +21,7 @@ import {
 
 export class EditCommunitySelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.COMMUNITY;
-  selectorType = DSpaceObjectType.COMMUNITY;
+  selectorTypes = [DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.EDIT;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.ts
@@ -17,7 +17,7 @@ import { DSOSelectorModalWrapperComponent, SelectorActionType } from '../dso-sel
 })
 export class EditItemSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.ITEM;
-  selectorType = DSpaceObjectType.ITEM;
+  selectorTypes = [DSpaceObjectType.ITEM];
   action = SelectorActionType.EDIT;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
@@ -130,9 +130,8 @@ describe('ExportMetadataSelectorComponent', () => {
         done()
       });
     });
-    it('should show error notification', () => {
-      expect(notificationService.error).toHaveBeenCalled();
-      expect(scriptRequestSucceeded).toBeFalse();
+    it('should not invoke metadata-export script', () => {
+      expect(scriptService.invoke).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
@@ -28,7 +28,7 @@ import { DSOSelectorModalWrapperComponent, SelectorActionType } from '../dso-sel
 })
 export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.DSPACEOBJECT;
-  selectorType = DSpaceObjectType.DSPACEOBJECT;
+  selectorTypes = [DSpaceObjectType.COLLECTION, DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.EXPORT_METADATA;
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router,

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
@@ -66,7 +66,6 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
       resp$.subscribe();
       return resp$;
     } else {
-      this.notificationsService.error(this.translationService.get('dso-selector.export-metadata.notValidDSO'));
       return observableOf(false);
     }
   }

--- a/src/app/shared/search/paginated-search-options.model.spec.ts
+++ b/src/app/shared/search/paginated-search-options.model.spec.ts
@@ -13,7 +13,7 @@ describe('PaginatedSearchOptions', () => {
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
   beforeEach(() => {
-    options = new PaginatedSearchOptions({sort: sortOptions, pagination: pageOptions, filters: filters, query: query, scope: scope, dsoType: DSpaceObjectType.ITEM});
+    options = new PaginatedSearchOptions({sort: sortOptions, pagination: pageOptions, filters: filters, query: query, scope: scope, dsoTypes: [DSpaceObjectType.ITEM]});
   });
 
   describe('when toRestUrl is called', () => {

--- a/src/app/shared/search/paginated-search-options.model.ts
+++ b/src/app/shared/search/paginated-search-options.model.ts
@@ -12,7 +12,7 @@ export class PaginatedSearchOptions extends SearchOptions {
   pagination?: PaginationComponentOptions;
   sort?: SortOptions;
 
-  constructor(options: {configuration?: string, scope?: string, query?: string, dsoType?: DSpaceObjectType, filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions}) {
+  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions}) {
     super(options);
     this.pagination = options.pagination;
     this.sort = options.sort;

--- a/src/app/shared/search/search-options.model.spec.ts
+++ b/src/app/shared/search/search-options.model.spec.ts
@@ -10,7 +10,7 @@ describe('SearchOptions', () => {
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
   beforeEach(() => {
-    options = new SearchOptions({ filters: filters, query: query, scope: scope , dsoType: DSpaceObjectType.ITEM});
+    options = new SearchOptions({ filters: filters, query: query, scope: scope , dsoTypes: [DSpaceObjectType.ITEM]});
   });
 
   describe('when toRestUrl is called', () => {

--- a/src/app/shared/search/search-options.model.ts
+++ b/src/app/shared/search/search-options.model.ts
@@ -12,15 +12,15 @@ export class SearchOptions {
   view?: ViewMode = ViewMode.ListElement;
   scope?: string;
   query?: string;
-  dsoType?: DSpaceObjectType;
+  dsoTypes?: DSpaceObjectType[];
   filters?: any;
   fixedFilter?: any;
 
-  constructor(options: {configuration?: string, scope?: string, query?: string, dsoType?: DSpaceObjectType, filters?: SearchFilter[], fixedFilter?: any}) {
+  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any}) {
       this.configuration = options.configuration;
       this.scope = options.scope;
       this.query = options.query;
-      this.dsoType = options.dsoType;
+      this.dsoTypes = options.dsoTypes;
       this.filters = options.filters;
       this.fixedFilter = options.fixedFilter;
   }
@@ -44,8 +44,10 @@ export class SearchOptions {
     if (isNotEmpty(this.scope)) {
       args.push(`scope=${this.scope}`);
     }
-    if (isNotEmpty(this.dsoType)) {
-      args.push(`dsoType=${this.dsoType}`);
+    if (isNotEmpty(this.dsoTypes)) {
+      this.dsoTypes.forEach((dsoType: string) => {
+        args.push(`dsoType=${dsoType}`);
+      })
     }
     if (isNotEmpty(this.filters)) {
       this.filters.forEach((filter: SearchFilter) => {

--- a/src/app/statistics/statistics.service.spec.ts
+++ b/src/app/statistics/statistics.service.spec.ts
@@ -112,8 +112,6 @@ describe('StatisticsService', () => {
     const body = JSON.parse(request.body);
 
     it('should specify the dsoType', () => {
-      // TODO: change when backend statistics search even can handle multiple dsoTypes in body
-      // expect(body.dsoTypes).toBe(['item']);
       expect(body.dsoType).toBe('item');
     });
 

--- a/src/app/statistics/statistics.service.spec.ts
+++ b/src/app/statistics/statistics.service.spec.ts
@@ -112,7 +112,9 @@ describe('StatisticsService', () => {
     const body = JSON.parse(request.body);
 
     it('should specify the dsoType', () => {
-      expect(body.dsoTypes).toBe('item');
+      // TODO: change when backend statistics search even can handle multiple dsoTypes in body
+      // expect(body.dsoTypes).toBe(['item']);
+      expect(body.dsoType).toBe('item');
     });
 
     it('should specify the scope', () => {

--- a/src/app/statistics/statistics.service.spec.ts
+++ b/src/app/statistics/statistics.service.spec.ts
@@ -82,7 +82,7 @@ describe('StatisticsService', () => {
     const mockSearch: any = new SearchOptions({
       query: 'mock-query',
       configuration: 'mock-configuration',
-      dsoType: DSpaceObjectType.ITEM,
+      dsoTypes: [DSpaceObjectType.ITEM],
       scope: 'mock-scope'
     });
 
@@ -112,7 +112,7 @@ describe('StatisticsService', () => {
     const body = JSON.parse(request.body);
 
     it('should specify the dsoType', () => {
-      expect(body.dsoType).toBe('item');
+      expect(body.dsoTypes).toBe('item');
     });
 
     it('should specify the scope', () => {

--- a/src/app/statistics/statistics.service.ts
+++ b/src/app/statistics/statistics.service.ts
@@ -69,8 +69,9 @@ export class StatisticsService {
       Object.assign(body, { configuration: searchOptions.configuration })
     }
     if (isNotEmpty(searchOptions.dsoTypes)) {
-      // TODO: check if backend statistics search even can handle multiple dsoTypes in body
-      Object.assign(body, { dsoTypes: searchOptions.dsoTypes.map( dsoType => dsoType.toLowerCase() ) })
+      // TODO: change when backend statistics search even can handle multiple dsoTypes in body
+      // Object.assign(body, { dsoTypes: searchOptions.dsoTypes.map( dsoType => dsoType.toLowerCase() ) })
+      Object.assign(body, { dsoType: searchOptions.dsoTypes[0].toLowerCase()  })
     }
     if (hasValue(searchOptions.scope)) {
       Object.assign(body, { scope: searchOptions.scope })

--- a/src/app/statistics/statistics.service.ts
+++ b/src/app/statistics/statistics.service.ts
@@ -68,8 +68,9 @@ export class StatisticsService {
     if (hasValue(searchOptions.configuration)) {
       Object.assign(body, { configuration: searchOptions.configuration })
     }
-    if (hasValue(searchOptions.dsoType)) {
-      Object.assign(body, { dsoType: searchOptions.dsoType.toLowerCase() })
+    if (isNotEmpty(searchOptions.dsoTypes)) {
+      // TODO: check if backend statistics search even can handle multiple dsoTypes in body
+      Object.assign(body, { dsoTypes: searchOptions.dsoTypes.map( dsoType => dsoType.toLowerCase() ) })
     }
     if (hasValue(searchOptions.scope)) {
       Object.assign(body, { scope: searchOptions.scope })

--- a/src/app/statistics/statistics.service.ts
+++ b/src/app/statistics/statistics.service.ts
@@ -69,8 +69,6 @@ export class StatisticsService {
       Object.assign(body, { configuration: searchOptions.configuration })
     }
     if (isNotEmpty(searchOptions.dsoTypes)) {
-      // TODO: change when backend statistics search even can handle multiple dsoTypes in body
-      // Object.assign(body, { dsoTypes: searchOptions.dsoTypes.map( dsoType => dsoType.toLowerCase() ) })
       Object.assign(body, { dsoType: searchOptions.dsoTypes[0].toLowerCase()  })
     }
     if (hasValue(searchOptions.scope)) {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -989,8 +989,6 @@
 
   "dso-selector.export-metadata.dspaceobject.head": "Export metadata from",
 
-  "dso-selector.export-metadata.notValidDSO": "You can only export metadata for collections and communities",
-
   "dso-selector.no-results": "No {{ type }} found",
 
   "dso-selector.placeholder": "Search for a {{ type }}",


### PR DESCRIPTION
## Description
This PR adds functionality to do a search where multiple dsoTypes are allowed to be returned (instead of just one or all). This is used by the export metadata modal in admin sidebar to export collections and communities (created in https://github.com/DSpace/dspace-angular/pull/798).  Other search modals still expect just one type of dso in their results and the general search works as before. 
In the statistics search event request creation, just the first one of the list of dsoTypes is added since the regular search will not have multiple dsoTypes and admin sidebar search will not count towards statistics

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
