### PR TITLE
fix #869 Submission embargo bug

### DIFF
--- a/src/app/core/config/models/config-access-condition-option.model.ts
+++ b/src/app/core/config/models/config-access-condition-option.model.ts
@@ -9,16 +9,6 @@ export class AccessConditionOption {
   name: string;
 
   /**
-   * The uuid of the Group this Access Condition applies to
-   */
-  groupUUID: string;
-
-  /**
-   * The uuid of the Group that contains set of groups this Resource Policy applies to
-   */
-  selectGroupUUID: string;
-
-  /**
    * A boolean representing if this Access Condition has a start date
    */
   hasStartDate: boolean;

--- a/src/app/core/submission/models/submission-upload-file-access-condition.model.ts
+++ b/src/app/core/submission/models/submission-upload-file-access-condition.model.ts
@@ -14,11 +14,6 @@ export class SubmissionUploadFileAccessConditionObject {
   name: string;
 
   /**
-   * The access group UUID defined in this access condition
-   */
-  groupUUID: string;
-
-  /**
    * Possible start date of the access condition
    */
   startDate: string;

--- a/src/app/shared/mocks/submission.mock.ts
+++ b/src/app/shared/mocks/submission.mock.ts
@@ -1284,27 +1284,23 @@ export const mockUploadConfigResponse = {
   accessConditionOptions: [
     {
       name: 'openaccess',
-      groupUUID: '123456-g',
       hasStartDate: false,
       hasEndDate: false
     },
     {
       name: 'lease',
-      groupUUID: '123456-g',
       hasStartDate: false,
       hasEndDate: true,
       maxEndDate: '2019-07-12T14:40:06.308+0000'
     },
     {
       name: 'embargo',
-      groupUUID: '123456-g',
       hasStartDate: true,
       hasEndDate: false,
       maxStartDate: '2022-01-12T14:40:06.308+0000'
     },
     {
       name: 'administrator',
-      groupUUID: '0f2773dd-1741-475f-80e7-ccdef153d655',
       hasStartDate: false,
       hasEndDate: false
     }
@@ -1322,35 +1318,6 @@ export const mockUploadConfigResponse = {
 
 // Clone the object and change one property
 export const mockUploadConfigResponseNotRequired = Object.assign({}, mockUploadConfigResponse, { required: false });
-
-export const mockAccessConditionOptions = [
-  {
-    name: 'openaccess',
-    groupUUID: '123456-g',
-    hasStartDate: false,
-    hasEndDate: false
-  },
-  {
-    name: 'lease',
-    groupUUID: '123456-g',
-    hasStartDate: false,
-    hasEndDate: true,
-    maxEndDate: '2019-07-12T14:40:06.308+0000'
-  },
-  {
-    name: 'embargo',
-    groupUUID: '123456-g',
-    hasStartDate: true,
-    hasEndDate: false,
-    maxStartDate: '2022-01-12T14:40:06.308+0000'
-  },
-  {
-    name: 'administrator',
-    groupUUID: '0f2773dd-1741-475f-80e7-ccdef153d655',
-    hasStartDate: false,
-    hasEndDate: false
-  }
-];
 
 export const mockGroup = Object.assign(new Group(), {
   handle: null,
@@ -1478,17 +1445,6 @@ export const mockFileFormData = {
           otherInformation: null
         }
       ],
-      groupUUID: [
-        {
-          value: '123456-g',
-          language: null,
-          authority: null,
-          display: '123456-g',
-          confidence: -1,
-          place: 0,
-          otherInformation: null
-        }
-      ]
     }
     ,
     {
@@ -1522,17 +1478,6 @@ export const mockFileFormData = {
           otherInformation: null
         }
       ],
-      groupUUID: [
-        {
-          value: '123456-g',
-          language: null,
-          authority: null,
-          display: '123456-g',
-          confidence: -1,
-          place: 0,
-          otherInformation: null
-        }
-      ]
     }
     ,
     {
@@ -1566,17 +1511,6 @@ export const mockFileFormData = {
           otherInformation: null
         }
       ],
-      groupUUID: [
-        {
-          value: '123456-g',
-          language: null,
-          authority: null,
-          display: '123456-g',
-          confidence: -1,
-          place: 0,
-          otherInformation: null
-        }
-      ]
     }
   ]
 };

--- a/src/app/submission/sections/upload/accessConditions/submission-section-upload-access-conditions.component.html
+++ b/src/app/submission/sections/upload/accessConditions/submission-section-upload-access-conditions.component.html
@@ -2,7 +2,6 @@
   <span *ngIf="accessCondition.action == 'DEFAULT_BITSTREAM_READ'" class="badge badge-primary mt-3 mr-2">
     {{accessCondition.name}} {{accessCondition.startDate}} {{accessCondition.endDate}}
   </span>
-  <span *ngIf="accessCondition.name == 'openaccess'" class="badge badge-success mt-3 mr-2">{{accessCondition.name}}</span>
   <span *ngIf="accessCondition.name == 'lease'" class="badge badge-primary mt-3 mr-2">{{accessCondition.name}} from {{accessCondition.endDate}}</span>
   <span *ngIf="accessCondition.name == 'embargo'" class="badge badge-dark mt-3 mr-2">{{accessCondition.name}} until {{accessCondition.startDate}}</span>
   <br>

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -43,10 +43,6 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
   const sectionId = 'upload';
   const collectionId = mockSubmissionCollectionId;
   const availableAccessConditionOptions = mockUploadConfigResponse.accessConditionOptions;
-  const availableGroupsMap: Map<string, Group[]> = new Map([
-    [mockUploadConfigResponse.accessConditionOptions[1].name, [mockGroup as any]],
-    [mockUploadConfigResponse.accessConditionOptions[2].name, [mockGroup as any]],
-  ]);
   const collectionPolicyType = POLICY_DEFAULT_WITH_LIST;
   const configMetadataForm: any = mockUploadConfigResponseMetadata;
   const fileIndex = '0';
@@ -123,7 +119,6 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       comp.collectionId = collectionId;
       comp.sectionId = sectionId;
       comp.availableAccessConditionOptions = availableAccessConditionOptions;
-      comp.availableAccessConditionGroups = availableGroupsMap;
       comp.collectionPolicyType = collectionPolicyType;
       comp.fileIndex = fileIndex;
       comp.fileId = fileId;
@@ -180,18 +175,15 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
       control.value = 'openaccess';
       comp.setOptions(model, control);
-      expect(formbuilderService.findById).not.toHaveBeenCalledWith('groupUUID', (model.parent as DynamicFormArrayGroupModel).group);
       expect(formbuilderService.findById).not.toHaveBeenCalledWith('endDate', (model.parent as DynamicFormArrayGroupModel).group);
       expect(formbuilderService.findById).not.toHaveBeenCalledWith('startDate', (model.parent as DynamicFormArrayGroupModel).group);
 
       control.value = 'lease';
       comp.setOptions(model, control);
-      expect(formbuilderService.findById).toHaveBeenCalledWith('groupUUID', (model.parent as DynamicFormArrayGroupModel).group);
       expect(formbuilderService.findById).toHaveBeenCalledWith('endDate', (model.parent as DynamicFormArrayGroupModel).group);
 
       control.value = 'embargo';
       comp.setOptions(model, control);
-      expect(formbuilderService.findById).toHaveBeenCalledWith('groupUUID', (model.parent as DynamicFormArrayGroupModel).group);
       expect(formbuilderService.findById).toHaveBeenCalledWith('startDate', (model.parent as DynamicFormArrayGroupModel).group);
     });
   });
