### PR TITLE
Communities and collections not shown right after creation

### DIFF
--- a/src/app/+collection-page/create-collection-page/create-collection-page.component.spec.ts
+++ b/src/app/+collection-page/create-collection-page/create-collection-page.component.spec.ts
@@ -12,6 +12,7 @@ import { CommunityDataService } from '../../core/data/community-data.service';
 import { CreateCollectionPageComponent } from './create-collection-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import {RequestService} from '../../core/data/request.service';
 
 describe('CreateCollectionPageComponent', () => {
   let comp: CreateCollectionPageComponent;
@@ -29,7 +30,8 @@ describe('CreateCollectionPageComponent', () => {
         },
         { provide: RouteService, useValue: { getQueryParameterValue: () => observableOf('1234') } },
         { provide: Router, useValue: {} },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() }
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: RequestService, useValue: {}}
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/+collection-page/create-collection-page/create-collection-page.component.ts
@@ -7,6 +7,7 @@ import { Collection } from '../../core/shared/collection.model';
 import { CollectionDataService } from '../../core/data/collection-data.service';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
+import {RequestService} from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can create a new Collection
@@ -26,8 +27,9 @@ export class CreateCollectionPageComponent extends CreateComColPageComponent<Col
     protected routeService: RouteService,
     protected router: Router,
     protected notificationsService: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
-    super(collectionDataService, communityDataService, routeService, router, notificationsService, translate);
+    super(collectionDataService, communityDataService, routeService, router, notificationsService, translate, requestService);
   }
 }

--- a/src/app/+collection-page/delete-collection-page/delete-collection-page.component.spec.ts
+++ b/src/app/+collection-page/delete-collection-page/delete-collection-page.component.spec.ts
@@ -9,6 +9,7 @@ import { of as observableOf } from 'rxjs';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { DeleteCollectionPageComponent } from './delete-collection-page.component';
 import { CollectionDataService } from '../../core/data/collection-data.service';
+import {RequestService} from '../../core/data/request.service';
 
 describe('DeleteCollectionPageComponent', () => {
   let comp: DeleteCollectionPageComponent;
@@ -22,6 +23,7 @@ describe('DeleteCollectionPageComponent', () => {
         { provide: CollectionDataService, useValue: {} },
         { provide: ActivatedRoute, useValue: { data: observableOf({ dso: { payload: {} } }) } },
         { provide: NotificationsService, useValue: {} },
+        { provide: RequestService, useValue: {} }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+collection-page/delete-collection-page/delete-collection-page.component.ts
+++ b/src/app/+collection-page/delete-collection-page/delete-collection-page.component.ts
@@ -5,6 +5,7 @@ import { NotificationsService } from '../../shared/notifications/notifications.s
 import { CollectionDataService } from '../../core/data/collection-data.service';
 import { Collection } from '../../core/shared/collection.model';
 import { TranslateService } from '@ngx-translate/core';
+import {RequestService} from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can delete an existing Collection
@@ -22,8 +23,9 @@ export class DeleteCollectionPageComponent extends DeleteComColPageComponent<Col
     protected router: Router,
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
-    super(dsoDataService, router, route, notifications, translate);
+    super(dsoDataService, router, route, notifications, translate, requestService);
   }
 }

--- a/src/app/+community-page/create-community-page/create-community-page.component.spec.ts
+++ b/src/app/+community-page/create-community-page/create-community-page.component.spec.ts
@@ -12,6 +12,7 @@ import { CommunityDataService } from '../../core/data/community-data.service';
 import { CreateCommunityPageComponent } from './create-community-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import {RequestService} from '../../core/data/request.service';
 
 describe('CreateCommunityPageComponent', () => {
   let comp: CreateCommunityPageComponent;
@@ -25,7 +26,8 @@ describe('CreateCommunityPageComponent', () => {
         { provide: CommunityDataService, useValue: { findById: () => observableOf({}) } },
         { provide: RouteService, useValue: { getQueryParameterValue: () => observableOf('1234') } },
         { provide: Router, useValue: {} },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() }
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: RequestService, useValue: {} }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/+community-page/create-community-page/create-community-page.component.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 import { CreateComColPageComponent } from '../../shared/comcol-forms/create-comcol-page/create-comcol-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
+import {RequestService} from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can create a new Community
@@ -24,8 +25,9 @@ export class CreateCommunityPageComponent extends CreateComColPageComponent<Comm
     protected routeService: RouteService,
     protected router: Router,
     protected notificationsService: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
-    super(communityDataService, communityDataService, routeService, router, notificationsService, translate);
+    super(communityDataService, communityDataService, routeService, router, notificationsService, translate, requestService);
   }
 }

--- a/src/app/+community-page/delete-community-page/delete-community-page.component.spec.ts
+++ b/src/app/+community-page/delete-community-page/delete-community-page.component.spec.ts
@@ -9,6 +9,7 @@ import { CommunityDataService } from '../../core/data/community-data.service';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { SharedModule } from '../../shared/shared.module';
 import { DeleteCommunityPageComponent } from './delete-community-page.component';
+import {RequestService} from '../../core/data/request.service';
 
 describe('DeleteCommunityPageComponent', () => {
   let comp: DeleteCommunityPageComponent;
@@ -22,6 +23,7 @@ describe('DeleteCommunityPageComponent', () => {
         { provide: CommunityDataService, useValue: {} },
         { provide: ActivatedRoute, useValue: { data: observableOf({ dso: { payload: {} } }) } },
         { provide: NotificationsService, useValue: {} },
+        { provide: RequestService, useValue: {}}
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/+community-page/delete-community-page/delete-community-page.component.ts
+++ b/src/app/+community-page/delete-community-page/delete-community-page.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DeleteComColPageComponent } from '../../shared/comcol-forms/delete-comcol-page/delete-comcol-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
+import {RequestService} from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can delete an existing Community
@@ -22,8 +23,10 @@ export class DeleteCommunityPageComponent extends DeleteComColPageComponent<Comm
     protected router: Router,
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
-    super(dsoDataService, router, route, notifications, translate);
+    super(dsoDataService, router, route, notifications, translate, requestService);
   }
+
 }

--- a/src/app/core/data/comcol-data.service.ts
+++ b/src/app/core/data/comcol-data.service.ts
@@ -123,7 +123,7 @@ export abstract class ComColDataService<T extends CacheableObject> extends DataS
   }
 
   public refreshCache(dso: T) {
-    const parentCommunityUrl = this.parentCommunityUrl(dso as any);
+    const parentCommunityUrl = this.parentCommunityUrlLookup(dso as any);
     if (!hasValue(parentCommunityUrl)) {
       return;
     }
@@ -136,7 +136,7 @@ export abstract class ComColDataService<T extends CacheableObject> extends DataS
     });
   }
 
