### PR TITLE
Fix for handle redirects

### DIFF
--- a/src/app/core/data/dso-redirect-data.service.ts
+++ b/src/app/core/data/dso-redirect-data.service.ts
@@ -11,7 +11,6 @@ import { RemoteDataBuildService } from '../cache/builders/remote-data-build.serv
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { CoreState } from '../core.reducers';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
-import { getFinishedRemoteData } from '../shared/operators';
 import { DataService } from './data.service';
 import { DSOChangeAnalyzer } from './dso-change-analyzer.service';
 import { RemoteData } from './remote-data';

--- a/src/app/core/data/dso-redirect-data.service.ts
+++ b/src/app/core/data/dso-redirect-data.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { take, tap } from 'rxjs/operators';
+import { filter, take, tap } from 'rxjs/operators';
 import { hasValue } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
@@ -56,7 +56,7 @@ export class DsoRedirectDataService extends DataService<any> {
   findByIdAndIDType(id: string, identifierType = IdentifierType.UUID): Observable<RemoteData<FindByIDRequest>> {
     this.setLinkPath(identifierType);
     return this.findById(id).pipe(
-      getFinishedRemoteData(),
+      filter((response) => hasValue(response.error) || hasValue(response.payload)),
       take(1),
       tap((response) => {
         if (response.hasSucceeded) {


### PR DESCRIPTION
## Reference
This PR refers to issue [#833](https://github.com/DSpace/dspace-angular/issues/883).

## Description
This PR fixes the issue where navigation to a handle page (Example: http://localhost:4000/handle/10673/1490) fails.

## Instructions for Reviewers
To test that the handle redirect works, perform the following steps:
* Navigate to a handle page that corresponds to an item in the repository. The aforementioned example can be used when using the default 4science backend.
* Verify that you get redirected to the corresponding item. When using the aforementioned item, this should resolve to the item with id 17307a98-0e78-45a6-83c3-7829eee024c6.
* Navigate to an invalid handle.
* Verify that you get redirected to the "No item found for the identifier" page.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
