### PR TITLE
Submission relationship lookup externalsources: Missing i18n labels & other issues

### DIFF
--- a/src/app/core/data/lookup-relation.service.ts
+++ b/src/app/core/data/lookup-relation.service.ts
@@ -1,6 +1,6 @@
 import { ExternalSourceService } from './external-source.service';
 import { SearchService } from '../shared/search/search.service';
-import { concat, map, multicast, startWith, take, takeWhile } from 'rxjs/operators';
+import { concat, distinctUntilChanged, map, multicast, startWith, take, takeWhile } from 'rxjs/operators';
 import { PaginatedSearchOptions } from '../../shared/search/paginated-search-options.model';
 import { ReplaySubject } from 'rxjs/internal/ReplaySubject';
 import { RemoteData } from './remote-data';
@@ -91,7 +91,8 @@ export class LookupRelationService {
       getAllSucceededRemoteData(),
       getRemoteDataPayload(),
       map((results: PaginatedList<ExternalSourceEntry>) => results.totalElements),
-      startWith(0)
+      startWith(0),
+      distinctUntilChanged()
     );
   }
 

--- a/src/app/entity-groups/research-entities/submission/item-list-elements/external-source-entry/external-source-entry-list-submission-element.component.ts
+++ b/src/app/entity-groups/research-entities/submission/item-list-elements/external-source-entry/external-source-entry-list-submission-element.component.ts
@@ -7,6 +7,7 @@ import { Component, OnInit } from '@angular/core';
 import { Metadata } from '../../../../../core/shared/metadata.utils';
 import { MetadataValue } from '../../../../../core/shared/metadata.models';
 