-  private parentCommunityUrl(dso: Collection | Community) {
+  private parentCommunityUrlLookup(dso: Collection | Community) {
     const parentCommunity = dso._links.parentCommunity;
     return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
   }

--- a/src/app/core/data/comcol-data.service.ts
+++ b/src/app/core/data/comcol-data.service.ts
@@ -21,12 +21,14 @@ import {
   configureRequest,
   getRemoteDataPayload,
   getResponseFromEntry,
+  getSucceededOrNoContentResponse,
   getSucceededRemoteData
 } from '../shared/operators';
 import { CacheableObject } from '../cache/object-cache.reducer';
 import { RestResponse } from '../cache/response.models';
 import { Bitstream } from '../shared/bitstream.model';
 import { DSpaceObject } from '../shared/dspace-object.model';
+import {Collection} from '../shared/collection.model';
 
 export abstract class ComColDataService<T extends CacheableObject> extends DataService<T> {
   protected abstract cds: CommunityDataService;
@@ -118,5 +120,24 @@ export abstract class ComColDataService<T extends CacheableObject> extends DataS
         getResponseFromEntry()
       );
     }
+  }
+
+  public refreshCache(dso: T) {
+    const parentCommunityUrl = this.parentCommunityUrl(dso as any);
+    if (!hasValue(parentCommunityUrl)) {
+      return;
+    }
+    this.findByHref(parentCommunityUrl).pipe(
+      getSucceededOrNoContentResponse(),
+      take(1),
+    ).subscribe((rd: RemoteData<any>) => {
+      const href = rd.hasSucceeded && !isEmpty(rd.payload.id) ? rd.payload.id : this.halService.getEndpoint('communities/search/top');
+      this.requestService.removeByHrefSubstring(href)
+    });
+  }
+
+  private parentCommunityUrl(dso: Collection | Community) {
+    const parentCommunity = dso._links.parentCommunity;
+    return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
   }
 }

--- a/src/app/core/data/remote-data.ts
+++ b/src/app/core/data/remote-data.ts
@@ -55,4 +55,8 @@ export class RemoteData<T> {
     return this.state === RemoteDataState.Success;
   }
 
+  get hasNoContent(): boolean {
+    return this.statusCode === 204;
+  }
+
 }

--- a/src/app/core/shared/operators.ts
+++ b/src/app/core/shared/operators.ts
@@ -75,6 +75,11 @@ export const getSucceededRemoteWithNotEmptyData = () =>
   <T>(source: Observable<RemoteData<T>>): Observable<RemoteData<T>> =>
     source.pipe(find((rd: RemoteData<T>) => rd.hasSucceeded && isNotEmpty(rd.payload)));
 
