### PR TITLE
Ensure CSR fallback only happens on actual errors

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -33,7 +33,7 @@ import { enableProdMode, NgModuleFactory, Type } from '@angular/core';
 import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 import { environment } from './src/environments/environment';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-import { hasValue } from './src/app/shared/empty.util';
+import { hasValue, hasNoValue } from './src/app/shared/empty.util';
 
 /*
  * Set path for the browser application's dist folder
@@ -140,12 +140,16 @@ function ngApp(req, res) {
       baseUrl: environment.ui.nameSpace,
       originUrl: environment.ui.baseUrl,
       requestUrl: req.originalUrl
-    }, (err) => {
-      console.warn('Error in SSR, serving for direct CSR.');
-      if (hasValue(err)) {
-        console.warn('Error details : ', err);
+    }, (err, data) => {
+      if (hasNoValue(err) && hasValue(data)) {
+        res.send(data);
+      } else {
+        console.warn('Error in SSR, serving for direct CSR.');
+        if (hasValue(err)) {
+          console.warn('Error details : ', err);
+        }
+        res.sendFile(DIST_FOLDER + '/index.html');
       }
-      res.sendFile(DIST_FOLDER + '/index.html');
     })
   } else {
     // If preboot is disabled, just serve the client


### PR DESCRIPTION
## References
Fixes issue introduced by #863

## Description
This PR fixes an issue introduced by #863, which caused the error handler on the express server to be triggered when there were no errors.

## Instructions for Reviewers
In #863 we switched to the native express error handler. But we noticed on dspace-demo that the error fallback happens for every request. 

The reason is that it's not a dedicated error handler, but simply the next function in the chain that can make changes to the response. There's only an error if `err` is defined. 

This PR fixes that issue by checking if there's an error, and if not, passing the data from the previous function (the angular app) through.

To test it, triggering a 404 (as suggested in #863) is not sufficient for causing an actual express error. So I suggest you simply add `throw new Error('A test error');` to [the constructor of ServerAppModule](https://github.com/DSpace/dspace-angular/blob/main/src/modules/app/server-app.module.ts#L103), in which case you should see `Error in SSR, serving for direct CSR` in the server output with a stack trace. And if you leave it out that fallback shouldn't trigger, so that message shouldn't be there.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
