### PR TITLE
Fix bug concerning bistream pagination on the item page

### DIFF
--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.html
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.html
@@ -1,87 +1,87 @@
 <ds-metadata-field-wrapper [label]="label | translate">
     <div *ngVar="(originals$ | async)?.payload as originals">
-        <h5 class="simple-view-element-header">{{"item.page.filesection.original.bundle" | translate}}</h5>
-        <ds-pagination *ngIf="originals?.page?.length > 0"
-                       [hideGear]="true"
-                       [hidePagerWhenSinglePage]="true"
-                       [paginationOptions]="originalOptions"
-                       [pageInfoState]="originals"
-                       [collectionSize]="originals?.totalElements"
-                       [disableRouteParameterUpdate]="true"
-                       (pageChange)="switchOriginalPage($event)">
+        <div *ngIf="hasValuesInBundle(originals)">
+            <h5 class="simple-view-element-header">{{"item.page.filesection.original.bundle" | translate}}</h5>
+            <ds-pagination *ngIf="originals?.page?.length > 0"
+                           [hideGear]="true"
+                           [hidePagerWhenSinglePage]="true"
+                           [paginationOptions]="originalOptions"
+                           [pageInfoState]="originals"
+                           [collectionSize]="originals?.totalElements"
+                           [disableRouteParameterUpdate]="true"
+                           (pageChange)="switchOriginalPage($event)">
 
 
+                <div class="file-section row" *ngFor="let file of originals?.page;">
+                    <div class="col-3">
+                        <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                    </div>
+                    <div class="col-7">
+                        <dl class="row">
+                            <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
+                            <dd class="col-md-8">{{file.name}}</dd>
 
-            <div class="file-section row" *ngFor="let file of originals?.page;">
-                <div class="col-3">
-                    <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                            <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
+                            <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
+
+
+                            <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
+                            <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
+
+
+                            <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
+                            <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
+                        </dl>
+                    </div>
+                    <div class="col-2">
+                        <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
+                            {{"item.page.filesection.download" | translate}}
+                        </ds-file-download-link>
+                    </div>
                 </div>
-                <div class="col-7">
-                    <dl class="row">
-                        <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
-                        <dd class="col-md-8">{{file.name}}</dd>
-
-                        <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
-                        <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
-
-
-                        <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
-                        <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
-
-
-                        <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
-                        <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
-                    </dl>
-                </div>
-                <div class="col-2">
-                    <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
-                        {{"item.page.filesection.download" | translate}}
-                    </ds-file-download-link>
-                </div>
-            </div>
-        </ds-pagination>
+            </ds-pagination>
+        </div>
     </div>
-
     <div *ngVar="(licenses$ | async)?.payload as licenses">
-        <h5 class="simple-view-element-header">{{"item.page.filesection.license.bundle" | translate}}</h5>
-        <ds-pagination *ngIf="licenses?.page?.length > 0"
-                       [hideGear]="true"
-                       [hidePagerWhenSinglePage]="true"
-                       [paginationOptions]="licenseOptions"
-                       [pageInfoState]="licenses"
-                       [collectionSize]="licenses?.totalElements"
-                       [disableRouteParameterUpdate]="true"
-                       (pageChange)="switchLicensePage($event)">
+        <div *ngIf="hasValuesInBundle(licenses)">
+            <h5 class="simple-view-element-header">{{"item.page.filesection.license.bundle" | translate}}</h5>
+            <ds-pagination *ngIf="licenses?.page?.length > 0"
+                           [hideGear]="true"
+                           [hidePagerWhenSinglePage]="true"
+                           [paginationOptions]="licenseOptions"
+                           [pageInfoState]="licenses"
+                           [collectionSize]="licenses?.totalElements"
+                           [disableRouteParameterUpdate]="true"
+                           (pageChange)="switchLicensePage($event)">
 
 
+                <div class="file-section row" *ngFor="let file of licenses?.page;">
+                    <div class="col-3">
+                        <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                    </div>
+                    <div class="col-7">
+                        <dl class="row">
+                            <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
+                            <dd class="col-md-8">{{file.name}}</dd>
 