+export const getSucceededOrNoContentResponse = () =>
+  <T>(source: Observable<RemoteData<T>>): Observable<RemoteData<T>> =>
+    source.pipe(find((rd: RemoteData<T>) => rd.hasSucceeded || rd.hasNoContent));
+
+
 /**
  * Get the first successful remotely retrieved object
  *

--- a/src/app/core/shared/operators.ts
+++ b/src/app/core/shared/operators.ts
@@ -79,7 +79,6 @@ export const getSucceededOrNoContentResponse = () =>
   <T>(source: Observable<RemoteData<T>>): Observable<RemoteData<T>> =>
     source.pipe(find((rd: RemoteData<T>) => rd.hasSucceeded || rd.hasNoContent));
 
-
 /**
  * Get the first successful remotely retrieved object
  *

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
@@ -36,6 +36,7 @@ describe('CreateComColPageComponent', () => {
   let routeServiceStub;
   let routerStub;
   let requestServiceStub;
+  let scheduler;
 
   const logoEndpoint = 'rest/api/logo/endpoint';
 
@@ -117,6 +118,7 @@ describe('CreateComColPageComponent', () => {
     communityDataService = (comp as any).communityDataService;
     routeService = (comp as any).routeService;
     router = (comp as any).router;
+    scheduler = getTestScheduler();
   });
 
   describe('onSubmit', () => {
@@ -146,8 +148,9 @@ describe('CreateComColPageComponent', () => {
 
       it('should navigate and refresh cache when successful', () => {
         spyOn(router, 'navigate');
-        spyOn((comp as any), 'refreshCache');
-        comp.onSubmit(data);
+        spyOn((comp as any), 'refreshCache')
+        scheduler.schedule(() => comp.onSubmit(data));
+        scheduler.flush();
         fixture.detectChanges();
         expect(router.navigate).toHaveBeenCalled();
         expect((comp as any).refreshCache).toHaveBeenCalled();
@@ -157,7 +160,8 @@ describe('CreateComColPageComponent', () => {
         spyOn(router, 'navigate');
         spyOn(dsoDataService, 'create').and.returnValue(createFailedRemoteDataObject$(newCommunity));
         spyOn((comp as any), 'refreshCache')
-        comp.onSubmit(data);
+        scheduler.schedule(() => comp.onSubmit(data));
+        scheduler.flush();
         fixture.detectChanges();
         expect(router.navigate).not.toHaveBeenCalled();
         expect((comp as any).refreshCache).not.toHaveBeenCalled();
@@ -173,6 +177,7 @@ describe('CreateComColPageComponent', () => {
               value: 'test'
             }]
           }),
+          _links: {},
           uploader: {
             options: {
               url: ''
@@ -189,27 +194,29 @@ describe('CreateComColPageComponent', () => {
 
       it('should not navigate', () => {
         spyOn(router, 'navigate');
-        comp.onSubmit(data);
+        scheduler.schedule(() => comp.onSubmit(data));
+        scheduler.flush();
         fixture.detectChanges();
         expect(router.navigate).not.toHaveBeenCalled();
       });
 
       it('should set the uploader\'s url to the logo\'s endpoint', () => {
-        comp.onSubmit(data);
+        scheduler.schedule(() => comp.onSubmit(data));
+        scheduler.flush();
         fixture.detectChanges();
         expect(data.uploader.options.url).toEqual(logoEndpoint);
       });
 
       it('should call the uploader\'s uploadAll', () => {
         spyOn(data.uploader, 'uploadAll');
-        comp.onSubmit(data);
+        scheduler.schedule(() => comp.onSubmit(data));
+        scheduler.flush();
         fixture.detectChanges();
         expect(data.uploader.uploadAll).toHaveBeenCalled();
       });
     });
 
     describe('cache refresh', () => {
-      let scheduler;
       let communityWithoutParentHref;
 
       beforeEach(() => {

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
@@ -46,7 +46,8 @@ describe('CreateComColPageComponent', () => {
       metadata: [{
         key: 'dc.title',
         value: 'test community'
-      }]
+      }],
+      _links: {}
     });
 
     parentCommunity = Object.assign(new Community(), {
@@ -55,7 +56,8 @@ describe('CreateComColPageComponent', () => {
       metadata: [{
         key: 'dc.title',
         value: 'parent community'
-      }]
+      }],
+      _links: {}
     });
 
     newCommunity = Object.assign(new Community(), {
@@ -63,7 +65,8 @@ describe('CreateComColPageComponent', () => {
       metadata: [{
         key: 'dc.title',
         value: 'new community'
-      }]
+      }],
+      _links: {}
     });
 
     communityDataServiceStub = {
@@ -102,7 +105,6 @@ describe('CreateComColPageComponent', () => {
         { provide: RouteService, useValue: routeServiceStub },
         { provide: Router, useValue: routerStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
-        { provide: TranslateService, useValue: {}},
         { provide: RequestService, useValue: requestServiceStub}
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -151,7 +153,6 @@ describe('CreateComColPageComponent', () => {
         spyOn((comp as any), 'refreshCache')
         scheduler.schedule(() => comp.onSubmit(data));
         scheduler.flush();
-        fixture.detectChanges();
         expect(router.navigate).toHaveBeenCalled();
         expect((comp as any).refreshCache).toHaveBeenCalled();
       });
@@ -162,7 +163,6 @@ describe('CreateComColPageComponent', () => {
         spyOn((comp as any), 'refreshCache')
         scheduler.schedule(() => comp.onSubmit(data));
         scheduler.flush();
-        fixture.detectChanges();
         expect(router.navigate).not.toHaveBeenCalled();
         expect((comp as any).refreshCache).not.toHaveBeenCalled();
       });
@@ -196,14 +196,12 @@ describe('CreateComColPageComponent', () => {
         spyOn(router, 'navigate');
         scheduler.schedule(() => comp.onSubmit(data));
         scheduler.flush();
-        fixture.detectChanges();
         expect(router.navigate).not.toHaveBeenCalled();
       });
 
       it('should set the uploader\'s url to the logo\'s endpoint', () => {
         scheduler.schedule(() => comp.onSubmit(data));
         scheduler.flush();
-        fixture.detectChanges();
         expect(data.uploader.options.url).toEqual(logoEndpoint);
       });
 
@@ -211,7 +209,6 @@ describe('CreateComColPageComponent', () => {
         spyOn(data.uploader, 'uploadAll');
         scheduler.schedule(() => comp.onSubmit(data));
         scheduler.flush();
-        fixture.detectChanges();
         expect(data.uploader.uploadAll).toHaveBeenCalled();
       });
     });

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.spec.ts
@@ -131,6 +131,7 @@ describe('CreateComColPageComponent', () => {
               value: 'test'
             }]
           }),
+          _links: {},
           uploader: {
             options: {
               url: ''

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -2,18 +2,24 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
+import {flatMap, map, take} from 'rxjs/operators';
 import { ComColDataService } from '../../../core/data/comcol-data.service';
 import { CommunityDataService } from '../../../core/data/community-data.service';
 import { RemoteData } from '../../../core/data/remote-data';
 import { RouteService } from '../../../core/services/route.service';
 import { Community } from '../../../core/shared/community.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
-import { getSucceededRemoteData } from '../../../core/shared/operators';
+import {
+  getFirstSucceededRemoteDataPayload,
+  getRemoteDataPayload,
+  getSucceededRemoteData
+} from '../../../core/shared/operators';
 import { ResourceType } from '../../../core/shared/resource-type';
-import { hasValue, isNotEmpty, isNotUndefined } from '../../empty.util';
+import {hasValue, isEmpty, isNotEmpty, isNotUndefined} from '../../empty.util';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { RequestParam } from '../../../core/cache/models/request-param.model';
+import {RequestService} from '../../../core/data/request.service';
+import {Collection} from '../../../core/shared/collection.model';
 
 /**
  * Component representing the create page for communities and collections
@@ -54,7 +60,8 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
     protected routeService: RouteService,
     protected router: Router,
     protected notificationsService: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
 
   }
@@ -76,25 +83,29 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
     const dso = event.dso;
     const uploader = event.uploader;
 
-    this.parentUUID$.pipe(take(1)).subscribe((uuid: string) => {
+    this.parentUUID$.pipe(
+      take(1),
+      flatMap((uuid: string) => {
       const params = uuid ? [new RequestParam('parent', uuid)] : [];
-      this.dsoDataService.create(dso, ...params)
-        .pipe(getSucceededRemoteData())
-        .subscribe((dsoRD: RemoteData<TDomain>) => {
-          if (isNotUndefined(dsoRD)) {
-            this.newUUID = dsoRD.payload.uuid;
-            if (uploader.queue.length > 0) {
-              this.dsoDataService.getLogoEndpoint(this.newUUID).pipe(take(1)).subscribe((href: string) => {
-                uploader.options.url = href;
-                uploader.uploadAll();
-              });
-            } else {
-              this.navigateToNewPage();
-            }
-            this.notificationsService.success(null, this.translate.get(this.type.value + '.create.notifications.success'));
+      return this.dsoDataService.create(dso, ...params)
+        .pipe(getFirstSucceededRemoteDataPayload()
+        )
+      }))
+      .subscribe((dsoRD: TDomain) => {
+        if (isNotUndefined(dsoRD)) {
+          this.newUUID = dsoRD.uuid;
+          if (uploader.queue.length > 0) {
+            this.dsoDataService.getLogoEndpoint(this.newUUID).pipe(take(1)).subscribe((href: string) => {
+              uploader.options.url = href;
+              uploader.uploadAll();
+            });
+          } else {
+            this.navigateToNewPage();
           }
-        });
-    });
+          this.refreshCache(dsoRD);
+        }
+        this.notificationsService.success(null, this.translate.get(this.type.value + '.create.notifications.success'));
+      });
   }
 
   /**
@@ -106,4 +117,21 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
     }
   }
 
+  private refreshCache(dso: TDomain) {
+      const parentCommunityUrl = this.parentCommunityUrl(dso as any);
+      if (!hasValue(parentCommunityUrl)) {
+        return;
+      }
+      this.dsoDataService.findByHref(parentCommunityUrl).pipe(
+        getSucceededRemoteData(),
+        getRemoteDataPayload(),
+        map((pc: TDomain) => isEmpty(pc) ? 'communities/search/top' : pc.id),
+        take(1)
+      ).subscribe((href: string) => this.requestService.removeByHrefSubstring(href));
+  }
+
+  private parentCommunityUrl(dso: Collection | Community) {
+    const parentCommunity = dso._links.parentCommunity;
+    return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
+  }
 }

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -11,8 +11,7 @@ import { Community } from '../../../core/shared/community.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import {
   getFirstSucceededRemoteDataPayload,
-  getRemoteDataPayload,
-  getSucceededRemoteData
+  getSucceededOrNoContentResponse,
 } from '../../../core/shared/operators';
 import { ResourceType } from '../../../core/shared/resource-type';
 import {hasValue, isEmpty, isNotEmpty, isNotUndefined} from '../../empty.util';
@@ -123,11 +122,12 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
         return;
       }
       this.dsoDataService.findByHref(parentCommunityUrl).pipe(
-        getSucceededRemoteData(),
-        getRemoteDataPayload(),
-        map((pc: TDomain) => isEmpty(pc) ? 'communities/search/top' : pc.id),
-        take(1)
-      ).subscribe((href: string) => this.requestService.removeByHrefSubstring(href));
+        getSucceededOrNoContentResponse(),
+        take(1),
+      ).subscribe((rd: RemoteData<TDomain>) => {
+        const href = rd.hasSucceeded && !isEmpty(rd.payload.id) ? rd.payload.id : 'communities/search/top';
+        this.requestService.removeByHrefSubstring(href)
+      });
   }
 
   private parentCommunityUrl(dso: Collection | Community) {

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -13,7 +13,7 @@ import {
   getFirstSucceededRemoteDataPayload,
 } from '../../../core/shared/operators';
 import { ResourceType } from '../../../core/shared/resource-type';
-import {hasValue, isEmpty, isNotEmpty, isNotUndefined} from '../../empty.util';
+import {hasValue, isNotEmpty, isNotUndefined} from '../../empty.util';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { RequestParam } from '../../../core/cache/models/request-param.model';
 import {RequestService} from '../../../core/data/request.service';

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
-import {flatMap, map, take} from 'rxjs/operators';
+import {flatMap, take} from 'rxjs/operators';
 import { ComColDataService } from '../../../core/data/comcol-data.service';
 import { CommunityDataService } from '../../../core/data/community-data.service';
 import { RemoteData } from '../../../core/data/remote-data';
@@ -11,14 +11,12 @@ import { Community } from '../../../core/shared/community.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import {
   getFirstSucceededRemoteDataPayload,
-  getSucceededOrNoContentResponse,
 } from '../../../core/shared/operators';
 import { ResourceType } from '../../../core/shared/resource-type';
 import {hasValue, isEmpty, isNotEmpty, isNotUndefined} from '../../empty.util';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { RequestParam } from '../../../core/cache/models/request-param.model';
 import {RequestService} from '../../../core/data/request.service';
-import {Collection} from '../../../core/shared/collection.model';
 
 /**
  * Component representing the create page for communities and collections

--- a/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -101,7 +101,7 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
           } else {
             this.navigateToNewPage();
           }
-          this.refreshCache(dsoRD);
+          this.dsoDataService.refreshCache(dsoRD);
         }
         this.notificationsService.success(null, this.translate.get(this.type.value + '.create.notifications.success'));
       });
@@ -114,24 +114,5 @@ export class CreateComColPageComponent<TDomain extends DSpaceObject> implements 
     if (hasValue(this.newUUID)) {
       this.router.navigate([this.frontendURL + this.newUUID]);
     }
-  }
-
-  private refreshCache(dso: TDomain) {
-      const parentCommunityUrl = this.parentCommunityUrl(dso as any);
-      if (!hasValue(parentCommunityUrl)) {
-        return;
-      }
-      this.dsoDataService.findByHref(parentCommunityUrl).pipe(
-        getSucceededOrNoContentResponse(),
-        take(1),
-      ).subscribe((rd: RemoteData<TDomain>) => {
-        const href = rd.hasSucceeded && !isEmpty(rd.payload.id) ? rd.payload.id : 'communities/search/top';
-        this.requestService.removeByHrefSubstring(href)
-      });
-  }
-
-  private parentCommunityUrl(dso: Collection | Community) {
-    const parentCommunity = dso._links.parentCommunity;
-    return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
   }
 }

--- a/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.spec.ts
@@ -16,6 +16,7 @@ import { NotificationsServiceStub } from '../../testing/notifications-service.st
 import {RequestService} from '../../../core/data/request.service';
 import {getTestScheduler} from 'jasmine-marbles';
 import {createNoContentRemoteDataObject$, createSuccessfulRemoteDataObject$} from '../../remote-data.utils';
+import {ComColDataService} from '../../../core/data/comcol-data.service';
 
 describe('DeleteComColPageComponent', () => {
   let comp: DeleteComColPageComponent<DSpaceObject>;
@@ -67,7 +68,8 @@ describe('DeleteComColPageComponent', () => {
       'dsoDataService',
       {
         delete: observableOf({ isSuccessful: true }),
-        findByHref: jasmine.createSpy('findByHref')
+        findByHref: jasmine.createSpy('findByHref'),
+        refreshCache: jasmine.createSpy('refreshCache')
       });
 
     routerStub = {
@@ -93,7 +95,7 @@ describe('DeleteComColPageComponent', () => {
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), SharedModule, CommonModule, RouterTestingModule],
       providers: [
-        { provide: DataService, useValue: dsoDataService },
+        { provide: ComColDataService, useValue: dsoDataService },
         { provide: Router, useValue: routerStub },
         { provide: ActivatedRoute, useValue: routeStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
@@ -153,23 +155,21 @@ describe('DeleteComColPageComponent', () => {
     it('should show an error notification on failure', () => {
       (dsoDataService.delete as any).and.returnValue(observableOf({ isSuccessful: false }));
       spyOn(router, 'navigate');
-      spyOn((comp as any), 'refreshCache');
       scheduler.schedule(() => comp.onConfirm(data2));
       scheduler.flush();
       fixture.detectChanges();
       expect(notificationsService.error).toHaveBeenCalled();
-      expect((comp as any).refreshCache).not.toHaveBeenCalled();
+      expect(dsoDataService.refreshCache).not.toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalled();
     });
 
     it('should show a success notification on success and navigate', () => {
       spyOn(router, 'navigate');
-      spyOn((comp as any), 'refreshCache');
       scheduler.schedule(() => comp.onConfirm(data1));
       scheduler.flush();
       fixture.detectChanges();
       expect(notificationsService.success).toHaveBeenCalled();
-      expect((comp as any).refreshCache).toHaveBeenCalled();
+      expect(dsoDataService.refreshCache).toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalled();
     });
 
@@ -177,73 +177,6 @@ describe('DeleteComColPageComponent', () => {
       comp.onConfirm(data1);
       fixture.detectChanges();
       expect(dsoDataService.delete).toHaveBeenCalledWith(data1.id);
-    });
-
-    describe('cache refresh', () => {
-      let communityWithoutParentHref;
-      let deletedCommunity;
-
-      describe('cache refreshed top level community', () => {
-        beforeEach(() => {
-          (dsoDataService.findByHref as any).and.returnValue(createNoContentRemoteDataObject$());
-          deletedCommunity = {
-            dso: Object.assign(new Community(), {
-              metadata: [{
-                key: 'dc.title',
-                value: 'top level community'
-              }]
-            }),
-            _links: {
-              parentCommunity: {
-                href: 'topLevel/parentCommunity'
-              }
-            }
-          };
-          communityWithoutParentHref = {
-            dso: Object.assign(new Community(), {
-              metadata: [{
-                key: 'dc.title',
-                value: 'top level community'
-              }]
-            }),
-            _links: {}
-          };
-        });
-        it('top level community cache refreshed', () => {
-          scheduler.schedule(() => (comp as any).refreshCache(deletedCommunity));
-          scheduler.flush();
-          expect(requestServiceStub.removeByHrefSubstring).toHaveBeenCalledWith('communities/search/top');
-        });
-        it('top level community without parent link, cache not refreshed', () => {
-          scheduler.schedule(() => (comp as any).refreshCache(communityWithoutParentHref));
-          scheduler.flush();
-          expect(requestServiceStub.removeByHrefSubstring).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('cache refreshed child community', () => {
-        beforeEach(() => {
-          (dsoDataService.findByHref as any).and.returnValue(createSuccessfulRemoteDataObject$(parentCommunity));
-          deletedCommunity = {
-            dso: Object.assign(new Community(), {
-              metadata: [{
-                key: 'dc.title',
-                value: 'child community'
-              }]
-            }),
-            _links: {
-              parentCommunity: {
-                href: 'child/parentCommunity'
-              }
-            }
-          };
-        });
-        it('child level community cache refreshed', () => {
-          scheduler.schedule(() => (comp as any).refreshCache(deletedCommunity));
-          scheduler.flush();
-          expect(requestServiceStub.removeByHrefSubstring).toHaveBeenCalledWith('a20da287-e174-466a-9926-f66as300d399');
-        });
-      });
     });
   });
 

--- a/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -2,19 +2,12 @@ import {Component, OnInit} from '@angular/core';
 import {Observable} from 'rxjs';
 import {ActivatedRoute, Router} from '@angular/router';
 import {RemoteData} from '../../../core/data/remote-data';
-import {first, map, take} from 'rxjs/operators';
-import {DataService} from '../../../core/data/data.service';
+import {first, map} from 'rxjs/operators';
 import {DSpaceObject} from '../../../core/shared/dspace-object.model';
 import {NotificationsService} from '../../notifications/notifications.service';
 import {TranslateService} from '@ngx-translate/core';
 import {RestResponse} from '../../../core/cache/response.models';
-import {hasValue, isEmpty, isNotEmpty} from '../../empty.util';
 import {RequestService} from '../../../core/data/request.service';
-import {
-  getSucceededOrNoContentResponse,
-} from '../../../core/shared/operators';
-import {Community} from '../../../core/shared/community.model';
-import {Collection} from '../../../core/shared/collection.model';
 import {ComColDataService} from '../../../core/data/comcol-data.service';
 
 /**

--- a/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../core/shared/operators';
 import {Community} from '../../../core/shared/community.model';
 import {Collection} from '../../../core/shared/collection.model';
+import {ComColDataService} from '../../../core/data/comcol-data.service';
 
 /**
  * Component representing the delete page for communities and collections
@@ -34,7 +35,7 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
   public dsoRD$: Observable<RemoteData<TDomain>>;
 
   public constructor(
-    protected dsoDataService: DataService<TDomain>,
+    protected dsoDataService: ComColDataService<TDomain>,
     protected router: Router,
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
@@ -58,7 +59,7 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
         if (response.isSuccessful) {
           const successMessage = this.translate.instant((dso as any).type + '.delete.notification.success');
           this.notifications.success(successMessage)
-          this.refreshCache(dso);
+          this.dsoDataService.refreshCache(dso);
         } else {
           const errorMessage = this.translate.instant((dso as any).type + '.delete.notification.fail');
           this.notifications.error(errorMessage)
@@ -73,24 +74,5 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
    */
   onCancel(dso: TDomain) {
     this.router.navigate([this.frontendURL + '/' + dso.uuid + '/edit']);
-  }
-
-  private refreshCache(dso: TDomain) {
-    const parentCommunityUrl = this.parentCommunityUrl(dso as any);
-    if (!hasValue(parentCommunityUrl)) {
-      return;
-    }
-    this.dsoDataService.findByHref(parentCommunityUrl).pipe(
-      getSucceededOrNoContentResponse(),
-      take(1),
-    ).subscribe((rd: RemoteData<TDomain>) => {
-      const href = rd.hasSucceeded && !isEmpty(rd.payload.id) ? rd.payload.id : 'communities/search/top';
-      this.requestService.removeByHrefSubstring(href)
-    });
-  }
-
-  private parentCommunityUrl(dso: Collection | Community): string {
-    const parentCommunity = dso._links.parentCommunity;
-    return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
   }
 }

