### PR TITLE
Submission external sources limited on metadata field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "0.0.0",
+  "version": "1.22.10",
   "scripts": {
     "ng": "ng",
     "config:dev": "ts-node --project ./tsconfig.ts-node.json scripts/set-env.ts --dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "1.22.10",
+  "version": "0.0.0",
   "scripts": {
     "ng": "ng",
     "config:dev": "ts-node --project ./tsconfig.ts-node.json scripts/set-env.ts --dev",

--- a/src/app/core/data/relationship-type.service.spec.ts
+++ b/src/app/core/data/relationship-type.service.spec.ts
@@ -9,10 +9,10 @@ import {
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { ItemType } from '../shared/item-relationships/item-type.model';
 import { RelationshipType } from '../shared/item-relationships/relationship-type.model';
-import { PageInfo } from '../shared/page-info.model';
-import { buildPaginatedList } from './paginated-list.model';
 import { RelationshipTypeService } from './relationship-type.service';
 import { RequestService } from './request.service';
+import { createPaginatedList } from '../../shared/testing/utils.test';
+import { hasValueOperator } from '../../shared/empty.util';
 
 describe('RelationshipTypeService', () => {
   let service: RelationshipTypeService;
@@ -62,7 +62,7 @@ describe('RelationshipTypeService', () => {
       rightType: createSuccessfulRemoteDataObject$(orgUnitType)
     });
 
-    buildList = createSuccessfulRemoteDataObject(buildPaginatedList(new PageInfo(), [relationshipType1, relationshipType2]));
+    buildList = createSuccessfulRemoteDataObject(createPaginatedList([relationshipType1, relationshipType2]));
     rdbService = getMockRemoteDataBuildService(undefined, observableOf(buildList));
     objectCache = Object.assign({
       /* tslint:disable:no-empty */
@@ -100,9 +100,10 @@ describe('RelationshipTypeService', () => {
   describe('getRelationshipTypeByLabelAndTypes', () => {
 
     it('should return the type filtered by label and type strings', (done) => {
-      const expected = service.getRelationshipTypeByLabelAndTypes(relationshipType1.leftwardType, publicationTypeString, personTypeString);
-      expected.subscribe((e) => {
-        expect(e).toBe(relationshipType1);
+      service.getRelationshipTypeByLabelAndTypes(relationshipType1.leftwardType, publicationTypeString, personTypeString).pipe(
+        hasValueOperator()
+      ).subscribe((e) => {
+        expect(e.id).toEqual(relationshipType1.id);
         done();
       });
     });

--- a/src/app/core/data/relationship-type.service.ts
+++ b/src/app/core/data/relationship-type.service.ts
@@ -23,7 +23,6 @@ import { PaginatedList } from './paginated-list.model';
 import { RemoteData } from './remote-data';
 import { RequestService } from './request.service';
 
-
 /**
  * Check if one side of a RelationshipType is the ItemType with the given label
  *

--- a/src/app/core/data/relationship-type.service.ts
+++ b/src/app/core/data/relationship-type.service.ts
@@ -2,9 +2,9 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
-import { filter, find, map, mergeMap, switchMap } from 'rxjs/operators';
+import { map, mergeMap, switchMap, toArray } from 'rxjs/operators';
 import { AppState } from '../../app.reducer';
-import { isNotUndefined } from '../../shared/empty.util';
+import { hasValue } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { followLink } from '../../shared/utils/follow-link-config.model';
 import { dataService } from '../cache/builders/build-decorators';
@@ -15,13 +15,23 @@ import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { ItemType } from '../shared/item-relationships/item-type.model';
 import { RelationshipType } from '../shared/item-relationships/relationship-type.model';
 import { RELATIONSHIP_TYPE } from '../shared/item-relationships/relationship-type.resource-type';
-import { getFirstSucceededRemoteData } from '../shared/operators';
+import { getFirstSucceededRemoteData, getFirstCompletedRemoteData } from '../shared/operators';
 import { DataService } from './data.service';
 import { DefaultChangeAnalyzer } from './default-change-analyzer.service';
 import { ItemDataService } from './item-data.service';
 import { PaginatedList } from './paginated-list.model';
 import { RemoteData } from './remote-data';
 import { RequestService } from './request.service';
+
+
+/**
+ * Check if one side of a RelationshipType is the ItemType with the given label
+ *
+ * @param typeRd the RemoteData for an ItemType
+ * @param label  the label to check. e.g. Author
+ */
+const checkSide = (typeRd: RemoteData<ItemType>, label: string): boolean =>
+  typeRd.hasSucceeded && typeRd.payload.label === label;
 
 /**
  * The service handling all relationship type requests
@@ -45,36 +55,70 @@ export class RelationshipTypeService extends DataService<RelationshipType> {
   }
 
   /**
-   * Get the RelationshipType for a relationship type by label
-   * @param label
+   * Find a RelationshipType object by its label, and the types of the items on either side.
+   *
+   * TODO this should be implemented as a rest endpoint, we shouldn't have logic on the client that
+   * requires using a huge page-size in order to process "everything".
+   *
+   * @param relationshipTypeLabel The name of the relationType we're looking for
+   *                              e.g. isAuthorOfPublication
+   * @param firstItemType         The type of one of the sides of the relationship e.g. Publication
+   * @param secondItemType        The type of the other side of the relationship e.g. Author
    */
-  getRelationshipTypeByLabelAndTypes(label: string, firstType: string, secondType: string): Observable<RelationshipType> {
+  getRelationshipTypeByLabelAndTypes(relationshipTypeLabel: string, firstItemType: string, secondItemType: string): Observable<RelationshipType> {
+    // Retrieve all relationship types from the server in a single page
     return this.findAll({ currentPage: 1, elementsPerPage: 9999 }, true, true, followLink('leftType'), followLink('rightType'))
       .pipe(
         getFirstSucceededRemoteData(),
-        /* Flatten the page so we can treat it like an observable */
+        // Emit each type in the page array separately
         switchMap((typeListRD: RemoteData<PaginatedList<RelationshipType>>) => typeListRD.payload.page),
-        mergeMap((type: RelationshipType) => {
-          if (type.leftwardType === label) {
-            return this.checkType(type, firstType, secondType);
-          } else if (type.rightwardType === label) {
-            return this.checkType(type, secondType, firstType);
+        // Check each type individually, to see if it matches the provided types
+        mergeMap((relationshipType: RelationshipType) => {
+          if (relationshipType.leftwardType === relationshipTypeLabel) {
+            return this.checkType(relationshipType, firstItemType, secondItemType);
+          } else if (relationshipType.rightwardType === relationshipTypeLabel) {
+            return this.checkType(relationshipType, secondItemType, firstItemType);
           } else {
             return [null];
           }
         }),
+        // Wait for all types to be checked and emit once, with the results combined back into an
+        // array
+        toArray(),
+        // Look for a match in the array and emit it if found, or null if one isn't found
+        map((types: RelationshipType[]) => {
+          const match = types.find((type: RelationshipType) => hasValue(type));
+          if (hasValue(match)) {
+            return match
+          } else {
+            return null;
+          }
+        })
       );
   }
 
-  // Check if relationship type matches the given types
-  // returns a void observable if there's not match
-  // returns an observable that emits the relationship type when there is a match
-  private checkType(type: RelationshipType, firstType: string, secondType: string): Observable<RelationshipType> {
-    const entityTypes = observableCombineLatest([type.leftType.pipe(getFirstSucceededRemoteData()), type.rightType.pipe(getFirstSucceededRemoteData())]);
-    return entityTypes.pipe(
-      find(([leftTypeRD, rightTypeRD]: [RemoteData<ItemType>, RemoteData<ItemType>]) => leftTypeRD.payload.label === firstType && rightTypeRD.payload.label === secondType),
-      filter((types) => isNotUndefined(types)),
-      map(() => type)
+  /**
+   * Check if the given RelationshipType has the given itemTypes on its left and right sides.
+   * Returns an observable of the given RelationshipType if it matches, null if it doesn't
+   *
+   * @param type            The RelationshipType to check
+   * @param leftItemType    The item type that should be on the left side
+   * @param rightItemType   The item type that should be on the right side
+   * @private
+   */
+  private checkType(type: RelationshipType, leftItemType: string, rightItemType: string): Observable<RelationshipType> {
+    return observableCombineLatest([
+      type.leftType.pipe(getFirstCompletedRemoteData()),
+      type.rightType.pipe(getFirstCompletedRemoteData())
+    ]).pipe(
+      map(([leftTypeRD, rightTypeRD]: [RemoteData<ItemType>, RemoteData<ItemType>]) => {
+        if (checkSide(leftTypeRD, leftItemType) && checkSide(rightTypeRD, rightItemType)
+        ) {
+          return type;
+        } else {
+          return null;
+        }
+      })
     );
   }
 }

--- a/src/app/core/data/relationship-type.service.ts
+++ b/src/app/core/data/relationship-type.service.ts
@@ -88,7 +88,7 @@ export class RelationshipTypeService extends DataService<RelationshipType> {
         map((types: RelationshipType[]) => {
           const match = types.find((type: RelationshipType) => hasValue(type));
           if (hasValue(match)) {
-            return match
+            return match;
           } else {
             return null;
           }

--- a/src/app/core/data/relationship-type.service.ts
+++ b/src/app/core/data/relationship-type.service.ts
@@ -60,7 +60,7 @@ export class RelationshipTypeService extends DataService<RelationshipType> {
           } else if (type.rightwardType === label) {
             return this.checkType(type, secondType, firstType);
           } else {
-            return [];
+            return [null];
           }
         }),
       );

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
@@ -22,7 +22,7 @@
                 </ds-dynamic-lookup-relation-search-tab>
             </ng-template>
         </ngb-tab>
-        <ngb-tab *ngFor="let source of (externalSourcesRD$ | async)?.payload?.page; let idx = index"
+        <ngb-tab *ngFor="let source of (externalSourcesRD$ | async); let idx = index"
                  [title]="'submission.sections.describe.relationship-lookup.search-tab.tab-title.' + source.id | translate  : {count: (totalExternal$ | async)[idx]}">
             <ng-template ngbTabContent>
                 <ds-dynamic-lookup-relation-external-source-tab

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -20,6 +20,7 @@ import { createSuccessfulRemoteDataObject$ } from '../../../../remote-data.utils
 import { createPaginatedList } from '../../../../testing/utils.test';
 import { ExternalSourceService } from '../../../../../core/data/external-source.service';
 import { LookupRelationService } from '../../../../../core/data/lookup-relation.service';
+import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
 
 describe('DsDynamicLookupRelationModalComponent', () => {
   let component: DsDynamicLookupRelationModalComponent;
@@ -38,6 +39,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
   let pSearchOptions;
   let externalSourceService;
   let lookupRelationService;
+  let rdbService;
   let submissionId;
 
   const externalSources = [
@@ -68,17 +70,22 @@ describe('DsDynamicLookupRelationModalComponent', () => {
       filter: 'filter',
       relationshipType: 'isAuthorOfPublication',
       nameVariants: true,
-      searchConfiguration: 'personConfig'
+      searchConfiguration: 'personConfig',
+      externalSources: ['orcidV2', 'sherpaPublisher']
     });
     nameVariant = 'Doe, J.';
     metadataField = 'dc.contributor.author';
     pSearchOptions = new PaginatedSearchOptions({});
     externalSourceService = jasmine.createSpyObj('externalSourceService', {
-      findAll: createSuccessfulRemoteDataObject$(createPaginatedList(externalSources))
+      findAll: createSuccessfulRemoteDataObject$(createPaginatedList(externalSources)),
+      findById: createSuccessfulRemoteDataObject$(externalSources[0])
     });
     lookupRelationService = jasmine.createSpyObj('lookupRelationService', {
       getTotalLocalResults: observableOf(totalLocal),
       getTotalExternalResults: observableOf(totalExternal)
+    });
+    rdbService = jasmine.createSpyObj('rdbService', {
+      aggregate: createSuccessfulRemoteDataObject$(externalSources)
     });
     submissionId = '1234';
   }
@@ -103,6 +110,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
           provide: RelationshipService, useValue: { getNameVariant: () => observableOf(nameVariant) }
         },
         { provide: RelationshipTypeService, useValue: {} },
+        { provide: RemoteDataBuildService, useValue: rdbService },
         {
           provide: Store, useValue: {
             // tslint:disable-next-line:no-empty

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
-import { combineLatest as observableCombineLatest, Observable, Subscription } from 'rxjs';
+import { combineLatest as observableCombineLatest, Observable, Subscription, zip } from 'rxjs';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { hasValue } from '../../../../empty.util';
+import { hasValue, isNotEmpty } from '../../../../empty.util';
 import { map, skip, switchMap, take } from 'rxjs/operators';
 import { SEARCH_CONFIG_SERVICE } from '../../../../../+my-dspace-page/my-dspace-page.component';
 import { SearchConfigurationService } from '../../../../../core/shared/search/search-configuration.service';
@@ -11,7 +11,11 @@ import { ListableObject } from '../../../../object-collection/shared/listable-ob
 import { RelationshipOptions } from '../../models/relationship-options.model';
 import { SearchResult } from '../../../../search/search-result.model';
 import { Item } from '../../../../../core/shared/item.model';
-import { getAllSucceededRemoteData, getRemoteDataPayload } from '../../../../../core/shared/operators';
+import {
+  getAllSucceededRemoteData,
+  getAllSucceededRemoteDataPayload,
+  getRemoteDataPayload
+} from '../../../../../core/shared/operators';
 import { AddRelationshipAction, RemoveRelationshipAction, UpdateRelationshipNameVariantAction } from './relationship.actions';
 import { RelationshipService } from '../../../../../core/data/relationship.service';
 import { RelationshipTypeService } from '../../../../../core/data/relationship-type.service';
@@ -24,6 +28,7 @@ import { PaginatedList } from '../../../../../core/data/paginated-list.model';
 import { ExternalSource } from '../../../../../core/shared/external-source.model';
 import { ExternalSourceService } from '../../../../../core/data/external-source.service';
 import { Router } from '@angular/router';
+import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
 
 @Component({
   selector: 'ds-dynamic-lookup-relation-modal',
@@ -101,7 +106,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   /**
    * A list of the available external sources configured for this relationship
    */
-  externalSourcesRD$: Observable<RemoteData<PaginatedList<ExternalSource>>>;
+  externalSourcesRD$: Observable<ExternalSource[]>;
 
   /**
    * The total amount of internal items for the current options
@@ -121,6 +126,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     private externalSourceService: ExternalSourceService,
     private lookupRelationService: LookupRelationService,
     private searchConfigService: SearchConfigurationService,
+    private rdbService: RemoteDataBuildService,
     private zone: NgZone,
     private store: Store<AppState>,
     private router: Router,
@@ -141,7 +147,18 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
       this.context = Context.EntitySearchModal;
     }
 
-    this.externalSourcesRD$ = this.externalSourceService.findAll();
+    if (isNotEmpty(this.relationshipOptions.externalSources)) {
+      this.externalSourcesRD$ = this.rdbService.aggregate(
+        this.relationshipOptions.externalSources.map((source) => this.externalSourceService.findById(source))
+      ).pipe(
+        getAllSucceededRemoteDataPayload()
+      );
+    } else {
+      this.externalSourcesRD$ = this.externalSourceService.findAll().pipe(
+        getAllSucceededRemoteDataPayload(),
+        map((list: PaginatedList<ExternalSource>) => list.page)
+      );
+    }
 
     this.setTotals();
   }
@@ -224,16 +241,13 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     );
 
     const externalSourcesAndOptions$ = observableCombineLatest(
-      this.externalSourcesRD$.pipe(
-        getAllSucceededRemoteData(),
-        getRemoteDataPayload()
-      ),
+      this.externalSourcesRD$,
       this.searchConfigService.paginatedSearchOptions
     );
 
     this.totalExternal$ = externalSourcesAndOptions$.pipe(
       switchMap(([sources, options]) =>
-        observableCombineLatest(...sources.page.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
+        observableCombineLatest(...sources.map((source: ExternalSource) => this.lookupRelationService.getTotalExternalResults(source, options))))
     );
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -153,11 +153,6 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
       ).pipe(
         getAllSucceededRemoteDataPayload()
       );
-    } else {
-      this.externalSourcesRD$ = this.externalSourceService.findAll().pipe(
-        getAllSucceededRemoteDataPayload(),
-        map((list: PaginatedList<ExternalSource>) => list.page)
-      );
     }
 
     this.setTotals();

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
-import { combineLatest as observableCombineLatest, Observable, Subscription, zip } from 'rxjs';
+import { combineLatest as observableCombineLatest, Observable, Subscription } from 'rxjs';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { hasValue, isNotEmpty } from '../../../../empty.util';
 import { map, skip, switchMap, take } from 'rxjs/operators';
@@ -11,11 +11,7 @@ import { ListableObject } from '../../../../object-collection/shared/listable-ob
 import { RelationshipOptions } from '../../models/relationship-options.model';
 import { SearchResult } from '../../../../search/search-result.model';
 import { Item } from '../../../../../core/shared/item.model';
-import {
-  getAllSucceededRemoteData,
-  getAllSucceededRemoteDataPayload,
-  getRemoteDataPayload
-} from '../../../../../core/shared/operators';
+import { getAllSucceededRemoteDataPayload } from '../../../../../core/shared/operators';
 import { AddRelationshipAction, RemoveRelationshipAction, UpdateRelationshipNameVariantAction } from './relationship.actions';
 import { RelationshipService } from '../../../../../core/data/relationship.service';
 import { RelationshipTypeService } from '../../../../../core/data/relationship-type.service';
@@ -23,8 +19,6 @@ import { Store } from '@ngrx/store';
 import { AppState } from '../../../../../app.reducer';
 import { Context } from '../../../../../core/shared/context.model';
 import { LookupRelationService } from '../../../../../core/data/lookup-relation.service';
-import { RemoteData } from '../../../../../core/data/remote-data';
-import { PaginatedList } from '../../../../../core/data/paginated-list.model';
 import { ExternalSource } from '../../../../../core/shared/external-source.model';
 import { ExternalSourceService } from '../../../../../core/data/external-source.service';
 import { Router } from '@angular/router';

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -20,6 +20,9 @@ import { SubmissionObjectDataService } from '../../../../../core/submission/subm
 import { WorkspaceItem } from '../../../../../core/submission/models/workspaceitem.model';
 import { ObjectCacheService } from '../../../../../core/cache/object-cache.service';
 import { RequestService } from '../../../../../core/data/request.service';
+import { NotificationsService } from '../../../../notifications/notifications.service';
+import { TranslateService } from '@ngx-translate/core';
+import { SelectableListService } from '../../../../object-list/selectable-list/selectable-list.service';
 
 describe('RelationshipEffects', () => {
   let relationEffects: RelationshipEffects;
@@ -45,6 +48,9 @@ describe('RelationshipEffects', () => {
   let relationship;
   let mockRelationshipService;
   let mockRelationshipTypeService;
+  let notificationsService;
+  let translateService;
+  let selectableListService;
   let testScheduler: TestScheduler;
 
   function init() {
@@ -95,6 +101,14 @@ describe('RelationshipEffects', () => {
       getRelationshipTypeByLabelAndTypes:
         () => observableOf(relationshipType)
     };
+    notificationsService = jasmine.createSpyObj('notificationsService', ['error']);
+    translateService = jasmine.createSpyObj('translateService', {
+      instant: 'translated-message'
+    });
+    selectableListService = jasmine.createSpyObj('selectableListService', {
+      findSelectedByCondition: observableOf({}),
+      deselectSingle: {}
+    });
   }
 
   beforeEach(waitForAsync(() => {
@@ -114,6 +128,9 @@ describe('RelationshipEffects', () => {
         { provide: Store, useValue: jasmine.createSpyObj('store', ['dispatch']) },
         { provide: ObjectCacheService, useValue: {} },
         { provide: RequestService, useValue: {} },
+        { provide: NotificationsService, useValue: notificationsService },
+        { provide: TranslateService, useValue: translateService },
+        { provide: SelectableListService, useValue: selectableListService },
       ],
     });
   }));

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
@@ -15,7 +15,7 @@ import {
   UpdateRelationshipNameVariantAction
 } from './relationship.actions';
 import { Item } from '../../../../../core/shared/item.model';
-import { hasNoValue, hasValue } from '../../../../empty.util';
+import { hasNoValue, hasValue, hasValueOperator } from '../../../../empty.util';
 import { Relationship } from '../../../../../core/shared/item-relationships/relationship.model';
 import { RelationshipType } from '../../../../../core/shared/item-relationships/relationship-type.model';
 import { RelationshipTypeService } from '../../../../../core/data/relationship-type.service';
@@ -30,6 +30,10 @@ import { ServerSyncBufferActionTypes } from '../../../../../core/cache/server-sy
 import { JsonPatchOperationsActionTypes } from '../../../../../core/json-patch/json-patch-operations.actions';
 import { followLink } from '../../../../utils/follow-link-config.model';
 import { RemoteData } from '../../../../../core/data/remote-data';
+import { NotificationsService } from '../../../../notifications/notifications.service';
+import { SelectableListService } from '../../../../object-list/selectable-list/selectable-list.service';
+import { TranslateService } from '@ngx-translate/core';
+import { error } from 'util';
 
 const DEBOUNCE_TIME = 500;
 
@@ -152,7 +156,10 @@ export class RelationshipEffects {
               private submissionObjectService: SubmissionObjectDataService,
               private store: Store<SubmissionState>,
               private objectCache: ObjectCacheService,
-              private requestService: RequestService
+              private requestService: RequestService,
+              private notificationsService: NotificationsService,
+              private translateService: TranslateService,
+              private selectableListService: SelectableListService,
   ) {
   }
 
@@ -166,6 +173,9 @@ export class RelationshipEffects {
     return this.relationshipTypeService.getRelationshipTypeByLabelAndTypes(relationshipType, type1, type2)
       .pipe(
         mergeMap((type: RelationshipType) => {
+          if (type === null) {
+            return [null];
+          } else {
             const isSwitched = type.rightwardType === relationshipType;
             if (isSwitched) {
               return this.relationshipService.addRelationship(type.id, item2, item1, nameVariant, undefined);
@@ -173,9 +183,28 @@ export class RelationshipEffects {
               return this.relationshipService.addRelationship(type.id, item1, item2, undefined, nameVariant);
             }
           }
-        ),
+        }),
         take(1),
-        switchMap(() => this.refreshWorkspaceItemInCache(submissionId)),
+        switchMap((rd: RemoteData<Relationship>) => {
+          if (hasNoValue(rd) || rd.hasFailed) {
+            // An error occurred, deselect the object from the selectable list and display an error notification
+            const listId = `list-${submissionId}-${relationshipType}`;
+            this.selectableListService.findSelectedByCondition(listId, (object: any) => hasValue(object.indexableObject) && object.indexableObject.uuid === item2.uuid).pipe(
+              take(1),
+              hasValueOperator()
+            ).subscribe((selected) => {
+              this.selectableListService.deselectSingle(listId, selected);
+            });
+            let errorContent;
+            if (hasNoValue(rd)) {
+              errorContent = this.translateService.instant('relationships.add.error.relationship-type.content', { type: relationshipType });
+            } else {
+              errorContent = this.translateService.instant('relationships.add.error.server.content');
+            }
+            this.notificationsService.error(this.translateService.instant('relationships.add.error.title'), errorContent);
+          }
+          return this.refreshWorkspaceItemInCache(submissionId);
+        }),
       ).subscribe((submissionObject: SubmissionObject) => this.store.dispatch(new SaveSubmissionSectionFormSuccessAction(submissionId, [submissionObject], false)));
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
@@ -33,7 +33,6 @@ import { RemoteData } from '../../../../../core/data/remote-data';
 import { NotificationsService } from '../../../../notifications/notifications.service';
 import { SelectableListService } from '../../../../object-list/selectable-list/selectable-list.service';
 import { TranslateService } from '@ngx-translate/core';
-import { error } from 'util';
 
 const DEBOUNCE_TIME = 500;
 

--- a/src/app/shared/form/builder/models/relationship-options.model.ts
+++ b/src/app/shared/form/builder/models/relationship-options.model.ts
@@ -8,6 +8,7 @@ export class RelationshipOptions {
   filter: string;
   searchConfiguration: string;
   nameVariants: string;
+  externalSources: string[];
 
   get metadataField() {
     return RELATION_METADATA_PREFIX + this.relationshipType;

--- a/src/app/shared/object-list/selectable-list/selectable-list.service.ts
+++ b/src/app/shared/object-list/selectable-list/selectable-list.service.ts
@@ -91,4 +91,15 @@ export class SelectableListService {
       distinctUntilChanged()
     );
   }
+
+  /**
+   * Find a selected object by a custom condition
+   * @param id        The ID of the selectable list to search in
+   * @param condition The condition that the required object has to match
+   */
+  findSelectedByCondition(id: string, condition: (object: ListableObject) => boolean): Observable<ListableObject> {
+    return this.getSelectableList(id).pipe(
+      map((state: SelectableListState) => (hasValue(state) && isNotEmpty(state.selection)) ? state.selection.find((selected) => condition(selected)) : undefined)
+    );
+  }
 }

--- a/src/app/submission/submission.module.ts
+++ b/src/app/submission/submission.module.ts
@@ -32,6 +32,8 @@ import { SubmissionImportExternalSearchbarComponent } from './import-external/im
 import { SubmissionImportExternalPreviewComponent } from './import-external/import-external-preview/submission-import-external-preview.component';
 import { SubmissionImportExternalCollectionComponent } from './import-external/import-external-collection/submission-import-external-collection.component';
 import { SubmissionSectionCcLicensesComponent } from './sections/cc-license/submission-section-cc-licenses.component';
+import { JournalEntitiesModule } from '../entity-groups/journal-entities/journal-entities.module';
+import { ResearchEntitiesModule } from '../entity-groups/research-entities/research-entities.module';
 
 @NgModule({
   imports: [
@@ -39,7 +41,9 @@ import { SubmissionSectionCcLicensesComponent } from './sections/cc-license/subm
     CoreModule.forRoot(),
     SharedModule,
     StoreModule.forFeature('submission', submissionReducers, storeModuleConfig as StoreConfig<SubmissionState, Action>),
-    EffectsModule.forFeature(submissionEffects)
+    EffectsModule.forFeature(submissionEffects),
+    JournalEntitiesModule.withEntryComponents(),
+    ResearchEntitiesModule.withEntryComponents(),
   ],
   declarations: [
     SubmissionSectionUploadAccessConditionsComponent,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2654,6 +2654,12 @@
 
 
 
+  "relationships.add.error.relationship-type.content": "No suitable match could be found for relationship type {{ type }} between the two items",
+
+  "relationships.add.error.server.content": "The server returned an error",
+
+  "relationships.add.error.title": "Unable to add relationship",
+
   "relationships.isAuthorOf": "Authors",
 
   "relationships.isAuthorOf.Person": "Authors (persons)",


### PR DESCRIPTION
## References
- Fixes #943
- Depends on #975
- The configured REST API requires [PR #3109](https://github.com/DSpace/DSpace/pull/3109) for the external sources to be limited.

## Description
Currently, the lookup window for relationships during submission displays all the available external sources to import from, even sources that don't match the field you're trying to import a relationship to.
This PR aims to only display only the configured external sources depending on the [new configuration returned by the REST API](https://github.com/DSpace/DSpace/pull/3109), as well as display error notifications when creating the relationship fails.

This PR seems a lot bigger than it is, because it depends on #975 You can see only the changes in this PR [here](https://github.com/atmire/dspace-angular/compare/cache-redesign-part-2...atmire:Submission-external-sources-limited-on-metadata-field)


## Instructions for Reviewers
Changes made:
- Added `externalsources` array property to `RelationshipOptions` (retrieved from REST API)
- Modified lookup modal to only retrieve the appropriate external source objects depending on this new property
- RelationShipService's `getRelationshipTypeByLabelAndTypes()` now emits "null" whenever the types found in the created item and/or submission item don't match the relationship.
- A notification is displayed upon creating a relationship where this method emits "null". The newly created item is also automatically deselected if this is the case.

How to test:
- Configure a REST API containing [PR #3109](https://github.com/DSpace/DSpace/pull/3109), as well as a collection with a submission form containing a relationship metadata field with a custom configuration for the external sources.
- Visit the submission form of this collection
- Open the lookup modal for the relationship metadata field containing configured external sources
- Verify only the configured external sources are available
- Verify you're able to import an item from the external source and add it as a relationship to the submission item

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
