### PR TITLE
Fix unnecessary calls when creating/deleting groups

### DIFF
--- a/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/group-form.component.ts
@@ -143,7 +143,9 @@ export class GroupFormComponent implements OnInit, OnDestroy {
 
   initialisePage() {
     this.subs.push(this.route.params.subscribe((params) => {
-      this.setActiveGroup(params.groupId);
+      if (params.groupId !== 'newGroup') {
+        this.setActiveGroup(params.groupId);
+      }
     }));
     this.canEdit$ = this.groupDataService.getActiveGroup().pipe(
       hasValueOperator(),
@@ -225,14 +227,12 @@ export class GroupFormComponent implements OnInit, OnDestroy {
               {
                 value: this.groupDescription.value
               }
-            ],
+            ]
           },
         };
         if (group === null) {
-          console.log('createNewGroup', values);
           this.createNewGroup(values);
         } else {
-          console.log('editGroup', group);
           this.editGroup(group);
         }
       }

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.html
@@ -24,10 +24,10 @@
     </div>
   </form>
 
-  <ds-pagination *ngIf="(searchResults$ | async)?.payload?.totalElements > 0"
+  <ds-pagination *ngIf="(ePeopleSearchDtos | async)?.totalElements > 0"
                  [paginationOptions]="configSearch"
-                 [pageInfoState]="(searchResults$ | async)?.payload"
-                 [collectionSize]="(searchResults$ | async)?.payload?.totalElements"
+                 [pageInfoState]="(ePeopleSearchDtos | async)"
+                 [collectionSize]="(ePeopleSearchDtos | async)?.totalElements"
                  [hideGear]="true"
                  [hidePagerWhenSinglePage]="true"
                  (pageChange)="onPageChangeSearch($event)">
@@ -42,23 +42,23 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let ePerson of (searchResults$ | async)?.payload?.page">
-          <td>{{ePerson.id}}</td>
-          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson)"
-                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.name}}</a></td>
+        <tr *ngFor="let ePerson of (ePeopleSearchDtos | async)?.page">
+          <td>{{ePerson.eperson.id}}</td>
+          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson.eperson)"
+                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.eperson.name}}</a></td>
           <td>
             <div class="btn-group edit-field">
-              <button *ngIf="(isMemberOfGroup(ePerson) | async)"
+              <button *ngIf="(ePerson.memberOfGroup)"
                       (click)="deleteMemberFromGroup(ePerson)"
                       class="btn btn-outline-danger btn-sm"
-                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.name} }}">
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.eperson.name} }}">
                 <i class="fas fa-trash-alt fa-fw"></i>
               </button>
 
-              <button *ngIf="!(isMemberOfGroup(ePerson) | async)"
+              <button *ngIf="!(ePerson.memberOfGroup)"
                       (click)="addMemberToGroup(ePerson)"
                       class="btn btn-outline-primary btn-sm"
-                      title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: ePerson.name} }}">
+                      title="{{messagePrefix + '.table.edit.buttons.add' | translate: {name: ePerson.eperson.name} }}">
                 <i class="fas fa-plus fa-fw"></i>
               </button>
             </div>
@@ -70,7 +70,7 @@
 
   </ds-pagination>
 
-  <div *ngIf="(searchResults$ | async)?.payload?.totalElements == 0 && searchDone"
+  <div *ngIf="(ePeopleSearchDtos | async)?.totalElements == 0 && searchDone"
        class="alert alert-info w-100 mb-2"
        role="alert">
     {{messagePrefix + '.no-items' | translate}}
@@ -78,10 +78,10 @@
 
   <h4>{{messagePrefix + '.headMembers' | translate}}</h4>
 
-  <ds-pagination *ngIf="(members$ | async)?.payload?.totalElements > 0"
+  <ds-pagination *ngIf="(ePeopleMembersOfGroupDtos | async)?.totalElements > 0"
                  [paginationOptions]="config"
