### PR TITLE
Switch codecov 'patch' checks to informational only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,10 +17,9 @@ coverage:
     # Configuration for patch-level checks. This checks the relative coverage of the new PR code ONLY.
     patch:
       default:
-         # For each PR, make sure the coverage of the new code is within 1% of current overall coverage.
-         # We let 'patch' be more lenient as we only require *project* coverage to not drop significantly.
-         target: auto
-         threshold: 1%
+         # Enable informational mode, which just provides info to reviewers & always passes
+         # https://docs.codecov.io/docs/commit-status#section-informational
+         informational: true
 
 # Turn PR comments "off". This feature adds the code coverage summary as a
 # comment on each PR. See https://docs.codecov.io/docs/pull-request-comments


### PR DESCRIPTION
As we don't require Codecov `patch` checks to succeed, I'm switching them to informational mode only.  This mode keeps the check enabled, but ensures the check **always** returns success.   See https://docs.codecov.io/docs/commit-status#informational

If this works as planned, I'm hoping this will ensure the (optional) `patch` check no longer places a red ❌ on PRs which otherwise pass all other checks.  This red ❌ is misleading, as it can make you assume the PR has a build/test failure, when it's just an optional check that failed.

(Sidenote: If this doesn't work as expected, we may need to disable `patch` checks entirely.  However, ideally, it'd be nice to keep it around if we can...the `patch` check's purpose is to check the code coverage of _just the new code added by the PR_.  So, when it's low it points out possible areas of missed coverage. The reason we don't require it though is that it's not always accurate when it comes to code refactors -- it wrongly assumes any code changes must be "new code", when in some cases you are simply changing code alignment or ordering.)
 
