### PR TITLE
[#879] Clarify the use of the production build script, and when configuration is processed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ package-lock.json
 .java-version
 
 .env
+/nbproject/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ export DSPACE_HOST=dspace7.4science.cloud
 
 The priority works as follows: **environment variable** overrides **variable in `.env` file** overrides **`environment.(prod, dev or test).ts`** overrides **`environment.common.ts`**
 
+These configuration sources are collected **at build time**, and written to `src/environments/environment.ts`.  At runtime the configuration is fixed, and neither `.env` nor the process' environment will be consulted.
 
 #### Using environment variables in code
 To use environment variables in a UI component, use:
@@ -134,14 +135,14 @@ To build the app for production and start the server run:
 ```bash
 yarn start
 ```
+This will run the application in an instance of the Express server, which is included.
 
 If you only want to build for production, without starting, run:
 
 ```bash
 yarn run build:prod
 ```
-
-This will build the application and put the result in the `dist` folder
+This will build the application and put the result in the `dist` folder.  You can copy this folder to wherever you need it for your application server.  If you will be using the built-in Express server, you'll also need a copy of the `node_modules` folder tucked inside your copy of `dist`.
 
 
 ### Running the application with Docker


### PR DESCRIPTION
## References
* Fixes #879

## Description
General description of how to use the product of running the `build:prod` script.
Note that configuration is collected and fixed at build time.

## Instructions for Reviewers
Please consider whether the changes accurately reflect the build process and its result.

List of changes in this PR:
* Small updates to README.md

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
