### PR TITLE
Metadata identifier for Communities and Collections 

### DIFF
--- a/src/app/+collection-page/edit-collection-page/collection-curate/collection-curate.component.spec.ts
+++ b/src/app/+collection-page/edit-collection-page/collection-curate/collection-curate.component.spec.ts
@@ -17,7 +17,7 @@ describe('CollectionCurateComponent', () => {
   let dsoNameService;
 
   const collection = Object.assign(new Collection(), {
-    handle: '123456789/1', metadata: {'dc.title': ['Collection Name']}
+    metadata: {'dc.title': ['Collection Name'], 'dc.identifier.uri': [ { value: '123456789/1'}]}
   });
 
   beforeEach(async(() => {

--- a/src/app/+community-page/edit-community-page/community-curate/community-curate.component.spec.ts
+++ b/src/app/+community-page/edit-community-page/community-curate/community-curate.component.spec.ts
@@ -17,7 +17,7 @@ describe('CommunityCurateComponent', () => {
   let dsoNameService;
 
   const community = Object.assign(new Community(), {
-    handle: '123456789/1', metadata: {'dc.title': ['Community Name']}
+    metadata: {'dc.title': ['Community Name'], 'dc.identifier.uri': [ { value: '123456789/1'}]}
   });
 
   beforeEach(async(() => {

--- a/src/app/core/shared/collection.model.spec.ts
+++ b/src/app/core/shared/collection.model.spec.ts
@@ -1,8 +1,8 @@
 import {Collection} from './collection.model';
 
-fdescribe('Collection', () => {
+describe('Collection', () => {
 
-  fdescribe('Collection handle value',  () => {
+  describe('Collection handle value',  () => {
 
     let metadataValue;
     let handleValue;

--- a/src/app/core/shared/collection.model.spec.ts
+++ b/src/app/core/shared/collection.model.spec.ts
@@ -1,0 +1,31 @@
+import {Collection} from './collection.model';
+
+fdescribe('Collection', () => {
+
+  fdescribe('Collection handle value',  () => {
+
+    let metadataValue;
+    let handleValue;
+
+    beforeEach(() => {
+      metadataValue = {'dc.identifier.uri': [ { value: '123456789/1'}]};
+      handleValue = '11111111111/1';
+    })
+
+    it('should return the handle value from metadata', () => {
+      const community = Object.assign(new Collection(), { metadata: metadataValue });
+      expect(community.handle).toEqual('123456789/1');
+    });
+
+    it('should return the handle value from metadata even when the handle field is provided', () => {
+      const community = Object.assign(new Collection(), { handle: handleValue, metadata: metadataValue });
+      expect(community.handle).toEqual('123456789/1');
+    });
+
+    it('should return undefined if the handle value from metadata is not present', () => {
+      const community = Object.assign(new Collection(), { handle: handleValue });
+      expect(community.handle).toEqual(undefined);
+    });
+  });
+
+});

--- a/src/app/core/shared/collection.model.spec.ts
+++ b/src/app/core/shared/collection.model.spec.ts
@@ -5,11 +5,9 @@ describe('Collection', () => {
   describe('Collection handle value',  () => {
 
     let metadataValue;
-    let handleValue;
 
     beforeEach(() => {
       metadataValue = {'dc.identifier.uri': [ { value: '123456789/1'}]};
-      handleValue = '11111111111/1';
     })
 
     it('should return the handle value from metadata', () => {
@@ -17,13 +15,8 @@ describe('Collection', () => {
       expect(community.handle).toEqual('123456789/1');
     });
 
-    it('should return the handle value from metadata even when the handle field is provided', () => {
-      const community = Object.assign(new Collection(), { handle: handleValue, metadata: metadataValue });
-      expect(community.handle).toEqual('123456789/1');
-    });
-
     it('should return undefined if the handle value from metadata is not present', () => {
-      const community = Object.assign(new Collection(), { handle: handleValue });
+      const community = Object.assign(new Collection(), { });
       expect(community.handle).toEqual(undefined);
     });
   });

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -1,4 +1,4 @@
-import { autoserialize, deserialize, inheritSerialization } from 'cerialize';
+import { autoserialize, deserialize, deserializeAs, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';
@@ -15,17 +15,16 @@ import { RESOURCE_POLICY } from '../resource-policy/models/resource-policy.resou
 import { COMMUNITY } from './community.resource-type';
 import { Community } from './community.model';
 import { ChildHALResource } from './child-hal-resource.model';
+import { excludeFromEquals } from '../utilities/equals.decorators';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Collection extends DSpaceObject implements ChildHALResource {
   static type = COLLECTION;
 
-  /**
-   * A string representing the unique handle of this Collection
-   */
-  @autoserialize
-  handle: string;
+  @excludeFromEquals
+  @deserializeAs('handle')
+  private _handle: string;
 
   /**
    * The {@link HALLink}s for this Collection
@@ -75,6 +74,18 @@ export class Collection extends DSpaceObject implements ChildHALResource {
   @link(COMMUNITY, false)
   parentCommunity?: Observable<RemoteData<Community>>;
 
+  /**
+   * A string representing the unique handle of this Collection
+   */
+  get handle(): string {
+    const metadataValue = this.firstMetadataValue('dc.identifier.uri');
+    return metadataValue ? metadataValue : this._handle;
+  }
+
+  set handle(value: string) {
+    this._handle = value;
+  }
+  
   /**
    * The introductory text of this Collection
    * Corresponds to the metadata field dc.description

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -1,4 +1,4 @@
-import { autoserialize, deserialize, deserializeAs, inheritSerialization } from 'cerialize';
+import { deserialize, deserializeAs, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -78,14 +78,13 @@ export class Collection extends DSpaceObject implements ChildHALResource {
    * A string representing the unique handle of this Collection
    */
   get handle(): string {
-    const metadataValue = this.firstMetadataValue('dc.identifier.uri');
-    return metadataValue ? metadataValue : this._handle;
+    return this.firstMetadataValue('dc.identifier.uri');
   }
 
   set handle(value: string) {
     this._handle = value;
   }
-  
+
   /**
    * The introductory text of this Collection
    * Corresponds to the metadata field dc.description

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -1,4 +1,4 @@
-import { deserialize, deserializeAs, inheritSerialization } from 'cerialize';
+import { deserialize, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';
@@ -15,16 +15,11 @@ import { RESOURCE_POLICY } from '../resource-policy/models/resource-policy.resou
 import { COMMUNITY } from './community.resource-type';
 import { Community } from './community.model';
 import { ChildHALResource } from './child-hal-resource.model';
-import { excludeFromEquals } from '../utilities/equals.decorators';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Collection extends DSpaceObject implements ChildHALResource {
   static type = COLLECTION;
-
-  @excludeFromEquals
-  @deserializeAs('handle')
-  private _handle: string;
 
   /**
    * The {@link HALLink}s for this Collection
@@ -79,10 +74,6 @@ export class Collection extends DSpaceObject implements ChildHALResource {
    */
   get handle(): string {
     return this.firstMetadataValue('dc.identifier.uri');
-  }
-
-  set handle(value: string) {
-    this._handle = value;
   }
 
   /**

--- a/src/app/core/shared/community.model.spec.ts
+++ b/src/app/core/shared/community.model.spec.ts
@@ -1,0 +1,31 @@
+import {Community} from './community.model';
+
+fdescribe('Community', () => {
+
+  fdescribe('Community handle value',  () => {
+
+    let metadataValue;
+    let handleValue;
+
+    beforeEach(() => {
+      metadataValue = {'dc.identifier.uri': [ { value: '123456789/1'}]};
+      handleValue = '11111111111/1';
+    })
+
+    it('should return the handle value from metadata', () => {
+      const community = Object.assign(new Community(), { metadata: metadataValue });
+      expect(community.handle).toEqual('123456789/1');
+    });
+
+    it('should return the handle value from metadata even when the handle field is provided', () => {
+      const community = Object.assign(new Community(), { handle: handleValue, metadata: metadataValue });
+      expect(community.handle).toEqual('123456789/1');
+    });
+
+    it('should return undefined if the handle value from metadata is not present', () => {
+      const community = Object.assign(new Community(), { handle: handleValue });
+      expect(community.handle).toEqual(undefined);
+    });
+  });
+
+});

--- a/src/app/core/shared/community.model.spec.ts
+++ b/src/app/core/shared/community.model.spec.ts
@@ -5,11 +5,9 @@ describe('Community', () => {
   describe('Community handle value',  () => {
 
     let metadataValue;
-    let handleValue;
 
     beforeEach(() => {
       metadataValue = {'dc.identifier.uri': [ { value: '123456789/1'}]};
-      handleValue = '11111111111/1';
     })
 
     it('should return the handle value from metadata', () => {
@@ -17,13 +15,8 @@ describe('Community', () => {
       expect(community.handle).toEqual('123456789/1');
     });
 
-    it('should return the handle value from metadata even when the handle field is provided', () => {
-      const community = Object.assign(new Community(), { handle: handleValue, metadata: metadataValue });
-      expect(community.handle).toEqual('123456789/1');
-    });
-
     it('should return undefined if the handle value from metadata is not present', () => {
-      const community = Object.assign(new Community(), { handle: handleValue });
+      const community = Object.assign(new Community(), { });
       expect(community.handle).toEqual(undefined);
     });
   });

--- a/src/app/core/shared/community.model.spec.ts
+++ b/src/app/core/shared/community.model.spec.ts
@@ -1,8 +1,8 @@
 import {Community} from './community.model';
 
-fdescribe('Community', () => {
+describe('Community', () => {
 
-  fdescribe('Community handle value',  () => {
+  describe('Community handle value',  () => {
 
     let metadataValue;
     let handleValue;

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -1,4 +1,4 @@
-import { autoserialize, deserialize, deserializeAs, inheritSerialization } from 'cerialize';
+import { deserialize, deserializeAs, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -1,4 +1,4 @@
-import { autoserialize, deserialize, inheritSerialization } from 'cerialize';
+import { autoserialize, deserialize, deserializeAs, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';
@@ -11,17 +11,16 @@ import { COMMUNITY } from './community.resource-type';
 import { DSpaceObject } from './dspace-object.model';
 import { HALLink } from './hal-link.model';
 import { ChildHALResource } from './child-hal-resource.model';
+import { excludeFromEquals } from '../utilities/equals.decorators';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Community extends DSpaceObject implements ChildHALResource {
   static type = COMMUNITY;
 
-  /**
-   * A string representing the unique handle of this Community
-   */
-  @autoserialize
-  handle: string;
+  @excludeFromEquals
+  @deserializeAs('handle')
+  private _handle: string;
 
   /**
    * The {@link HALLink}s for this Community
@@ -63,6 +62,18 @@ export class Community extends DSpaceObject implements ChildHALResource {
    */
   @link(COMMUNITY, false)
   parentCommunity?: Observable<RemoteData<Community>>;
+
+  /**
+   * A string representing the unique handle of this Community
+   */
+  get handle(): string {
+    const metadataValue = this.firstMetadataValue('dc.identifier.uri');
+    return metadataValue ? metadataValue : this._handle;
+  }
+
+  set handle(value: string) {
+    this._handle = value;
+  }
 
   /**
    * The introductory text of this Community

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -1,4 +1,4 @@
-import { deserialize, deserializeAs, inheritSerialization } from 'cerialize';
+import { deserialize, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../cache/builders/build-decorators';
 import { PaginatedList } from '../data/paginated-list';
@@ -11,16 +11,11 @@ import { COMMUNITY } from './community.resource-type';
 import { DSpaceObject } from './dspace-object.model';
 import { HALLink } from './hal-link.model';
 import { ChildHALResource } from './child-hal-resource.model';
-import { excludeFromEquals } from '../utilities/equals.decorators';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Community extends DSpaceObject implements ChildHALResource {
   static type = COMMUNITY;
-
-  @excludeFromEquals
-  @deserializeAs('handle')
-  private _handle: string;
 
   /**
    * The {@link HALLink}s for this Community
@@ -68,10 +63,6 @@ export class Community extends DSpaceObject implements ChildHALResource {
    */
   get handle(): string {
     return this.firstMetadataValue('dc.identifier.uri');
-  }
-
-  set handle(value: string) {
-    this._handle = value;
   }
 
   /**

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -67,8 +67,7 @@ export class Community extends DSpaceObject implements ChildHALResource {
    * A string representing the unique handle of this Community
    */
   get handle(): string {
-    const metadataValue = this.firstMetadataValue('dc.identifier.uri');
-    return metadataValue ? metadataValue : this._handle;
+    return this.firstMetadataValue('dc.identifier.uri');
   }
 
   set handle(value: string) {

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
@@ -1,0 +1,62 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { By } from '@angular/platform-browser';
+import { UIURLCombiner } from 'src/app/core/url-combiner/ui-url-combiner';
+import { ComcolPageHandleComponent } from './comcol-page-handle.component';
+
+const handleWithProtocol = 'http://localhost:4000/handle/123456789/2';
+
+const handleWithoutProtocol = '123456789/2';
+const handleWithoutProtocolUIURLCombined = new UIURLCombiner('/handle/', '123456789/2').toString();
+
+describe('ComcolPageHandleComponent', () => {
+  let component: ComcolPageHandleComponent;
+  let fixture: ComponentFixture<ComcolPageHandleComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [ ComcolPageHandleComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ComcolPageHandleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should be empty if no content is passed', () => {
+    component.content = undefined;
+    fixture.detectChanges();
+    const div = fixture.debugElement.query(By.css('div'));
+    expect(div).toBeNull();
+  });
+
+  describe('should create a link pointing the handle', () => {
+  
+    it('should use the content if it includes the http protocol', () => {
+      component.content = handleWithProtocol;
+      fixture.detectChanges();
+
+      const link = fixture.debugElement.query(By.css('a'));
+      expect(link.nativeElement.getAttribute('href')).toBe(handleWithProtocol);
+      expect(link.nativeElement.innerHTML).toBe(handleWithProtocol);
+    });
+
+    it('should combine the base uri to the content if it doesnt include the http protocol', () => {
+      component.content = handleWithoutProtocol;
+      fixture.detectChanges();
+      const link = fixture.debugElement.query(By.css('a'));
+      expect(link.nativeElement.getAttribute('href')).toBe(handleWithoutProtocolUIURLCombined);
+      expect(link.nativeElement.innerHTML).toBe(handleWithoutProtocolUIURLCombined);
+    });
+    
+  });
+ 
+});

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
@@ -1,15 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { By } from '@angular/platform-browser';
-import { UIURLCombiner } from 'src/app/core/url-combiner/ui-url-combiner';
 import { ComcolPageHandleComponent } from './comcol-page-handle.component';
 
-const handleWithProtocol = 'http://localhost:4000/handle/123456789/2';
+const handle = 'http://localhost:4000/handle/123456789/2';
 
-const handleWithoutProtocol = '123456789/2';
-const handleWithoutProtocolUIURLCombined = new UIURLCombiner('/handle/', '123456789/2').toString();
-
-describe('ComcolPageHandleComponent', () => {
+fdescribe('ComcolPageHandleComponent', () => {
   let component: ComcolPageHandleComponent;
   let fixture: ComponentFixture<ComcolPageHandleComponent>;
 
@@ -38,16 +34,15 @@ describe('ComcolPageHandleComponent', () => {
     expect(div).toBeNull();
   });
 
-  describe('should create a link pointing the handle', () => {
+  it('should create a link pointing the handle when present', () => {
 
-    it('should use the content if it includes the http protocol', () => {
-      component.content = handleWithProtocol;
-      fixture.detectChanges();
+    component.content = handle;
+    fixture.detectChanges();
 
-      const link = fixture.debugElement.query(By.css('a'));
-      expect(link.nativeElement.getAttribute('href')).toBe(handleWithProtocol);
-      expect(link.nativeElement.innerHTML).toBe(handleWithProtocol);
-    });
+    const link = fixture.debugElement.query(By.css('a'));
+    expect(link.nativeElement.getAttribute('href')).toBe(handle);
+    expect(link.nativeElement.innerHTML).toBe(handle);
+
   });
 
 });

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
@@ -5,7 +5,7 @@ import { ComcolPageHandleComponent } from './comcol-page-handle.component';
 
 const handle = 'http://localhost:4000/handle/123456789/2';
 
-fdescribe('ComcolPageHandleComponent', () => {
+describe('ComcolPageHandleComponent', () => {
   let component: ComcolPageHandleComponent;
   let fixture: ComponentFixture<ComcolPageHandleComponent>;
 

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.spec.ts
@@ -39,7 +39,7 @@ describe('ComcolPageHandleComponent', () => {
   });
 
   describe('should create a link pointing the handle', () => {
-  
+
     it('should use the content if it includes the http protocol', () => {
       component.content = handleWithProtocol;
       fixture.detectChanges();
@@ -48,15 +48,6 @@ describe('ComcolPageHandleComponent', () => {
       expect(link.nativeElement.getAttribute('href')).toBe(handleWithProtocol);
       expect(link.nativeElement.innerHTML).toBe(handleWithProtocol);
     });
-
-    it('should combine the base uri to the content if it doesnt include the http protocol', () => {
-      component.content = handleWithoutProtocol;
-      fixture.detectChanges();
-      const link = fixture.debugElement.query(By.css('a'));
-      expect(link.nativeElement.getAttribute('href')).toBe(handleWithoutProtocolUIURLCombined);
-      expect(link.nativeElement.innerHTML).toBe(handleWithoutProtocolUIURLCombined);
-    });
-    
   });
- 
+
 });

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
@@ -1,5 +1,4 @@
 import { Component, Injectable, Input } from '@angular/core';
-import { UIURLCombiner } from '../../core/url-combiner/ui-url-combiner';
 
 /**
  * This component builds a URL from the value of "handle"

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
@@ -21,7 +21,6 @@ export class ComcolPageHandleComponent {
   @Input() content: string;
 
   public getHandle(): string {
-    return this.content.includes('http') ? this.content
-      : new UIURLCombiner('/handle/', this.content).toString();
-  }}
-
+    return this.content;
+  }
+}

--- a/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
+++ b/src/app/shared/comcol-page-handle/comcol-page-handle.component.ts
@@ -21,6 +21,7 @@ export class ComcolPageHandleComponent {
   @Input() content: string;
 
   public getHandle(): string {
-    return new UIURLCombiner('/handle/', this.content).toString();
-  }
-}
+    return this.content.includes('http') ? this.content
+      : new UIURLCombiner('/handle/', this.content).toString();
+  }}
+

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
@@ -53,12 +53,26 @@ describe('ExportMetadataSelectorComponent', () => {
   const mockCollection: Collection = Object.assign(new Collection(), {
     id: 'test-collection-1-1',
     name: 'test-collection-1',
-    handle: 'fake/test-collection-1',
+    metadata: {
+      'dc.identifier.uri': [
+        {
+          language: null,
+          value: 'fake/test-collection-1'
+        }
+      ]
+    }
   });
 
   const mockCommunity = Object.assign(new Community(), {
     id: 'test-uuid',
-    handle: 'fake/test-community-1',
+    metadata: {
+      'dc.identifier.uri': [
+        {
+          language: null,
+          value: 'fake/test-community-1'
+        }
+      ]
+    }
   });
 
   const itemRD = createSuccessfulRemoteDataObject(mockItem);

--- a/src/app/shared/search-form/search-form.component.spec.ts
+++ b/src/app/shared/search-form/search-form.component.spec.ts
@@ -109,7 +109,6 @@ describe('SearchFormComponent', () => {
 
 export const objects: DSpaceObject[] = [
   Object.assign(new Community(), {
-    handle: '10673/11',
     logo: {
       self: {
         _isScalar: true,
@@ -162,12 +161,17 @@ export const objects: DSpaceObject[] = [
           language: null,
           value: 'OR2017 - Demonstration'
         }
-      ]
+      ],
+      'dc.identifier.uri': [
+        {
+          language: null,
+          value: 'http://localhost:4000/handle/10673/11'
+        }
+      ],
     }
   }),
   Object.assign(new Community(),
     {
-      handle: '10673/1',
       logo: {
         self: {
           _isScalar: true,
@@ -220,7 +224,13 @@ export const objects: DSpaceObject[] = [
             language: null,
             value: 'Sample Community'
           }
-        ]
+        ],
+        'dc.identifier.uri': [
+          {
+            language: null,
+            value: 'http://localhost:4000/handle/10673/1'
+          }
+        ],
       }
     }
   )

--- a/src/app/shared/search/search-results/search-results.component.spec.ts
+++ b/src/app/shared/search/search-results/search-results.component.spec.ts
@@ -96,7 +96,6 @@ describe('SearchResultsComponent', () => {
 
 export const objects = [
   Object.assign(new Community(), {
-    handle: '10673/11',
     logo: {
       self: {
         _isScalar: true,
@@ -149,12 +148,17 @@ export const objects = [
           language: null,
           value: 'OR2017 - Demonstration'
         }
+      ],
+      'dc.identifier.uri': [
+        {
+          language: null,
+          value: 'http://localhost:4000/handle/10673/11'
+        }
       ]
     }
   }),
   Object.assign(new Community(),
     {
-      handle: '10673/1',
       logo: {
         self: {
           _isScalar: true,
@@ -206,6 +210,12 @@ export const objects = [
           {
             language: null,
             value: 'Sample Community'
+          }
+        ],
+        'dc.identifier.uri': [
+          {
+            language: null,
+            value: 'http://localhost:4000/handle/10673/1'
           }
         ]
       }


### PR DESCRIPTION
## References
* Fixes [#887](https://github.com/DSpace/dspace-angular/issues/887)
* Requires DSpace/DSpace [#3046](https://github.com/DSpace/DSpace/pull/3046)

## Description
The Community and Collection rest repositories should now return the handle value inside the metadata attribute 'dc.identifier.uri'. We ensure that that value is presented in place of the previously used handle field.


## Instructions for Reviewers
The community and community objects have been enhanced with a getter method for the handle field. The getter takes care of fetching the value from the metadata. The old value is still stored in a private field (_handle) but never used.


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
