### PR TITLE
844: Fix file upload to use section ID instead of 'upload'

### DIFF
--- a/src/app/submission/sections/upload/section-upload.component.html
+++ b/src/app/submission/sections/upload/section-upload.component.html
@@ -36,7 +36,7 @@
                                        [fileId]="fileIndexes[fileList.indexOf(fileEntry)]"
                                        [fileIndex]="fileList.indexOf(fileEntry)"
                                        [fileName]="fileNames[fileList.indexOf(fileEntry)]"
-                                       [sectionId]="'upload'"
+                                       [sectionId]="sectionData.id"
                                        [submissionId]="submissionId"></ds-submission-upload-section-file>
     <div class="row">
       <div class="col-md-12">

--- a/src/app/submission/sections/upload/section-upload.component.spec.ts
+++ b/src/app/submission/sections/upload/section-upload.component.spec.ts
@@ -97,7 +97,7 @@ describe('SubmissionSectionUploadComponent test suite', () => {
       },
       errors: [],
       header: 'submit.progressbar.describe.upload',
-      id: 'upload',
+      id: 'upload-id',
       sectionType: SectionsType.Upload
     };
     submissionId = mockSubmissionId;


### PR DESCRIPTION
## References
* Fixes [GitHub issue](https://github.com/DSpace/dspace-angular/issues/844)

## Description
When using the UploadStep with a different ID than "upload" (e.g. to use other access conditions or make the file upload optional), the UI breaks.
This is occurring because the UI mixes the ID with the type (it uses the type assuming it's the ID)

## Instructions for Reviewers
Steps to reproduce the behavior:
1. In item-submission.xml create an upload step with ID upload2 and type upload
2. Upload a file in the UI
3. The ID of the section is now used to determine which files are associated
4. The uploaded file is now displayed

Without a different item-submission.xml, no changes are present

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