--- a/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -1,13 +1,18 @@
-import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
-import { ActivatedRoute, Router } from '@angular/router';
-import { RemoteData } from '../../../core/data/remote-data';
-import { first, map } from 'rxjs/operators';
-import { DataService } from '../../../core/data/data.service';
-import { DSpaceObject } from '../../../core/shared/dspace-object.model';
-import { NotificationsService } from '../../notifications/notifications.service';
-import { TranslateService } from '@ngx-translate/core';
-import { RestResponse } from '../../../core/cache/response.models';
+import {Component, OnInit} from '@angular/core';
+import {Observable} from 'rxjs';
+import {ActivatedRoute, Router} from '@angular/router';
+import {RemoteData} from '../../../core/data/remote-data';
+import {first, map, take} from 'rxjs/operators';
+import {DataService} from '../../../core/data/data.service';
+import {DSpaceObject} from '../../../core/shared/dspace-object.model';
+import {NotificationsService} from '../../notifications/notifications.service';
+import {TranslateService} from '@ngx-translate/core';
+import {RestResponse} from '../../../core/cache/response.models';
+import {hasValue, isEmpty, isNotEmpty} from '../../empty.util';
+import {RequestService} from '../../../core/data/request.service';
+import {getRemoteDataPayload, getSucceededRemoteData} from '../../../core/shared/operators';
+import {Community} from '../../../core/shared/community.model';
+import {Collection} from '../../../core/shared/collection.model';
 
 /**
  * Component representing the delete page for communities and collections
@@ -31,7 +36,8 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
     protected router: Router,
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
-    protected translate: TranslateService
+    protected translate: TranslateService,
+    protected requestService: RequestService
   ) {
   }
 
@@ -50,6 +56,7 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
         if (response.isSuccessful) {
           const successMessage = this.translate.instant((dso as any).type + '.delete.notification.success');
           this.notifications.success(successMessage)
+          this.refreshCache(dso);
         } else {
           const errorMessage = this.translate.instant((dso as any).type + '.delete.notification.fail');
           this.notifications.error(errorMessage)
@@ -64,5 +71,23 @@ export class DeleteComColPageComponent<TDomain extends DSpaceObject> implements 
    */
   onCancel(dso: TDomain) {
     this.router.navigate([this.frontendURL + '/' + dso.uuid + '/edit']);
+  }
+
+  private refreshCache(dso: TDomain) {
+    const parentCommunity = this.parentCommunityUrl(dso as any);
+    if (!hasValue(parentCommunity)) {
+      return;
+    }
+    this.dsoDataService.findByHref(parentCommunity).pipe(
+      getSucceededRemoteData(),
+      getRemoteDataPayload(),
+      map((pc: TDomain) =>  isEmpty(pc) ? 'communities/search/top' : pc.id ),
+      take(1)
+    ).subscribe((id: string) => this.requestService.removeByHrefSubstring(id));
+  }
+
+  private parentCommunityUrl(dso: Collection | Community): string {
+    const parentCommunity = dso._links.parentCommunity;
+    return isNotEmpty(parentCommunity) ? parentCommunity.href : null;
   }
 }