@@ -208,7 +200,6 @@ class TestComponent {
   availableAccessConditionOptions;
   collectionId = mockSubmissionCollectionId;
   collectionPolicyType;
-  configMetadataForm$;
   fileIndexes = [];
   fileList = [];
   fileNames = [];

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
@@ -108,32 +108,3 @@ export const BITSTREAM_FORM_ACCESS_CONDITION_END_DATE_LAYOUT: DynamicFormControl
     host: 'col-md-4'
   }
 };
-
-export const BITSTREAM_FORM_ACCESS_CONDITION_GROUPS_CONFIG: DynamicSelectModelConfig<any> = {
-  id: 'groupUUID',
-  label: 'submission.sections.upload.form.group-label',
-  options: [],
-  relations: [
-    {
-      match: MATCH_ENABLED,
-      operator: OR_OPERATOR,
-      when: []
-    }
-  ],
-  required: true,
-  validators: {
-    required: null
-  },
-  errorMessages: {
-    required: 'submission.sections.upload.form.group-required'
-  }
-};
-export const BITSTREAM_FORM_ACCESS_CONDITION_GROUPS_LAYOUT: DynamicFormControlLayout = {
-  element: {
-    container: 'p-0',
-      label: 'col-form-label'
-  },
-  grid: {
-    host: 'col-sm-10'
-  }
-};

