### PR TITLE
Use of embed sizes in the ComCol tree

### DIFF
--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -102,7 +102,7 @@ const communityListStateSelector = (state: AppState) => state.communityList;
 const expandedNodesSelector = createSelector(communityListStateSelector, (communityList: CommunityListState) => communityList.expandedNodes);
 const loadingNodeSelector = createSelector(communityListStateSelector, (communityList: CommunityListState) => communityList.loadingNode);
 
-export const MAX_COMCOLS_PER_PAGE = 50;
+export const MAX_COMCOLS_PER_PAGE = 20;
 
 /**
  * Service class for the community list, responsible for the creating of the flat list used by communityList dataSource

--- a/src/app/community-list-page/community-list-service.ts
+++ b/src/app/community-list-page/community-list-service.ts
@@ -19,6 +19,7 @@ import { CommunityListState } from './community-list.reducer';
 import { getCommunityPageRoute } from '../+community-page/community-page-routing-paths';
 import { getCollectionPageRoute } from '../+collection-page/collection-page-routing-paths';
 import { getFirstSucceededRemoteData, getFirstCompletedRemoteData } from '../core/shared/operators';
+import { followLink } from '../shared/utils/follow-link-config.model';
 
 /**
  * Each node in the tree is represented by a flatNode which contains info about the node itself and its position and
@@ -115,6 +116,10 @@ export class CommunityListService {
               private store: Store<any>) {
   }
 
+  private configOnePage: FindListOptions = Object.assign(new FindListOptions(), {
+    elementsPerPage: 1
+  });
+
   saveCommunityListStateToStore(expandedNodes: FlatNode[], loadingNode: FlatNode): void {
     this.store.dispatch(new CommunityListSaveAction(expandedNodes, loadingNode));
   }
@@ -162,16 +167,19 @@ export class CommunityListService {
    */
   private getTopCommunities(options: FindListOptions): Observable<PaginatedList<Community>> {
     return this.communityDataService.findTop({
-      currentPage: options.currentPage,
-      elementsPerPage: MAX_COMCOLS_PER_PAGE,
-      sort: {
-        field: options.sort.field,
-        direction: options.sort.direction
-      }
-    }).pipe(
-      getFirstSucceededRemoteData(),
-      map((results) => results.payload),
-    );
+        currentPage: options.currentPage,
+        elementsPerPage: MAX_COMCOLS_PER_PAGE,
+        sort: {
+          field: options.sort.field,
+          direction: options.sort.direction
+        }
+      },
+      followLink('subcommunities', this.configOnePage, true, true),
+      followLink('collections', this.configOnePage, true, true))
+      .pipe(
+        getFirstSucceededRemoteData(),
+        map((results) => results.payload),
+      );
   }
 
   /**
@@ -231,9 +239,11 @@ export class CommunityListService {
       let subcoms = [];
       for (let i = 1; i <= currentCommunityPage; i++) {
         const nextSetOfSubcommunitiesPage = this.communityDataService.findByParent(community.uuid, {
-          elementsPerPage: MAX_COMCOLS_PER_PAGE,
-          currentPage: i
-        })
+            elementsPerPage: MAX_COMCOLS_PER_PAGE,
+            currentPage: i
+          },
+          followLink('subcommunities', this.configOnePage, true, true),
+          followLink('collections', this.configOnePage, true, true))
           .pipe(
             getFirstCompletedRemoteData(),
             switchMap((rd: RemoteData<PaginatedList<Community>>) => {
@@ -289,7 +299,7 @@ export class CommunityListService {
   public getIsExpandable(community: Community): Observable<boolean> {
     let hasSubcoms$: Observable<boolean>;
     let hasColls$: Observable<boolean>;
-    hasSubcoms$ = this.communityDataService.findByParent(community.uuid, { elementsPerPage: 1 })
+    hasSubcoms$ = this.communityDataService.findByParent(community.uuid, this.configOnePage)
       .pipe(
         map((rd: RemoteData<PaginatedList<Community>>) => {
           if (hasValue(rd) && hasValue(rd.payload)) {
@@ -300,7 +310,7 @@ export class CommunityListService {
         }),
       );
 
-    hasColls$ = this.collectionDataService.findByParent(community.uuid, { elementsPerPage: 1 })
+    hasColls$ = this.collectionDataService.findByParent(community.uuid, this.configOnePage)
       .pipe(
         map((rd: RemoteData<PaginatedList<Collection>>) => {
           if (hasValue(rd) && hasValue(rd.payload)) {

--- a/src/app/core/data/comcol-data.service.ts
+++ b/src/app/core/data/comcol-data.service.ts
@@ -18,6 +18,7 @@ import { BitstreamDataService } from './bitstream-data.service';
 import { NoContent } from '../shared/NoContent.model';
 import { createFailedRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { URLCombiner } from '../url-combiner/url-combiner';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 
 export abstract class ComColDataService<T extends Community | Collection> extends DataService<T> {
   protected abstract cds: CommunityDataService;
@@ -66,11 +67,11 @@ export abstract class ComColDataService<T extends Community | Collection> extend
 
   protected abstract getFindByParentHref(parentUUID: string): Observable<string>;
 
-  public findByParent(parentUUID: string, options: FindListOptions = {}): Observable<RemoteData<PaginatedList<T>>> {
+  public findByParent(parentUUID: string, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<T>[]): Observable<RemoteData<PaginatedList<T>>> {
     const href$ = this.getFindByParentHref(parentUUID).pipe(
       map((href: string) => this.buildHrefFromFindOptions(href, options))
     );
-    return this.findAllByHref(href$);
+    return this.findAllByHref(href$, options, true, true, ...linksToFollow);
   }
 
   /**

--- a/src/app/core/data/community-data.service.ts
+++ b/src/app/core/data/community-data.service.ts
@@ -19,6 +19,7 @@ import { RemoteData } from './remote-data';
 import { FindListOptions } from './request.models';
 import { RequestService } from './request.service';
 import { BitstreamDataService } from './bitstream-data.service';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 
 @Injectable()
 @dataService(COMMUNITY)
@@ -45,9 +46,9 @@ export class CommunityDataService extends ComColDataService<Community> {
     return this.halService.getEndpoint(this.linkPath);
   }
 
-  findTop(options: FindListOptions = {}): Observable<RemoteData<PaginatedList<Community>>> {
+  findTop(options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<Community>[]): Observable<RemoteData<PaginatedList<Community>>> {
     const hrefObs = this.getFindAllHref(options, this.topLinkPath);
-    return this.findAllByHref(hrefObs, undefined);
+    return this.findAllByHref(hrefObs, undefined, true, true, ...linksToFollow);
   }
 
   protected getFindByParentHref(parentUUID: string): Observable<string> {

--- a/src/app/core/data/data.service.spec.ts
+++ b/src/app/core/data/data.service.spec.ts
@@ -193,10 +193,32 @@ describe('DataService', () => {
       });
     });
 
+    it('should include single linksToFollow as embed and its size', () => {
+      const expected = `${endpoint}?embed.size=bundles=5&embed=bundles`;
+      const config: FindListOptions = Object.assign(new FindListOptions(), {
+        elementsPerPage: 5
+      });
+      (service as any).getFindAllHref({}, null, followLink('bundles', config,  true, true, true)).subscribe((value) => {
+        expect(value).toBe(expected);
+      });
+    });
+
     it('should include multiple linksToFollow as embed', () => {
       const expected = `${endpoint}?embed=bundles&embed=owningCollection&embed=templateItemOf`;
 
       (service as any).getFindAllHref({}, null, followLink('bundles'), followLink('owningCollection'), followLink('templateItemOf')).subscribe((value) => {
+        expect(value).toBe(expected);
+      });
+    });
+
+    it('should include multiple linksToFollow as embed and its sizes if given', () => {
+      const expected = `${endpoint}?embed=bundles&embed.size=owningCollection=2&embed=owningCollection&embed=templateItemOf`;
+
+      const config: FindListOptions = Object.assign(new FindListOptions(), {
+        elementsPerPage: 2
+      });
+
+      (service as any).getFindAllHref({}, null, followLink('bundles'), followLink('owningCollection', config, true, true, true), followLink('templateItemOf')).subscribe((value) => {
         expect(value).toBe(expected);
       });
     });
@@ -213,6 +235,16 @@ describe('DataService', () => {
       const expected = `${endpoint}?embed=owningCollection/itemtemplate/relationships`;
 
       (service as any).getFindAllHref({}, null, followLink('owningCollection', undefined, true, true, true, followLink('itemtemplate', undefined, true, true, true, followLink('relationships')))).subscribe((value) => {
+        expect(value).toBe(expected);
+      });
+    });
+
+    it('should include nested linksToFollow 2lvl and nested embed\'s size', () => {
+      const expected = `${endpoint}?embed.size=owningCollection/itemtemplate=4&embed=owningCollection/itemtemplate`;
+      const config: FindListOptions = Object.assign(new FindListOptions(), {
+        elementsPerPage: 4
+      });
+      (service as any).getFindAllHref({}, null, followLink('owningCollection', undefined, true, true, true, followLink('itemtemplate', config, true, true, true))).subscribe((value) => {
         expect(value).toBe(expected);
       });
     });

--- a/src/app/core/index/index.selectors.spec.ts
+++ b/src/app/core/index/index.selectors.spec.ts
@@ -1,4 +1,5 @@
-import { getUrlWithoutEmbedParams } from './index.selectors';
+import { getEmbedSizeParams, getUrlWithoutEmbedParams } from './index.selectors';
+
 
 describe(`index selectors`, () => {
 
@@ -25,6 +26,40 @@ describe(`index selectors`, () => {
     it(`should return undefined or null unmodified`, () => {
       expect(getUrlWithoutEmbedParams(undefined)).toBe(undefined);
       expect(getUrlWithoutEmbedParams(null)).toBe(null);
+    });
+
+  });
+
+  describe(`getEmbedSizeParams`, () => {
+
+    it(`url with single embed size param => should return list with ['subcommunities' - size]`, () => {
+      const source = 'https://rest.api/core/communities/search/top?page=0&size=50&sort=dc.title,ASC&embed.size=subcommunities=5&embed=subcommunities';
+      const result = getEmbedSizeParams(source);
+      expect(result).toHaveSize(1);
+      expect(result[0]).toEqual({name: 'subcommunities', size: 5});
+    });
+
+    it(`url with multiple embed size param => should return list with {name, size}`, () => {
+      const source = 'https://rest.api/core/communities/search/top?page=0&size=50&sort=dc.title,ASC&embed.size=subcommunities=5&embed=subcommunities&embed.size=collections=1&embed=collections';
+      const result = getEmbedSizeParams(source);
+      expect(result).toHaveSize(2);
+      expect(result[0]).toEqual({name: 'subcommunities', size: 5});
+      expect(result[1]).toEqual({name: 'collections', size: 1});
+    });
+
+    it(`url without params => should return empty list`, () => {
+      const source = 'https://rest.api/core/collections/uuid';
+      expect(getEmbedSizeParams(source)).toHaveSize(0);
+    });
+
+    it(`url without embed size params => should return empty list`, () => {
+      const source = 'https://rest.api/core/collections/uuid?page=0&size=50';
+      expect(getEmbedSizeParams(source)).toHaveSize(0);
+    });
+
+    it(`undefined or null url => should return empty list`, () => {
+      expect(getEmbedSizeParams(undefined)).toHaveSize(0);
+      expect(getEmbedSizeParams(null)).toHaveSize(0);
     });
 
   });

--- a/src/app/core/index/index.selectors.ts
+++ b/src/app/core/index/index.selectors.ts
@@ -24,7 +24,7 @@ export const getUrlWithoutEmbedParams = (url: string): string => {
     if (isNotEmpty(parsed.query)) {
       const parts = parsed.query.split(/[?|&]/)
         .filter((part: string) => isNotEmpty(part))
-        .filter((part: string) => !part.startsWith('embed='));
+        .filter((part: string) => !(part.startsWith('embed=') || part.startsWith('embed.size=')));
       let args = '';
       if (isNotEmpty(parts)) {
         args = `?${parts.join('&')}`;
@@ -35,6 +35,27 @@ export const getUrlWithoutEmbedParams = (url: string): string => {
   }
 
   return url;
+};
+
+/**
+ * Parse the embed size params from a url
+ * @param url The url to parse
+ */
+export const getEmbedSizeParams = (url: string): { name: string, size: number }[] => {
+  if (isNotEmpty(url)) {
+    const parsed = parse(url);
+    if (isNotEmpty(parsed.query)) {
+      return parsed.query.split(/[?|&]/)
+        .filter((part: string) => isNotEmpty(part))
+        .map((part: string) => part.match(/^embed.size=([^=]+)=(\d+)$/))
+        .filter((matches: RegExpMatchArray) => hasValue(matches) && hasValue(matches[1]) && hasValue(matches[2]))
+        .map((matches: RegExpMatchArray) => {
+          return { name: matches[1], size: Number(matches[2]) };
+        });
+    }
+  }
+
+  return [];
 };
 
 /**


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/918
* See also DSpace/DSpace#3174

## Description
The communities and collections expandable tree at {baseUrl}/community-list has been refactored so the requests required to find out if a node in the tree has children (i.e. if a community has sub-communities or collections) are now embedded in the initial request with the new embed and nested embed size functionalities. (see https://github.com/DSpace/DSpace/pull/3114)
This should reduce the number of requests needed for rendering the ComCol tree nodes and their shevrons to the ones mentioned in the review instructions (fixes issue https://github.com/DSpace/dspace-angular/issues/918)

Might be an issue with the embed sizes resulting in non-identical result alternative links (see https://github.com/DSpace/DSpace/issues/3174), but doesn't seem to be an issue in this use of the functionality.

## Instructions for Reviewers
- Go the communities-collections tree at {baseUrl}/community-list and open network tab:
=> Should send only one request to `/communities/search/top` with embedded collections/subcommunities with embed.size 1.
=> No additional requests (with size=1 like before) should be needed
- Expanding any node should result in just 2 requests: the collections and the subcommunities, again with its collections/subcommunities embedded with size 1.
=> No additional requests (with size=1 like before) should be needed

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
