### PR TITLE
Remove circular dependencies part 2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@ _This checklist provides a reminder of what we are going to look for when review
 
 - [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
 - [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
+- [ ] My PR doesn't introduce circular dependencies
 - [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
 - [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
 - [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

--- a/src/app/core/shared/operators.ts
+++ b/src/app/core/shared/operators.ts
@@ -14,7 +14,7 @@ import { MetadataSchema } from '../metadata/metadata-schema.model';
 import { BrowseDefinition } from './browse-definition.model';
 import { DSpaceObject } from './dspace-object.model';
 import { getUnauthorizedRoute } from '../../app-routing-paths';
-import { getEndUserAgreementPath } from '../../info/info-routing.module';
+import { getEndUserAgreementPath } from '../../info/info-routing-paths';
 
 /**
  * This file contains custom RxJS operators that can be used in multiple places

--- a/src/app/info/info-routing-paths.ts
+++ b/src/app/info/info-routing-paths.ts
@@ -1,0 +1,16 @@
+import { getInfoModulePath } from '../app-routing-paths';
+
+export const END_USER_AGREEMENT_PATH = 'end-user-agreement';
+export const PRIVACY_PATH = 'privacy';
+
+export function getEndUserAgreementPath() {
+    return getSubPath(END_USER_AGREEMENT_PATH);
+}
+
+export function getPrivacyPath() {
+    return getSubPath(PRIVACY_PATH);
+}
+
+function getSubPath(path: string) {
+    return `${getInfoModulePath()}/${path}`;
+}

--- a/src/app/info/info-routing.module.ts
+++ b/src/app/info/info-routing.module.ts
@@ -1,24 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { EndUserAgreementComponent } from './end-user-agreement/end-user-agreement.component';
-import { getInfoModulePath } from '../app-routing-paths';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 import { PrivacyComponent } from './privacy/privacy.component';
-
-const END_USER_AGREEMENT_PATH = 'end-user-agreement';
-const PRIVACY_PATH = 'privacy';
-
-export function getEndUserAgreementPath() {
-  return getSubPath(END_USER_AGREEMENT_PATH);
-}
-
-export function getPrivacyPath() {
-  return getSubPath(PRIVACY_PATH);
-}
-
-function getSubPath(path: string) {
-  return `${getInfoModulePath()}/${path}`;
-}
+import { PRIVACY_PATH, END_USER_AGREEMENT_PATH } from './info-routing-paths';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
## References
- Fixes an issue introduced in #862 the same way #850 did

## Description
#862 [added new circular dependencies](https://travis-ci.com/github/DSpace/dspace-angular/jobs/386237237#L7772-L7800). This PR removes them, and adds a line to the PR template checklist to verify that a new PR isn't introducing new circular dependencies.

As in #850, I didn't add any new code, just moved a few functions and variables to a different file.

## Instructions for Reviewers
You can test this PR by verifying that it doesn't break anything involving the user agreement or privacy statement page.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