-            <div class="file-section row" *ngFor="let file of licenses?.page;">
-                <div class="col-3">
-                    <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
+                            <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
+                            <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
+
+                            <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
+                            <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
+
+
+                            <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
+                            <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
+                        </dl>
+                    </div>
+                    <div class="col-2">
+                        <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
+                            {{"item.page.filesection.download" | translate}}
+                        </ds-file-download-link>
+                    </div>
                 </div>
-                <div class="col-7">
-                    <dl class="row">
-                        <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
-                        <dd class="col-md-8">{{file.name}}</dd>
-
-                        <dt class="col-md-4">{{"item.page.filesection.size" | translate}}</dt>
-                        <dd class="col-md-8">{{(file.sizeBytes) | dsFileSize }}</dd>
-
-
-                        <dt class="col-md-4">{{"item.page.filesection.format" | translate}}</dt>
-                        <dd class="col-md-8">{{(file.format | async)?.payload?.description}}</dd>
-
-
-                        <dt class="col-md-4">{{"item.page.filesection.description" | translate}}</dt>
-                        <dd class="col-md-8">{{file.firstMetadataValue("dc.description")}}</dd>
-                    </dl>
-                </div>
-                <div class="col-2">
-                    <ds-file-download-link [href]="file._links.content.href" [download]="file.name">
-                        {{"item.page.filesection.download" | translate}}
-                    </ds-file-download-link>
-                </div>
-            </div>
-        </ds-pagination>
+            </ds-pagination>
+        </div>
     </div>
 </ds-metadata-field-wrapper>

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.spec.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.spec.ts
@@ -14,6 +14,8 @@ import {Bitstream} from '../../../../core/shared/bitstream.model';
 import {of as observableOf} from 'rxjs';
 import {MockBitstreamFormat1} from '../../../../shared/mocks/item.mock';
 import {By} from '@angular/platform-browser';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { NotificationsServiceStub } from '../../../../shared/testing/notifications-service.stub';
 
 describe('FullFileSectionComponent', () => {
     let comp: FullFileSectionComponent;
@@ -61,7 +63,8 @@ describe('FullFileSectionComponent', () => {
             }), BrowserAnimationsModule],
             declarations: [FullFileSectionComponent, VarDirective, FileSizePipe, MetadataFieldWrapperComponent],
             providers: [
-                {provide: BitstreamDataService, useValue: bitstreamDataService}
+                {provide: BitstreamDataService, useValue: bitstreamDataService},
+                {provide: NotificationsService, useValue: new NotificationsServiceStub()}
             ],
 
             schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -113,7 +113,6 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   }
 
   hasValuesInBundle(bundle: PaginatedList<Bitstream>) {
-    console.log(bundle, hasValue(bundle), hasValue(bundle) && !isEmpty(bundle.page));
     return hasValue(bundle) && !isEmpty(bundle.page);
   }
 }

--- a/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/+item-page/full/field-components/file-section/full-file-section.component.ts
@@ -10,6 +10,10 @@ import { PaginationComponentOptions } from '../../../../shared/pagination/pagina
 import { PaginatedList } from '../../../../core/data/paginated-list';
 import { RemoteData } from '../../../../core/data/remote-data';
 import { switchMap } from 'rxjs/operators';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { TranslateService } from '@ngx-translate/core';
