### PR TITLE
Fix: Search filter from entity page carries over to discovery

### DIFF
--- a/src/app/+search-page/configuration-search-page.component.spec.ts
+++ b/src/app/+search-page/configuration-search-page.component.spec.ts
@@ -2,20 +2,63 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { configureSearchComponentTestingModule } from './search.component.spec';
 import { ConfigurationSearchPageComponent } from './configuration-search-page.component';
 import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
+import { Component, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { RouteService } from '../core/services/route.service';
+import createSpy = jasmine.createSpy;
+
+const CONFIGURATION = 'test-configuration';
+const QUERY = 'test query';
+
+@Component({
+  template: `
+    <ds-configuration-search-page [configuration]="'${CONFIGURATION}'"
+                                  [fixedFilterQuery]="'${QUERY}'"
+                                  #configurationSearchPage>
+    </ds-configuration-search-page>
+  `,
+})
+class HostComponent {
+  @ViewChild('configurationSearchPage') configurationSearchPage: ConfigurationSearchPageComponent;
+}
 
 describe('ConfigurationSearchPageComponent', () => {
   let comp: ConfigurationSearchPageComponent;
-  let fixture: ComponentFixture<ConfigurationSearchPageComponent>;
+  let fixture: ComponentFixture<HostComponent>;
   let searchConfigService: SearchConfigurationService;
+  let routeService: RouteService;
 
   beforeEach(waitForAsync(() => {
-    configureSearchComponentTestingModule(ConfigurationSearchPageComponent);
+    configureSearchComponentTestingModule(ConfigurationSearchPageComponent, [HostComponent]);
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ConfigurationSearchPageComponent);
-    comp = fixture.componentInstance;
-    searchConfigService = (comp as any).searchConfigService;
+    fixture = TestBed.createComponent(HostComponent);
+
+    // Set router url to a dummy value for SearchComponent#ngOnInit
+    spyOnProperty(TestBed.inject(Router), 'url', 'get').and.returnValue('some/url/here');
+
+    routeService = TestBed.inject(RouteService);
+    routeService.setParameter = createSpy('setParameter');
+
     fixture.detectChanges();
+
+    comp = fixture.componentInstance.configurationSearchPage;
+    searchConfigService = (comp as any).searchConfigService;
+  });
+
+  it('should set route parameters on init', () => {
+    expect(comp.configuration).toBe(CONFIGURATION);
+    expect(comp.fixedFilterQuery).toBe(QUERY);
+
+    expect(routeService.setParameter).toHaveBeenCalledWith('configuration', CONFIGURATION);
+    expect(routeService.setParameter).toHaveBeenCalledWith('fixedFilterQuery', QUERY);
+  });
+
+  it('should reset route parameters on destroy', () => {
+    fixture.destroy();
+
+    expect(routeService.setParameter).toHaveBeenCalledWith('configuration', undefined);
+    expect(routeService.setParameter).toHaveBeenCalledWith('fixedFilterQuery', undefined);
   });
 });

--- a/src/app/+search-page/configuration-search-page.component.ts
+++ b/src/app/+search-page/configuration-search-page.component.ts
@@ -1,7 +1,7 @@
 import { HostWindowService } from '../shared/host-window.service';
 import { SidebarService } from '../shared/sidebar/sidebar.service';
 import { SearchComponent } from './search.component';
-import { ChangeDetectionStrategy, Component, Inject, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { pushInOut } from '../shared/animations/push';
 import { SEARCH_CONFIG_SERVICE } from '../+my-dspace-page/my-dspace-page.component';
 import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
@@ -27,7 +27,7 @@ import { Router } from '@angular/router';
   ]
 })
 
-export class ConfigurationSearchPageComponent extends SearchComponent implements OnInit {
+export class ConfigurationSearchPageComponent extends SearchComponent implements OnInit, OnDestroy {
   /**
    * The configuration to use for the search options
    * If empty, the configuration will be determined by the route parameter called 'configuration'
@@ -63,6 +63,19 @@ export class ConfigurationSearchPageComponent extends SearchComponent implements
     }
     if (hasValue(this.fixedFilterQuery)) {
       this.routeService.setParameter('fixedFilterQuery', this.fixedFilterQuery);
+    }
+  }
+
+  /**
+   * Reset the updated query/configuration set in ngOnInit()
+   */
+  ngOnDestroy(): void {
+    super.ngOnDestroy();
+    if (hasValue(this.configuration)) {
+      this.routeService.setParameter('configuration', undefined);
+    }
+    if (hasValue(this.fixedFilterQuery)) {
+      this.routeService.setParameter('fixedFilterQuery', undefined);
     }
   }
 }

--- a/src/app/+search-page/search.component.spec.ts
+++ b/src/app/+search-page/search.component.spec.ts
@@ -84,10 +84,10 @@ const routeServiceStub = {
   }
 };
 
-export function configureSearchComponentTestingModule(compType) {
+export function configureSearchComponentTestingModule(compType, additionalDeclarations: any[] = []) {
   TestBed.configureTestingModule({
     imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), NoopAnimationsModule, NgbCollapseModule],
-    declarations: [compType],
+    declarations: [compType, ...additionalDeclarations],
     providers: [
       { provide: SearchService, useValue: searchServiceStub },
       {


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1016

## Description
Reset the Store values of `fixedFilterQuery` and `properties` to `undefined` when `ConfigurationSearchPageComponent` gets destroyed to prevent them from carrying over

## Instructions for Reviewers
Verifying the fix:
* Open a page with a `ConfigurationSearchPageComponent` (e.g. https://demo7.dspace.org/items/4b0bb46a-9086-4398-a6b4-09840404d8dc)
* (Optional: execute a query from the search form)
* Go to the search page
* Results for an empty query should be shown instead of the results of the previous page

List of changes in this PR:
* [`ConfigurationSearchPageComponent` resets the `RouteService` parameters set in `ngOnInit()` back to `undefined` in `ngOnDestroy()`](https://github.com/DSpace/dspace-angular/compare/main...atmire:w2p-76922_Search-filter-from-entity-page-carries-over-to-discovery?expand=1#diff-2dbb839dc72b42691904c399f46ac641cab4630517cd35253e4518538ca6c719R68-R80)
* Added tests for the `RouteService.setParameter()` calls on init and destroy
* `configureSearchComponentTestingModule()`: specify an optional array of additional declarations (to enable testing with a wrapper component)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
