### PR TITLE
Removal of email option for the curation script

### DIFF
--- a/src/app/curation-form/curation-form.component.spec.ts
+++ b/src/app/curation-form/curation-form.component.spec.ts
@@ -4,13 +4,11 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CurationFormComponent } from './curation-form.component';
 import { ScriptDataService } from '../core/data/processes/script-data.service';
 import { ProcessDataService } from '../core/data/processes/process-data.service';
-import { AuthService } from '../core/auth/auth.service';
 import { of as observableOf } from 'rxjs';
 import { RequestEntry } from '../core/data/request.reducer';
 import { DSOSuccessResponse, RestResponse } from '../core/cache/response.models';
 import { Process } from '../process-page/processes/process.model';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
-import { EPerson } from '../core/eperson/models/eperson.model';
 import { NotificationsServiceStub } from '../shared/testing/notifications-service.stub';
 import { RouterStub } from '../shared/testing/router.stub';
 import { NotificationsService } from '../shared/notifications/notifications.service';
@@ -27,7 +25,6 @@ describe('CurationFormComponent', () => {
   let scriptDataService: ScriptDataService;
   let processDataService: ProcessDataService;
   let configurationDataService: ConfigurationDataService;
-  let authService: AuthService;
   let notificationsService;
   let router;
 
@@ -46,10 +43,6 @@ describe('CurationFormComponent', () => {
 
     processDataService = jasmine.createSpyObj('processDataService', {
       findByHref: createSuccessfulRemoteDataObject$(process)
-    });
-
-    authService = jasmine.createSpyObj('authService', {
-      getAuthenticatedUserFromStore: observableOf(Object.assign(new EPerson(), {email: 'test@mail'}))
     });
 
     configurationDataService = jasmine.createSpyObj('configurationDataService', {
@@ -74,7 +67,6 @@ describe('CurationFormComponent', () => {
       providers: [
         {provide: ScriptDataService, useValue: scriptDataService},
         {provide: ProcessDataService, useValue: processDataService},
-        {provide: AuthService, useValue: authService},
         {provide: NotificationsService, useValue: notificationsService},
         {provide: Router, useValue: router},
         {provide: ConfigurationDataService, useValue: configurationDataService},
@@ -119,7 +111,6 @@ describe('CurationFormComponent', () => {
       expect(scriptDataService.invoke).toHaveBeenCalledWith('curate', [
         {name: '-t', value: 'profileformats'},
         {name: '-i', value: 'test-handle'},
-        {name: '-e', value: 'test@mail'},
       ], []);
       expect(notificationsService.success).toHaveBeenCalled();
       expect(processDataService.findByHref).toHaveBeenCalledWith('process-link');
@@ -134,7 +125,6 @@ describe('CurationFormComponent', () => {
       expect(scriptDataService.invoke).toHaveBeenCalledWith('curate', [
         {name: '-t', value: 'profileformats'},
         {name: '-i', value: 'test-handle'},
-        {name: '-e', value: 'test@mail'},
       ], []);
       expect(notificationsService.error).toHaveBeenCalled();
       expect(processDataService.findByHref).not.toHaveBeenCalled();
@@ -149,7 +139,6 @@ describe('CurationFormComponent', () => {
     expect(scriptDataService.invoke).toHaveBeenCalledWith('curate', [
       {name: '-t', value: 'profileformats'},
       {name: '-i', value: 'form-handle'},
-      {name: '-e', value: 'test@mail'},
     ], []);
   });
   it('should use "all" when the handle provided by the form is empty and when no dsoHandle is provided', () => {
@@ -159,7 +148,6 @@ describe('CurationFormComponent', () => {
     expect(scriptDataService.invoke).toHaveBeenCalledWith('curate', [
       {name: '-t', value: 'profileformats'},
       {name: '-i', value: 'all'},
-      {name: '-e', value: 'test@mail'},
     ], []);
   });
 });

--- a/src/app/curation-form/curation-form.component.ts
+++ b/src/app/curation-form/curation-form.component.ts
@@ -3,9 +3,7 @@ import { ScriptDataService } from '../core/data/processes/script-data.service';
 import { FormControl, FormGroup } from '@angular/forms';
 import { getResponseFromEntry } from '../core/shared/operators';
 import { DSOSuccessResponse } from '../core/cache/response.models';
-import { AuthService } from '../core/auth/auth.service';
-import { filter, map, switchMap, take } from 'rxjs/operators';
-import { EPerson } from '../core/eperson/models/eperson.model';
+import { filter, map, take } from 'rxjs/operators';
 import { NotificationsService } from '../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
 import { hasValue, isEmpty, isNotEmpty } from '../shared/empty.util';
@@ -40,7 +38,6 @@ export class CurationFormComponent implements OnInit {
     private scriptDataService: ScriptDataService,
     private configurationDataService: ConfigurationDataService,
     private processDataService: ProcessDataService,
-    private authService: AuthService,
     private notificationsService: NotificationsService,
     private translateService: TranslateService,
     private router: Router
@@ -90,16 +87,10 @@ export class CurationFormComponent implements OnInit {
         handle = 'all';
       }
     }
-    this.authService.getAuthenticatedUserFromStore().pipe(
-      take(1),
-      switchMap((eperson: EPerson) => {
-        return this.scriptDataService.invoke('curate', [
+    this.scriptDataService.invoke('curate', [
           {name: '-t', value: taskName},
           {name: '-i', value: handle},
-          {name: '-e', value: eperson.email},
-        ], []).pipe(getResponseFromEntry());
-      })
-    ).subscribe((response: DSOSuccessResponse) => {
+        ], []).pipe(getResponseFromEntry()).subscribe((response: DSOSuccessResponse) => {
       if (response.isSuccessful) {
         this.notificationsService.success(this.translateService.get('curation.form.submit.success.head'),
           this.translateService.get('curation.form.submit.success.content'));


### PR DESCRIPTION
## References
* Fixes [PR related issue](https://github.com/DSpace/DSpace/pull/2926#pullrequestreview-477868288)

## Description
This PR will remove the "email/-e" option from the curate script on Angular's end. See linked PR for REST related info.

## Instructions for Reviewers

**In the CurationFormComponent:**
* All authentication related code is removed
    * authService and it's related calls are removed
    * The -e option is not added to the call anymore

**In the related test component**
* -e option is not added anymore
* unused code is cleaned up 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