-                 [pageInfoState]="(members$ | async)?.payload"
-                 [collectionSize]="(members$ | async)?.payload?.totalElements"
+                 [pageInfoState]="(ePeopleMembersOfGroupDtos | async)"
+                 [collectionSize]="(ePeopleMembersOfGroupDtos | async)?.totalElements"
                  [hideGear]="true"
                  [hidePagerWhenSinglePage]="true"
                  (pageChange)="onPageChange($event)">
@@ -96,15 +96,15 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let ePerson of (members$ | async)?.payload?.page">
-          <td>{{ePerson.id}}</td>
-          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson)"
-                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.name}}</a></td>
+        <tr *ngFor="let ePerson of (ePeopleMembersOfGroupDtos | async)?.page">
+          <td>{{ePerson.eperson.id}}</td>
+          <td><a (click)="ePersonDataService.startEditingNewEPerson(ePerson.eperson)"
+                 [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">{{ePerson.eperson.name}}</a></td>
           <td>
             <div class="btn-group edit-field">
               <button (click)="deleteMemberFromGroup(ePerson)"
                       class="btn btn-outline-danger btn-sm"
-                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.name} }}">
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: {name: ePerson.eperson.name} }}">
                 <i class="fas fa-trash-alt fa-fw"></i>
               </button>
             </div>
@@ -116,7 +116,7 @@
 
   </ds-pagination>
 
-  <div *ngIf="(members$ | async)?.payload?.totalElements == 0" class="alert alert-info w-100 mb-2"
+  <div *ngIf="(ePeopleMembersOfGroupDtos | async) == undefined || (ePeopleMembersOfGroupDtos | async)?.totalElements == 0" class="alert alert-info w-100 mb-2"
        role="alert">
     {{messagePrefix + '.no-members-yet' | translate}}
   </div>

