### PR TITLE
Admin search dialogs

### DIFF
--- a/src/app/+collection-page/collection-page.component.html
+++ b/src/app/+collection-page/collection-page.component.html
@@ -3,37 +3,41 @@
          *ngVar="(collectionRD$ | async) as collectionRD">
         <div *ngIf="collectionRD?.hasSucceeded" @fadeInOut>
             <div *ngIf="collectionRD?.payload as collection">
-                <ds-view-tracker [object]="collection"></ds-view-tracker>
-                <header class="comcol-header border-bottom mb-4 pb-4">
+              <ds-view-tracker [object]="collection"></ds-view-tracker>
+              <div class="d-flex flex-row border-bottom mb-4 pb-4">
+                <header class="comcol-header mr-auto">
                   <!-- Collection Name -->
-                <ds-comcol-page-header
-                        [name]="collection.name">
-                </ds-comcol-page-header>
-                    <!-- Collection logo -->
-                    <ds-comcol-page-logo *ngIf="logoRD$"
-                                     [logo]="(logoRD$ | async)?.payload"
-                                     [alternateText]="'Collection Logo'"
-                        [alternateText]="'Collection Logo'">
-                    </ds-comcol-page-logo>
+                  <ds-comcol-page-header
+                          [name]="collection.name">
+                  </ds-comcol-page-header>
+                  <!-- Collection logo -->
+                  <ds-comcol-page-logo *ngIf="logoRD$"
+                                   [logo]="(logoRD$ | async)?.payload"
+                                   [alternateText]="'Collection Logo'"
+                      [alternateText]="'Collection Logo'">
+                  </ds-comcol-page-logo>
 
-                 <!-- Handle -->
-                <ds-comcol-page-handle
-                        [content]="collection.handle"
-                        [title]="'collection.page.handle'" >
-                </ds-comcol-page-handle>
-                <!-- Introductory text -->
-                <ds-comcol-page-content
-                        [content]="collection.introductoryText"
-                        [hasInnerHtml]="true">
-                </ds-comcol-page-content>
-                <!-- News -->
-                <ds-comcol-page-content
-                        [content]="collection.sidebarText"
-                        [hasInnerHtml]="true"
-                        [title]="'collection.page.news'">
-                </ds-comcol-page-content>
-
-              </header>
+                  <!-- Handle -->
+                  <ds-comcol-page-handle
+                          [content]="collection.handle"
+                          [title]="'collection.page.handle'" >
+                  </ds-comcol-page-handle>
+                  <!-- Introductory text -->
+                  <ds-comcol-page-content
+                          [content]="collection.introductoryText"
+                          [hasInnerHtml]="true">
+                  </ds-comcol-page-content>
+                  <!-- News -->
+                  <ds-comcol-page-content
+                          [content]="collection.sidebarText"
+                          [hasInnerHtml]="true"
+                          [title]="'collection.page.news'">
+                  </ds-comcol-page-content>
+                </header>
+                <div class="pl-2">
+                  <ds-dso-page-edit-button [pageRoutePrefix]="'collections'" [dso]="collection" [tooltipMsg]="'collection.page.edit'"></ds-dso-page-edit-button>
+                </div>
+              </div>
               <section class="comcol-page-browse-section">
               <!-- Browse-By Links -->
               <ds-comcol-page-browse-by

--- a/src/app/+community-page/community-page.component.html
+++ b/src/app/+community-page/community-page.component.html
@@ -2,24 +2,28 @@
   <div class="community-page" *ngIf="communityRD?.hasSucceeded" @fadeInOut>
     <div *ngIf="communityRD?.payload; let communityPayload">
       <ds-view-tracker [object]="communityPayload"></ds-view-tracker>
-      <header class="comcol-header border-bottom mb-4 pb-4">
-        <!-- Community name -->
-        <ds-comcol-page-header [name]="communityPayload.name"></ds-comcol-page-header>
-        <!-- Community logo -->
-        <ds-comcol-page-logo *ngIf="logoRD$" [logo]="(logoRD$ | async)?.payload" [alternateText]="'Community Logo'">
-        </ds-comcol-page-logo>
-        <!-- Handle -->
-        <ds-comcol-page-handle [content]="communityPayload.handle" [title]="'community.page.handle'">
-        </ds-comcol-page-handle>
-        <!-- Introductory text -->
-        <ds-comcol-page-content [content]="communityPayload.introductoryText" [hasInnerHtml]="true">
-        </ds-comcol-page-content>
-        <!-- News -->
-        <ds-comcol-page-content [content]="communityPayload.sidebarText" [hasInnerHtml]="true"
-          [title]="'community.page.news'">
-        </ds-comcol-page-content>
-
-      </header>
+      <div class="d-flex flex-row border-bottom mb-4 pb-4">
+        <header class="comcol-header mr-auto">
+          <!-- Community name -->
+          <ds-comcol-page-header [name]="communityPayload.name"></ds-comcol-page-header>
+          <!-- Community logo -->
+          <ds-comcol-page-logo *ngIf="logoRD$" [logo]="(logoRD$ | async)?.payload" [alternateText]="'Community Logo'">
+          </ds-comcol-page-logo>
+          <!-- Handle -->
+          <ds-comcol-page-handle [content]="communityPayload.handle" [title]="'community.page.handle'">
+          </ds-comcol-page-handle>
+          <!-- Introductory text -->
+          <ds-comcol-page-content [content]="communityPayload.introductoryText" [hasInnerHtml]="true">
+          </ds-comcol-page-content>
+          <!-- News -->
+          <ds-comcol-page-content [content]="communityPayload.sidebarText" [hasInnerHtml]="true"
+            [title]="'community.page.news'">
+          </ds-comcol-page-content>
+        </header>
+        <div class="pl-2">
+          <ds-dso-page-edit-button [pageRoutePrefix]="'communities'" [dso]="communityPayload" [tooltipMsg]="'community.page.edit'"></ds-dso-page-edit-button>
+        </div>
+      </div>
       <section class="comcol-page-browse-section">
         <!-- Browse-By Links -->
         <ds-comcol-page-browse-by [id]="communityPayload.id" [contentType]="communityPayload.type">

