### PR TITLE
Tighten security of our Auth Token (JWT) via CSRF prevention techniques

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -266,7 +266,7 @@ export class AuthService {
     let headers = new HttpHeaders();
     headers = headers.append('Content-Type', 'application/x-www-form-urlencoded');
     const options: HttpOptions = Object.create({ headers, responseType: 'text' });
-    return this.authRequestService.getRequest('logout', options).pipe(
+    return this.authRequestService.postToEndpoint('logout', options).pipe(
       map((status: AuthStatus) => {
         if (!status.authenticated) {
           return true;

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -172,6 +172,7 @@ import { EndUserAgreementCookieGuard } from './end-user-agreement/end-user-agree
 import { EndUserAgreementService } from './end-user-agreement/end-user-agreement.service';
 import { SiteRegisterGuard } from './data/feature-authorization/feature-authorization-guard/site-register.guard';
 import { UsageReport } from './statistics/models/usage-report.model';
+import { DSpaceHeaderInterceptor } from './dspace-header/dspace-header.interceptor';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
@@ -312,6 +313,12 @@ const PROVIDERS = [
   {
     provide: HTTP_INTERCEPTORS,
     useClass: LocaleInterceptor,
+    multi: true
+  },
+  // register DSpaceHeaderInterceptor as HttpInterceptor
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: DSpaceHeaderInterceptor,
     multi: true
   },
   NotificationsService,

--- a/src/app/core/dspace-header/dspace-header.interceptor.spec.ts
+++ b/src/app/core/dspace-header/dspace-header.interceptor.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController, } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { DSpaceRESTv2Service } from '../dspace-rest-v2/dspace-rest-v2.service';
+import { DSpaceHeaderInterceptor } from './dspace-header.interceptor';
+import { UIURLCombiner } from '../url-combiner/ui-url-combiner';
+
+describe(`DSpaceHeaderInterceptor`, () => {
+  let service: DSpaceRESTv2Service;
+  let httpMock: HttpTestingController;
+  // Dummy request path
+  const requestUrl = 'test-url';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DSpaceRESTv2Service,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: DSpaceHeaderInterceptor,
+          multi: true,
+        },
+      ],
+    });
+
+    service = TestBed.get(DSpaceRESTv2Service);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should add an X-DSpace-UI header matching the configured URL', () => {
+    // We don't care about the response to this request. It's just here to
+    // check whether the header was inserted as expected.
+    service.get(requestUrl).subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+
+    const httpRequest = httpMock.expectOne(requestUrl);
+    expect(httpRequest.request.headers.has('X-DSpace-UI'));
+    expect(httpRequest.request.headers.get('X-DSpace-UI'))
+          .toEqual(new UIURLCombiner('/').toString().toLowerCase());
+  });
+});

