### PR TITLE
Sync Docker compose scripts with backend (DSpace/DSpace)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@
   - Starts DSpace Angular with Docker Compose from the current branch.  This file assumes that a DSpace 7 REST instance will also be started in Docker.
 - docker-compose-rest.yml
   - Runs a published instance of the DSpace 7 REST API - persists data in Docker volumes
-- docker-compose-travis.yml
+- docker-compose-ci.yml
   - Runs a published instance of the DSpace 7 REST API for CI testing.  The database is re-populated from a SQL dump on each startup.
 - cli.yml
   - Docker compose file that provides a DSpace CLI container to work with a running DSpace REST container.

--- a/docker/cli.assetstore.yml
+++ b/docker/cli.assetstore.yml
@@ -1,3 +1,17 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# This is a copy of the cli.ingest.yml that is available in the DSpace/DSpace
+# (Backend) at:
+# https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.assetstore.yml
+#
+# Therefore, it should be kept in sync with that file
 version: "3.7"
 
 networks:
@@ -8,7 +22,7 @@ services:
     networks:
       dspacenet: {}
     environment:
-      - LOADASSETS=https://www.dropbox.com/s/zv7lj8j2lp3egjs/assetstore.tar.gz?dl=1
+      - LOADASSETS=https://www.dropbox.com/s/v3ahfcuatklbmi0/assetstore-2019-11-28.tar.gz?dl=1
     entrypoint:
       - /bin/bash
       - '-c'
@@ -21,3 +35,5 @@ services:
         fi
 
         /dspace/bin/dspace index-discovery
+        /dspace/bin/dspace oai import
+        /dspace/bin/dspace oai clean-cache

--- a/docker/cli.ingest.yml
+++ b/docker/cli.ingest.yml
@@ -6,6 +6,12 @@
 # http://www.dspace.org/license/
 #
 
+#
+# This is a copy of the cli.ingest.yml that is available in the DSpace/DSpace
+# (Backend) at:
+# https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.ingest.yml
+#
+# Therefore, it should be kept in sync with that file
 version: "3.7"
 
 services:

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -1,3 +1,17 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# This is a copy of the docker-compose-cli.yml that is available in the DSpace/DSpace
+# (Backend) at:
+# https://github.com/DSpace/DSpace/blob/main/docker-compose-cli.yml
+#
+# Therefore, it should be kept in sync with that file
 version: "3.7"
 
 services:

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -6,11 +6,17 @@
 # http://www.dspace.org/license/
 #
 
+#
+# This is a copy of the db.entities.yml that is available in the DSpace/DSpace
+# (Backend) at:
+# https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
+#
+# # Therefore, it should be kept in sync with that file
 version: "3.7"
 
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:loadsql
     environment:
-      # Double underbars in env names will be replaced with periods for apache commons
-      - LOADSQL=https://www.dropbox.com/s/xh3ack0vg0922p2/configurable-entities-2019-05-08.sql?dl=1
+      # This LOADSQL should be kept in sync with the URL in DSpace/DSpace
+      - LOADSQL=https://www.dropbox.com/s/4ap1y6deseoc8ws/dspace7-entities-2019-11-28.sql?dl=1

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,4 +1,13 @@
-# Docker Compose for running the DSpace backend for e2e testing in CI
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# Docker Compose for running the DSpace backend for e2e testing in a CI environment
+# This is used by our GitHub CI at .github/workflows/build.yml
 networks:
   dspacenet:
 services:
@@ -20,7 +29,9 @@ services:
   dspacedb:
     container_name: dspacedb
     environment:
-      LOADSQL: https://www.dropbox.com/s/xh3ack0vg0922p2/configurable-entities-2019-05-08.sql?dl=1
+      # This LOADSQL should be kept in sync with the LOADSQL in
+      # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
+      LOADSQL: https://www.dropbox.com/s/4ap1y6deseoc8ws/dspace7-entities-2019-11-28.sql?dl=1
       PGDATA: /pgdata
     image: dspace/dspace-postgres-pgcrypto:loadsql
     networks:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -1,11 +1,24 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# Docker Compose for running the DSpace backend for testing/development
+# This is based heavily on the docker-compose.yml that is available in the DSpace/DSpace
+# (Backend) at:
+# https://github.com/DSpace/DSpace/blob/main/docker-compose.yml
+version: '3.7'
 networks:
   dspacenet:
 services:
   dspace:
     container_name: dspace
+    image: dspace/dspace:dspace-7_x-test
     depends_on:
     - dspacedb
-    image: dspace/dspace:dspace-7_x-test
     networks:
       dspacenet:
     ports:
@@ -16,20 +29,27 @@ services:
     volumes:
     - assetstore:/dspace/assetstore
     - "./local.cfg:/dspace/config/local.cfg"
-    # Ensure that the database is ready before starting tomcat
+    # Ensure that the database is ready BEFORE starting tomcat
+    # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
+    # 2. Then, run database migration to init database tables
+    # 3. Finally, start Tomcat
     entrypoint:
     - /bin/bash
     - '-c'
     - |
+      while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
       catalina.sh run
   dspacedb:
     container_name: dspacedb
-    image: dspace/dspace-postgres-pgcrypto
     environment:
       PGDATA: /pgdata
+    image: dspace/dspace-postgres-pgcrypto
     networks:
       dspacenet:
+    ports:
+    - published: 5432
+      target: 5432
     stdin_open: true
     tty: true
     volumes:
@@ -49,7 +69,6 @@ services:
     - solr_oai:/opt/solr/server/solr/oai/data
     - solr_search:/opt/solr/server/solr/search/data
     - solr_statistics:/opt/solr/server/solr/statistics/data
-version: '3.7'
 volumes:
   assetstore:
   pgdata:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,14 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# Docker Compose for running the DSpace Angular UI for testing/development
+# Requires also running a REST API backend (either locally or remotely),
+# for example via 'docker-compose-rest.yml'
 version: '3.7'
 networks:
   dspacenet:


### PR DESCRIPTION
The Docker compose scripts in the Angular UI have become outdated, and were never updated when the Entities test data set was updated on the backend in https://github.com/DSpace/DSpace/pull/2623

This means that the data set being used for `e2e` tests in GitHub CI is outdated, and this has recently resulted in errors which are not reproducible on the more recent Entities test data set. For example in https://github.com/DSpace/dspace-angular/pull/961/checks?check_run_id=1524916589

This PR updates all Docker compose scripts to include:
* Comments describing / linking back to related dockers scripts (in backend project)
* Updates Entities data sets to the same ones used by Backend.
* Other minor updates to sync the scripts with related backend scripts (as necessary)