### PR TITLE
Collection mapper

### DIFF
--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.html
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <h2>{{'collection.edit.item-mapper.head' | translate}}</h2>
-      <p [innerHTML]="'collection.edit.item-mapper.collection' | translate:{ name: (collectionRD$ | async)?.payload?.name }" id="collection-name"></p>
+      <p [innerHTML]="'collection.edit.item-mapper.collection' | translate:{ name: (collectionName$ |async) }" id="collection-name"></p>
       <p>{{'collection.edit.item-mapper.description' | translate}}</p>
 
       <ngb-tabset (tabChange)="tabChange($event)" [destroyOnHide]="true" #tabs="ngbTabset">

--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.spec.ts
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.spec.ts
@@ -6,7 +6,6 @@ import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SearchFormComponent } from '../../shared/search-form/search-form.component';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ActivatedRouteStub } from '../../shared/testing/active-router.stub';
 import { RouterStub } from '../../shared/testing/router.stub';
 import { SearchServiceStub } from '../../shared/testing/search-service.stub';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
@@ -28,7 +27,7 @@ import { ItemSelectComponent } from '../../shared/object-select/item-select/item
 import { ObjectSelectService } from '../../shared/object-select/object-select.service';
 import { ObjectSelectServiceStub } from '../../shared/testing/object-select-service.stub';
 import { VarDirective } from '../../shared/utils/var.directive';
-import { of as observableOf, of } from 'rxjs';
+import { of as observableOf } from 'rxjs/internal/observable/of';
 import { RouteService } from '../../core/services/route.service';
 import { ErrorComponent } from '../../shared/error/error.component';
 import { LoadingComponent } from '../../shared/loading/loading.component';
@@ -66,7 +65,7 @@ describe('CollectionItemMapperComponent', () => {
     }
   });
   const mockCollectionRD: RemoteData<Collection> = createSuccessfulRemoteDataObject(mockCollection);
-  const mockSearchOptions = of(new PaginatedSearchOptions({
+  const mockSearchOptions = observableOf(new PaginatedSearchOptions({
     pagination: Object.assign(new PaginationComponentOptions(), {
       id: 'search-page-configuration',
       pageSize: 10,
@@ -88,23 +87,34 @@ describe('CollectionItemMapperComponent', () => {
   const emptyList = createSuccessfulRemoteDataObject(createPaginatedList([]));
   const itemDataServiceStub = {
     mapToCollection: () => createSuccessfulRemoteDataObject$({}),
-    findAllByHref: () => of(emptyList)
+    findAllByHref: () => observableOf(emptyList)
   };
-  const activatedRouteStub = new ActivatedRouteStub({}, { dso: mockCollectionRD });
+  const activatedRouteStub = {
+    parent: {
+      data: observableOf({
+        dso: mockCollectionRD
+      })
+    },
+    snapshot: {
+      queryParamMap: new Map([
+        ['query', 'test'],
+      ])
+    }
+  };
   const translateServiceStub = {
-    get: () => of('test-message of collection ' + mockCollection.name),
+    get: () => observableOf('test-message of collection ' + mockCollection.name),
     onLangChange: new EventEmitter(),
     onTranslationChange: new EventEmitter(),
     onDefaultLangChange: new EventEmitter()
   };
   const searchServiceStub = Object.assign(new SearchServiceStub(), {
-    search: () => of(emptyList),
+    search: () => observableOf(emptyList),
     /* tslint:disable:no-empty */
     clearDiscoveryRequests: () => {}
     /* tslint:enable:no-empty */
   });
   const collectionDataServiceStub = {
-    getMappedItems: () => of(emptyList),
+    getMappedItems: () => observableOf(emptyList),
     /* tslint:disable:no-empty */
     clearMappedItemsRequests: () => {}
     /* tslint:enable:no-empty */

--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
@@ -143,7 +143,7 @@ export class CollectionItemMapperComponent implements OnInit {
           sort: this.defaultSortOptions
         }),!shouldUpdate, false, followLink('owningCollection')).pipe(
           getAllSucceededRemoteData()
-        )
+        );
       })
     );
     this.mappedItemsRD$ = collectionAndOptions$.pipe(

--- a/src/app/+collection-page/collection-page-routing.module.ts
+++ b/src/app/+collection-page/collection-page-routing.module.ts
@@ -9,7 +9,6 @@ import { CreateCollectionPageGuard } from './create-collection-page/create-colle
 import { DeleteCollectionPageComponent } from './delete-collection-page/delete-collection-page.component';
 import { EditItemTemplatePageComponent } from './edit-item-template-page/edit-item-template-page.component';
 import { ItemTemplatePageResolver } from './edit-item-template-page/item-template-page.resolver';
-import { CollectionItemMapperComponent } from './collection-item-mapper/collection-item-mapper.component';
 import { CollectionBreadcrumbResolver } from '../core/breadcrumbs/collection-breadcrumb.resolver';
 import { DSOBreadcrumbsService } from '../core/breadcrumbs/dso-breadcrumbs.service';
 import { LinkService } from '../core/cache/builders/link.service';
@@ -65,12 +64,6 @@ import { LinkMenuItemModel } from '../shared/menu/menu-item/models/link.model';
             path: '',
             component: CollectionPageComponent,
             pathMatch: 'full',
-          },
-          {
-            path: '/edit/mapper',
-            component: CollectionItemMapperComponent,
-            pathMatch: 'full',
-            canActivate: [AuthenticatedGuard]
           }
         ],
         data: {

--- a/src/app/+collection-page/edit-collection-page/edit-collection-page.routing.module.ts
+++ b/src/app/+collection-page/edit-collection-page/edit-collection-page.routing.module.ts
@@ -1,5 +1,6 @@
 import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
+import { CollectionItemMapperComponent } from '../collection-item-mapper/collection-item-mapper.component';
 import { EditCollectionPageComponent } from './edit-collection-page.component';
 import { CollectionMetadataComponent } from './collection-metadata/collection-metadata.component';
 import { CollectionRolesComponent } from './collection-roles/collection-roles.component';
@@ -86,7 +87,12 @@ import { ResourcePolicyEditComponent } from '../../shared/resource-policies/edit
                 data: { title: 'collection.edit.tabs.authorizations.title', showBreadcrumbs: true }
               }
             ]
-          }
+          },
+          {
+            path: 'mapper',
+            component: CollectionItemMapperComponent,
+            data: { title: 'collection.edit.tabs.item-mapper.title', showBreadcrumbs: true }
+          },
         ]
       }
     ])

