### PR TITLE
Item view relationship query fix

### DIFF
--- a/src/app/+item-page/simple/related-entities/related-entities-search/related-entities-search.component.spec.ts
+++ b/src/app/+item-page/simple/related-entities/related-entities-search/related-entities-search.component.spec.ts
@@ -15,7 +15,7 @@ describe('RelatedEntitiesSearchComponent', () => {
   });
   const mockRelationType = 'publicationsOfAuthor';
   const mockConfiguration = 'publication';
-  const mockFilter= `f.${mockRelationType}=${mockItem.id}`;
+  const mockFilter= `f.${mockRelationType}=${mockItem.id},equals`;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/app/shared/utils/relation-query.utils.spec.ts
+++ b/src/app/shared/utils/relation-query.utils.spec.ts
@@ -6,13 +6,13 @@ describe('Relation Query Utils', () => {
   describe('getQueryByRelations', () => {
     it('Should return the correct query based on relationtype and uuid', () => {
       const result = getQueryByRelations(relationtype, itemUUID);
-      expect(result).toEqual('query=relation.isAuthorOfPublication:a7939af0-36ad-430d-af09-7be8b0a4dadd');
+      expect(result).toEqual('query=relation.isAuthorOfPublication:"a7939af0-36ad-430d-af09-7be8b0a4dadd"');
     });
   });
   describe('getFilterByRelation', () => {
     it('Should return the correct query based on relationtype and uuid', () => {
       const result = getFilterByRelation(relationtype, itemUUID);
-      expect(result).toEqual('f.isAuthorOfPublication=a7939af0-36ad-430d-af09-7be8b0a4dadd');
+      expect(result).toEqual('f.isAuthorOfPublication=a7939af0-36ad-430d-af09-7be8b0a4dadd,equals');
     });
   });
 });

--- a/src/app/shared/utils/relation-query.utils.ts
+++ b/src/app/shared/utils/relation-query.utils.ts
@@ -5,7 +5,7 @@
  * @returns {string}              Query
  */
 export function getQueryByRelations(relationType: string, itemUUID: string): string {
-  return `query=relation.${relationType}:${itemUUID}`;
+  return `query=relation.${relationType}:"${itemUUID}"`;
 }
 
 /**
@@ -14,5 +14,5 @@ export function getQueryByRelations(relationType: string, itemUUID: string): str
  * @param itemUUID        The item's UUID
  */
 export function getFilterByRelation(relationType: string, itemUUID: string): string {
-  return `f.${relationType}=${itemUUID}`;
+  return `f.${relationType}=${itemUUID},equals`;
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #966 

## Description
Altering the item view relationship queries to use exact matching for the UUID of the item. 

## Instructions for Reviewers
See the issue for detailed instructions

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