--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -37,7 +37,6 @@
       <ds-submission-section-upload-file-view *ngIf="readMode"
                                               [fileData]="fileData"></ds-submission-section-upload-file-view>
       <ds-submission-section-upload-file-edit *ngIf="!readMode"
-                                              [availableAccessConditionGroups]="availableAccessConditionGroups"
                                               [availableAccessConditionOptions]="availableAccessConditionOptions"
                                               [collectionId]="collectionId"
                                               [collectionPolicyType]="collectionPolicyType"

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -162,7 +162,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       comp.collectionId = collectionId;
       comp.sectionId = sectionId;
       comp.availableAccessConditionOptions = availableAccessConditionOptions;
-      comp.availableAccessConditionGroups = availableGroupsMap;
       comp.collectionPolicyType = collectionPolicyType;
       comp.fileIndex = fileIndex;
       comp.fileId = fileId;
@@ -258,9 +257,9 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       operationsService.jsonPatchByResourceID.and.returnValue(observableOf(response));
 
       const accessConditionsToSave = [
-        { name: 'openaccess', groupUUID: '123456-g' },
-        { name: 'lease', endDate: '2019-01-16T00:00:00Z', groupUUID: '123456-g' },
-        { name: 'embargo', startDate: '2019-01-16T00:00:00Z', groupUUID: '123456-g' }
+        { name: 'openaccess' },
+        { name: 'lease', endDate: '2019-01-16T00:00:00Z' },
+        { name: 'embargo', startDate: '2019-01-16T00:00:00Z' },
       ];
       comp.saveBitstreamData(event);
       tick();

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -12,7 +12,6 @@ import { JsonPatchOperationsBuilder } from '../../../../core/json-patch/builder/
 import { JsonPatchOperationPathCombiner } from '../../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { WorkspaceitemSectionUploadFileObject } from '../../../../core/submission/models/workspaceitem-section-upload-file.model';
 import { SubmissionFormsModel } from '../../../../core/config/models/config-submission-forms.model';
-import { deleteProperty } from '../../../../shared/object.util';
 import { dateToISOFormat } from '../../../../shared/date.util';
 import { SubmissionService } from '../../../submission.service';
 import { FileService } from '../../../../core/shared/file.service';
@@ -21,7 +20,6 @@ import { SubmissionJsonPatchOperationsService } from '../../../../core/submissio
 import { SubmissionObject } from '../../../../core/submission/models/submission-object.model';
 import { WorkspaceitemSectionUploadObject } from '../../../../core/submission/models/workspaceitem-section-upload.model';
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
-import { Group } from '../../../../core/eperson/models/group.model';
 
 /**
  * This component represents a single bitstream contained in the submission
@@ -38,12 +36,6 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
    * @type {Array}
    */
   @Input() availableAccessConditionOptions: any[];