--- a/src/app/+item-page/edit-item-page/edit-item-page.routing.module.ts
+++ b/src/app/+item-page/edit-item-page/edit-item-page.routing.module.ts
@@ -90,6 +90,11 @@ import { ItemPageWithdrawGuard } from './item-page-withdraw.guard';
                 path: 'versionhistory',
                 component: ItemVersionHistoryComponent,
                 data: { title: 'item.edit.tabs.versionhistory.title', showBreadcrumbs: true }
+              },
+              {
+                path: 'mapper',
+                component: ItemCollectionMapperComponent,
+                data: { title: 'item.edit.tabs.item-mapper.title', showBreadcrumbs: true }
               }
             ]
           },

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <h2>{{'item.edit.item-mapper.head' | translate}}</h2>
-      <p [innerHTML]="'item.edit.item-mapper.item' | translate:{ name: (itemRD$ | async)?.payload?.name }" id="item-name"></p>
+      <p [innerHTML]="'item.edit.item-mapper.item' | translate:{ name: (itemName$ | async) }" id="item-name"></p>
       <p>{{'item.edit.item-mapper.description' | translate}}</p>
 
       <ngb-tabset (tabChange)="tabChange($event)" [destroyOnHide]="true" #tabs="ngbTabset">

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { of as observableOf } from 'rxjs/internal/observable/of';
 import { SortDirection, SortOptions } from '../../../core/cache/models/sort-options.model';
 import { CollectionDataService } from '../../../core/data/collection-data.service';
 import { ItemDataService } from '../../../core/data/item-data.service';
@@ -26,7 +26,6 @@ import { PaginationComponentOptions } from '../../../shared/pagination/paginatio
 import { PaginationComponent } from '../../../shared/pagination/pagination.component';
 import { SearchFormComponent } from '../../../shared/search-form/search-form.component';
 import { PaginatedSearchOptions } from '../../../shared/search/paginated-search-options.model';
-import { ActivatedRouteStub } from '../../../shared/testing/active-router.stub';
 import { HostWindowServiceStub } from '../../../shared/testing/host-window-service.stub';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 import { ObjectSelectServiceStub } from '../../../shared/testing/object-select-service.stub';