--- a/src/app/core/dspace-header/dspace-header.interceptor.spec.ts
+++ b/src/app/core/dspace-header/dspace-header.interceptor.spec.ts
@@ -9,8 +9,13 @@ import { UIURLCombiner } from '../url-combiner/ui-url-combiner';
 describe(`DSpaceHeaderInterceptor`, () => {
   let service: DSpaceRESTv2Service;
   let httpMock: HttpTestingController;
-  // Dummy request path
-  const requestUrl = 'test-url';
+
+  // Mock url/payload/statuses are fake as we are not testing the results
+  // of any below requests. We are only testing for X-DSpace-UI header.
+  const mockRequestUrl = 'test-url';
+  const mockPayload = { id: 1 };
+  const mockStatusCode = 200;
+  const mockStatusText = 'SUCCESS';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -29,16 +34,21 @@ describe(`DSpaceHeaderInterceptor`, () => {
     httpMock = TestBed.get(HttpTestingController);
   });
 
-  it('should add an X-DSpace-UI header matching the configured URL', () => {
-    // We don't care about the response to this request. It's just here to
-    // check whether the header was inserted as expected.
-    service.get(requestUrl).subscribe((response) => {
+  it('should add an X-DSpace-UI header matching the configured URL', (done) => {
+    // start a request, subscribing to it
+    service.get(mockRequestUrl).subscribe((response) => {
       expect(response).toBeTruthy();
+      done();
     });
 
-    const httpRequest = httpMock.expectOne(requestUrl);
+    // check that a single request was made to URL & expected header is there
+    const httpRequest = httpMock.expectOne(mockRequestUrl);
     expect(httpRequest.request.headers.has('X-DSpace-UI'));
     expect(httpRequest.request.headers.get('X-DSpace-UI'))
           .toEqual(new UIURLCombiner('/').toString().toLowerCase());
+
+    // end request, providing dummy values to the response
+    httpRequest.flush(mockPayload,
+        { status: mockStatusCode, statusText: mockStatusText });
   });
 });

--- a/src/app/core/dspace-header/dspace-header.interceptor.ts
+++ b/src/app/core/dspace-header/dspace-header.interceptor.ts
@@ -1,0 +1,36 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/internal/Observable';
+import { UIURLCombiner } from '../url-combiner/ui-url-combiner';
+
+@Injectable()
+/**
+ * Http Interceptor intercepting Http Requests, adding the URL of our DSpace UI
+ * into a custom X-DSpace-UI header.
+ *
+ * This header provides our REST API with the URL of the User Interface making
+ * the request, for the purposes of validating whether the Auth (JWT) Token can
+ * be used by this User Interface. (By default Auth Tokens only work from the
+ * client/UI which created the token.)
+ *
+ * In most scenarios, the 'Origin' or 'Referer' headers are used for Token
+ * validation (as those are written automatically by web browsers). However,
+ * this interceptor is necessary for Angular Universal (Server Side Rendering).
+ * SSR requests do not always include "Origin" or "Referer" headers, and
+ * therefore the X-DSpace-UI header may be used as a fallback.
+ */
+export class DSpaceHeaderInterceptor implements HttpInterceptor {
+
+  /**
+   * Intercept http requests and add X-DSpace-UI header.
+   * @param httpRequest
+   * @param next
+   */
+  intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // Get root URL of UI (from environment configuration)
+    const uiUrl = new UIURLCombiner('/').toString().toLowerCase();
+
+    // Send our UI's URL in X-DSpace-UI custom header in every request
+    return next.handle(httpRequest.clone({ setHeaders: { 'X-DSpace-UI': uiUrl } }));
+  }
+}


### PR DESCRIPTION
## References
* Requires https://github.com/DSpace/DSpace/pull/3001  (REST PR MUST be merged prior to, or at the same time as this PR)

## Description
This PR makes minor changes to the Angular UI corresponding to the tightened security applied in https://github.com/DSpace/DSpace/pull/3001

Namely, it does the following:
* Updates Logout to send a `POST` request (instead of `GET`), as required by ttps://github.com/DSpace/DSpace/pull/3001
* Ensures a new `X-DSpace-UI` custom header is passed on every request (see new `DSpaceHeaderInterceptor` & corresponding tests).  This new header is used to pass the UI's URL/origin to the backend just in case the `Origin` or `Referer` headers are not sent.  As Angular Universal seems to not send the `Origin` or `Referer` headers, this custom header is primarily for SSR requests (as user browsers tend to send either `Origin` or `Referer` or both).

## Instructions for Reviewers

* Review the code & tests
* Install & run against https://github.com/DSpace/DSpace/pull/3001
    * When run with `yarn start` (AoT compilation), verify that Login succeeds. When in production mode, a Login will trigger SSR during the hard refresh.  So, this Login will not succeed if you ran `main` against  https://github.com/DSpace/DSpace/pull/3001 (as the `X-DSpace-UI` header is required for SSR to use the Auth Token)
    * Also verify Logout still works.  Again, if you ran `main` against ttps://github.com/DSpace/DSpace/pull/3001, then logout would not succeed, as it is currently sent via a `GET` request.
* **WARNING: End-to-end tests are EXPECTED TO FAIL** with this PR.  The reason is that e2e testing runs against live backend which is *NOT* currently running  https://github.com/DSpace/DSpace/pull/3001.  This results in CORS policy errors as the `X-DSpace-UI` custom header will be **blocked**.
    * You can see these CORS errors locally by running `yarn run e2e:ci`. They look will look like this: 
    ```
    [1019/123317.621:INFO:CONSOLE(0)] "Access to XMLHttpRequest at 'https://dspace7.4science.cloud/server/api/sites' from origin 'http://localhost:4000' has been blocked by CORS policy: Request header field x-dspace-ui is not allowed by Access-Control-Allow-Headers in preflight response.", source: http://localhost:4000/ (0)
    ```

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
    * **All Unit Tests succeed**
    * **NOTE: e2e tests will FAIL** until https://github.com/DSpace/DSpace/pull/3001 is merged, because this PR relies on a new, (currently untrusted) `X-DSpace-UI` header.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