-
-  /**
-   * The list of available groups for an access condition
-   * @type {Array}
-   */
-  @Input() availableAccessConditionGroups: Map<string, Group[]>;
 
   /**
    * The submission id
@@ -172,7 +164,7 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
    * Retrieve bitstream's metadata
    */
   ngOnChanges() {
-    if (this.availableAccessConditionOptions && this.availableAccessConditionGroups) {
+    if (this.availableAccessConditionOptions) {
       // Retrieve file state
       this.subscriptions.push(
         this.uploadService
@@ -272,28 +264,17 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
               .forEach((element) => accessConditionOpt = element);
 
             if (accessConditionOpt) {
-
-              if (accessConditionOpt.hasStartDate !== true && accessConditionOpt.hasEndDate !== true) {
-                accessConditionOpt = deleteProperty(accessConditionOpt, 'hasStartDate');
-
-                accessConditionOpt = deleteProperty(accessConditionOpt, 'hasEndDate');
-                accessConditionsToSave.push(accessConditionOpt);
-              } else {
                 accessConditionOpt = Object.assign({}, accessCondition);
                 accessConditionOpt.name = this.retrieveValueFromField(accessCondition.name);
-                accessConditionOpt.groupUUID = this.retrieveValueFromField(accessCondition.groupUUID);
                 if (accessCondition.startDate) {
                   const startDate = this.retrieveValueFromField(accessCondition.startDate);
                   accessConditionOpt.startDate = dateToISOFormat(startDate);
-                  accessConditionOpt = deleteProperty(accessConditionOpt, 'endDate');
                 }
                 if (accessCondition.endDate) {
                   const endDate = this.retrieveValueFromField(accessCondition.endDate);
                   accessConditionOpt.endDate = dateToISOFormat(endDate);
-                  accessConditionOpt = deleteProperty(accessConditionOpt, 'startDate');
                 }
                 accessConditionsToSave.push(accessConditionOpt);
-              }
             }
           });
 

--- a/src/app/submission/sections/upload/section-upload.component.html
+++ b/src/app/submission/sections/upload/section-upload.component.html
@@ -28,7 +28,7 @@
   </div>
 
   <ng-container *ngFor="let fileEntry of fileList">
-    <ds-submission-upload-section-file [availableAccessConditionGroups]="availableGroups"
+    <ds-submission-upload-section-file
                                        [availableAccessConditionOptions]="availableAccessConditionOptions"
                                        [collectionId]="collectionId"
                                        [collectionPolicyType]="collectionPolicyType"

--- a/src/app/submission/sections/upload/section-upload.component.spec.ts
+++ b/src/app/submission/sections/upload/section-upload.component.spec.ts
@@ -260,8 +260,6 @@ describe('SubmissionSectionUploadComponent test suite', () => {
       expect(comp.availableAccessConditionOptions).toEqual(mockUploadConfigResponse.accessConditionOptions as any);
       expect(comp.required$.getValue()).toBe(true);
       expect(compAsAny.subs.length).toBe(2);
-      expect(compAsAny.availableGroups.size).toBe(2);
-      expect(compAsAny.availableGroups).toEqual(expectedGroupsMap);
       expect(compAsAny.fileList).toEqual([]);
       expect(compAsAny.fileIndexes).toEqual([]);
       expect(compAsAny.fileNames).toEqual([]);
@@ -298,8 +296,6 @@ describe('SubmissionSectionUploadComponent test suite', () => {
       expect(comp.availableAccessConditionOptions).toEqual(mockUploadConfigResponse.accessConditionOptions as any);
       expect(comp.required$.getValue()).toBe(true);
       expect(compAsAny.subs.length).toBe(2);
-      expect(compAsAny.availableGroups.size).toBe(2);
-      expect(compAsAny.availableGroups).toEqual(expectedGroupsMap);
       expect(compAsAny.fileList).toEqual(mockUploadFiles);
       expect(compAsAny.fileIndexes).toEqual(['123456-test-upload']);
       expect(compAsAny.fileNames).toEqual(['123456-test-upload.jpg']);

--- a/src/app/submission/sections/upload/section-upload.component.ts
+++ b/src/app/submission/sections/upload/section-upload.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, Inject } from '@angular/core';
 
 import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, find, map, mergeMap, reduce, switchMap, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 
 import { SectionModelComponent } from '../models/section.model';
 import { hasValue, isNotEmpty, isNotUndefined, isUndefined } from '../../../shared/empty.util';
@@ -23,7 +23,6 @@ import { SectionsService } from '../sections.service';
 import { SubmissionService } from '../../submission.service';
 import { Collection } from '../../../core/shared/collection.model';
 import { AccessConditionOption } from '../../../core/config/models/config-access-condition-option.model';
-import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { followLink } from '../../../shared/utils/follow-link-config.model';
 import { getFirstSucceededRemoteData } from '../../../core/shared/operators';
 
@@ -99,11 +98,6 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
    * List of available access conditions that could be set to files
    */
   public availableAccessConditionOptions: AccessConditionOption[];  // List of accessConditions that an user can select
-
-  /**
-   * List of Groups available for every access condition
-   */
-  public availableGroups: Map<string, Group[]>; // Groups for any policy
 
   /**
    * Is the upload required
@@ -184,53 +178,12 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
           }
         }),*/
         mergeMap(() => config$),
-        mergeMap((config: SubmissionUploadsModel) => {
-          this.required$.next(config.required);
-          this.availableAccessConditionOptions = isNotEmpty(config.accessConditionOptions) ? config.accessConditionOptions : [];
-
-          this.collectionPolicyType = this.availableAccessConditionOptions.length > 0
-            ? POLICY_DEFAULT_WITH_LIST
-            : POLICY_DEFAULT_NO_LIST;
-
-          this.availableGroups = new Map();
-          const mapGroups$: Observable<AccessConditionGroupsMapEntry>[] = [];
-          // Retrieve Groups for accessCondition Policies
-          this.availableAccessConditionOptions.forEach((accessCondition: AccessConditionOption) => {
-            if (accessCondition.hasEndDate === true || accessCondition.hasStartDate === true) {
-              if (accessCondition.groupUUID) {
-                mapGroups$.push(
-                  this.groupService.findById(accessCondition.groupUUID).pipe(
-                    find((rd: RemoteData<Group>) => !rd.isResponsePending && rd.hasSucceeded),
-                    map((rd: RemoteData<Group>) => ({
-                      accessCondition: accessCondition.name,
-                      groups: [rd.payload]
-                    } as AccessConditionGroupsMapEntry)))
-                );
-              } else if (accessCondition.selectGroupUUID) {
-                mapGroups$.push(
-                  this.groupService.findById(accessCondition.selectGroupUUID).pipe(
-                    find((rd: RemoteData<Group>) => !rd.isResponsePending && rd.hasSucceeded),
-                    mergeMap((group: RemoteData<Group>) => group.payload.subgroups),
-                    find((rd: RemoteData<PaginatedList<Group>>) => !rd.isResponsePending && rd.hasSucceeded),
-                    map((rd: RemoteData<PaginatedList<Group>>) => ({
-                      accessCondition: accessCondition.name,
-                      groups: rd.payload.page
-                    } as AccessConditionGroupsMapEntry))
-                  ));
-              }
-            }
-          });
-          return mapGroups$;
-        }),
-        mergeMap((entry) => entry),
-        reduce((acc: any[], entry: AccessConditionGroupsMapEntry) => {
-          acc.push(entry);
-          return acc;
-        }, []),
-      ).subscribe((entries: AccessConditionGroupsMapEntry[]) => {
-        entries.forEach((entry: AccessConditionGroupsMapEntry) => {
-          this.availableGroups.set(entry.accessCondition, entry.groups);
-        });
+      ).subscribe((config: SubmissionUploadsModel) => {
+        this.required$.next(config.required);
+        this.availableAccessConditionOptions = isNotEmpty(config.accessConditionOptions) ? config.accessConditionOptions : [];
+        this.collectionPolicyType = this.availableAccessConditionOptions.length > 0
+          ? POLICY_DEFAULT_WITH_LIST
+          : POLICY_DEFAULT_NO_LIST;
         this.changeDetectorRef.detectChanges();
       }),
 


### PR DESCRIPTION
## References
* Angular part of [DSpace/dspace-angular#869](https://github.com/DSpace/dspace-angular/issues/869) (Does not fully fix issue though)
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract/pull/152)
* Related to https://github.com/DSpace/DSpace/pull/3136

## Description
This is the Angular part to fix the embargo bug [DSpace/dspace-angular#869](https://github.com/DSpace/dspace-angular/issues/869)
It removes the group select as discussed in the issue and REST contract

## Instructions for Reviewers
Keep in mind for this change, the REST part is also required. The REST contract details how the access conditions can be defined

## List of changes in this PR:
* The 'groupUUID' and 'selectGroupUUID' fields have been removed from the AccessConditionOption model, which is used by the SubmissionUploadModel, for which the contract has been changed
* The 'groupUUID' field has been removed from the SubmissionUploadFileAccessConditionObject model, which is used by the WorkspaceItem and WorkflowItem models for which the contracts have been changed
* The group select has been removed from the SubmissionSectionUploadFileEditComponent, along with the related fields/inputs (also cascaded upwards to the SubmissionSectionUploadFileComponent and SubmissionSectionUploadComponent)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