@@ -59,7 +58,7 @@ describe('ItemCollectionMapperComponent', () => {
     name: 'test-item'
   });
   const mockItemRD: RemoteData<Item> = createSuccessfulRemoteDataObject(mockItem);
-  const mockSearchOptions = of(new PaginatedSearchOptions({
+  const mockSearchOptions = observableOf(new PaginatedSearchOptions({
     pagination: Object.assign(new PaginationComponentOptions(), {
       id: 'search-page-configuration',
       pageSize: 10,
@@ -82,7 +81,7 @@ describe('ItemCollectionMapperComponent', () => {
     mapToCollection: () => createSuccessfulRemoteDataObject$({}),
     removeMappingFromCollection: () => createSuccessfulRemoteDataObject$({}),
     getMappedCollectionsEndpoint: () => of('rest/api/mappedCollectionsEndpoint'),
-    getMappedCollections: () => of(mockCollectionsRD),
+    getMappedCollections: () => observableOf(mockCollectionsRD),
     /* tslint:disable:no-empty */
     clearMappedCollectionsRequests: () => {}
     /* tslint:enable:no-empty */
@@ -91,14 +90,20 @@ describe('ItemCollectionMapperComponent', () => {
     findAllByHref: () => of(mockCollectionsRD)
   };
   const searchServiceStub = Object.assign(new SearchServiceStub(), {
-    search: () => of(mockCollectionsRD),
+    search: () => observableOf(mockCollectionsRD),
     /* tslint:disable:no-empty */
     clearDiscoveryRequests: () => {}
     /* tslint:enable:no-empty */
   });
-  const activatedRouteStub = new ActivatedRouteStub({}, { dso: mockItemRD });
+  const activatedRouteStub = {
+    parent: {
+      data: observableOf({
+        dso: mockItemRD
+      })
+    }
+  };
   const translateServiceStub = {
-    get: () => of('test-message of item ' + mockItem.name),
+    get: () => observableOf('test-message of item ' + mockItem.name),
     onLangChange: new EventEmitter(),
     onTranslationChange: new EventEmitter(),
     onDefaultLangChange: new EventEmitter()

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
@@ -80,14 +80,14 @@ describe('ItemCollectionMapperComponent', () => {
   const itemDataServiceStub = {
     mapToCollection: () => createSuccessfulRemoteDataObject$({}),
     removeMappingFromCollection: () => createSuccessfulRemoteDataObject$({}),
-    getMappedCollectionsEndpoint: () => of('rest/api/mappedCollectionsEndpoint'),
+    getMappedCollectionsEndpoint: () => observableOf('rest/api/mappedCollectionsEndpoint'),
     getMappedCollections: () => observableOf(mockCollectionsRD),
     /* tslint:disable:no-empty */
     clearMappedCollectionsRequests: () => {}
     /* tslint:enable:no-empty */
   };
   const collectionDataServiceStub = {
-    findAllByHref: () => of(mockCollectionsRD)
+    findAllByHref: () => observableOf(mockCollectionsRD)
   };
   const searchServiceStub = Object.assign(new SearchServiceStub(), {
     search: () => observableOf(mockCollectionsRD),

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -649,6 +649,10 @@
 
 
 
+  "collection.edit.tabs.mapper.head": "Item Mapper",
+
+  "collection.edit.tabs.item-mapper.title": "Collection Edit - Item Mapper",
+
   "collection.edit.item-mapper.cancel": "Cancel",
 
   "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
@@ -1462,6 +1466,9 @@
   "item.edit.breadcrumbs": "Edit Item",
 
 
+  "item.edit.tabs.mapper.head": "Collection Mapper",
+
+  "item.edit.tabs.item-mapper.title": "Item Edit - Collection Mapper",
 
   "item.edit.item-mapper.buttons.add": "Map item to selected collections",
 


### PR DESCRIPTION
## References
* Fixes #974
* Depends on #975

## Description
This PR fixes the item and collection mapper pages created in #348 and adds links to them as tabs on the respective edit collection and edit item pages as tabs. 

This PR seems a lot bigger than it is, because it depends on #975 You can see only the changes in this PR [here](https://github.com/atmire/dspace-angular/compare/cache-redesign-part-2...atmire:collection-mapper)

## Instructions for Reviewers
Go to a collection edit page > Item Mapper tab:
Try to map new items to the collection and remove some of them.
Go to one of the mapped items > edit page > Collection Mapper tab:
Your previous collection should be present in mapped collections.
Try to add/remove mapped collections of item on collection mapper tab.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