+@listableObjectComponent(ExternalSourceEntry, ViewMode.ListElement, Context.EntitySearchModal)
 @listableObjectComponent(ExternalSourceEntry, ViewMode.ListElement, Context.EntitySearchModalWithNameVariants)
 @Component({
   selector: 'ds-external-source-entry-list-submission-element',

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -407,7 +407,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     modalComp.repeatable = this.model.repeatable;
     modalComp.listId = this.listId;
     modalComp.relationshipOptions = this.model.relationship;
-    modalComp.label = this.model.label;
+    modalComp.label = this.model.relationship.relationshipType;
     modalComp.metadataFields = this.model.metadataFields;
     modalComp.item = this.item;
     modalComp.collection = this.collection;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -233,7 +233,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
 
     this.totalExternal$ = externalSourcesAndOptions$.pipe(
       switchMap(([sources, options]) =>
-        observableZip(...sources.page.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
+        combineLatest(...sources.page.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
     );
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
-import { combineLatest, Observable, Subscription, zip as observableZip } from 'rxjs';
+import { combineLatest as observableCombineLatest, Observable, Subscription } from 'rxjs';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { hasValue } from '../../../../empty.util';
 import { map, skip, switchMap, take } from 'rxjs/operators';
@@ -157,7 +157,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   select(...selectableObjects: Array<SearchResult<Item>>) {
     this.zone.runOutsideAngular(
       () => {
-        const obs: Observable<any[]> = combineLatest(...selectableObjects.map((sri: SearchResult<Item>) => {
+        const obs: Observable<any[]> = observableCombineLatest(...selectableObjects.map((sri: SearchResult<Item>) => {
             this.addNameVariantSubscription(sri);
             return this.relationshipService.getNameVariant(this.listId, sri.indexableObject.uuid)
               .pipe(
@@ -223,7 +223,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
       switchMap((options) => this.lookupRelationService.getTotalLocalResults(this.relationshipOptions, options))
     );
 
-    const externalSourcesAndOptions$ = combineLatest(
+    const externalSourcesAndOptions$ = observableCombineLatest(
       this.externalSourcesRD$.pipe(
         getAllSucceededRemoteData(),
         getRemoteDataPayload()
@@ -233,7 +233,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
 
     this.totalExternal$ = externalSourcesAndOptions$.pipe(
       switchMap(([sources, options]) =>
-        combineLatest(...sources.page.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
+        observableCombineLatest(...sources.page.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
     );
   }
 

--- a/src/app/shared/object-collection/shared/importable-list-item-control/importable-list-item-control.component.html
+++ b/src/app/shared/object-collection/shared/importable-list-item-control/importable-list-item-control.component.html
@@ -1,4 +1,4 @@
-<div class="d-inline-block mr-2">
+<div class="mr-2">
   <button (click)="importObject.emit(object)"
           class="btn btn-outline-primary btn-sm float-left"
           title="{{importConfig?.buttonLabel | translate}}">

--- a/src/app/shared/object-list/object-list.component.html
+++ b/src/app/shared/object-list/object-list.component.html
@@ -12,20 +12,16 @@
         (sortFieldChange)="onSortFieldChange($event)"
         (paginationChange)="onPaginationChange($event)">
     <ul *ngIf="objects?.hasSucceeded" class="list-unstyled" [ngClass]="{'ml-4': selectable}">
-        <li *ngFor="let object of objects?.payload?.page; let i = index; let last = last" class="mt-4 mb-4" [class.border-bottom]="hasBorder && !last">
-          <span *ngIf="selectable">
-                   <ds-selectable-list-item-control [index]="i"
-                                                    [object]="object"
-                                                    [selectionConfig]="selectionConfig"
-                                                    (deselectObject)="deselectObject.emit($event)"
-                                                    (selectObject)="selectObject.emit($event)"></ds-selectable-list-item-control>
-              </span>
-          <span *ngIf="importable">
-            <ds-importable-list-item-control  [object]="object"
-                                              [importConfig]="importConfig"
-                                              (importObject)="importObject.emit($event)"></ds-importable-list-item-control>
-          </span>
-            <ds-listable-object-component-loader [object]="object" [viewMode]="viewMode" [index]="i" [context]="context" [linkType]="linkType"
+        <li *ngFor="let object of objects?.payload?.page; let i = index; let last = last" class="mt-4 mb-4 d-flex" [class.border-bottom]="hasBorder && !last">
+          <ds-selectable-list-item-control *ngIf="selectable" [index]="i"
+                                           [object]="object"
+                                           [selectionConfig]="selectionConfig"
+                                           (deselectObject)="deselectObject.emit($event)"
+                                           (selectObject)="selectObject.emit($event)"></ds-selectable-list-item-control>
+          <ds-importable-list-item-control *ngIf="importable" [object]="object"
+                                           [importConfig]="importConfig"
+                                           (importObject)="importObject.emit($event)"></ds-importable-list-item-control>
+          <ds-listable-object-component-loader [object]="object" [viewMode]="viewMode" [index]="i" [context]="context" [linkType]="linkType"
                                                  [listID]="selectionConfig?.listId"></ds-listable-object-component-loader>
         </li>
     </ul>

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2952,7 +2952,7 @@
 
   "submission.sections.describe.relationship-lookup.external-source.added": "Successfully added local entry to the selection",
 
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Author": "Import remote author",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Import remote author",
 
   "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Import remote journal",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2960,11 +2960,11 @@
 
   "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Import remote journal volume",
 
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Author.title": "Import Remote Author",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Import Remote Author",
 
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Author.added.local-entity": "Successfully added local author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Successfully added local author to the selection",
 
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Author.added.new-entity": "Successfully imported and added external author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Successfully imported and added external author to the selection",
 
   "submission.sections.describe.relationship-lookup.external-source.import-modal.authority": "Authority",
 
@@ -2985,6 +2985,10 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Importing from Sherpa Journal",
 
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaPublisher": "Importing from Sherpa Publisher",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Importing from PubMed",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Importing from arXiv",
 
   "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
 
@@ -3040,6 +3044,10 @@
 
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "LC Names ({{ count }})",
 
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.pubmed": "PubMed ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.arxiv": "arXiv ({{ count }})",
+
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Search for Funding Agencies",
 
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Search for Funding",
@@ -3093,6 +3101,8 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Search Results",
 
   "submission.sections.describe.relationship-lookup.selection-tab.title.pubmed": "Search Results",
+
+  "submission.sections.describe.relationship-lookup.selection-tab.title.arxiv": "Search Results",
 
   "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Would you like to save \"{{ value }}\" as a name variant for this person so you and others can reuse it for future submissions? If you don\'t you can still use it for this submission.",
 


### PR DESCRIPTION
## References
https://github.com/DSpace/dspace-angular/issues/867

## Description
This PR adds the missing labels mentioned in https://github.com/DSpace/dspace-angular/issues/867 .

It also solves an issue that the search result list items for the external sources (ex PubMed) were not rendering in the lookup Author modal during submission. Cause was that there was no @listableObjectComponent for the case that there were *no* name variants configured.

  Lastly, it solves an issue that the count of number of results in sources tab wasn’t updating (remained on (0)) for the external sources.

## Instructions for Reviewers
Submission => Author lookup => External source tab like PubMed/arXiv

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