--- a/src/app/shared/remote-data.utils.ts
+++ b/src/app/shared/remote-data.utils.ts
@@ -69,3 +69,24 @@ export function createPendingRemoteDataObject<T>(object?: T): RemoteData<T> {
 export function createPendingRemoteDataObject$<T>(object?: T): Observable<RemoteData<T>> {
   return observableOf(createPendingRemoteDataObject(object));
 }
+
+/**
+ * Method to create a remote data object with no content
+ */
+export function createNoContentRemoteDataObject<T>(): RemoteData<T> {
+  return new RemoteData(
+    true,
+    true,
+    true,
+    null,
+    null,
+    204
+  );
+}
+
+/**
+ * Method to create a remote data object that has succeeded with no content, wrapped in an observable
+ */
+export function createNoContentRemoteDataObject$<T>(): Observable<RemoteData<T>> {
+  return observableOf(createNoContentRemoteDataObject());
+}


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #842 

## Description

After a collection or community is created or deleted, href request to its parent is removed from requests cache, so that list of communities or collections belonging to a given community, at any level, from top level on, has to be reloaded and new collection / community is immediately displayed in case of creation or not displayed anymore in case of deletion.

## Instructions for Reviewers

a new function named `refreshCache` has been added to `CreateComColPageComponent` and `DeleteComColPageComponent`, and it is called by the `onSubmit` function of `CreateComColPageComponent` during the flow that observes result of `DSpaceObject` creation performed by `dsoDataService`, and by the `onConfirm` function of `DeleteComColPageComponent` during the flow that observes the result of `DSpaceObject` deletion performed by `dsoDataService`.


List of changes in this PR:
* `refreshCache` function in `CreateComColPageComponent` and its invocation
* `refreshCache` function in `DeleteComColPageComponent` and its invocation

To reproduce the bug: 

* Create a subcommunity within a community.
* Click on "All of DSpace" on the top of the page.
* Select the "parent-community" within which you added the subcommunity.
* The just created subcommunity doesn't appear in the list of the subcommunities.
* Delete a subcommunity within a community.
* Click on "All of DSpace" on the top of the page.
* Select the "parent-community" within which you deleted the subcommunity. 
* The just deleted subcommunity still appears in the list of subcommunities
* Create a collection within a community.
* Click on "All of DSpace" on the top of the page.
* Select the "parent-community" within which you added the collection.
* The just created collection doesn't appear in the list of the community collections.
* Delete a collection within a community.
* Click on "All of DSpace" on the top of the page.
* Select the "parent-community" within which you deleted the collection. 
* The just deleted collection still appears in the list of collections

To test changes: 

* Create a new top level community
* Newly created top level community should appear in dspace home page and in community-list page list
* Delete created top level community
* Deleted community should not appear anymore in DSpace home page and in community-list page list
* Create a new subcommunity
* Newly created subcommunity should appear immediately as child of its parent community in community-list page and between 'Communities of this community' section in community page
* Delete newly created subcommunity
* Deleted sub-community should not appear anymore  as child of its parent community in community-list page and between 'Communities of this community' section in community page
* Create a new collection of a Community
* Newly created collection should immediately appear between 'Collections of this community' section in community page
* Delete newly created collection
* Deleted collection should not appear anymore between 'Collections of this community' section in community page.



## Checklist


- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
