### PR TITLE
Fix grid search result shadows

### DIFF
--- a/src/app/+admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-grid-element/workflow-item/workflow-item-search-result-admin-workflow-grid-element.component.spec.ts
+++ b/src/app/+admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-grid-element/workflow-item/workflow-item-search-result-admin-workflow-grid-element.component.spec.ts
@@ -18,6 +18,7 @@ import { WorkflowItemSearchResult } from '../../../../../shared/object-collectio
 import { BitstreamDataService } from '../../../../../core/data/bitstream-data.service';
 import { createSuccessfulRemoteDataObject$ } from '../../../../../shared/remote-data.utils';
 import { getMockLinkService } from '../../../../../shared/mocks/link-service.mock';
+import { of as observableOf } from 'rxjs';
 
 describe('WorkflowItemAdminWorkflowGridElementComponent', () => {
   let component: WorkflowItemSearchResultAdminWorkflowGridElementComponent;
@@ -50,7 +51,9 @@ describe('WorkflowItemAdminWorkflowGridElementComponent', () => {
         ],
         providers: [
           { provide: LinkService, useValue: linkService },
-          { provide: TruncatableService, useValue: {} },
+          { provide: TruncatableService, useValue: {
+              isCollapsed: () => observableOf(true),
+            } },
           { provide: BitstreamDataService, useValue: {} },
         ],
         schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/shared/object-grid/search-result-grid-element/search-result-grid-element.component.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/search-result-grid-element.component.ts
@@ -32,9 +32,6 @@ export class SearchResultGridElementComponent<T extends SearchResult<K>, K exten
     protected bitstreamDataService: BitstreamDataService
   ) {
     super();
-    if (hasValue(this.object)) {
-      this.isCollapsed$ = this.isCollapsed();
-    }
   }
 
   /**
@@ -43,6 +40,7 @@ export class SearchResultGridElementComponent<T extends SearchResult<K>, K exten
   ngOnInit(): void {
     if (hasValue(this.object)) {
       this.dso = this.object.indexableObject;
+      this.isCollapsed$ = this.isCollapsed();
     }
   }
 


### PR DESCRIPTION
## References
* Fixes an issue I noticed when reviewing #901 

## Description
Item search results in grid view are supposed to only get a shadow when you click them to expand the truncated text. But they get it all the time, which looks strange when they're between results that aren't truncated:


The screenshot below shows the situation as it is now. The first two are truncated, the third isn't
![Screen Shot 2020-10-21 at 10 25 56](https://user-images.githubusercontent.com/1567693/96694284-9028b900-1388-11eb-903e-bcbbd986d8a4.png)

---

With this PR none of them have a shadow initially:
![Screen Shot 2020-10-21 at 10 26 22](https://user-images.githubusercontent.com/1567693/96695528-0aa60880-138a-11eb-9e77-f8810e54b154.png)

---

Only if you click a truncated card to open it, will it get a shadow, that will disappear when you close it again

![Screen Shot 2020-10-21 at 10 26 28](https://user-images.githubusercontent.com/1567693/96695598-1f829c00-138a-11eb-9837-7b2f6f342bae.png)

---

**Note**: while this PR restores the intended behavior, it is still slightly confusing in my opinion, as Collection results aren't truncated, and therefore can't be clicked and will never get a shadow. But if we decide that's a problem, we can fix it in a later PR, as it will be more involved than this one.

## Instructions for Reviewers
All this PR does is initialize the `isCollapsed$` observable in ngOnInit instead of the constructor of the component, which ensures everything is loaded first.

To test it, go to a search results page, open grid view and verify that you don't see shadows initially. If there are truncated results (you can tell if the text on the card fades out in the end), they should get a shadow when you click them. The shadow should disappear if you click them again.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
