### PR TITLE
Cleanup duplicative or incorrect Angular UI i18n keys

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -468,6 +468,8 @@
 
   "admin.search.title": "Administrative Search",
 
+  "administrativeView.search.results.head": "Administrative Search",
+
 
 
 
@@ -2489,64 +2491,6 @@
 
 
 
-  "profile.breadcrumbs": "Update Profile",
-
-  "profile.card.identify": "Identify",
-
-  "profile.card.security": "Security",
-
-  "profile.form.submit": "Update Profile",
-
-  "profile.groups.head": "Authorization groups you belong to",
-
-  "profile.head": "Update Profile",
-
-  "profile.metadata.form.error.firstname.required": "First Name is required",
-
-  "profile.metadata.form.error.lastname.required": "Last Name is required",
-
-  "profile.metadata.form.label.email": "Email Address",
-
-  "profile.metadata.form.label.firstname": "First Name",
-
-  "profile.metadata.form.label.language": "Language",
-
-  "profile.metadata.form.label.lastname": "Last Name",
-
-  "profile.metadata.form.label.phone": "Contact Telephone",
-
-  "profile.metadata.form.notifications.success.content": "Your changes to the profile were saved.",
-
-  "profile.metadata.form.notifications.success.title": "Profile saved",
-
-  "profile.notifications.warning.no-changes.content": "No changes were made to the Profile.",
-
-  "profile.notifications.warning.no-changes.title": "No changes",
-
-  "profile.security.form.error.matching-passwords": "The passwords do not match.",
-
-  "profile.security.form.error.password-length": "The password should be at least 6 characters long.",
-
-  "profile.security.form.info": "Optionally, you can enter a new password in the box below, and confirm it by typing it again into the second box. It should be at least six characters long.",
-
-  "profile.security.form.label.password": "Password",
-
-  "profile.security.form.label.passwordrepeat": "Retype to confirm",
-
-  "profile.security.form.notifications.success.content": "Your changes to the password were saved.",
-
-  "profile.security.form.notifications.success.title": "Password saved",
-
-  "profile.security.form.notifications.error.title": "Error changing passwords",
-
-  "profile.security.form.notifications.error.not-long-enough": "The password has to be at least 6 characters long.",
-
-  "profile.security.form.notifications.error.not-same": "The provided passwords are not the same.",
-
-  "profile.title": "Update Profile",
-
-
-
   "project.listelement.badge": "Research Project",
 
   "project.page.contributor": "Contributors",
@@ -3485,7 +3429,6 @@
 
 
 
-
   "vocabulary-treeview.header": "Hierarchical tree view",
 
   "vocabulary-treeview.load-more": "Load more",
@@ -3499,12 +3442,6 @@
   "vocabulary-treeview.tree.description.nsi": "The Norwegian Science Index",
 
   "vocabulary-treeview.tree.description.srsc": "Research Subject Categories",
-
-
-
-  "administrativeView.search.results.head": "Administrative Search",
-
-  "menu.section.admin_search": "Admin Search",
 
 
 
@@ -3563,4 +3500,3 @@
 
   "workflow-item.send-back.button.confirm": "Send back"
 }
-


### PR DESCRIPTION
## References
* Fixes #1010

## Description
As described in ticket, removes keys that are duplicated in `en.json5`.  

Also renamed `administrativeView.search.results.head` to be simply `admin.search.results.head` (and corrected `admin-search-page.component.html` to support that change), as this places it alphabetically alongside the other Admin Search keys.

## Instructions for Reviewers
* Review changes
* Optionally test Admin Search & Profile to verify no keys are missing.