--- a/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -163,7 +163,7 @@ export class MembersListComponent implements OnInit, OnDestroy {
         }));
         return dtos$.pipe(map((dtos: EpersonDtoModel[]) => {
           return buildPaginatedList(epersonListRD.payload.pageInfo, dtos);
-        }))
+        }));
       }))
       .subscribe((paginatedListOfDTOs: PaginatedList<EpersonDtoModel>) => {
         this.ePeopleMembersOfGroupDtos.next(paginatedListOfDTOs);
@@ -285,7 +285,7 @@ export class MembersListComponent implements OnInit, OnDestroy {
           }));
           return dtos$.pipe(map((dtos: EpersonDtoModel[]) => {
             return buildPaginatedList(epersonListRD.payload.pageInfo, dtos);
-          }))
+          }));
         }))
         .subscribe((paginatedListOfDTOs: PaginatedList<EpersonDtoModel>) => {
           this.ePeopleSearchDtos.next(paginatedListOfDTOs);

--- a/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/group-form/subgroup-list/subgroups-list.component.ts
@@ -130,7 +130,7 @@ export class SubgroupsListComponent implements OnInit, OnDestroy {
       SubKey.Members,
       this.groupDataService.findAllByHref(this.groupBeingEdited._links.subgroups.href, {
           currentPage: page,
-          elementsPerPage: this.config.pageSize
+      elementsPerPage: this.config.pageSize
         }
       ).subscribe((rd: RemoteData<PaginatedList<Group>>) => {
         this.subGroups$.next(rd);

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.html
@@ -8,7 +8,7 @@
         <button class="mr-auto btn btn-success"
                 [routerLink]="['newGroup']">
           <i class="fas fa-plus"></i>
-          <span class="d-none d-sm-inline">&nbsp;{{messagePrefix + 'button.add' | translate}}</span>
+          <span class="d-none d-sm-inline">{{messagePrefix + 'button.add' | translate}}</span>
         </button>
       </div>
 
@@ -45,7 +45,6 @@
               <th scope="col">{{messagePrefix + 'table.id' | translate}}</th>
               <th scope="col">{{messagePrefix + 'table.name' | translate}}</th>
               <th scope="col">{{messagePrefix + 'table.members' | translate}}</th>
-              <!--              <th scope="col">{{messagePrefix + 'table.comcol' | translate}}</th>-->
               <th>{{messagePrefix + 'table.edit' | translate}}</th>
             </tr>
             </thead>
@@ -53,8 +52,7 @@
             <tr *ngFor="let groupDto of (groupsDto$ | async)?.page">
               <td>{{groupDto.group.id}}</td>
               <td>{{groupDto.group.name}}</td>
-              <td>{{(getMembers(groupDto.group) | async)?.payload?.totalElements + (getSubgroups(groupDto.group) | async)?.payload?.totalElements}}</td>
-              <!--              <td>{{getOptionalComColFromName(group.name)}}</td>-->
+              <td>{{groupDto.epersons?.totalElements + groupDto.subgroups?.totalElements}}</td>
               <td>
                 <div class="btn-group edit-field">
                   <button [routerLink]="groupService.getGroupEditPageRouterLink(groupDto.group)"
@@ -63,7 +61,7 @@
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
                   <button *ngIf="!groupDto.group?.permanent && groupDto.ableToDelete"
-                          (click)="deleteGroup(groupDto.group)" class="btn btn-outline-danger btn-sm"
+                          (click)="deleteGroup(groupDto)" class="btn btn-outline-danger btn-sm"
                           title="{{messagePrefix + 'table.edit.buttons.remove' | translate: {name: groupDto.group.name} }}">
                     <i class="fas fa-trash-alt fa-fw"></i>
                   </button>

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -26,7 +26,7 @@ import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import {
   getAllSucceededRemoteDataPayload,
   getFirstCompletedRemoteData,
-  getAllSucceededRemoteData
+  getFirstSucceededRemoteData
 } from '../../../core/shared/operators';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { hasValue } from '../../../shared/empty.util';
@@ -56,14 +56,11 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
   });
 
   /**
-   * A list of all the current Groups within the repository or the result of the search
-   */
-  groups$: BehaviorSubject<RemoteData<PaginatedList<Group>>> = new BehaviorSubject<RemoteData<PaginatedList<Group>>>({} as any);
-  /**
    * A BehaviorSubject with the list of GroupDtoModel objects made from the Groups in the repository or
    * as the result of the search
    */
   groupsDto$: BehaviorSubject<PaginatedList<GroupDtoModel>> = new BehaviorSubject<PaginatedList<GroupDtoModel>>({} as any);
+  deletedGroupsIds: string[] = [];
 
   /**
    * An observable for the pageInfo, needed to pass to the pagination component
@@ -104,35 +101,6 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.search({ query: this.currentSearchQuery });
-
-    this.subs.push(this.groups$.pipe(
-      getAllSucceededRemoteDataPayload(),
-      switchMap((groups: PaginatedList<Group>) => {
-        return observableCombineLatest(groups.page.map((group: Group) => {
-          return observableCombineLatest([
-            this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(group) ? group.self : undefined),
-            this.hasLinkedDSO(group),
-            this.getSubgroups(group),
-            this.getMembers(group)
-          ]).pipe(
-            map(([isAuthorized, hasLinkedDSO, subgroups, members]:
-                   [boolean, boolean, RemoteData<PaginatedList<Group>>, RemoteData<PaginatedList<EPerson>>]) => {
-                const groupDtoModel: GroupDtoModel = new GroupDtoModel();
-                groupDtoModel.ableToDelete = isAuthorized && !hasLinkedDSO;
-                groupDtoModel.group = group;
-                groupDtoModel.subgroups = subgroups.payload;
-                groupDtoModel.epersons = members.payload;
-                return groupDtoModel;
-              }
-            )
-          );
-        })).pipe(map((dtos: GroupDtoModel[]) => {
-          return buildPaginatedList(groups.pageInfo, dtos);
-        }));
-      })).subscribe((value: PaginatedList<GroupDtoModel>) => {
-      this.groupsDto$.next(value);
-      this.pageInfoState$.next(value.pageInfo);
-    }));
   }
 
   /**
@@ -159,14 +127,42 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
       this.searchSub.unsubscribe();
       this.subs = this.subs.filter((sub: Subscription) => sub !== this.searchSub);
     }
+
     this.searchSub = this.groupService.searchGroups(this.currentSearchQuery.trim(), {
       currentPage: this.config.currentPage,
       elementsPerPage: this.config.pageSize
     }).pipe(
-      getAllSucceededRemoteData()
-    ).subscribe((groupsRD: RemoteData<PaginatedList<Group>>) => {
-      this.groups$.next(groupsRD);
-      this.pageInfoState$.next(groupsRD.payload.pageInfo);
+      getAllSucceededRemoteDataPayload(),
+      switchMap((groups: PaginatedList<Group>) => {
+        if (groups.page.length === 0) {
+          return observableOf(buildPaginatedList(groups.pageInfo, []));
+        }
+        return observableCombineLatest(groups.page.map((group: Group) => {
+          if (!this.deletedGroupsIds.includes(group.id)) {
+            return observableCombineLatest([
+              this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(group) ? group.self : undefined),
+              this.hasLinkedDSO(group),
+              this.getSubgroups(group),
+              this.getMembers(group)
+            ]).pipe(
+              map(([isAuthorized, hasLinkedDSO, subgroups, members]:
+                     [boolean, boolean, RemoteData<PaginatedList<Group>>, RemoteData<PaginatedList<EPerson>>]) => {
+                  const groupDtoModel: GroupDtoModel = new GroupDtoModel();
+                  groupDtoModel.ableToDelete = isAuthorized && !hasLinkedDSO;
+                  groupDtoModel.group = group;
+                  groupDtoModel.subgroups = subgroups.payload;
+                  groupDtoModel.epersons = members.payload;
+                  return groupDtoModel;
+                }
+              )
+            );
+          }
+        })).pipe(map((dtos: GroupDtoModel[]) => {
+          return buildPaginatedList(groups.pageInfo, dtos);
+        }));
+      })).subscribe((value: PaginatedList<GroupDtoModel>) => {
+      this.groupsDto$.next(value);
+      this.pageInfoState$.next(value.pageInfo);
     });
     this.subs.push(this.searchSub);
   }
@@ -179,6 +175,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
       this.groupService.delete(group.group.id).pipe(getFirstCompletedRemoteData())
         .subscribe((rd: RemoteData<NoContent>) => {
           if (rd.hasSucceeded) {
+            this.deletedGroupsIds = [...this.deletedGroupsIds, group.group.id];
             this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: group.group.name }));
             this.reset();
           } else {
@@ -199,14 +196,14 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
     ).subscribe((href: string) => {
       this.requestService.setStaleByHrefSubstring(href);
     });
-}
+  }
 
   /**
    * Get the members (epersons embedded value of a group)
    * @param group
    */
   getMembers(group: Group): Observable<RemoteData<PaginatedList<EPerson>>> {
-    return this.ePersonDataService.findAllByHref(group._links.epersons.href);
+    return this.ePersonDataService.findAllByHref(group._links.epersons.href).pipe(getFirstSucceededRemoteData());
   }
 
   /**
@@ -214,7 +211,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
    * @param group
    */
   getSubgroups(group: Group): Observable<RemoteData<PaginatedList<Group>>> {
-    return this.groupService.findAllByHref(group._links.subgroups.href);
+    return this.groupService.findAllByHref(group._links.subgroups.href).pipe(getFirstSucceededRemoteData());
   }
 
   /**
@@ -223,6 +220,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
    */
   hasLinkedDSO(group: Group): Observable<boolean> {
     return this.dSpaceObjectDataService.findByHref(group._links.object.href).pipe(
+      getFirstSucceededRemoteData(),
       map((rd: RemoteData<DSpaceObject>) => hasValue(rd) && hasValue(rd.payload)),
       catchError(() => observableOf(false)),
     );

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -111,12 +111,17 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
         return observableCombineLatest(groups.page.map((group: Group) => {
           return observableCombineLatest([
             this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(group) ? group.self : undefined),
-            this.hasLinkedDSO(group)
+            this.hasLinkedDSO(group),
+            this.getSubgroups(group),
+            this.getMembers(group)
           ]).pipe(
-            map(([isAuthorized, hasLinkedDSO]: boolean[]) => {
+            map(([isAuthorized, hasLinkedDSO, subgroups, members]:
+                   [boolean, boolean, RemoteData<PaginatedList<Group>>, RemoteData<PaginatedList<EPerson>>]) => {
                 const groupDtoModel: GroupDtoModel = new GroupDtoModel();
                 groupDtoModel.ableToDelete = isAuthorized && !hasLinkedDSO;
                 groupDtoModel.group = group;
+                groupDtoModel.subgroups = subgroups.payload;
+                groupDtoModel.epersons = members.payload;
                 return groupDtoModel;
               }
             )

--- a/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
+++ b/src/app/+admin/admin-access-control/group-registry/groups-registry.component.ts
@@ -169,16 +169,16 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
   /**
    * Delete Group
    */
-  deleteGroup(group: Group) {
-    if (hasValue(group.id)) {
-      this.groupService.delete(group.id).pipe(getFirstCompletedRemoteData())
+  deleteGroup(group: GroupDtoModel) {
+    if (hasValue(group.group.id)) {
+      this.groupService.delete(group.group.id).pipe(getFirstCompletedRemoteData())
         .subscribe((rd: RemoteData<NoContent>) => {
           if (rd.hasSucceeded) {
-            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: group.name }));
+            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: group.group.name }));
             this.reset();
           } else {
             this.notificationsService.error(
-              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: group.name }),
+              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: group.group.name }),
               this.translateService.get(this.messagePrefix + 'notification.deleted.failure.content', { cause: rd.errorMessage }));
           }
       });
@@ -194,7 +194,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
     ).subscribe((href: string) => {
       this.requestService.setStaleByHrefSubstring(href);
     });
-  }
+}
 
   /**
    * Get the members (epersons embedded value of a group)
@@ -231,15 +231,6 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
       query: '',
     });
     this.search({ query: '' });
-  }
-
-  /**
-   * Extract optional UUID from a group name => To be resolved to community or collection with link
-   * (Or will be resolved in backend and added to group object, tbd) //TODO
-   * @param groupName
-   */
-  getOptionalComColFromName(groupName: string): string {
-    return this.groupService.getUUIDFromString(groupName);
   }
 
   /**

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -63,10 +63,10 @@ export class EPersonDataService extends DataService<EPerson> {
    * @param query   Query of search
    * @param options Options of search request
    */
