### PR TITLE
Environment files merging with overwriteMerge

### DIFF
--- a/scripts/set-env.ts
+++ b/scripts/set-env.ts
@@ -10,7 +10,7 @@ const targetPath = './src/environments/environment.ts';
 const colors = require('colors');
 require('dotenv').config();
 const merge = require('deepmerge');
-
+const mergeOptions = { arrayMerge: (destinationArray, sourceArray, options) => sourceArray };
 const environment = process.argv[2];
 let environmentFilePath;
 let production = false;
@@ -45,10 +45,10 @@ const processEnv = {
 } as GlobalConfig;
 
 import(environmentFilePath)
-  .then((file) => generateEnvironmentFile(merge.all([commonEnv, file.environment, processEnv])))
+  .then((file) => generateEnvironmentFile(merge.all([commonEnv, file.environment, processEnv], mergeOptions)))
   .catch(() => {
     console.log(colors.yellow.bold(`No specific environment file found for ` + environment));
-    generateEnvironmentFile(merge(commonEnv, processEnv))
+    generateEnvironmentFile(merge(commonEnv, processEnv, mergeOptions))
   });
 
 function generateEnvironmentFile(file: GlobalConfig): void {
@@ -65,7 +65,7 @@ function generateEnvironmentFile(file: GlobalConfig): void {
 }
 
 // allow to override a few important options by environment variables
-function createServerConfig(host?: string,  port?: string, nameSpace?: string, ssl?: string): ServerConfig {
+function createServerConfig(host?: string, port?: string, nameSpace?: string, ssl?: string): ServerConfig {
   const result = {} as any;
   if (hasValue(host)) {
     result.host = host;

--- a/src/app/core/shared/metadata.utils.ts
+++ b/src/app/core/shared/metadata.utils.ts
@@ -156,9 +156,7 @@ export class Metadata {
     const outputKeys: string[] = [];
     for (const inputKey of inputKeys) {
       if (inputKey.includes('*')) {
-
         const inputKeyRegex = new RegExp('^' + inputKey.replace('.', '\.').replace('*', '.*') + '$');
-
         for (const mapKey of Object.keys(mdMap)) {
           if (!outputKeys.includes(mapKey) && inputKeyRegex.test(mapKey)) {
             outputKeys.push(mapKey);

--- a/src/app/core/shared/metadata.utils.ts
+++ b/src/app/core/shared/metadata.utils.ts
@@ -156,7 +156,9 @@ export class Metadata {
     const outputKeys: string[] = [];
     for (const inputKey of inputKeys) {
       if (inputKey.includes('*')) {
+
         const inputKeyRegex = new RegExp('^' + inputKey.replace('.', '\.').replace('*', '.*') + '$');
+
         for (const mapKey of Object.keys(mdMap)) {
           if (!outputKeys.includes(mapKey) && inputKeyRegex.test(mapKey)) {
             outputKeys.push(mapKey);


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/909

## Description
This PR ensures that you can merge the common environment with the dev environment. Any values that are specified in the dev environment, will be getting priority over the common profile. If any properties aren't present in the dev file, they'll be taken from the common file.
This PR also ensures that lists are taken from the dev file as a whole if they're present, this means that lists like the "Languages" list, won't be merged anymore. All the values will be taken from the dev file and the list in the common file will be ignored if the list is present in the dev file.

We decided against converting the arrays to objects as that'd mean that we'd have to specifically set each object to null if we didn't want to include it anymore. For example if we're specifying browse indices, with this code we'll have to specify the list of browse indices that we want to use in the dev file. If we were to convert it into objects, we'd have to copy all the browse indices to the dev file and set the ones that we don't want to use to null. This feels like a lot more overhead and more error-prone than just using the list that you want.

## Instructions for Reviewers

List of changes in this PR:
* Now using overwriteMerge for the merging of environment files

Please test this PR by setting up a common environment and a dev environment.
* Configure the property "logDirectory" in the common environment with the value '.'
* Leave out the property "logDirectory" in the dev environment
* Configure the property "debug" in the common environment with the value "false"
* Configure the property "debug" in the dev environment with the value "true"
* Configure a list of languages in the common environment
* Configure a different list of languages in the dev environment

Now run the merge script and verify:
* The logDirectory is still set to the value in the common environment
* The debug property is set to true, the value in the dev environment
* The list of languages is set to exactly what's in the dev environment

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
