### PR TITLE
#945 Clean node at end to avoid rimraf error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean:bld": "rimraf build",
     "clean:node": "rimraf node_modules",
     "clean:prod": "yarn run clean:coverage && yarn run clean:doc && yarn run clean:dist && yarn run clean:log && yarn run clean:json && yarn run clean:bld",
-    "clean": "yarn run clean:prod && yarn run clean:node && yarn run clean:env",
+    "clean": "yarn run clean:prod && yarn run clean:env && yarn run clean:node",
     "clean:env": "rimraf src/environments/environment.ts",
     "sync-i18n": "yarn run config:dev && ts-node --project ./tsconfig.ts-node.json scripts/sync-i18n-files.ts"
   },


### PR DESCRIPTION
## References
* Fixes #945 

## Description
Cleans node at end in order to avoid rimraf deleting itself.

## Instructions for Reviewers
Quick fix