### PR TITLE
Remove workaround for baseUrl ending in /api

### DIFF
--- a/scripts/set-env.ts
+++ b/scripts/set-env.ts
@@ -54,13 +54,6 @@ import(environmentFilePath)
 function generateEnvironmentFile(file: GlobalConfig): void {
   file.production = production;
   buildBaseUrls(file);
-
-  // TODO remove workaround in beta 5
-  if (file.rest.nameSpace.match("(.*)/api/?$") !== null) {
-    file.rest.nameSpace = getNameSpace(file.rest.nameSpace);
-    console.log(colors.white.bgMagenta.bold(`The rest.nameSpace property in your environment file or in your DSPACE_REST_NAMESPACE environment variable ends with '/api'.\nThis is deprecated. As '/api' isn't configurable on the rest side, it shouldn't be repeated in every environment file.\nPlease change the rest nameSpace to '${file.rest.nameSpace}'`));
-  }
-
   const contents = `export const environment = ` + JSON.stringify(file);
   writeFile(targetPath, contents, (err) => {
     if (err) {
@@ -119,16 +112,5 @@ function getPort(port: number): string {
 }
 
 function getNameSpace(nameSpace: string): string {
-  // TODO remove workaround in beta 5
-  const apiMatches = nameSpace.match("(.*)/api/?$");
-  if (apiMatches != null) {
-    let newValue = '/'
-    if (hasValue(apiMatches[1])) {
-      newValue = apiMatches[1];
-    }
-    return newValue;
-  }
-  else {
-    return nameSpace ? nameSpace.charAt(0) === '/' ? nameSpace : '/' + nameSpace : '';
-  }
+  return nameSpace ? nameSpace.charAt(0) === '/' ? nameSpace : '/' + nameSpace : '';
 }


### PR DESCRIPTION
## References
Fixes #826

## Description
In #825 , the use of /api in the nameSpace of the rest server config became deprecated. A workaround was added back then in #877. This PR removes the workaround.

## Instructions for Reviewers
To verify the fix, the following steps can be performed: 
* Configure a correct nameSpace without 'api'
* Verify that the UI works
* Configure an incorrect nameSpace ending with '/api', e.g. `nameSpace: '/server/api'`
* Verify that no warning is shown and the UI does not work

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