-  public searchByScope(scope: string, query: string, options: FindListOptions = {}): Observable<RemoteData<PaginatedList<EPerson>>> {
+  public searchByScope(scope: string, query: string, options: FindListOptions = {}, useCachedVersionIfAvailable?: boolean): Observable<RemoteData<PaginatedList<EPerson>>> {
     switch (scope) {
       case 'metadata':
-        return this.getEpeopleByMetadata(query.trim(), options);
+        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable);
       case 'email':
         return this.getEPersonByEmail(query.trim()).pipe(
           map((rd: RemoteData<EPerson | NoContent>) => {
@@ -100,7 +100,7 @@ export class EPersonDataService extends DataService<EPerson> {
           })
         );
       default:
-        return this.getEpeopleByMetadata(query.trim(), options);
+        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable);
     }
   }
 

--- a/src/app/core/eperson/models/eperson-dto.model.ts
+++ b/src/app/core/eperson/models/eperson-dto.model.ts
@@ -13,5 +13,9 @@ export class EpersonDtoModel {
      * Whether or not the linked EPerson is able to be deleted
      */
     public ableToDelete: boolean;
+    /**
+     * Whether or not this EPerson is member of group on page it is being used on
+     */
+    public memberOfGroup: boolean;
 
 }

--- a/src/app/core/eperson/models/group-dto.model.ts
+++ b/src/app/core/eperson/models/group-dto.model.ts
@@ -1,7 +1,9 @@
+import { PaginatedList } from '../../data/paginated-list.model';
+import { EPerson } from './eperson.model';
 import { Group } from './group.model';
 
 /**
- * This class serves as a Data Transfer Model that contains the Group and whether or not it's able to be deleted
+ * This class serves as a Data Transfer Model that contains the Group, whether or not it's able to be deleted and its members
  */
 export class GroupDtoModel {
 
@@ -9,9 +11,20 @@ export class GroupDtoModel {
    * The Group linked to this object
    */
   public group: Group;
+
   /**
    * Whether or not the linked Group is able to be deleted
    */
   public ableToDelete: boolean;
+
+  /**
+   * List of subgroups of this group
+   */
+  public subgroups: PaginatedList<Group>;
+
+  /**
+   * List of members of this group
+   */
+  public epersons: PaginatedList<EPerson>;
 
 }

--- a/src/app/core/eperson/models/group.model.ts
+++ b/src/app/core/eperson/models/group.model.ts
@@ -1,4 +1,4 @@
-import { autoserialize, deserialize, inheritSerialization } from 'cerialize';
+import { autoserialize, autoserializeAs, deserialize, inheritSerialization } from 'cerialize';
 import { Observable } from 'rxjs';
 import { link, typedObject } from '../../cache/builders/build-decorators';
 import { PaginatedList } from '../../data/paginated-list.model';
@@ -10,11 +10,19 @@ import { HALLink } from '../../shared/hal-link.model';
 import { EPerson } from './eperson.model';
 import { EPERSON } from './eperson.resource-type';
 import { GROUP } from './group.resource-type';
+import { excludeFromEquals } from '../../utilities/equals.decorators';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
 export class Group extends DSpaceObject {
   static type = GROUP;
+
+  /**
+   * A string representing the unique name of this Group
+   */
+  @excludeFromEquals
+  @autoserializeAs('name')
+  protected _name: string;
 
   /**
    * A string representing the unique handle of this Group

--- a/src/app/core/shared/dspace-object.model.ts
+++ b/src/app/core/shared/dspace-object.model.ts
@@ -29,7 +29,7 @@ export class DSpaceObject extends ListableObject implements CacheableObject {
 
   @excludeFromEquals
   @deserializeAs('name')
-  private _name: string;
+  protected _name: string;
 
   /**
    * The human-readable identifier of this DSpaceObject

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -308,8 +308,6 @@
 
   "admin.access-control.groups.table.members": "Members",
 
-  "admin.access-control.groups.table.comcol": "Community / Collection",
-
   "admin.access-control.groups.table.edit": "Edit",
 
   "admin.access-control.groups.table.edit.buttons.edit": "Edit \"{{name}}\"",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -402,6 +402,8 @@
 
   "admin.access-control.groups.form.members-list.no-items": "No EPeople found in that search",
 
+  "admin.access-control.groups.form.subgroups-list.notification.failure": "Something went wrong: \"{{cause}}\"",
+
   "admin.access-control.groups.form.subgroups-list.head": "Groups",
 
   "admin.access-control.groups.form.subgroups-list.search.head": "Add Subgroup",


### PR DESCRIPTION
## References
* Fixes #962

## Description
The 404 errors in network tab (dev tools) should no longer appear when you start a new group, nor when you delete a group from the group repository. Some refactoring with DTO's to prevent unneeded calls.

## Instructions for Reviewers
- Open dev tools network tab & log in as admin
- Go to groups registry at /admin/access-control/groups
- 1. "+ Add group" to add a new group => No 404 errors in network tab
- 2. When deleting a group from the groups registry view => No 404 error in network tab (for /object /epersons and /subgroups)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