+import { hasValue, isEmpty } from '../../../../shared/empty.util';
+import { tap } from 'rxjs/internal/operators/tap';
 
 /**
  * This component renders the file section of the item
@@ -31,14 +35,14 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   licenses$: Observable<RemoteData<PaginatedList<Bitstream>>>;
 
   pageSize = 5;
-  originalOptions = Object.assign(new PaginationComponentOptions(),{
+  originalOptions = Object.assign(new PaginationComponentOptions(), {
     id: 'original-bitstreams-options',
     currentPage: 1,
     pageSize: this.pageSize
   });
   originalCurrentPage$ = new BehaviorSubject<number>(1);
 
-  licenseOptions = Object.assign(new PaginationComponentOptions(),{
+  licenseOptions = Object.assign(new PaginationComponentOptions(), {
     id: 'license-bitstreams-options',
     currentPage: 1,
     pageSize: this.pageSize
@@ -46,9 +50,11 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   licenseCurrentPage$ = new BehaviorSubject<number>(1);
 
   constructor(
-    bitstreamDataService: BitstreamDataService
+    bitstreamDataService: BitstreamDataService,
+    protected notificationsService: NotificationsService,
+    protected translateService: TranslateService
   ) {
-    super(bitstreamDataService);
+    super(bitstreamDataService, notificationsService, translateService);
   }
 
   ngOnInit(): void {
@@ -57,21 +63,33 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
 
   initialize(): void {
     this.originals$ = this.originalCurrentPage$.pipe(
-        switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
-            this.item,
-            'ORIGINAL',
-            { elementsPerPage: this.pageSize, currentPage: pageNumber },
-            followLink( 'format')
-        ))
+      switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
+        this.item,
+        'ORIGINAL',
+        {elementsPerPage: this.pageSize, currentPage: pageNumber},
+        followLink('format')
+      )),
+      tap((rd: RemoteData<PaginatedList<Bitstream>>) => {
+          if (hasValue(rd.error)) {
+            this.notificationsService.error(this.translateService.get('file-section.error.header'), `${rd.error.statusCode} ${rd.error.message}`);
+          }
+        }
+      )
     );
 
     this.licenses$ = this.licenseCurrentPage$.pipe(
-        switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
-            this.item,
-            'LICENSE',
-            { elementsPerPage: this.pageSize, currentPage: pageNumber },
-            followLink( 'format')
-        ))
+      switchMap((pageNumber: number) => this.bitstreamDataService.findAllByItemAndBundleName(
+        this.item,
+        'LICENSE',
+        {elementsPerPage: this.pageSize, currentPage: pageNumber},
+        followLink('format')
+      )),
+      tap((rd: RemoteData<PaginatedList<Bitstream>>) => {
+          if (hasValue(rd.error)) {
+            this.notificationsService.error(this.translateService.get('file-section.error.header'), `${rd.error.statusCode} ${rd.error.message}`);
+          }
+        }
+      )
     );
 
   }
@@ -92,5 +110,10 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
   switchLicensePage(page: number) {
     this.licenseOptions.currentPage = page;
     this.licenseCurrentPage$.next(page);
+  }
+
+  hasValuesInBundle(bundle: PaginatedList<Bitstream>) {
+    console.log(bundle, hasValue(bundle), hasValue(bundle) && !isEmpty(bundle.page));
+    return hasValue(bundle) && !isEmpty(bundle.page);
   }
 }

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.spec.ts
@@ -15,6 +15,8 @@ import {FileSizePipe} from '../../../../shared/utils/file-size-pipe';
 import {PageInfo} from '../../../../core/shared/page-info.model';
 import {MetadataFieldWrapperComponent} from '../../../field-components/metadata-field-wrapper/metadata-field-wrapper.component';
 import {createPaginatedList} from '../../../../shared/testing/utils.test';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { NotificationsServiceStub } from '../../../../shared/testing/notifications-service.stub';
 
 describe('FileSectionComponent', () => {
     let comp: FileSectionComponent;
@@ -62,7 +64,8 @@ describe('FileSectionComponent', () => {
             }), BrowserAnimationsModule],
             declarations: [FileSectionComponent, VarDirective, FileSizePipe, MetadataFieldWrapperComponent],
             providers: [
-                {provide: BitstreamDataService, useValue: bitstreamDataService}
+                {provide: BitstreamDataService, useValue: bitstreamDataService},
+                {provide: NotificationsService, useValue: new NotificationsServiceStub()}
             ],
 
             schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -66,8 +66,7 @@ export class FileSectionComponent implements OnInit {
       currentPage: this.currentPage,
       elementsPerPage: this.pageSize
     }).pipe(
-      filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
-      filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(!bitstreamsRD.isLoading)),
+      filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD) && (hasValue(bitstreamsRD.error) || hasValue(bitstreamsRD.payload))),
       take(1),
     ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
       if (bitstreamsRD.error) {

--- a/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/app/+item-page/simple/field-components/file-section/file-section.component.ts
@@ -4,10 +4,12 @@ import { BitstreamDataService } from '../../../../core/data/bitstream-data.servi
 
 import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { Item } from '../../../../core/shared/item.model';
-import { filter, takeWhile } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 import { RemoteData } from '../../../../core/data/remote-data';
-import { hasNoValue, hasValue } from '../../../../shared/empty.util';
+import { hasValue } from '../../../../shared/empty.util';
 import { PaginatedList } from '../../../../core/data/paginated-list';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * This component renders the file section of the item
@@ -36,7 +38,9 @@ export class FileSectionComponent implements OnInit {
   pageSize = 5;
 
   constructor(
-    protected bitstreamDataService: BitstreamDataService
+    protected bitstreamDataService: BitstreamDataService,
+    protected notificationsService: NotificationsService,
+    protected translateService: TranslateService
   ) {
   }
 
@@ -58,14 +62,22 @@ export class FileSectionComponent implements OnInit {
     } else {
       this.currentPage++;
     }
-    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: this.currentPage, elementsPerPage: this.pageSize }).pipe(
-        filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
-        takeWhile((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasNoValue(bitstreamsRD.payload) && hasNoValue(bitstreamsRD.error), true)
+    this.bitstreamDataService.findAllByItemAndBundleName(this.item, 'ORIGINAL', {
+      currentPage: this.currentPage,
+      elementsPerPage: this.pageSize
+    }).pipe(
+      filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(bitstreamsRD)),
+      filter((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => hasValue(!bitstreamsRD.isLoading)),
+      take(1),
     ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
-      const current: Bitstream[] = this.bitstreams$.getValue();
-      this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
-      this.isLoading = false;
-      this.isLastPage = this.currentPage === bitstreamsRD.payload.totalPages;
+      if (bitstreamsRD.error) {
+        this.notificationsService.error(this.translateService.get('file-section.error.header'), `${bitstreamsRD.error.statusCode} ${bitstreamsRD.error.message}`);
+      } else if (hasValue(bitstreamsRD.payload)) {
+        const current: Bitstream[] = this.bitstreams$.getValue();
+        this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
+        this.isLoading = false;
+        this.isLastPage = this.currentPage === bitstreamsRD.payload.totalPages;
+      }
     });
   }
 }

--- a/src/app/core/data/bundle-data.service.ts
+++ b/src/app/core/data/bundle-data.service.ts
@@ -22,6 +22,7 @@ import { FindListOptions, GetRequest } from './request.models';
 import { RequestService } from './request.service';
 import { PaginatedSearchOptions } from '../../shared/search/paginated-search-options.model';
 import { Bitstream } from '../shared/bitstream.model';
+import { RemoteDataError } from './remote-data-error';
 
 /**
  * A service to retrieve {@link Bundle}s from the REST API
@@ -71,13 +72,17 @@ export class BundleDataService extends DataService<Bundle> {
         if (hasValue(rd.payload) && hasValue(rd.payload.page)) {
           const matchingBundle = rd.payload.page.find((bundle: Bundle) =>
             bundle.name === bundleName);
-          return new RemoteData(
-            false,
-            false,
-            true,
-            undefined,
-            matchingBundle
-          );
+          if (hasValue(matchingBundle)) {
+            return new RemoteData(
+              false,
+              false,
+              true,
+              undefined,
+              matchingBundle
+            );
+          } else {
+            return new RemoteData(false, false, false, new RemoteDataError(404, 'Not found', `The bundle with name ${bundleName} was not found.` ))
+          }
         } else {
           return rd as any;
         }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1045,6 +1045,10 @@
 
 
 
+  "file-section.error.header": "Error obtaining files for this item",
+
+
+
   "footer.copyright": "copyright © 2002-{{ year }}",
 
   "footer.link.dspace": "DSpace software",


### PR DESCRIPTION
## References
This is a fix to an issue introduced in #838

This PR fixes an issue that is visible in the browser console when loading an item without any bitstreams: [example](https://dspace7-demo.atmire.com/items/b7c3a324-3e07-466c-887a-57bf8be42f2d)

## Description
* Fix an issue with the bitstream loading on the item page when no bitstreams are present
* Add an error notification when an error occurs with retrieving the item bitstreams
* Hide the labels for empty bundles on the full item page

## Instructions for Reviewers
* Navigate to an item without any bitstreams
* Verify that no error message is shown in the browser console and that the page fully loads 
* Verify that the full item page doesn't show labels for empty bundles
* Verify that loading extra pages of bitstreams on the simple or full item pages is not affected by this fix

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