--- a/src/app/+item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
+++ b/src/app/+item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
@@ -48,7 +48,7 @@ export class AbstractItemUpdateComponent extends AbstractTrackableComponent impl
   ngOnInit(): void {
     observableCombineLatest(this.route.data, this.route.parent.data).pipe(
       map(([data, parentData]) => Object.assign({}, data, parentData)),
-      map((data) => data.item),
+      map((data) => data.dso),
       first(),
       map((data: RemoteData<Item>) => data.payload)
     ).subscribe((item: Item) => {

--- a/src/app/+item-page/edit-item-page/edit-item-page.component.ts
+++ b/src/app/+item-page/edit-item-page/edit-item-page.component.ts
@@ -47,7 +47,7 @@ export class EditItemPageComponent implements OnInit {
     this.pages = this.route.routeConfig.children
       .map((child: any) => child.path)
       .filter((path: string) => isNotEmpty(path)); // ignore reroutes
-    this.itemRD$ = this.route.data.pipe(map((data) => data.item));
+    this.itemRD$ = this.route.data.pipe(map((data) => data.dso));
   }
 
   /**

--- a/src/app/+item-page/edit-item-page/item-authorizations/item-authorizations.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-authorizations/item-authorizations.component.spec.ts
@@ -74,7 +74,7 @@ describe('ItemAuthorizationsComponent test suite', () => {
 
   const routeStub = {
     data: observableOf({
-      item: createSuccessfulRemoteDataObject(item)
+      dso: createSuccessfulRemoteDataObject(item)
     })
   };
 

--- a/src/app/+item-page/edit-item-page/item-authorizations/item-authorizations.component.ts
+++ b/src/app/+item-page/edit-item-page/item-authorizations/item-authorizations.component.ts
@@ -75,7 +75,7 @@ export class ItemAuthorizationsComponent implements OnInit, OnDestroy {
    */
   ngOnInit(): void {
     this.item$ = this.route.data.pipe(
-      map((data) => data.item),
+      map((data) => data.dso),
       getFirstSucceededRemoteDataWithNotEmptyPayload(),
       map((item: Item) => this.linkService.resolveLink(
         item,

--- a/src/app/+item-page/edit-item-page/item-bitstreams/item-bitstreams.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-bitstreams/item-bitstreams.component.spec.ts
@@ -140,7 +140,7 @@ describe('ItemBitstreamsComponent', () => {
     });
     route = Object.assign({
       parent: {
-        data: observableOf({ item: createMockRD(item) })
+        data: observableOf({ dso: createMockRD(item) })
       },
       data: observableOf({}),
       url: url

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
@@ -89,7 +89,7 @@ describe('ItemCollectionMapperComponent', () => {
     clearDiscoveryRequests: () => {}
     /* tslint:enable:no-empty */
   });
-  const activatedRouteStub = new ActivatedRouteStub({}, { item: mockItemRD });
+  const activatedRouteStub = new ActivatedRouteStub({}, { dso: mockItemRD });
   const translateServiceStub = {
     get: () => of('test-message of item ' + mockItem.name),
     onLangChange: new EventEmitter(),

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
@@ -92,7 +92,7 @@ export class ItemCollectionMapperComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.itemRD$ = this.route.data.pipe(map((data) => data.item)).pipe(getSucceededRemoteData()) as Observable<RemoteData<Item>>;
+    this.itemRD$ = this.route.data.pipe(map((data) => data.dso)).pipe(getSucceededRemoteData()) as Observable<RemoteData<Item>>;
     this.searchOptions$ = this.searchConfigService.paginatedSearchOptions;
     this.loadCollectionLists();
   }

--- a/src/app/+item-page/edit-item-page/item-delete/item-delete.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-delete/item-delete.component.spec.ts
@@ -138,7 +138,7 @@ describe('ItemDeleteComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject(mockItem)
+        dso: createSuccessfulRemoteDataObject(mockItem)
       })
     };
 

--- a/src/app/+item-page/edit-item-page/item-metadata/item-metadata.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-metadata/item-metadata.component.spec.ts
@@ -130,7 +130,7 @@ describe('ItemMetadataComponent', () => {
       routeStub = {
         data: observableOf({}),
         parent: {
-          data: observableOf({ item: createSuccessfulRemoteDataObject(item) })
+          data: observableOf({ dso: createSuccessfulRemoteDataObject(item) })
         }
       };
       paginatedMetadataFields = new PaginatedList(undefined, [mdField1, mdField2, mdField3]);

--- a/src/app/+item-page/edit-item-page/item-move/item-move.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-move/item-move.component.spec.ts
@@ -44,7 +44,7 @@ describe('ItemMoveComponent', () => {
 
   const routeStub = {
     data: observableOf({
-      item: new RemoteData(false, false, true, null, {
+      dso: new RemoteData(false, false, true, null, {
         id: 'item1'
       })
     })

--- a/src/app/+item-page/edit-item-page/item-move/item-move.component.ts
+++ b/src/app/+item-page/edit-item-page/item-move/item-move.component.ts
@@ -55,7 +55,7 @@ export class ItemMoveComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.itemRD$ = this.route.data.pipe(map((data) => data.item), getSucceededRemoteData()) as Observable<RemoteData<Item>>;
+    this.itemRD$ = this.route.data.pipe(map((data) => data.dso), getSucceededRemoteData()) as Observable<RemoteData<Item>>;
     this.itemRD$.subscribe((rd) => {
         this.itemId = rd.payload.id;
       }

--- a/src/app/+item-page/edit-item-page/item-private/item-private.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-private/item-private.component.spec.ts
@@ -51,7 +51,7 @@ describe('ItemPrivateComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject({
+        dso: createSuccessfulRemoteDataObject({
           id: 'fake-id'
         })
       })

--- a/src/app/+item-page/edit-item-page/item-public/item-public.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-public/item-public.component.spec.ts
@@ -51,7 +51,7 @@ describe('ItemPublicComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject({
+        dso: createSuccessfulRemoteDataObject({
           id: 'fake-id'
         })
       })

--- a/src/app/+item-page/edit-item-page/item-reinstate/item-reinstate.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-reinstate/item-reinstate.component.spec.ts
@@ -51,7 +51,7 @@ describe('ItemReinstateComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject({
+        dso: createSuccessfulRemoteDataObject({
           id: 'fake-id'
         })
       })

--- a/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.spec.ts
@@ -142,7 +142,7 @@ describe('ItemRelationshipsComponent', () => {
     routeStub = {
       data: observableOf({}),
       parent: {
-        data: observableOf({ item: new RemoteData(false, false, true, null, item) })
+        data: observableOf({ dso: new RemoteData(false, false, true, null, item) })
       }
     };
 

--- a/src/app/+item-page/edit-item-page/item-status/item-status.component.ts
+++ b/src/app/+item-page/edit-item-page/item-status/item-status.component.ts
@@ -56,7 +56,7 @@ export class ItemStatusComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.itemRD$ = this.route.parent.data.pipe(map((data) => data.item));
+    this.itemRD$ = this.route.parent.data.pipe(map((data) => data.dso));
     this.itemRD$.pipe(
       first(),
       map((data: RemoteData<Item>) => data.payload)

--- a/src/app/+item-page/edit-item-page/item-version-history/item-version-history.component.ts
+++ b/src/app/+item-page/edit-item-page/item-version-history/item-version-history.component.ts
@@ -30,6 +30,6 @@ export class ItemVersionHistoryComponent {
   }
 
   ngOnInit(): void {
-    this.itemRD$ = this.route.parent.data.pipe(map((data) => data.item)).pipe(getSucceededRemoteData()) as Observable<RemoteData<Item>>;
+    this.itemRD$ = this.route.parent.data.pipe(map((data) => data.dso)).pipe(getSucceededRemoteData()) as Observable<RemoteData<Item>>;
   }
 }

--- a/src/app/+item-page/edit-item-page/item-withdraw/item-withdraw.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-withdraw/item-withdraw.component.spec.ts
@@ -51,7 +51,7 @@ describe('ItemWithdrawComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject({
+        dso: createSuccessfulRemoteDataObject({
           id: 'fake-id'
         })
       })

--- a/src/app/+item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
@@ -74,7 +74,7 @@ describe('AbstractSimpleItemActionComponent', () => {
 
     routeStub = {
       data: observableOf({
-        item: createSuccessfulRemoteDataObject({
+        dso: createSuccessfulRemoteDataObject({
           id: 'fake-id'
         })
       })

--- a/src/app/+item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
+++ b/src/app/+item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
@@ -42,7 +42,7 @@ export class AbstractSimpleItemActionComponent implements OnInit {
 
   ngOnInit(): void {
     this.itemRD$ = this.route.data.pipe(
-      map((data) => data.item),
+      map((data) => data.dso),
       getSucceededRemoteData()
     )as Observable<RemoteData<Item>>;
 

--- a/src/app/+item-page/full/full-item-page.component.html
+++ b/src/app/+item-page/full/full-item-page.component.html
@@ -3,7 +3,12 @@
     <div *ngIf="itemRD?.payload as item">
       <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
       <ds-view-tracker [object]="item"></ds-view-tracker>
-      <ds-item-page-title-field [item]="item"></ds-item-page-title-field>
+      <div class="d-flex flex-row">
+        <ds-item-page-title-field class="mr-auto" [item]="item"></ds-item-page-title-field>
+        <div class="pl-2">
+          <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="item" [tooltipMsg]="'item.page.edit'"></ds-dso-page-edit-button>
+        </div>
+      </div>
       <div class="simple-view-link my-3">
         <a class="btn btn-outline-primary" [routerLink]="['/items/' + item.id]">
           {{"item.page.link.simple" | translate}}

--- a/src/app/+item-page/full/full-item-page.component.spec.ts
+++ b/src/app/+item-page/full/full-item-page.component.spec.ts
@@ -34,7 +34,7 @@ const mockItem: Item = Object.assign(new Item(), {
     }
 });
 const routeStub = Object.assign(new ActivatedRouteStub(), {
-  data: observableOf({ item: createSuccessfulRemoteDataObject(mockItem) })
+  data: observableOf({ dso: createSuccessfulRemoteDataObject(mockItem) })
 });
 const metadataServiceStub = {
   /* tslint:disable:no-empty */

--- a/src/app/+item-page/item-page-routing.module.ts
+++ b/src/app/+item-page/item-page-routing.module.ts
@@ -20,7 +20,7 @@ import { LinkMenuItemModel } from '../shared/menu/menu-item/models/link.model';
       {
         path: ':id',
         resolve: {
-          item: ItemPageResolver,
+          dso: ItemPageResolver,
           breadcrumb: ItemBreadcrumbResolver
         },
         runGuardsAndResolvers: 'always',

--- a/src/app/+item-page/simple/item-page.component.spec.ts
+++ b/src/app/+item-page/simple/item-page.component.spec.ts
@@ -37,7 +37,7 @@ describe('ItemPageComponent', () => {
     /* tslint:enable:no-empty */
   };
   const mockRoute = Object.assign(new ActivatedRouteStub(), {
-    data: observableOf({ item: createSuccessfulRemoteDataObject(mockItem) })
+    data: observableOf({ dso: createSuccessfulRemoteDataObject(mockItem) })
   });
 
   beforeEach(async(() => {

--- a/src/app/+item-page/simple/item-page.component.ts
+++ b/src/app/+item-page/simple/item-page.component.ts
@@ -55,7 +55,7 @@ export class ItemPageComponent implements OnInit {
    */
   ngOnInit(): void {
     this.itemRD$ = this.route.data.pipe(
-      map((data) => data.item as RemoteData<Item>),
+      map((data) => data.dso as RemoteData<Item>),
       redirectToPageNotFoundOn404(this.router)
     );
     this.metadataService.processRemoteData(this.itemRD$);

--- a/src/app/+item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'publication.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'publication.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'publication.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -2,7 +2,7 @@
     <nav *ngIf="showBreadcrumbs" aria-label="breadcrumb">
         <ol class="breadcrumb">
             <ng-container
-                    *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'Home', url: '/'}"></ng-container>
+                    *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
             <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
                 <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
             </ng-container>

--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -5,6 +5,7 @@ export enum FeatureID {
   LoginOnBehalfOf = 'loginOnBehalfOf',
   AdministratorOf = 'administratorOf',
   CanDelete = 'canDelete',
+  CanEditMetadata = 'canEditMetadata',
   WithdrawItem = 'withdrawItem',
   ReinstateItem = 'reinstateItem',
   EPersonRegistration = 'epersonRegistration',

--- a/src/app/core/shared/context.model.ts
+++ b/src/app/core/shared/context.model.ts
@@ -13,4 +13,5 @@ export enum Context {
   EntitySearchModal = 'EntitySearchModal',
   AdminSearch = 'adminSearch',
   AdminWorkflowSearch = 'adminWorkflowSearch',
+  SideBarSearchModal = 'sideBarSearchModal',
 }

--- a/src/app/core/shared/context.model.ts
+++ b/src/app/core/shared/context.model.ts
@@ -14,4 +14,5 @@ export enum Context {
   AdminSearch = 'adminSearch',
   AdminWorkflowSearch = 'adminWorkflowSearch',
   SideBarSearchModal = 'sideBarSearchModal',
+  SideBarSearchModalCurrent = 'sideBarSearchModalCurrent',
 }

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,42 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { JournalIssueSidebarSearchListElementComponent } from './journal-issue-sidebar-search-list-element.component';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'publicationvolume.volumeNumber': [
+        {
+          value: '5'
+        }
+      ],
+      'publicationissue.issueNumber': [
+        {
+          value: '7'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('JournalIssueSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(JournalIssueSidebarSearchListElementComponent, object, parent, 'parent title', 'title', '5 - 7')
+);

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.ts
@@ -1,0 +1,38 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+
+@listableObjectComponent('JournalIssueSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-journal-issue-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "JournalIssue" within the context of
+ * a sidebar search modal
+ */
+export class JournalIssueSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  /**
+   * Get the description of the Journal Issue by returning its volume number(s) and/or issue number(s)
+   */
+  getDescription(): string {
+    const volumeNumbers = this.allMetadataValues(['publicationvolume.volumeNumber']);
+    const issueNumbers = this.allMetadataValues(['publicationissue.issueNumber']);
+    let description = '';
+    if (isNotEmpty(volumeNumbers)) {
+      description += volumeNumbers.join(', ');
+    }
+    if (isNotEmpty(description) && isNotEmpty(issueNumbers)) {
+      description += ' - ';
+    }
+    if (isNotEmpty(issueNumbers)) {
+      description += issueNumbers.join(', ');
+    }
+    return this.undefinedIfEmpty(description);
+  }
+}

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component.ts
@@ -8,6 +8,7 @@ import { Item } from '../../../../../core/shared/item.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('JournalIssueSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('JournalIssueSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-journal-issue-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,45 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { JournalVolumeSidebarSearchListElementComponent } from './journal-volume-sidebar-search-list-element.component';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'journal.title': [
+        {
+          value: 'journal title'
+        }
+      ],
+      'publicationvolume.volumeNumber': [
+        {
+          value: '1'
+        },
+        {
+          value: '2'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('JournalVolumeSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(JournalVolumeSidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'journal title (1) (2)')
+);

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.ts
@@ -8,6 +8,7 @@ import { Item } from '../../../../../core/shared/item.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('JournalVolumeSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('JournalVolumeSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-journal-volume-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component.ts
@@ -1,0 +1,38 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+
+@listableObjectComponent('JournalVolumeSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-journal-volume-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "JournalVolume" within the context of
+ * a sidebar search modal
+ */
+export class JournalVolumeSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  /**
+   * Get the description of the Journal Volume by returning the journal title and volume number(s) (between parentheses)
+   */
+  getDescription(): string {
+    const titles = this.allMetadataValues(['journal.title']);
+    const numbers = this.allMetadataValues(['publicationvolume.volumeNumber']);
+    let description = '';
+    if (isNotEmpty(titles)) {
+      description += titles.join(', ');
+    }
+    if (isNotEmpty(numbers)) {
+      if (isNotEmpty(description)) {
+        description += ' ';
+      }
+      description += numbers.map((n) => `(${n})`).join(' ');
+    }
+    return this.undefinedIfEmpty(description);
+  }
+}

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,40 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { JournalSidebarSearchListElementComponent } from './journal-sidebar-search-list-element.component';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'creativeworkseries.issn': [
+        {
+          value: '1234'
+        },
+        {
+          value: '5678'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('JournalSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(JournalSidebarSearchListElementComponent, object, parent, 'parent title', 'title', '1234, 5678')
+);

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.ts
@@ -1,0 +1,31 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+
+@listableObjectComponent('JournalSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-journal-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "Journal" within the context of
+ * a sidebar search modal
+ */
+export class JournalSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  /**
+   * Get the description of the Journal by returning its ISSN(s)
+   */
+  getDescription(): string {
+    const issns = this.allMetadataValues(['creativeworkseries.issn']);
+    let description = '';
+    if (isNotEmpty(issns)) {
+      description += issns.join(', ');
+    }
+    return this.undefinedIfEmpty(description);
+  }
+}

--- a/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/journal-entities/item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component.ts
@@ -8,6 +8,7 @@ import { Item } from '../../../../../core/shared/item.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('JournalSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('JournalSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-journal-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'journalissue.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'journalissue.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'journalissue.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'journalvolume.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'journalvolume.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'journalvolume.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'journal.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'journal.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'journal.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/journal-entities/journal-entities.module.ts
+++ b/src/app/entity-groups/journal-entities/journal-entities.module.ts
@@ -18,6 +18,9 @@ import { JournalIssueSearchResultListElementComponent } from './item-list-elemen
 import { JournalVolumeSearchResultListElementComponent } from './item-list-elements/search-result-list-elements/journal-volume/journal-volume-search-result-list-element.component';
 import { JournalIssueSearchResultGridElementComponent } from './item-grid-elements/search-result-grid-elements/journal-issue/journal-issue-search-result-grid-element.component';
 import { JournalVolumeSearchResultGridElementComponent } from './item-grid-elements/search-result-grid-elements/journal-volume/journal-volume-search-result-grid-element.component';
+import { JournalVolumeSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/journal-volume/journal-volume-sidebar-search-list-element.component';
+import { JournalIssueSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/journal-issue/journal-issue-sidebar-search-list-element.component';
+import { JournalSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/journal/journal-sidebar-search-list-element.component';
 
 const ENTRY_COMPONENTS = [
   JournalComponent,
@@ -34,7 +37,10 @@ const ENTRY_COMPONENTS = [
   JournalVolumeSearchResultListElementComponent,
   JournalIssueSearchResultGridElementComponent,
   JournalVolumeSearchResultGridElementComponent,
-  JournalSearchResultGridElementComponent
+  JournalSearchResultGridElementComponent,
+  JournalVolumeSidebarSearchListElementComponent,
+  JournalIssueSidebarSearchListElementComponent,
+  JournalSidebarSearchListElementComponent,
 ];
 
 @NgModule({

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,37 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { OrgUnitSidebarSearchListElementComponent } from './org-unit-sidebar-search-list-element.component';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'organization.legalName': [
+        {
+          value: 'title'
+        }
+      ],
+      'dc.description': [
+        {
+          value: 'description'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('OrgUnitSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(OrgUnitSidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description')
+);

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
@@ -5,7 +5,6 @@ import { ItemSearchResult } from '../../../../../shared/object-collection/shared
 import { Component } from '@angular/core';
 import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
 import { Item } from '../../../../../core/shared/item.model';
-import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('OrgUnitSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent('OrgUnitSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
@@ -8,6 +8,7 @@ import { Item } from '../../../../../core/shared/item.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('OrgUnitSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('OrgUnitSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-org-unit-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component.ts
@@ -1,0 +1,33 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+
+@listableObjectComponent('OrgUnitSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-org-unit-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "OrgUnit" within the context of
+ * a sidebar search modal
+ */
+export class OrgUnitSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  /**
+   * Get the title of the Org Unit by returning its legal name
+   */
+  getTitle(): string {
+    return this.firstMetadataValue('organization.legalName');
+  }
+
+  /**
+   * Get the description of the Org Unit by returning its dc.description
+   */
+  getDescription(): string {
+    return this.firstMetadataValue('dc.description');
+  }
+}

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,45 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { PersonSidebarSearchListElementComponent } from './person-sidebar-search-list-element.component';
+import { TranslateService } from '@ngx-translate/core';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'person.familyName': [
+        {
+          value: 'family name'
+        }
+      ],
+      'person.givenName': [
+        {
+          value: 'given name'
+        }
+      ],
+      'person.jobTitle': [
+        {
+          value: 'job title'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('PersonSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(PersonSidebarSearchListElementComponent, object, parent, 'parent title', 'family name, given name', 'job title', [
+    { provide: TranslateService, useValue: jasmine.createSpyObj('translate', { instant: '' }) }
+  ])
+);

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
@@ -11,6 +11,7 @@ import { LinkService } from '../../../../../core/cache/builders/link.service';
 import { TranslateService } from '@ngx-translate/core';
 
 @listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-person-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
@@ -1,0 +1,59 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+import { TruncatableService } from '../../../../../shared/truncatable/truncatable.service';
+import { LinkService } from '../../../../../core/cache/builders/link.service';
+import { TranslateService } from '@ngx-translate/core';
+
+@listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-person-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "Person" within the context of
+ * a sidebar search modal
+ */
+export class PersonSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  constructor(protected truncatableService: TruncatableService,
+              protected linkService: LinkService,
+              protected translateService: TranslateService) {
+    super(truncatableService, linkService);
+  }
+
+  /**
+   * Get the title of the Person by returning a combination of its family name and given name (or "No name found")
+   */
+  getTitle(): string {
+    const familyName = this.firstMetadataValue('person.familyName');
+    const givenName = this.firstMetadataValue('person.givenName');
+    let title = '';
+    if (isNotEmpty(familyName)) {
+      title = familyName;
+    }
+    if (isNotEmpty(title)) {
+      title += ', ';
+    }
+    if (isNotEmpty(givenName)) {
+      title += givenName;
+    }
+    return this.defaultIfEmpty(title, this.translateService.instant('person.listelement.no-title'));
+  }
+
+  /**
+   * Get the description of the Person by returning its job title(s)
+   */
+  getDescription(): string {
+    const titles = this.allMetadataValues(['person.jobTitle']);
+    let description = '';
+    if (isNotEmpty(titles)) {
+      description += titles.join(', ');
+    }
+    return this.undefinedIfEmpty(description);
+  }
+}

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,32 @@
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { createSidebarSearchListElementTests } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec';
+import { ProjectSidebarSearchListElementComponent } from './project-sidebar-search-list-element.component';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('ProjectSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(ProjectSidebarSearchListElementComponent, object, parent, 'parent title', 'title', undefined)
+);

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
@@ -5,7 +5,6 @@ import { ItemSearchResult } from '../../../../../shared/object-collection/shared
 import { Component } from '@angular/core';
 import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
 import { Item } from '../../../../../core/shared/item.model';
-import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('ProjectSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent('ProjectSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
@@ -8,6 +8,7 @@ import { Item } from '../../../../../core/shared/item.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 
 @listableObjectComponent('ProjectSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('ProjectSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-project-sidebar-search-list-element',
   templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component.ts
@@ -1,0 +1,26 @@
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
+import { Component } from '@angular/core';
+import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { Item } from '../../../../../core/shared/item.model';
+import { isNotEmpty } from '../../../../../shared/empty.util';
+
+@listableObjectComponent('ProjectSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-project-sidebar-search-list-element',
+  templateUrl: '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "Project" within the context of
+ * a sidebar search modal
+ */
+export class ProjectSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+  /**
+   * Projects currently don't support a description
+   */
+  getDescription(): string {
+    return undefined;
+  }
+}

--- a/src/app/entity-groups/research-entities/item-pages/org-unit/org-unit.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/org-unit/org-unit.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'orgunit.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['organization.legalName'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'orgunit.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['organization.legalName'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'orgunit.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'person.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="[object?.firstMetadata('person.familyName'), object?.firstMetadata('person.givenName')]" [separator]="', '"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'person.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="[object?.firstMetadata('person.familyName'), object?.firstMetadata('person.givenName')]" [separator]="', '"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'person.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.html
@@ -1,6 +1,11 @@
-<h2 class="item-page-title-field">
-  {{'project.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
-</h2>
+<div class="d-flex flex-row">
+  <h2 class="item-page-title-field mr-auto">
+    {{'project.page.titleprefix' | translate}}<ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
+  </h2>
+  <div class="pl-2">
+    <ds-dso-page-edit-button [pageRoutePrefix]="'items'" [dso]="object" [tooltipMsg]="'project.page.edit'"></ds-dso-page-edit-button>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
     <ds-metadata-field-wrapper>

--- a/src/app/entity-groups/research-entities/research-entities.module.ts
+++ b/src/app/entity-groups/research-entities/research-entities.module.ts
@@ -26,6 +26,9 @@ import { NameVariantModalComponent } from './submission/name-variant-modal/name-
 import { OrgUnitInputSuggestionsComponent } from './submission/item-list-elements/org-unit/org-unit-suggestions/org-unit-input-suggestions.component';
 import { OrgUnitSearchResultListSubmissionElementComponent } from './submission/item-list-elements/org-unit/org-unit-search-result-list-submission-element.component';
 import { ExternalSourceEntryListSubmissionElementComponent } from './submission/item-list-elements/external-source-entry/external-source-entry-list-submission-element.component';
+import { OrgUnitSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/org-unit/org-unit-sidebar-search-list-element.component';
+import { PersonSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component';
+import { ProjectSidebarSearchListElementComponent } from './item-list-elements/sidebar-search-list-elements/project/project-sidebar-search-list-element.component';
 
 const ENTRY_COMPONENTS = [
   OrgUnitComponent,
@@ -50,7 +53,10 @@ const ENTRY_COMPONENTS = [
   NameVariantModalComponent,
   OrgUnitSearchResultListSubmissionElementComponent,
   OrgUnitInputSuggestionsComponent,
-  ExternalSourceEntryListSubmissionElementComponent
+  ExternalSourceEntryListSubmissionElementComponent,
+  OrgUnitSidebarSearchListElementComponent,
+  PersonSidebarSearchListElementComponent,
+  ProjectSidebarSearchListElementComponent,
 ];
 
 @NgModule({

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.html
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.html
@@ -1,0 +1,6 @@
+<a *ngIf="isAuthorized$ | async"
+   [routerLink]="['/' + pageRoutePrefix, dso.id, 'edit']"
+   class="edit-button btn btn-dark text-light btn-sm"
+   [tooltip]="tooltipMsg | translate">
+  <i class="fas fa-pencil-alt fa-fw"></i>
+</a>

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.scss
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.scss
@@ -1,0 +1,3 @@
+.btn-dark {
+  background-color: $admin-sidebar-bg;
+}

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.spec.ts
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.spec.ts
@@ -1,25 +1,76 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { DsoPageEditButtonComponent } from './dso-page-edit-button.component';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { Item } from '../../../core/shared/item.model';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { of as observableOf } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
+import { By } from '@angular/platform-browser';
+import { TooltipModule } from 'ngx-bootstrap';
 
 describe('DsoPageEditButtonComponent', () => {
   let component: DsoPageEditButtonComponent;
   let fixture: ComponentFixture<DsoPageEditButtonComponent>;
 
+  let authorizationService: AuthorizationDataService;
+  let dso: DSpaceObject;
+
   beforeEach(async(() => {
+    dso = Object.assign(new Item(), {
+      id: 'test-item',
+      _links: {
+        self: { href: 'test-item-selflink' }
+      }
+    });
+    authorizationService = jasmine.createSpyObj('authorizationService', {
+      isAuthorized: observableOf(true)
+    });
     TestBed.configureTestingModule({
-      declarations: [ DsoPageEditButtonComponent ]
-    })
-    .compileComponents();
+      declarations: [ DsoPageEditButtonComponent ],
+      imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), TooltipModule.forRoot()],
+      providers: [
+        { provide: AuthorizationDataService, useValue: authorizationService }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DsoPageEditButtonComponent);
     component = fixture.componentInstance;
+    component.dso = dso;
+    component.pageRoutePrefix = 'test';
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should check the authorization of the current user', () => {
+    expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.CanEditMetadata, dso.self);
+  });
+
+  describe('when the user is authorized', () => {
+    beforeEach(() => {
+      (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(true));
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should render a link', () => {
+      const link = fixture.debugElement.query(By.css('a'));
+      expect(link).not.toBeNull();
+    });
+  });
+
+  describe('when the user is not authorized', () => {
+    beforeEach(() => {
+      (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should not render a link', () => {
+      const link = fixture.debugElement.query(By.css('a'));
+      expect(link).toBeNull();
+    });
   });
 });

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.spec.ts
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DsoPageEditButtonComponent } from './dso-page-edit-button.component';
+
+describe('DsoPageEditButtonComponent', () => {
+  let component: DsoPageEditButtonComponent;
+  let fixture: ComponentFixture<DsoPageEditButtonComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DsoPageEditButtonComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DsoPageEditButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.ts
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.ts
@@ -9,14 +9,29 @@ import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
   templateUrl: './dso-page-edit-button.component.html',
   styleUrls: ['./dso-page-edit-button.component.scss']
 })
+/**
+ * Display a button linking to the edit page of a DSpaceObject
+ */
 export class DsoPageEditButtonComponent implements OnInit {
-
+  /**
+   * The DSpaceObject to display a button to the edit page for
+   */
   @Input() dso: DSpaceObject;
 
+  /**
+   * The prefix of the route to the edit page (before the object's UUID, e.g. "items")
+   */
   @Input() pageRoutePrefix: string;
 
+  /**
+   * A message for the tooltip on the button
+   * Supports i18n keys
+   */
   @Input() tooltipMsg: string;
 
+  /**
+   * Whether or not the current user is authorized to edit the DSpaceObject
+   */
   isAuthorized$: Observable<boolean>;
 
   constructor(protected authorizationService: AuthorizationDataService) { }

--- a/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.ts
+++ b/src/app/shared/dso-page/dso-page-edit-button/dso-page-edit-button.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { Observable } from 'rxjs/internal/Observable';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
+
+@Component({
+  selector: 'ds-dso-page-edit-button',
+  templateUrl: './dso-page-edit-button.component.html',
+  styleUrls: ['./dso-page-edit-button.component.scss']
+})
+export class DsoPageEditButtonComponent implements OnInit {
+
+  @Input() dso: DSpaceObject;
+
+  @Input() pageRoutePrefix: string;
+
+  @Input() tooltipMsg: string;
+
+  isAuthorized$: Observable<boolean>;
+
+  constructor(protected authorizationService: AuthorizationDataService) { }
+
+  ngOnInit() {
+    this.isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanEditMetadata, this.dso.self);
+  }
+
+}

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.spec.ts
@@ -1,0 +1,56 @@
+import { AuthorizedCollectionSelectorComponent } from './authorized-collection-selector.component';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { VarDirective } from '../../../utils/var.directive';
+import { TranslateModule } from '@ngx-translate/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { SearchService } from '../../../../core/shared/search/search.service';
+import { CollectionDataService } from '../../../../core/data/collection-data.service';
+import { createSuccessfulRemoteDataObject$ } from '../../../remote-data.utils';
+import { createPaginatedList } from '../../../testing/utils.test';
+import { Collection } from '../../../../core/shared/collection.model';
+import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
+
+describe('AuthorizedCollectionSelectorComponent', () => {
+  let component: AuthorizedCollectionSelectorComponent;
+  let fixture: ComponentFixture<AuthorizedCollectionSelectorComponent>;
+
+  let collectionService;
+  let collection;
+
+  beforeEach(async(() => {
+    collection = Object.assign(new Collection(), {
+      id: 'authorized-collection'
+    });
+    collectionService = jasmine.createSpyObj('collectionService', {
+      getAuthorizedCollection: createSuccessfulRemoteDataObject$(createPaginatedList([collection]))
+    });
+    TestBed.configureTestingModule({
+      declarations: [AuthorizedCollectionSelectorComponent, VarDirective],
+      imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: SearchService, useValue: {} },
+        { provide: CollectionDataService, useValue: collectionService }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthorizedCollectionSelectorComponent);
+    component = fixture.componentInstance;
+    component.types = [DSpaceObjectType.COLLECTION];
+    fixture.detectChanges();
+  });
+
+  describe('search', () => {
+    it('should call getAuthorizedCollection and return the authorized collection in a SearchResult', (done) => {
+      component.search('', 1).subscribe((result) => {
+        expect(collectionService.getAuthorizedCollection).toHaveBeenCalled();
+        expect(result.page.length).toEqual(1);
+        expect(result.page[0].indexableObject).toEqual(collection);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { DSOSelectorComponent } from '../dso-selector.component';
+import { SearchService } from '../../../../core/shared/search/search.service';
+import { CollectionDataService } from '../../../../core/data/collection-data.service';
+import { Observable } from 'rxjs/internal/Observable';
+import { PaginatedList } from '../../../../core/data/paginated-list';
+import { getFirstSucceededRemoteDataPayload } from '../../../../core/shared/operators';
+import { map } from 'rxjs/operators';
+import { CollectionSearchResult } from '../../../object-collection/shared/collection-search-result.model';
+import { SearchResult } from '../../../search/search-result.model';
+import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
+
+@Component({
+  selector: 'ds-authorized-collection-selector',
+  templateUrl: '../dso-selector.component.html'
+})
+/**
+ * Component rendering a list of collections to select from
+ */
+export class AuthorizedCollectionSelectorComponent extends DSOSelectorComponent {
+  constructor(protected searchService: SearchService,
+              protected collectionDataService: CollectionDataService) {
+    super(searchService);
+  }
+
+  /**
+   * Perform a search for authorized collections with the current query and page
+   * @param query Query to search objects for
+   * @param page  Page to retrieve
+   */
+  search(query: string, page: number): Observable<PaginatedList<SearchResult<DSpaceObject>>> {
+    return this.collectionDataService.getAuthorizedCollection(query, Object.assign({
+      currentPage: page,
+      elementsPerPage: this.defaultPagination.pageSize
+    })).pipe(
+      getFirstSucceededRemoteDataPayload(),
+      map((list) => new PaginatedList(list.pageInfo, list.page.map((col) => Object.assign(new CollectionSearchResult(), { indexableObject: col }))))
+    );
+  }
+}

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
@@ -25,6 +25,13 @@ export class AuthorizedCollectionSelectorComponent extends DSOSelectorComponent 
   }
 
   /**
+   * Get a query to send for retrieving the current DSO
+   */
+  getCurrentDSOQuery(): string {
+    return this.currentDSOId;
+  }
+
+  /**
    * Perform a search for authorized collections with the current query and page
    * @param query Query to search objects for
    * @param page  Page to retrieve

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
@@ -12,6 +12,7 @@ import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 
 @Component({
   selector: 'ds-authorized-collection-selector',
+  styleUrls: ['../dso-selector.component.scss'],
   templateUrl: '../dso-selector.component.html'
 })
 /**

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -22,6 +22,7 @@
             class="list-group-item list-group-item-action border-0 list-entry"
             [ngClass]="{'bg-primary': listEntry.indexableObject.id === currentDSOId}"
             title="{{ listEntry.indexableObject.name }}"
+            dsHoverClass="ds-hover"
             (click)="onSelect.emit(listEntry.indexableObject)" #listEntryElement>
       <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"
                                            [linkType]=linkTypes.None [context]="getContext(listEntry.indexableObject.id)"></ds-listable-object-component-loader>

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -20,6 +20,7 @@
     </button>
     <button *ngFor="let listEntry of listEntries"
             class="list-group-item list-group-item-action border-0 list-entry"
+            [ngClass]="{'current': listEntry.indexableObject.id === currentDSOId}"
             title="{{ listEntry.indexableObject.name }}"
             (click)="onSelect.emit(listEntry.indexableObject)" #listEntryElement>
       <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -7,15 +7,23 @@
 </div>
 <div class="dropdown-divider"></div>
 <div class="scrollable-menu list-group">
+  <div
+    infiniteScroll
+    [infiniteScrollDistance]="0.2"
+    [infiniteScrollThrottle]="300"
+    [infiniteScrollContainer]="'.scrollable-menu'"
+    [fromRoot]="true"
+    (scrolled)="onScrollDown()">
     <button class="list-group-item list-group-item-action border-0 disabled"
-            *ngIf="(listEntries$ | async)?.payload.page.length == 0">
+            *ngIf="listEntries.length == 0">
         {{'dso-selector.no-results' | translate: { type: typesString } }}
     </button>
-    <button *ngFor="let listEntry of (listEntries$ | async)?.payload.page"
+    <button *ngFor="let listEntry of listEntries"
             class="list-group-item list-group-item-action border-0 list-entry"
             title="{{ listEntry.indexableObject.name }}"
             (click)="onSelect.emit(listEntry.indexableObject)" #listEntryElement>
       <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"
                                            [linkType]=linkTypes.None [context]="context"></ds-listable-object-component-loader>
     </button>
+  </div>
 </div>

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -16,6 +16,6 @@
             title="{{ listEntry.indexableObject.name }}"
             (click)="onSelect.emit(listEntry.indexableObject)" #listEntryElement>
       <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"
-                                           [linkType]=linkTypes.None></ds-listable-object-component-loader>
+                                           [linkType]=linkTypes.None [context]="context"></ds-listable-object-component-loader>
     </button>
 </div>

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -9,7 +9,7 @@
 <div class="scrollable-menu list-group">
   <div
     infiniteScroll
-    [infiniteScrollDistance]="0.2"
+    [infiniteScrollDistance]="1"
     [infiniteScrollThrottle]="300"
     [infiniteScrollContainer]="'.scrollable-menu'"
     [fromRoot]="true"

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -20,11 +20,15 @@
     </button>
     <button *ngFor="let listEntry of listEntries"
             class="list-group-item list-group-item-action border-0 list-entry"
-            [ngClass]="{'current': listEntry.indexableObject.id === currentDSOId}"
+            [ngClass]="{'bg-primary': listEntry.indexableObject.id === currentDSOId}"
             title="{{ listEntry.indexableObject.name }}"
             (click)="onSelect.emit(listEntry.indexableObject)" #listEntryElement>
       <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"
-                                           [linkType]=linkTypes.None [context]="context"></ds-listable-object-component-loader>
+                                           [linkType]=linkTypes.None [context]="getContext(listEntry.indexableObject.id)"></ds-listable-object-component-loader>
+    </button>
+    <button *ngIf="hasNextPage"
+            class="list-group-item list-group-item-action border-0 list-entry">
+      <ds-loading [showMessage]="false"></ds-loading>
     </button>
   </div>
 </div>

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
@@ -1,0 +1,5 @@
+.scrollable-menu {
+  height: auto;
+  max-height: $dso-selector-list-max-height;
+  overflow-x: hidden;
+}

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
@@ -3,3 +3,10 @@
   max-height: $dso-selector-list-max-height;
   overflow-x: hidden;
 }
+
+.current {
+  background-color: $dso-selector-current-background-color;
+  &:hover {
+    background-color: $dso-selector-current-background-hover-color;
+  }
+}

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
@@ -1,12 +1,5 @@
 .scrollable-menu {
   height: auto;
-  max-height: $dso-selector-list-max-height;
+  max-height: min(70vh, 475px);
   overflow-x: hidden;
-}
-
-.current {
-  background-color: $dso-selector-current-background-color;
-  &:hover {
-    background-color: $dso-selector-current-background-hover-color;
-  }
 }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.scss
@@ -1,5 +1,5 @@
 .scrollable-menu {
   height: auto;
-  max-height: min(70vh, 475px);
+  max-height: $dso-selector-list-max-height;
   overflow-x: hidden;
 }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -6,10 +6,10 @@ import { SearchService } from '../../../core/shared/search/search.service';
 import { DSpaceObjectType } from '../../../core/shared/dspace-object-type.model';
 import { ItemSearchResult } from '../../object-collection/shared/item-search-result.model';
 import { Item } from '../../../core/shared/item.model';
-import { PaginatedList } from '../../../core/data/paginated-list';
-import { MetadataValue } from '../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
 import { PaginatedSearchOptions } from '../../search/paginated-search-options.model';
+import { hasValue } from '../../empty.util';
+import { createPaginatedList } from '../../testing/utils.test';
 
 describe('DSOSelectorComponent', () => {
   let component: DSOSelectorComponent;
@@ -18,19 +18,46 @@ describe('DSOSelectorComponent', () => {
 
   const currentDSOId = 'test-uuid-ford-sose';
   const type = DSpaceObjectType.ITEM;
-  const searchResult = new ItemSearchResult();
-  const item = new Item();
-  item.metadata = {
-    'dc.title': [Object.assign(new MetadataValue(), {
-      value: 'Item title',
-      language: undefined
-    })]
-  };
-  searchResult.indexableObject = item;
-  searchResult.hitHighlights = {};
-  const searchService = jasmine.createSpyObj('searchService', {
-    search: createSuccessfulRemoteDataObject$(new PaginatedList(undefined, [searchResult]))
-  });
+  const searchResult = createSearchResult('current');
+
+  const firstPageResults = [
+    createSearchResult('1'),
+    createSearchResult('2'),
+    createSearchResult('3'),
+  ];
+
+  const nextPageResults = [
+    createSearchResult('4'),
+    createSearchResult('5'),
+    createSearchResult('6'),
+  ];
+
+  const searchService = {
+    search: (options: PaginatedSearchOptions) => {
+      if (hasValue(options.query) && options.query.startsWith('search.resourceid')) {
+        return createSuccessfulRemoteDataObject$(createPaginatedList([searchResult]));
+      } else if (options.pagination.currentPage === 1) {
+        return createSuccessfulRemoteDataObject$(createPaginatedList(firstPageResults));
+      } else {
+        return createSuccessfulRemoteDataObject$(createPaginatedList(nextPageResults));
+      }
+    }
+  }
+
+  function createSearchResult(name: string): ItemSearchResult {
+    return Object.assign(new ItemSearchResult(), {
+      indexableObject: Object.assign(new Item(), {
+        id: `test-result-${name}`,
+        metadata: {
+          'dc.title': [
+            {
+              value: `test result - ${name}`
+            }
+          ]
+        }
+      })
+    })
+  }
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -58,13 +85,23 @@ describe('DSOSelectorComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initially call the search method on the SearchService with the given DSO uuid', () => {
-    const searchOptions = new PaginatedSearchOptions({
-      query: currentDSOId,
-      dsoTypes: [type],
-      pagination: (component as any).defaultPagination
+  describe('populating listEntries', () => {
+    it('should not be empty', () => {
+      expect(component.listEntries.length).toBeGreaterThan(0);
     });
 
-    expect(searchService.search).toHaveBeenCalledWith(searchOptions);
+    it('should contain a combination of the current DSO and first page results', () => {
+      expect(component.listEntries).toEqual([searchResult, ...firstPageResults]);
+    });
+
+    describe('when current page increases', () => {
+      beforeEach(() => {
+        component.currentPage$.next(2);
+      });
+
+      it('should contain a combination of the current DSO, as well as first and second page results', () => {
+        expect(component.listEntries).toEqual([searchResult, ...firstPageResults, ...nextPageResults]);
+      });
+    });
   });
 });

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -131,7 +131,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
     // Create an observable searching for the current DSO (return empty list if there's no current DSO)
     let currentDSOResult$;
     if (isNotEmpty(this.currentDSOId)) {
-      currentDSOResult$ = this.search(`search.resourceid:${this.currentDSOId}`, 1);
+      currentDSOResult$ = this.search(this.getCurrentDSOQuery(), 1);
     } else {
       currentDSOResult$ = observableOf(new PaginatedList(undefined, []));
     }
@@ -173,6 +173,13 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       // Check if there are more pages available after the current one
       this.hasNextPage = list.totalElements > this.listEntries.length;
     }));
+  }
+
+  /**
+   * Get a query to send for retrieving the current DSO
+   */
+  getCurrentDSOQuery(): string {
+    return `search.resourceid:${this.currentDSOId}`;
   }
 
   /**

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -68,7 +68,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   /**
    * Default pagination for this feature
    */
-  defaultPagination = { id: 'dso-selector', currentPage: 1, pageSize: 5 } as any;
+  defaultPagination = { id: 'dso-selector', currentPage: 1, pageSize: 10 } as any;
 
   /**
    * List with search results of DSpace objects for the current query

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -3,29 +3,33 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
   QueryList,
   ViewChildren
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
-
-import { Observable } from 'rxjs';
-import { debounceTime, startWith, switchMap } from 'rxjs/operators';
+import { debounceTime, startWith, switchMap, tap } from 'rxjs/operators';
 import { SearchService } from '../../../core/shared/search/search.service';
 import { CollectionElementLinkType } from '../../object-collection/collection-element-link.type';
 import { PaginatedSearchOptions } from '../../search/paginated-search-options.model';
 import { DSpaceObjectType } from '../../../core/shared/dspace-object-type.model';
-import { RemoteData } from '../../../core/data/remote-data';
-import { PaginatedList } from '../../../core/data/paginated-list';
-import { SearchResult } from '../../search/search-result.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { ViewMode } from '../../../core/shared/view-mode.model';
 import { Context } from '../../../core/shared/context.model';
+import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
+import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
+import { Subscription } from 'rxjs/internal/Subscription';
+import { hasValue } from '../../empty.util';
+import { combineLatest as observableCombineLatest } from 'rxjs';
+import { Observable } from 'rxjs/internal/Observable';
+import { PaginatedList } from '../../../core/data/paginated-list';
+import { SearchResult } from '../../search/search-result.model';
 
 @Component({
   selector: 'ds-dso-selector',
-  // styleUrls: ['./dso-selector.component.scss'],
+  styleUrls: ['./dso-selector.component.scss'],
   templateUrl: './dso-selector.component.html'
 })
 
@@ -33,7 +37,7 @@ import { Context } from '../../../core/shared/context.model';
  * Component to render a list of DSO's of which one can be selected
  * The user can search the list by using the input field
  */
-export class DSOSelectorComponent implements OnInit {
+export class DSOSelectorComponent implements OnInit, OnDestroy {
   /**
    * The view mode of the listed objects
    */
@@ -64,12 +68,29 @@ export class DSOSelectorComponent implements OnInit {
   /**
    * Default pagination for this feature
    */
-  private defaultPagination = { id: 'dso-selector', currentPage: 1, pageSize: 5 } as any;
+  defaultPagination = { id: 'dso-selector', currentPage: 1, pageSize: 5 } as any;
 
   /**
    * List with search results of DSpace objects for the current query
    */
-  listEntries$: Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>>;
+  listEntries: Array<SearchResult<DSpaceObject>> = [];
+
+  /**
+   * The current page to load
+   * Dynamically goes up as the user scrolls down until it reaches the last page possible
+   */
+  currentPage$ = new BehaviorSubject(1);
+
+  /**
+   * Whether or not the list contains a next page to load
+   * This allows us to avoid next pages from trying to load when there are none
+   */
+  hasNextPage = false;
+
+  /**
+   * Whether or not the list should be reset next time it receives a page to load
+   */
+  resetList = false;
 
   /**
    * List of element references to all elements
@@ -91,31 +112,76 @@ export class DSOSelectorComponent implements OnInit {
    */
   context = Context.SideBarSearchModal;
 
-  constructor(private searchService: SearchService) {
+  /**
+   * Array to track all subscriptions and unsubscribe them onDestroy
+   * @type {Array}
+   */
+  public subs: Subscription[] = [];
+
+  constructor(protected searchService: SearchService) {
   }
 
   /**
-   * Fills the listEntries$ variable with search results based on the input field's current value
+   * Fills the listEntries variable with search results based on the input field's current value and the current page
    * The search will always start with the initial currentDSOId value
    */
   ngOnInit(): void {
     this.input.setValue(this.currentDSOId);
     this.typesString = this.types.map((type: string) => type.toString().toLowerCase()).join(', ');
-    this.listEntries$ = this.input.valueChanges
-      .pipe(
+
+    this.subs.push(observableCombineLatest(
+      this.input.valueChanges.pipe(
         debounceTime(this.debounceTime),
         startWith(this.currentDSOId),
-        switchMap((query) => {
-            return this.searchService.search(
-              new PaginatedSearchOptions({
-                query: query,
-                dsoTypes: this.types,
-                pagination: this.defaultPagination
-              })
-            )
-          }
-        )
-      )
+        tap(() => this.currentPage$.next(1))
+      ),
+      this.currentPage$
+    ).pipe(
+      switchMap(([query, page]: [string, number]) => {
+        if (page === 1) {
+          // The first page is loading, this means we should reset the list instead of adding to it
+          this.resetList = true;
+        }
+        return this.search(query, page);
+      })
+    ).subscribe((list) => {
+      if (this.resetList) {
+        this.listEntries = list.page;
+        this.resetList = false;
+      } else {
+        this.listEntries.push(...list.page);
+      }
+      // Check if there are more pages available after the current one
+      this.hasNextPage = list.totalElements > this.listEntries.length;
+    }));
+  }
+
+  /**
+   * Perform a search for the current query and page
+   * @param query Query to search objects for
+   * @param page  Page to retrieve
+   */
+  search(query: string, page: number): Observable<PaginatedList<SearchResult<DSpaceObject>>> {
+    return this.searchService.search(
+      new PaginatedSearchOptions({
+        query: query,
+        dsoTypes: this.types,
+        pagination: Object.assign({}, this.defaultPagination, {
+          currentPage: page
+        })
+      })
+    ).pipe(
+      getFirstSucceededRemoteDataPayload()
+    );
+  }
+
+  /**
+   * When the user reaches the bottom of the page (or almost) and there's a next page available, increase the current page
+   */
+  onScrollDown() {
+    if (this.hasNextPage) {
+      this.currentPage$.next(this.currentPage$.value + 1);
+    }
   }
 
   /**
@@ -125,5 +191,12 @@ export class DSOSelectorComponent implements OnInit {
     if (this.listElements.length > 0) {
       this.listElements.first.nativeElement.click();
     }
+  }
+
+  /**
+   * Unsubscribe from all subscriptions
+   */
+  ngOnDestroy(): void {
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
   }
 }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -108,6 +108,11 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   linkTypes = CollectionElementLinkType;
 
   /**
+   * Track whether the element has the mouse over it
+   */
+  isMouseOver = false
+
+  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    * @type {Array}
    */

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -21,6 +21,7 @@ import { PaginatedList } from '../../../core/data/paginated-list';
 import { SearchResult } from '../../search/search-result.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { ViewMode } from '../../../core/shared/view-mode.model';
+import { Context } from '../../../core/shared/context.model';
 
 @Component({
   selector: 'ds-dso-selector',
@@ -84,6 +85,11 @@ export class DSOSelectorComponent implements OnInit {
    * The available link types
    */
   linkTypes = CollectionElementLinkType;
+
+  /**
+   * This component's context to display listable objects for
+   */
+  context = Context.SideBarSearchModal;
 
   constructor(private searchService: SearchService) {
   }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -108,11 +108,6 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   linkTypes = CollectionElementLinkType;
 
   /**
-   * This component's context to display listable objects for
-   */
-  context = Context.SideBarSearchModal;
-
-  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    * @type {Array}
    */
@@ -209,6 +204,17 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   selectSingleResult(): void {
     if (this.listElements.length > 0) {
       this.listElements.first.nativeElement.click();
+    }
+  }
+
+  /**
+   * Get the context for element with the given id
+   */
+  getContext(id: string) {
+    if (id === this.currentDSOId) {
+      return Context.SideBarSearchModalCurrent;
+    } else {
+      return Context.SideBarSearchModal;
     }
   }
 

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
@@ -22,6 +22,7 @@ export class CreateCollectionParentSelectorComponent extends DSOSelectorModalWra
   objectType = DSpaceObjectType.COLLECTION;
   selectorTypes = [DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.CREATE;
+  header = 'dso-selector.create.collection.sub-level';
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {
     super(activeModal, route);

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
@@ -5,7 +5,6 @@
     </button>
   </div>
   <div class="modal-body">
-    <ds-collection-dropdown (selectionChange)="selectObject($event.collection)">
-    </ds-collection-dropdown>
+    <ds-authorized-collection-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-authorized-collection-selector>
   </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
@@ -5,6 +5,7 @@
     </button>
   </div>
   <div class="modal-body">
-    <ds-authorized-collection-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-authorized-collection-selector>
+    <h5 *ngIf="header" class="px-2">{{header | translate}}</h5>
+    <ds-authorized-collection-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-authorized-collection-selector>
   </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.ts
@@ -20,6 +20,7 @@ export class CreateItemParentSelectorComponent extends DSOSelectorModalWrapperCo
   objectType = DSpaceObjectType.ITEM;
   selectorTypes = [DSpaceObjectType.COLLECTION];
   action = SelectorActionType.CREATE;
+  header = 'dso-selector.create.item.sub-level';
 
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {
     super(activeModal, route);

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
@@ -5,6 +5,7 @@
     </button>
   </div>
   <div class="modal-body">
-    <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid ? 'search.resourceid:' + dsoRD?.payload.uuid : null" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-dso-selector>
+    <h5 *ngIf="header" class="px-2">{{header | translate}}</h5>
+    <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="selectorTypes" (onSelect)="selectObject($event)"></ds-dso-selector>
   </div>
 </div>

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
@@ -24,6 +24,12 @@ export abstract class DSOSelectorModalWrapperComponent implements OnInit {
   @Input() dsoRD: RemoteData<DSpaceObject>;
 
   /**
+   * Optional header to display above the selection list
+   * Supports i18n keys
+   */
+  @Input() header: string;
+
+  /**
    * The type of the DSO that's being edited, created or exported
    */
   objectType: DSpaceObjectType;

--- a/src/app/shared/hover-class.directive.spec.ts
+++ b/src/app/shared/hover-class.directive.spec.ts
@@ -1,0 +1,35 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HoverClassDirective } from './hover-class.directive';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  template: `<div dsHoverClass="ds-hover"></div>`
+})
+class TestComponent { }
+
+describe('HoverClassDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let el: DebugElement;
+
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [TestComponent, HoverClassDirective]
+    }).createComponent(TestComponent);
+
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+    el = fixture.debugElement.query(By.css('div'));
+  });
+
+  it('should add the class on mouseenter and remove on mouseleave', () => {
+    el.triggerEventHandler('mouseenter', null);
+    fixture.detectChanges();
+    expect(el.nativeElement.classList).toContain('ds-hover');
+
+    el.triggerEventHandler('mouseleave', null);
+    fixture.detectChanges();
+    expect(el.nativeElement.classList).not.toContain('ds-hover');
+  });
+});

--- a/src/app/shared/hover-class.directive.ts
+++ b/src/app/shared/hover-class.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+
+@Directive({
+  selector: '[dsHoverClass]'
+})
+export class HoverClassDirective {
+​
+  constructor(public elementRef: ElementRef) { }
+  @Input('dsHoverClass') hoverClass: string;
+​
+  @HostListener('mouseenter') onMouseEnter() {
+    this.elementRef.nativeElement.classList.add(this.hoverClass);
+  }
+​
+  @HostListener('mouseleave') onMouseLeave() {
+    this.elementRef.nativeElement.classList.remove(this.hoverClass);
+  }
+​
+}

--- a/src/app/shared/hover-class.directive.ts
+++ b/src/app/shared/hover-class.directive.ts
@@ -3,15 +3,27 @@ import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 @Directive({
   selector: '[dsHoverClass]'
 })
+/**
+ * A directive adding a class to an element when hovered over
+ */
 export class HoverClassDirective {
-​
-  constructor(public elementRef: ElementRef) { }
+  /**
+   * The name of the class to add on hover
+   */
   @Input('dsHoverClass') hoverClass: string;
 ​
+  constructor(public elementRef: ElementRef) { }
+​
+  /**
+   * On mouse enter, add the class to the element's class list
+   */
   @HostListener('mouseenter') onMouseEnter() {
     this.elementRef.nativeElement.classList.add(this.hoverClass);
   }
 ​
+  /**
+   * On mouse leave, remove the class from the element's class list
+   */
   @HostListener('mouseleave') onMouseLeave() {
     this.elementRef.nativeElement.classList.remove(this.hoverClass);
   }

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,37 @@
+import { CollectionSidebarSearchListElementComponent } from './collection-sidebar-search-list-element.component';
+import { CollectionSearchResult } from '../../../object-collection/shared/collection-search-result.model';
+import { Collection } from '../../../../core/shared/collection.model';
+import { Community } from '../../../../core/shared/community.model';
+import { createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+
+const object = Object.assign(new CollectionSearchResult(), {
+  indexableObject: Object.assign(new Collection(), {
+    id: 'test-collection',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'dc.description.abstract': [
+        {
+          value: 'description'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Community(), {
+  id: 'test-community',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('CollectionSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(CollectionSidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description')
+);

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
@@ -7,6 +7,7 @@ import { ViewMode } from '../../../../core/shared/view-mode.model';
 import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
 
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-collection-sidebar-search-list-element',
   templateUrl: '../sidebar-search-list-element.component.html'

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CollectionSearchResult } from '../../../object-collection/shared/collection-search-result.model';
+import { Collection } from '../../../../core/shared/collection.model';
+import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
+import { Context } from '../../../../core/shared/context.model';
+import { ViewMode } from '../../../../core/shared/view-mode.model';
+import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
+
+@listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-collection-sidebar-search-list-element',
+  templateUrl: '../sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link CollectionSearchResult} within the context of a sidebar search modal
+ */
+export class CollectionSidebarSearchListElementComponent extends SidebarSearchListElementComponent<CollectionSearchResult, Collection> {
+  /**
+   * Get the description of the Collection by returning its abstract
+   */
+  getDescription(): string {
+    return this.firstMetadataValue('dc.description.abstract');
+  }
+}

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,36 @@
+import { Community } from '../../../../core/shared/community.model';
+import { createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+import { CommunitySidebarSearchListElementComponent } from './community-sidebar-search-list-element.component';
+import { CommunitySearchResult } from '../../../object-collection/shared/community-search-result.model';
+
+const object = Object.assign(new CommunitySearchResult(), {
+  indexableObject: Object.assign(new Community(), {
+    id: 'test-community',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'dc.description.abstract': [
+        {
+          value: 'description'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Community(), {
+  id: 'test-parent-community',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('CommunitySidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(CommunitySidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description')
+);

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
@@ -7,6 +7,7 @@ import { CommunitySearchResult } from '../../../object-collection/shared/communi
 import { Community } from '../../../../core/shared/community.model';
 
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-collection-sidebar-search-list-element',
   templateUrl: '../sidebar-search-list-element.component.html'

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
+import { Context } from '../../../../core/shared/context.model';
+import { ViewMode } from '../../../../core/shared/view-mode.model';
+import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
+import { CommunitySearchResult } from '../../../object-collection/shared/community-search-result.model';
+import { Community } from '../../../../core/shared/community.model';
+
+@listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-collection-sidebar-search-list-element',
+  templateUrl: '../sidebar-search-list-element.component.html'
+})
+/**
+ * Component displaying a list element for a {@link CommunitySearchResult} within the context of a sidebar search modal
+ */
+export class CommunitySidebarSearchListElementComponent extends SidebarSearchListElementComponent<CommunitySearchResult, Community> {
+  /**
+   * Get the description of the Community by returning its abstract
+   */
+  getDescription(): string {
+    return this.firstMetadataValue('dc.description.abstract');
+  }
+}

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.html
@@ -1,1 +1,0 @@
-<span>Test display for sidebar-search list elements</span>

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.html
@@ -1,0 +1,1 @@
+<span>Test display for sidebar-search list elements</span>

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,47 @@
+import { createSidebarSearchListElementTests } from '../../sidebar-search-list-element.component.spec';
+import { PublicationSidebarSearchListElementComponent } from './publication-sidebar-search-list-element.component';
+import { ItemSearchResult } from '../../../../object-collection/shared/item-search-result.model';
+import { Item } from '../../../../../core/shared/item.model';
+import { Collection } from '../../../../../core/shared/collection.model';
+
+const object = Object.assign(new ItemSearchResult(), {
+  indexableObject: Object.assign(new Item(), {
+    id: 'test-item',
+    metadata: {
+      'dc.title': [
+        {
+          value: 'title'
+        }
+      ],
+      'dc.publisher': [
+        {
+          value: 'publisher'
+        }
+      ],
+      'dc.date.issued': [
+        {
+          value: 'date'
+        }
+      ],
+      'dc.contributor.author': [
+        {
+          value: 'author'
+        }
+      ]
+    }
+  })
+});
+const parent = Object.assign(new Collection(), {
+  id: 'test-collection',
+  metadata: {
+    'dc.title': [
+      {
+        value: 'parent title'
+      }
+    ]
+  }
+});
+
+describe('PublicationSidebarSearchListElementComponent',
+  createSidebarSearchListElementTests(PublicationSidebarSearchListElementComponent, object, parent, 'parent title', 'title', '(publisher, date) author')
+);

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
@@ -12,6 +12,10 @@ import { SidebarSearchListElementComponent } from '../../sidebar-search-list-ele
   selector: 'ds-publication-sidebar-search-list-element',
   templateUrl: '../../sidebar-search-list-element.component.html'
 })
+/**
+ * Component displaying a list element for a {@link ItemSearchResult} of type "Publication" within the context of
+ * a sidebar search modal
+ */
 export class PublicationSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
 
 }

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
@@ -7,7 +7,9 @@ import { Item } from '../../../../../core/shared/item.model';
 import { SidebarSearchListElementComponent } from '../../sidebar-search-list-element.component';
 
 @listableObjectComponent('PublicationSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent('PublicationSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
   selector: 'ds-publication-sidebar-search-list-element',
   templateUrl: '../../sidebar-search-list-element.component.html'

--- a/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component.ts
@@ -1,0 +1,17 @@
+import { listableObjectComponent } from '../../../../object-collection/shared/listable-object/listable-object.decorator';
+import { ViewMode } from '../../../../../core/shared/view-mode.model';
+import { Component } from '@angular/core';
+import { Context } from '../../../../../core/shared/context.model';
+import { ItemSearchResult } from '../../../../object-collection/shared/item-search-result.model';
+import { Item } from '../../../../../core/shared/item.model';
+import { SidebarSearchListElementComponent } from '../../sidebar-search-list-element.component';
+
+@listableObjectComponent('PublicationSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
+@listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
+@Component({
+  selector: 'ds-publication-sidebar-search-list-element',
+  templateUrl: '../../sidebar-search-list-element.component.html'
+})
+export class PublicationSidebarSearchListElementComponent extends SidebarSearchListElementComponent<ItemSearchResult, Item> {
+
+}

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,3 +1,3 @@
-<ds-truncatable-part *ngIf="parentTitle$ | async" [maxLines]="1"><div class="text-secondary">{{ parentTitle$ | async }}</div></ds-truncatable-part>
-<ds-truncatable-part [maxLines]="1"><div class="text-primary">{{ title }}</div></ds-truncatable-part>
-<ds-truncatable-part [maxLines]="1"><div class="text-secondary">{{ description }}</div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1"><div class="text-secondary">{{ parentTitle$ | async }}</div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="title" [maxLines]="1"><div class="text-primary">{{ title }}</div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="description" [maxLines]="1"><div class="text-secondary">{{ description }}</div></ds-truncatable-part>

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,13 +1,13 @@
-<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1">
+<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
   <div [ngClass]="isCurrent() ? 'text-light' : 'text-body'"
        [innerHTML]="parentTitle$ | async"></div>
 </ds-truncatable-part>
-<ds-truncatable-part *ngIf="title" [maxLines]="1">
+<ds-truncatable-part *ngIf="title" [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
   <div class="font-weight-bold"
        [ngClass]="isCurrent() ? 'text-light' : 'text-primary'"
        [innerHTML]="title"></div>
 </ds-truncatable-part>
-<ds-truncatable-part *ngIf="description" [maxLines]="1">
+<ds-truncatable-part *ngIf="description" [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
   <div class="text-secondary"
        [ngClass]="isCurrent() ? 'text-light' : 'text-secondary'"
        [innerHTML]="description"></div>

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,3 +1,14 @@
-<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1"><div class="text-secondary" [innerHTML]="parentTitle$ | async"></div></ds-truncatable-part>
-<ds-truncatable-part *ngIf="title" [maxLines]="1"><div class="text-primary" [innerHTML]="title"></div></ds-truncatable-part>
-<ds-truncatable-part *ngIf="description" [maxLines]="1"><div class="text-secondary" [innerHTML]="description"></div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1">
+  <div [ngClass]="isCurrent() ? 'text-light' : 'text-body'"
+       [innerHTML]="parentTitle$ | async"></div>
+</ds-truncatable-part>
+<ds-truncatable-part *ngIf="title" [maxLines]="1">
+  <div class="font-weight-bold"
+       [ngClass]="isCurrent() ? 'text-light' : 'text-primary'"
+       [innerHTML]="title"></div>
+</ds-truncatable-part>
+<ds-truncatable-part *ngIf="description" [maxLines]="1">
+  <div class="text-secondary"
+       [ngClass]="isCurrent() ? 'text-light' : 'text-secondary'"
+       [innerHTML]="description"></div>
+</ds-truncatable-part>

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,6 +1,6 @@
-<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
+<ds-truncatable-part [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
   <div [ngClass]="isCurrent() ? 'text-light' : 'text-body'"
-       [innerHTML]="parentTitle$ | async"></div>
+       [innerHTML]="(parentTitle$ && parentTitle$ | async) ? (parentTitle$ | async) : ('home.breadcrumbs' | translate)"></div>
 </ds-truncatable-part>
 <ds-truncatable-part *ngIf="title" [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'">
   <div class="font-weight-bold"

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,3 +1,3 @@
-<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1"><div class="text-secondary">{{ parentTitle$ | async }}</div></ds-truncatable-part>
-<ds-truncatable-part *ngIf="title" [maxLines]="1"><div class="text-primary">{{ title }}</div></ds-truncatable-part>
-<ds-truncatable-part *ngIf="description" [maxLines]="1"><div class="text-secondary">{{ description }}</div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="parentTitle$ && parentTitle$ | async" [maxLines]="1"><div class="text-secondary" [innerHTML]="parentTitle$ | async"></div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="title" [maxLines]="1"><div class="text-primary" [innerHTML]="title"></div></ds-truncatable-part>
+<ds-truncatable-part *ngIf="description" [maxLines]="1"><div class="text-secondary" [innerHTML]="description"></div></ds-truncatable-part>

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,0 +1,3 @@
+<ds-truncatable-part *ngIf="parentTitle$ | async" [maxLines]="1"><div class="text-secondary">{{ parentTitle$ | async }}</div></ds-truncatable-part>
+<ds-truncatable-part [maxLines]="1"><div class="text-primary">{{ title }}</div></ds-truncatable-part>
+<ds-truncatable-part [maxLines]="1"><div class="text-secondary">{{ description }}</div></ds-truncatable-part>

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
@@ -1,0 +1,69 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { VarDirective } from '../../utils/var.directive';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { SearchResult } from '../../search/search-result.model';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { TruncatableService } from '../../truncatable/truncatable.service';
+import { LinkService } from '../../../core/cache/builders/link.service';
+import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
+import { HALResource } from '../../../core/shared/hal-resource.model';
+import { ChildHALResource } from '../../../core/shared/child-hal-resource.model';
+
+export function createSidebarSearchListElementTests(
+  componentClass: any,
+  object: SearchResult<DSpaceObject & ChildHALResource>,
+  parent: DSpaceObject,
+  expectedParentTitle: string,
+  expectedTitle: string,
+  expectedDescription: string,
+  extraProviders: any[] = []
+) {
+  return () => {
+    let component;
+    let fixture: ComponentFixture<any>;
+
+    let linkService;
+
+    beforeEach(async(() => {
+      linkService = jasmine.createSpyObj('linkService', {
+        resolveLink: Object.assign(new HALResource(), {
+          [object.indexableObject.getParentLinkKey()]: createSuccessfulRemoteDataObject$(parent)
+        })
+      });
+      TestBed.configureTestingModule({
+        declarations: [componentClass, VarDirective],
+        imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([])],
+        providers: [
+          { provide: TruncatableService, useValue: {} },
+          { provide: LinkService, useValue: linkService },
+          ...extraProviders
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(componentClass);
+      component = fixture.componentInstance;
+      component.object = object;
+      fixture.detectChanges();
+    });
+
+    it('should contain the correct parent title', (done) => {
+      component.parentTitle$.subscribe((title) => {
+        expect(title).toEqual(expectedParentTitle);
+        done();
+      });
+    });
+
+    it('should contain the correct title', () => {
+      expect(component.title).toEqual(expectedTitle);
+    });
+
+    it('should contain the correct description', () => {
+      expect(component.description).toEqual(expectedDescription);
+    });
+  };
+}

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
@@ -11,6 +11,7 @@ import { ChildHALResource } from '../../../core/shared/child-hal-resource.model'
 import { followLink } from '../../utils/follow-link-config.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { of as observableOf } from 'rxjs';
+import { Context } from '../../../core/shared/context.model';
 
 @Component({
   selector: 'ds-sidebar-search-list-element',
@@ -55,13 +56,20 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
   }
 
   /**
+   * returns true if this element represents the current dso
+   */
+  isCurrent(): boolean {
+    return this.context === Context.SideBarSearchModalCurrent;
+  }
+
+  /**
    * Get the title of the object's parent
    * Retrieve the parent by using the object's parent link and retrieving its 'dc.title' metadata
    */
   getParentTitle(): Observable<string> {
     return this.getParent().pipe(
       map((parentRD: RemoteData<DSpaceObject>) => {
-        return parentRD ? parentRD.payload.firstMetadataValue('dc.title') : undefined;
+        return hasValue(parentRD) && hasValue(parentRD.payload) ? parentRD.payload.firstMetadataValue('dc.title') : undefined;
       })
     );
   }

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
@@ -1,0 +1,56 @@
+import { SearchResult } from '../../search/search-result.model';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { SearchResultListElementComponent } from '../search-result-list-element/search-result-list-element.component';
+import { Component } from '@angular/core';
+import { hasValue } from '../../empty.util';
+import { Observable } from 'rxjs/internal/Observable';
+import { TruncatableService } from '../../truncatable/truncatable.service';
+import { LinkService } from '../../../core/cache/builders/link.service';
+import { find, map } from 'rxjs/operators';
+import { ChildHALResource } from '../../../core/shared/child-hal-resource.model';
+import { followLink } from '../../utils/follow-link-config.model';
+import { RemoteData } from '../../../core/data/remote-data';
+
+@Component({
+  selector: 'ds-sidebar-search-list-element',
+  templateUrl: './sidebar-search-list-element.component.html'
+})
+export class SidebarSearchListElementComponent<T extends SearchResult<K>, K extends DSpaceObject> extends SearchResultListElementComponent<T, K> {
+  parentTitle$: Observable<string>;
+  title: string;
+  description: string;
+
+  public constructor(protected truncatableService: TruncatableService,
+                     protected linkService: LinkService) {
+    super(truncatableService);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    if (hasValue(this.dso)) {
+      this.parentTitle$ = this.getParentTitle();
+      this.title = this.getTitle();
+      this.description = this.getDescription();
+    }
+  }
+
+  getTitle(): string {
+    return this.firstMetadataValue('dc.title');
+  }
+
+  getDescription(): string {
+    // TODO: Expand description
+    return this.firstMetadataValue('dc.publisher');
+  }
+
+  getParentTitle(): Observable<string> {
+    // TODO: Remove cast to "any" and replace with proper type-check
+    const propertyName = (this.dso as any).getParentLinkKey();
+    return this.linkService.resolveLink(this.dso, followLink(propertyName))[propertyName].pipe(
+      find((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => parentRD.hasSucceeded || parentRD.statusCode === 204),
+      map((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => {
+        return parentRD.payload.firstMetadataValue('dc.title');
+      })
+    );
+  }
+}

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
@@ -2,7 +2,7 @@ import { SearchResult } from '../../search/search-result.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { SearchResultListElementComponent } from '../search-result-list-element/search-result-list-element.component';
 import { Component } from '@angular/core';
-import { hasValue } from '../../empty.util';
+import { hasValue, isNotEmpty } from '../../empty.util';
 import { Observable } from 'rxjs/internal/Observable';
 import { TruncatableService } from '../../truncatable/truncatable.service';
 import { LinkService } from '../../../core/cache/builders/link.service';
@@ -10,14 +10,31 @@ import { find, map } from 'rxjs/operators';
 import { ChildHALResource } from '../../../core/shared/child-hal-resource.model';
 import { followLink } from '../../utils/follow-link-config.model';
 import { RemoteData } from '../../../core/data/remote-data';
+import { of as observableOf } from 'rxjs';
 
 @Component({
   selector: 'ds-sidebar-search-list-element',
   templateUrl: './sidebar-search-list-element.component.html'
 })
+/**
+ * Component displaying a list element for a {@link SearchResult} in the sidebar search modal
+ * It displays the name of the parent, title and description of the object. All of which are customizable in the child
+ * component by overriding the relevant methods of this component
+ */
 export class SidebarSearchListElementComponent<T extends SearchResult<K>, K extends DSpaceObject> extends SearchResultListElementComponent<T, K> {
+  /**
+   * Observable for the title of the parent object (displayed above the object's title)
+   */
   parentTitle$: Observable<string>;
+
+  /**
+   * The title for the object to display
+   */
   title: string;
+
+  /**
+   * A description to display below the title
+   */
   description: string;
 
   public constructor(protected truncatableService: TruncatableService,
@@ -25,6 +42,9 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
     super(truncatableService);
   }
 
+  /**
+   * Initialise the component variables
+   */
   ngOnInit(): void {
     super.ngOnInit();
     if (hasValue(this.dso)) {
@@ -34,23 +54,92 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
     }
   }
 
+  /**
+   * Get the title of the object's parent
+   * Retrieve the parent by using the object's parent link and retrieving its 'dc.title' metadata
+   */
+  getParentTitle(): Observable<string> {
+    return this.getParent().pipe(
+      map((parentRD: RemoteData<DSpaceObject>) => {
+        return parentRD ? parentRD.payload.firstMetadataValue('dc.title') : undefined;
+      })
+    );
+  }
+
+  /**
+   * Get the parent of the object
+   */
+  getParent(): Observable<RemoteData<DSpaceObject>> {
+    if (typeof (this.dso as any).getParentLinkKey === 'function') {
+      const propertyName = (this.dso as any).getParentLinkKey();
+      return this.linkService.resolveLink(this.dso, followLink(propertyName))[propertyName].pipe(
+        find((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => parentRD.hasSucceeded || parentRD.statusCode === 204)
+      );
+    }
+    return observableOf(undefined);
+  }
+
+  /**
+   * Get the title of the object
+   * Default: "dc.title"
+   */
   getTitle(): string {
     return this.firstMetadataValue('dc.title');
   }
 
+  /**
+   * Get the description of the object
+   * Default: "(dc.publisher, dc.date.issued) authors"
+   */
   getDescription(): string {
-    // TODO: Expand description
-    return this.firstMetadataValue('dc.publisher');
+    const publisher = this.firstMetadataValue('dc.publisher');
+    const date = this.firstMetadataValue('dc.date.issued');
+    const authors = this.allMetadataValues(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']);
+    let description = '';
+    if (isNotEmpty(publisher) || isNotEmpty(date)) {
+      description += '(';
+    }
+    if (isNotEmpty(publisher)) {
+      description += publisher;
+    }
+    if (isNotEmpty(date)) {
+      if (isNotEmpty(publisher)) {
+        description += ', ';
+      }
+      description += date;
+    }
+    if (isNotEmpty(description)) {
+      description += ') ';
+    }
+    if (isNotEmpty(authors)) {
+      authors.forEach((author, i) => {
+        description += author;
+        if (i < (authors.length - 1)) {
+          description += '; ';
+        }
+      });
+    }
+    return this.undefinedIfEmpty(description);
   }
 
-  getParentTitle(): Observable<string> {
-    // TODO: Remove cast to "any" and replace with proper type-check
-    const propertyName = (this.dso as any).getParentLinkKey();
-    return this.linkService.resolveLink(this.dso, followLink(propertyName))[propertyName].pipe(
-      find((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => parentRD.hasSucceeded || parentRD.statusCode === 204),
-      map((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => {
-        return parentRD.payload.firstMetadataValue('dc.title');
-      })
-    );
+  /**
+   * Return undefined if the provided string is empty
+   * @param value Value to check
+   */
+  undefinedIfEmpty(value: string) {
+    return this.defaultIfEmpty(value, undefined);
+  }
+
+  /**
+   * Return a default value if the provided string is empty
+   * @param value Value to check
+   * @param def   Default in case value is empty
+   */
+  defaultIfEmpty(value: string, def: string) {
+    if (isNotEmpty(value)) {
+      return value;
+    } else {
+      return def;
+    }
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -210,6 +210,8 @@ import { CollectionDropdownComponent } from './collection-dropdown/collection-dr
 import { DsSelectComponent } from './ds-select/ds-select.component';
 import { VocabularyTreeviewComponent } from './vocabulary-treeview/vocabulary-treeview.component';
 import { CurationFormComponent } from '../curation-form/curation-form.component';
+import { PublicationSidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component';
+import { SidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/sidebar-search-list-element.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -483,7 +485,9 @@ const ENTRY_COMPONENTS = [
   CurationFormComponent,
   ExportMetadataSelectorComponent,
   ConfirmationModalComponent,
-  VocabularyTreeviewComponent
+  VocabularyTreeviewComponent,
+  SidebarSearchListElementComponent,
+  PublicationSidebarSearchListElementComponent,
 ];
 
 const SHARED_ITEM_PAGE_COMPONENTS = [

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -216,6 +216,7 @@ import { CollectionSidebarSearchListElementComponent } from './object-list/sideb
 import { CommunitySidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component';
 import { AuthorizedCollectionSelectorComponent } from './dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component';
 import { DsoPageEditButtonComponent } from './dso-page/dso-page-edit-button/dso-page-edit-button.component';
+import { HoverClassDirective } from './hover-class.directive';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -501,6 +502,7 @@ const ENTRY_COMPONENTS = [
 const SHARED_ITEM_PAGE_COMPONENTS = [
   MetadataFieldWrapperComponent,
   MetadataValuesComponent,
+  DsoPageEditButtonComponent
 ];
 
 const PROVIDERS = [
@@ -531,7 +533,8 @@ const DIRECTIVES = [
   FileValidator,
   ClaimedTaskActionsDirective,
   NgForTrackByIdDirective,
-  MetadataFieldValidator
+  MetadataFieldValidator,
+  HoverClassDirective
 ];
 
 @NgModule({
@@ -545,7 +548,6 @@ const DIRECTIVES = [
     ...DIRECTIVES,
     ...ENTRY_COMPONENTS,
     ...SHARED_ITEM_PAGE_COMPONENTS,
-    DsoPageEditButtonComponent
   ],
   providers: [
     ...PROVIDERS
@@ -556,8 +558,7 @@ const DIRECTIVES = [
         ...COMPONENTS,
         ...SHARED_ITEM_PAGE_COMPONENTS,
         ...DIRECTIVES,
-        CurationFormComponent,
-        DsoPageEditButtonComponent
+        CurationFormComponent
     ],
   entryComponents: [
     ...ENTRY_COMPONENTS

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -212,6 +212,9 @@ import { VocabularyTreeviewComponent } from './vocabulary-treeview/vocabulary-tr
 import { CurationFormComponent } from '../curation-form/curation-form.component';
 import { PublicationSidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/item-types/publication/publication-sidebar-search-list-element.component';
 import { SidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/sidebar-search-list-element.component';
+import { CollectionSidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component';
+import { CommunitySidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component';
+import { AuthorizedCollectionSelectorComponent } from './dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -405,7 +408,8 @@ const COMPONENTS = [
   CollectionDropdownComponent,
   ExportMetadataSelectorComponent,
   ConfirmationModalComponent,
-  VocabularyTreeviewComponent
+  VocabularyTreeviewComponent,
+  AuthorizedCollectionSelectorComponent,
 ];
 
 const ENTRY_COMPONENTS = [
@@ -488,6 +492,9 @@ const ENTRY_COMPONENTS = [
   VocabularyTreeviewComponent,
   SidebarSearchListElementComponent,
   PublicationSidebarSearchListElementComponent,
+  CollectionSidebarSearchListElementComponent,
+  CommunitySidebarSearchListElementComponent,
+  AuthorizedCollectionSelectorComponent,
 ];
 
 const SHARED_ITEM_PAGE_COMPONENTS = [

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -215,6 +215,7 @@ import { SidebarSearchListElementComponent } from './object-list/sidebar-search-
 import { CollectionSidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component';
 import { CommunitySidebarSearchListElementComponent } from './object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component';
 import { AuthorizedCollectionSelectorComponent } from './dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component';
+import { DsoPageEditButtonComponent } from './dso-page/dso-page-edit-button/dso-page-edit-button.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -543,19 +544,21 @@ const DIRECTIVES = [
     ...COMPONENTS,
     ...DIRECTIVES,
     ...ENTRY_COMPONENTS,
-    ...SHARED_ITEM_PAGE_COMPONENTS
+    ...SHARED_ITEM_PAGE_COMPONENTS,
+    DsoPageEditButtonComponent
   ],
   providers: [
     ...PROVIDERS
   ],
-  exports: [
-    ...MODULES,
-    ...PIPES,
-    ...COMPONENTS,
-    ...SHARED_ITEM_PAGE_COMPONENTS,
-    ...DIRECTIVES,
-    CurationFormComponent
-  ],
+    exports: [
+        ...MODULES,
+        ...PIPES,
+        ...COMPONENTS,
+        ...SHARED_ITEM_PAGE_COMPONENTS,
+        ...DIRECTIVES,
+        CurationFormComponent,
+        DsoPageEditButtonComponent
+    ],
   entryComponents: [
     ...ENTRY_COMPONENTS
   ]

--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
@@ -1,4 +1,4 @@
-<div class="clamp-{{lines}} min-{{minLines}} {{type}} {{fixedHeight ? 'fixedHeight' : ''}}">
+<div class="clamp-{{background}}-{{lines}} min-{{minLines}} {{type}} {{fixedHeight ? 'fixedHeight' : ''}}">
     <div class="content">
         <ng-content></ng-content>
     </div>

--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.scss
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.scss
@@ -1,4 +1,4 @@
-@mixin clamp($lines, $size-factor: 1, $line-height: $line-height-base) {
+@mixin clamp($lines, $bg, $size-factor: 1, $line-height: $line-height-base) {
     $height: $line-height * $font-size-base * $size-factor;
     &.fixedHeight {
         height: $lines * $height;
@@ -19,10 +19,11 @@
             min-width: 75px;
             max-width: 150px;
             height: $height;
-            background: linear-gradient(to right, rgba(255, 255, 255, 0), $body-bg 70%);
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), $bg 70%);
             pointer-events: none;
         }
     }
+
 }
 
 @mixin min($lines, $size-factor: 1, $line-height: $line-height-base) {
@@ -31,16 +32,32 @@
 }
 
 $h4-factor: strip-unit($h4-font-size);
+
+@mixin clamp-with-titles($i, $bg) {
+  transition: height 1s;
+  @include clamp($i, $bg);
+  &.title {
+    @include clamp($i, $bg, 1.25);
+  }
+  &.h4 {
+    @include clamp($i, $bg, $h4-factor, $headings-line-height);
+  }
+}
+
 @for $i from 1 through 15 {
-    .clamp-#{$i} {
-        transition: height 1s;
-        @include clamp($i);
-        &.title {
-            @include clamp($i, 1.25);
-        }
-        &.h4 {
-            @include clamp($i, $h4-factor, $headings-line-height);
-        }
+    .clamp-default-#{$i} {
+        @include clamp-with-titles($i, $body-bg);
+    }
+    :host-context(.ds-hover) .clamp-default-#{$i} {
+        @include clamp-with-titles($i, $list-group-hover-bg);
+    }
+
+    .clamp-primary-#{$i} {
+      @include clamp-with-titles($i, $primary);
+    }
+
+    :host-context(.ds-hover) .clamp-primary-#{$i} {
+      @include clamp-with-titles($i, darken($primary, 10%));
     }
 }
 

--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.ts
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.ts
@@ -38,6 +38,8 @@ export class TruncatablePartComponent implements OnInit, OnDestroy {
    */
   @Input() fixedHeight = false;
 
+  @Input() background = 'default';
+
   /**
    * Current amount of lines shown of this part
    */

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2194,6 +2194,8 @@
 
   "person.listelement.badge": "Person",
 
+  "person.listelement.no-title": "No name found",
+
   "person.page.birthdate": "Birth Date",
 
   "person.page.email": "Email Address",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1254,6 +1254,8 @@
 
   "home.description": "",
 
+  "home.breadcrumbs": "Home",
+
   "home.title": "DSpace Angular :: Home",
 
   "home.top-level-communities.head": "Communities in DSpace",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -764,6 +764,8 @@
 
   "collection.page.browse.recent.empty": "No items to show",
 
+  "collection.page.edit": "Edit this collection",
+
   "collection.page.handle": "Permanent URI for this collection",
 
   "collection.page.license": "License",
@@ -926,6 +928,8 @@
   "community.form.tableofcontents": "News (HTML)",
 
   "community.form.title": "Name",
+
+  "community.page.edit": "Edit this community",
 
   "community.page.handle": "Permanent URI for this community",
 
@@ -1676,6 +1680,8 @@
 
   "item.page.date": "Date",
 
+  "item.page.edit": "Edit this item",
+
   "item.page.files": "Files",
 
   "item.page.filesection.description": "Description:",
@@ -1782,6 +1788,8 @@
 
   "journal.page.description": "Description",
 
+  "journal.page.edit": "Edit this item",
+
   "journal.page.editor": "Editor-in-Chief",
 
   "journal.page.issn": "ISSN",
@@ -1800,6 +1808,8 @@
 
   "journalissue.page.description": "Description",
 
+  "journalissue.page.edit": "Edit this item",
+
   "journalissue.page.issuedate": "Issue Date",
 
   "journalissue.page.journal-issn": "Journal ISSN",
@@ -1817,6 +1827,8 @@
   "journalvolume.listelement.badge": "Journal Volume",
 
   "journalvolume.page.description": "Description",
+
+  "journalvolume.page.edit": "Edit this item",
 
   "journalvolume.page.issuedate": "Issue Date",
 
@@ -2180,6 +2192,8 @@
 
   "orgunit.page.description": "Description",
 
+  "orgunit.page.edit": "Edit this item",
+
   "orgunit.page.id": "ID",
 
   "orgunit.page.titleprefix": "Organizational Unit: ",
@@ -2201,6 +2215,8 @@
   "person.listelement.no-title": "No name found",
 
   "person.page.birthdate": "Birth Date",
+
+  "person.page.edit": "Edit this item",
 
   "person.page.email": "Email Address",
 
@@ -2433,6 +2449,8 @@
 
   "project.page.description": "Description",
 
+  "project.page.edit": "Edit this item",
+
   "project.page.expectedcompletion": "Expected Completion",
 
   "project.page.funder": "Funders",
@@ -2452,6 +2470,8 @@
   "publication.listelement.badge": "Publication",
 
   "publication.page.description": "Description",
+
+  "publication.page.edit": "Edit this item",
 
   "publication.page.journal-issn": "Journal ISSN",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1037,6 +1037,8 @@
 
   "dso-selector.create.collection.head": "New collection",
 
+  "dso-selector.create.collection.sub-level": "Create a new collection in",
+
   "dso-selector.create.community.head": "New community",
 
   "dso-selector.create.community.sub-level": "Create a new community in",
@@ -1044,6 +1046,8 @@
   "dso-selector.create.community.top-level": "Create a new top-level community",
 
   "dso-selector.create.item.head": "New item",
+
+  "dso-selector.create.item.sub-level": "Create a new item in",
 
   "dso-selector.create.submission.head": "New submission",
 

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -39,3 +39,5 @@ $edit-item-language-field-width: 43px !default;
 $thumbnail-max-width: 175px !default;
 
 $dso-selector-list-max-height: 475px !default;
+$dso-selector-current-background-color: #eeeeee;
+$dso-selector-current-background-hover-color: darken($dso-selector-current-background-color, 10%);

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -37,3 +37,5 @@ $edit-item-metadata-field-width: 190px !default;
 $edit-item-language-field-width: 43px !default;
 
 $thumbnail-max-width: 175px !default;
+
+$dso-selector-list-max-height: 475px !default;


### PR DESCRIPTION
## References
This PR:
- fixes #831
- fixes #843 
- fixes #889
- fixes #890

## Description
This PR improves the modals to search for objects using the sidebar functions like create/edit item/collection/community etc.
It also adds a button to every item/collection/community page linking to the object's edit page for easy accessibility (only when the user is logged in and has edit permissions)

## Instructions for Reviewers

When opening a modal to edit/create an object:
- If the modal is accessed from a DSpaceObject's page (e.g. an item page), that object will by default show up on top of the search results (until the user starts typing a search query). I'll be referring to this object as the "current object" throughout this PR.
- The listed objects now contain a custom template defined by annotation @listableObjectComponent with context SideBarSearchModal (for any listed item that is not the current object) and SideBarSearchModalCurrent (for the listed item that is the current object)
- All of the current objects will use the template `sidebar-search-list-element.component.html`, which displays 3 lines of text for each object:
-- The title of the object's parent
-- The title of the object itself
-- A description of the object
-- All of the above are customisable by overwriting the parent component (`SidebarSearchListElementComponent`)'s getters: `getParentTitle()`, `getTitle()` and `getDescription()`
- The current object is highlighted by default (a custom template can be created using context SideBarSearchModalCurrent)
- The list is infinitely scrollable. It will load new results when scrolling down with a page size of 10 until there are no more.
- For new item and collection, a header has been added explaining what the user is searching for

Upon visiting an item/collection/community's page:
- When anonymous, it should look exactly the same as before
- When logged in as a user that has edit items for said object, it should display a button on the top right of the page, linking to the object's edit page for easy access

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

This PR has more than 1,000 lines of code mostly because I had to create a new template for each DSO and entity type. All of these templates are very similar.

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
