### PR TITLE
Issue 2988: Password (re)set for eperson with add PatchOperation

### DIFF
--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -303,7 +303,7 @@ describe('EPersonDataService', () => {
     it('should sent a patch request with an uuid, token and new password to the epersons endpoint', () => {
       service.patchPasswordWithToken('test-uuid', 'test-token','test-password');
 
-      const operation = Object.assign({ op: 'replace', path: '/password', value: 'test-password' });
+      const operation = Object.assign({ op: 'add', path: '/password', value: 'test-password' });
       const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/test-uuid?token=test-token', [operation]);
 
       expect(requestService.configure).toHaveBeenCalledWith(expected);

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -280,7 +280,7 @@ export class EPersonDataService extends DataService<EPerson> {
   patchPasswordWithToken(uuid: string, token: string, password: string): Observable<RestResponse> {
     const requestId = this.requestService.generateRequestId();
 
-    const operation = Object.assign({ op: 'replace', path: '/password', value: password });
+    const operation = Object.assign({ op: 'add', path: '/password', value: password });
 
     const hrefObs = this.halService.getEndpoint(this.linkPath).pipe(
       map((endpoint: string) => this.getIDHref(endpoint, uuid)),

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -177,7 +177,7 @@ describe('ProfilePageComponent', () => {
         component.setPasswordValue('testest');
         component.setInvalid(false);
 
-        operations = [{op: 'replace', path: '/password', value: 'testest'}];
+        operations = [{op: 'add', path: '/password', value: 'testest'}];
         result = component.updateSecurity();
       });
 

--- a/src/app/profile-page/profile-page.component.ts
+++ b/src/app/profile-page/profile-page.component.ts
@@ -120,7 +120,7 @@ export class ProfilePageComponent implements OnInit {
       this.notificationsService.error(this.translate.instant(this.PASSWORD_NOTIFICATIONS_PREFIX + 'error.general'));
     }
     if (!this.invalidSecurity && passEntered) {
-      const operation = Object.assign({op: 'replace', path: '/password', value: this.password});
+      const operation = Object.assign({op: 'add', path: '/password', value: this.password});
       this.epersonService.patch(this.currentUser, [operation]).subscribe((response: RestResponse) => {
         if (response.isSuccessful) {
           this.notificationsService.success(


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2988
* Requires https://github.com/DSpace/DSpace/pull/3041

## Description
This PR changes the Replace PATCH operations for the EPerson Password Replacement to an Add PATCH operation as changed in the backend in the linked PR.

## Instructions for Reviewers

List of changes in this PR:
* Changed the REPLACE patch operations to ADD patch operations

How to test this PR:
* Setup a local backend with the linked PR's code and this PR's code
* Follow the steps in the linked issue
* Verify that everything works as expected

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
