### PR TITLE
680 Fix change event reference for recent submission

### DIFF
--- a/src/app/+collection-page/collection-page.component.ts
+++ b/src/app/+collection-page/collection-page.component.ts
@@ -104,11 +104,15 @@ export class CollectionPageComponent implements OnInit {
   }
 
   onPaginationChange(event) {
-    this.paginationConfig.currentPage = +event.page || this.paginationConfig.currentPage;
-    this.paginationConfig.pageSize = +event.pageSize || this.paginationConfig.pageSize;
-    this.sortConfig.direction = event.sortDirection || this.sortConfig.direction;
-    this.sortConfig.field = event.sortField || this.sortConfig.field;
-
+    this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
+      currentPage: event.pagination.currentPage || this.paginationConfig.currentPage,
+      pageSize: event.pagination.pageSize || this.paginationConfig.pageSize,
+      id: 'collection-page-pagination'
+    });
+    this.sortConfig = Object.assign(new SortOptions('dc.date.accessioned', SortDirection.DESC), {
+      direction: event.sort.direction || this.sortConfig.direction,
+      field: event.sort.field || this.sortConfig.field
+    });
     this.paginationChanges$.next({
       paginationConfig: this.paginationConfig,
       sortConfig: this.sortConfig

--- a/src/app/+collection-page/collection-page.component.ts
+++ b/src/app/+collection-page/collection-page.component.ts
@@ -21,6 +21,7 @@ import { fadeIn, fadeInOut } from '../shared/animations/fade';
 import { hasValue, isNotEmpty } from '../shared/empty.util';
 import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
 import { AuthService } from '../core/auth/auth.service';
+import {PaginationChangeEvent} from '../shared/pagination/paginationChangeEvent.interface';
 
 @Component({
   selector: 'ds-collection-page',
@@ -93,9 +94,8 @@ export class CollectionPageComponent implements OnInit {
       )
     );
 
-    this.route.queryParams.pipe(take(1)).subscribe((params) => {
+    this.route.queryParams.pipe(take(1)).subscribe((params: PaginationChangeEvent) => {
       this.metadata.processRemoteData(this.collectionRD$);
-      this.onPaginationChange(params);
     });
   }
 
@@ -103,7 +103,7 @@ export class CollectionPageComponent implements OnInit {
     return isNotEmpty(object);
   }
 
-  onPaginationChange(event) {
+  onPaginationChange(event: PaginationChangeEvent) {
     this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
       currentPage: event.pagination.currentPage || this.paginationConfig.currentPage,
       pageSize: event.pagination.pageSize || this.paginationConfig.pageSize,

--- a/src/app/+collection-page/collection-page.component.ts
+++ b/src/app/+collection-page/collection-page.component.ts
@@ -94,7 +94,7 @@ export class CollectionPageComponent implements OnInit {
       )
     );
 
-    this.route.queryParams.pipe(take(1)).subscribe((params: PaginationChangeEvent) => {
+    this.route.queryParams.pipe(take(1)).subscribe((params) => {
       this.metadata.processRemoteData(this.collectionRD$);
     });
   }

--- a/src/app/shared/pagination/paginationChangeEvent.interface.ts
+++ b/src/app/shared/pagination/paginationChangeEvent.interface.ts
@@ -1,7 +1,19 @@
 import {PaginationComponentOptions} from './pagination-component-options.model';
 import {SortOptions} from '../../core/cache/models/sort-options.model';
 
+
+/**
+ * The pagination event that contains updated pagination properties
+ * for a given view
+ */
 export interface PaginationChangeEvent {
+  /**
+   * The pagination component object that contains id, current page, max size, page size options, and page size
+   */
   pagination: PaginationComponentOptions;
+
+  /**
+   * The sort options object that contains which field to sort by and the sorting direction
+   */
   sort: SortOptions;
 }

--- a/src/app/shared/pagination/paginationChangeEvent.interface.ts
+++ b/src/app/shared/pagination/paginationChangeEvent.interface.ts
@@ -1,0 +1,7 @@
+import {PaginationComponentOptions} from './pagination-component-options.model';
+import {SortOptions} from '../../core/cache/models/sort-options.model';
+
+export interface PaginationChangeEvent {
+  pagination: PaginationComponentOptions;
+  sort: SortOptions;
+}


### PR DESCRIPTION
Fixes #680 
I've updated the event change references to valid ones so the `onPaginationChange(event)` functions properly. Tested my additions in my local environment.

NOTE: The following error was reported before my changes but seems rather strange that this particular error is still present in my console given I've seen the pattern I used elsewhere in the code base without such an error. It's unclear to me why `paginationConfig` properties throw an error when attempting to be set. Would be great to get some insight on this: 
`core.js:4002 ERROR TypeError: Cannot read property 'currentPage' of undefined
    at CollectionPageComponent.push../src/app/+collection-page/collection-page.component.ts.CollectionPageComponent.onPaginationChange (collection-page.component.ts:112)
    at SafeSubscriber._next (collection-page.component.ts:102)
    at SafeSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.SafeSubscriber.__tryOrUnsub (Subscriber.js:194)
    at SafeSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.SafeSubscriber.next (Subscriber.js:132)
    at Subscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber._next (Subscriber.js:76)
    at Subscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (Subscriber.js:53)
    at TakeSubscriber.push../node_modules/rxjs/_esm5/internal/operators/take.js.TakeSubscriber._next (take.js:40)
    at TakeSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (Subscriber.js:53)
    at BehaviorSubject.push../node_modules/rxjs/_esm5/internal/BehaviorSubject.js.BehaviorSubject._subscribe (BehaviorSubject.js:22)
    at BehaviorSubject.push../node_modules/rxjs/_esm5/internal/Observable.js.Observable._trySubscribe (Observable.js:43)`