### PR TITLE
remove remaining uses of /api in the rest namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   # Direct that step to utilize a DSpace REST service that has been started in docker.
   DSPACE_REST_HOST: localhost
   DSPACE_REST_PORT: 8080
-  DSPACE_REST_NAMESPACE: '/server/api'
+  DSPACE_REST_NAMESPACE: '/server'
   DSPACE_REST_SSL: false
 
 before_install:

--- a/docker/environment.dev.ts
+++ b/docker/environment.dev.ts
@@ -13,6 +13,6 @@ export const environment = {
     host: 'localhost',
     port: 8080,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
-    nameSpace: '/server/api'
+    nameSpace: '/server'
   }
 };

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -42,7 +42,7 @@ export const environment = {
     host: 'dspace7.4science.cloud',
     port: 443,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
-    nameSpace: '/server/api'
+    nameSpace: '/server'
   }
 };
 ```
@@ -52,7 +52,7 @@ Alternately you can set the following environment variables. If any of these are
   DSPACE_REST_SSL=true
   DSPACE_REST_HOST=dspace7.4science.cloud
   DSPACE_REST_PORT=443
-  DSPACE_REST_NAMESPACE=/server/api
+  DSPACE_REST_NAMESPACE=/server
 ```
 
 ## Supporting analytics services other than Google Analytics

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -16,13 +16,12 @@ export const environment: GlobalConfig = {
   },
   // The REST API server settings.
   // NOTE: these must be "synced" with the 'dspace.server.url' setting in your backend's local.cfg.
-  // The 'nameSpace' must always end in "/api" as that's the subpath of the REST API in the backend.
   rest: {
     ssl: true,
     host: 'dspace7.4science.cloud',
     port: 443,
     // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
-    nameSpace: '/server/api',
+    nameSpace: '/server',
   },
   // Caching settings
   cache: {

--- a/src/environments/environment.template.ts
+++ b/src/environments/environment.template.ts
@@ -4,7 +4,7 @@ export const environment = {
    * e.g.
    * rest: {
    *   host: 'rest.api',
-   *   nameSpace: '/rest/api',
+   *   nameSpace: '/rest',
    * }
    */
 };


### PR DESCRIPTION
## References
* Addresses [a comment in #826](https://github.com/DSpace/dspace-angular/issues/826#issuecomment-700879946)
* Rest namespaces ending in `/api` were deprecated by #825 

## Description
This PR removes `/api` from the rest namespaces of `environment.common.ts` and `.travis.yml`, as it was deprecated in #825

## Instructions for Reviewers
- Test this PR by verifying the travis build works, and that the build logs don't show the deprecation warning.
- Test that if you don't override the rest namespace in your local environment files, you don't get the deprecation warning when building.

If you notice any other uses of `/api` I've forgotten please let me know.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
