### PR TITLE
(Angular UI) Rename / move 'relationship.type' metadata field to 'dspace.entity.type'

### DIFF
--- a/src/app/+admin/admin-search-page/admin-search-results/admin-search-result-grid-element/item-search-result/item-admin-search-result-grid-element.component.ts
+++ b/src/app/+admin/admin-search-page/admin-search-results/admin-search-result-grid-element/item-search-result/item-admin-search-result-grid-element.component.ts
@@ -61,7 +61,7 @@ export class ItemAdminSearchResultGridElementComponent extends SearchResultGridE
   }
 
   /**
-   * Fetch the component depending on the item's relationship type, view mode and context
+   * Fetch the component depending on the item's entity type, view mode and context
    * @returns {GenericConstructor<Component>}
    */
   private getComponent(): GenericConstructor<Component> {

--- a/src/app/+admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-grid-element/workflow-item/workflow-item-search-result-admin-workflow-grid-element.component.ts
+++ b/src/app/+admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-grid-element/workflow-item/workflow-item-search-result-admin-workflow-grid-element.component.ts
@@ -96,7 +96,7 @@ export class WorkflowItemSearchResultAdminWorkflowGridElementComponent extends S
   }
 
   /**
-   * Fetch the component depending on the item's relationship type, view mode and context
+   * Fetch the component depending on the item's entity type, view mode and context
    * @returns {GenericConstructor<Component>}
    */
   private getComponent(item: Item): GenericConstructor<Component> {

--- a/src/app/+item-page/edit-item-page/item-delete/item-delete.component.ts
+++ b/src/app/+item-page/edit-item-page/item-delete/item-delete.component.ts
@@ -112,7 +112,7 @@ export class ItemDeleteComponent
     super.ngOnInit();
     this.url = this.router.url;
 
-    const label = this.item.firstMetadataValue('relationship.type');
+    const label = this.item.firstMetadataValue('dspace.entity.type');
     if (label !== undefined) {
       this.types$ = this.entityTypeService.getEntityTypeByLabel(label).pipe(
         getFirstSucceededRemoteData(),

--- a/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/item-relationships.component.ts
@@ -75,7 +75,7 @@ export class ItemRelationshipsComponent extends AbstractItemUpdateComponent {
    */
   public initializeUpdates(): void {
 
-    const label = this.item.firstMetadataValue('relationship.type');
+    const label = this.item.firstMetadataValue('dspace.entity.type');
     if (label !== undefined) {
 
       this.entityType$ = this.entityTypeService.getEntityTypeByLabel(label).pipe(

--- a/src/app/+item-page/item-page-routing-paths.ts
+++ b/src/app/+item-page/item-page-routing-paths.ts
@@ -10,11 +10,11 @@ export function getItemModuleRoute() {
 
 /**
  * Get the route to an item's page
- * Depending on the item's relationship type, the route will either start with /items or /entities
+ * Depending on the item's entity type, the route will either start with /items or /entities
  * @param item  The item to retrieve the route for
  */
 export function getItemPageRoute(item: Item) {
-  const type = item.firstMetadataValue('relationship.type');
+  const type = item.firstMetadataValue('dspace.entity.type');
   return getEntityPageRoute(type, item.uuid);
 }
 

--- a/src/app/+item-page/simple/field-components/specific-field/title/item-page-title-field.component.html
+++ b/src/app/+item-page/simple/field-components/specific-field/title/item-page-title-field.component.html
@@ -1,5 +1,5 @@
 <h2 class="item-page-title-field">
-  <div *ngIf="item.firstMetadataValue('relationship.type') as type">
+  <div *ngIf="item.firstMetadataValue('dspace.entity.type') as type">
     {{ type.toLowerCase() + '.page.titleprefix' | translate }}
   </div>
   <ds-metadata-values [mdValues]="item?.allMetadata(fields)"></ds-metadata-values>

--- a/src/app/core/data/dso-redirect-data.service.spec.ts
+++ b/src/app/core/data/dso-redirect-data.service.spec.ts
@@ -120,7 +120,7 @@ describe('DsoRedirectDataService', () => {
     it('should navigate to entities route with the corresponding entity type', () => {
       remoteData.payload.type = 'item';
       remoteData.payload.metadata =  {
-        'relationship.type': [
+        'dspace.entity.type': [
           {
             language: 'en_US',
             value: 'Publication'

--- a/src/app/core/shared/item.model.ts
+++ b/src/app/core/shared/item.model.ts
@@ -104,7 +104,7 @@ export class Item extends DSpaceObject implements ChildHALResource {
    * Method that returns as which type of object this object should be rendered
    */
   getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
-    const entityType = this.firstMetadataValue('relationship.type');
+    const entityType = this.firstMetadataValue('dspace.entity.type');
     if (isEmpty(entityType)) {
       return super.getRenderTypes();
     }

--- a/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.spec.ts
+++ b/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.spec.ts
@@ -24,7 +24,7 @@ describe('ItemMetadataRepresentation', () => {
   for (const metadataField of Object.keys(item.metadata)) {
     describe(`when creating an ItemMetadataRepresentation`, () => {
       beforeEach(() => {
-        item.metadata['relationship.type'] = [
+        item.metadata['dspace.entity.type'] = [
           Object.assign(new MetadataValue(), {
             value: itemType
           })
@@ -41,7 +41,7 @@ describe('ItemMetadataRepresentation', () => {
       });
 
       it('should return the correct item type', () => {
-        expect(itemMetadataRepresentation.itemType).toEqual(item.firstMetadataValue('relationship.type'));
+        expect(itemMetadataRepresentation.itemType).toEqual(item.firstMetadataValue('dspace.entity.type'));
       });
     });
   }

--- a/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.ts
+++ b/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.ts
@@ -21,7 +21,7 @@ export class ItemMetadataRepresentation extends Item implements MetadataRepresen
    * The type of item this item can be represented as
    */
   get itemType(): string {
-    return this.firstMetadataValue('relationship.type');
+    return this.firstMetadataValue('dspace.entity.type');
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -66,12 +66,12 @@ describe('RelationshipEffects', () => {
 
     leftItem = Object.assign(new Item(), {
       uuid: testUUID1,
-      metadata: { 'relationship.type': [leftTypeMD] }
+      metadata: { 'dspace.entity.type': [leftTypeMD] }
     });
 
     rightItem = Object.assign(new Item(), {
       uuid: testUUID2,
-      metadata: { 'relationship.type': [rightTypeMD] }
+      metadata: { 'dspace.entity.type': [rightTypeMD] }
     });
 
     relationshipType = Object.assign(new RelationshipType(), {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
@@ -167,8 +167,8 @@ export class RelationshipEffects {
   }
 
   private addRelationship(item1: Item, item2: Item, relationshipType: string, submissionId: string, nameVariant?: string) {
-    const type1: string = item1.firstMetadataValue('relationship.type');
-    const type2: string = item2.firstMetadataValue('relationship.type');
+    const type1: string = item1.firstMetadataValue('dspace.entity.type');
+    const type2: string = item2.firstMetadataValue('dspace.entity.type');
     return this.relationshipTypeService.getRelationshipTypeByLabelAndTypes(relationshipType, type1, type2)
       .pipe(
         mergeMap((type: RelationshipType) => {

--- a/src/app/shared/metadata-representation/metadata-representation-loader.component.ts
+++ b/src/app/shared/metadata-representation/metadata-representation-loader.component.ts
@@ -14,7 +14,7 @@ import { ThemeService } from '../theme-support/theme.service';
   templateUrl: './metadata-representation-loader.component.html'
 })
 /**
- * Component for determining what component to use depending on the item's relationship type (relationship.type), its metadata representation and, optionally, its context
+ * Component for determining what component to use depending on the item's entity type (dspace.entity.type), its metadata representation and, optionally, its context
  */
 export class MetadataRepresentationLoaderComponent implements OnInit {
   private componentRefInstance: MetadataRepresentationListElementComponent;

--- a/src/app/shared/metadata-representation/metadata-representation-loader.component.ts
+++ b/src/app/shared/metadata-representation/metadata-representation-loader.component.ts
@@ -64,7 +64,7 @@ export class MetadataRepresentationLoaderComponent implements OnInit {
   }
 
   /**
-   * Fetch the component depending on the item's relationship type, metadata representation type and context
+   * Fetch the component depending on the item's entity type, metadata representation type and context
    * @returns {string}
    */
   private getComponent(): GenericConstructor<MetadataRepresentationListElementComponent> {

--- a/src/app/shared/mocks/dspace-rest/mocks/mock-publication-response.json
+++ b/src/app/shared/mocks/dspace-rest/mocks/mock-publication-response.json
@@ -157,7 +157,7 @@
         "place": 0
       }
     ],
-    "relationship.type": [
+    "dspace.entity.type": [
       {
         "value": "Publication",
         "language": null,

--- a/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
+++ b/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
@@ -179,7 +179,7 @@ export class ListableObjectComponentLoaderComponent implements OnInit, OnDestroy
   }
 
   /**
-   * Fetch the component depending on the item's relationship type, view mode and context
+   * Fetch the component depending on the item's entity type, view mode and context
    * @returns {GenericConstructor<Component>}
    */
   getComponent(renderTypes: (string | GenericConstructor<ListableObject>)[],

--- a/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
+++ b/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
@@ -27,7 +27,7 @@ import { ThemeService } from '../../../theme-support/theme.service';
   templateUrl: './listable-object-component-loader.component.html'
 })
 /**
- * Component for determining what component to use depending on the item's relationship type (relationship.type)
+ * Component for determining what component to use depending on the item's entity type (dspace.entity.type)
  */
 export class ListableObjectComponentLoaderComponent implements OnInit, OnDestroy {
   /**

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
@@ -57,7 +57,7 @@ const mockItemWithEntityType: Item = Object.assign(new Item(), {
         value: 'This is just another title'
       }
     ],
-    'relationship.type': [
+    'dspace.entity.type': [
       {
         language: null,
         value: 'Publication'

--- a/src/app/shared/object-list/type-badge/type-badge.component.spec.ts
+++ b/src/app/shared/object-list/type-badge/type-badge.component.spec.ts
@@ -15,7 +15,7 @@ const type = 'authorOfPublication';
 const mockItemWithRelationshipType = Object.assign(new Item(), {
   bundles: observableOf({}),
   metadata: {
-    'relationship.type': [
+    'dspace.entity.type': [
       {
         language: 'en_US',
         value: type

--- a/src/app/shared/object-list/type-badge/type-badge.component.spec.ts
+++ b/src/app/shared/object-list/type-badge/type-badge.component.spec.ts
@@ -12,7 +12,7 @@ let fixture: ComponentFixture<TypeBadgeComponent>;
 
 const type = 'authorOfPublication';
 
-const mockItemWithRelationshipType = Object.assign(new Item(), {
+const mockItemWithEntityType = Object.assign(new Item(), {
   bundles: observableOf({}),
   metadata: {
     'dspace.entity.type': [
@@ -24,7 +24,7 @@ const mockItemWithRelationshipType = Object.assign(new Item(), {
   }
 });
 
-const mockItemWithoutRelationshipType = Object.assign(new Item(), {
+const mockItemWithoutEntityType = Object.assign(new Item(), {
   bundles: observableOf({}),
   metadata: {
     'dc.title': [
@@ -52,21 +52,21 @@ describe('ItemTypeBadgeComponent', () => {
     comp = fixture.componentInstance;
   }));
 
-  describe('When the item has a relationship type', () => {
+  describe('When the item has an entity type', () => {
     beforeEach(() => {
-      comp.object = mockItemWithRelationshipType;
+      comp.object = mockItemWithEntityType;
       fixture.detectChanges();
     });
 
-    it('should show the relationship type badge', () => {
+    it('should show the entity type badge', () => {
       const badge = fixture.debugElement.query(By.css('span.badge'));
       expect(badge.nativeElement.textContent).toContain(type.toLowerCase());
     });
   });
 
-  describe('When the item has no relationship type', () => {
+  describe('When the item has no entity type', () => {
     beforeEach(() => {
-      comp.object = mockItemWithoutRelationshipType;
+      comp.object = mockItemWithoutEntityType;
       fixture.detectChanges();
     });
 

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -3180,9 +3180,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3120,9 +3120,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -2789,9 +2789,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Speichern",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1668,7 +1668,7 @@
 
   "item.edit.relationships.save-button": "Save",
 
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
 
 
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -2861,9 +2861,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Guardar",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -2625,9 +2625,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Tallenna",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -2864,9 +2864,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Sauvegarder",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -2430,8 +2430,8 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Mentés",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
-  "item.edit.relationships.no-entity-type": "Adja hozzá a 'relationship.type' metaadatot ezen elem hivatkozásánek engedélyezéséhez",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Adja hozzá a 'dspace.entity.type' metaadatot ezen elem hivatkozásánek engedélyezéséhez",
   
   
   

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -3180,9 +3180,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -2620,9 +2620,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Saglabāt",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -2860,9 +2860,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Opslaan",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -3180,9 +3180,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -2818,9 +2818,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Salvar",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -2818,9 +2818,9 @@
   // "item.edit.relationships.save-button": "Save",
   "item.edit.relationships.save-button": "Salvar",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -3180,9 +3180,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -3180,9 +3180,9 @@
   // TODO New key - Add a translation
   "item.edit.relationships.save-button": "Save",
   
-  // "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   // TODO New key - Add a translation
-  "item.edit.relationships.no-entity-type": "Add 'relationship.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
   
   
   


### PR DESCRIPTION
## References
* Fixes #744 
* Requires https://github.com/DSpace/DSpace/pull/3183 (Must be merged at the same time as this PR)

## Description
This updates all UI usages of the `relationship.type` metadata field to instead use `dspace.entity.type` as required by https://github.com/DSpace/DSpace/pull/3183

## Instructions for Reviewers

* Review code changes
     * Keep in mind, there are still usages of the phrase "relationship type" or "RelationshipType" in the Angular codebase, because there is an actual [`/api/core/relationshiptypes`](https://github.com/DSpace/RestContract/blob/main/relationshiptypes.md) endpoint. This PR only corrects usages of "relationship type" when they actually refer to the *Entity Type* retrieved via `dspace.entity.type` or the separate [`/api/core/entitytypes`](https://github.com/DSpace/RestContract/blob/main/entitytypes.md) endpoint.
     * In summary, Entity Types are things like "Person", "Publication", etc. while Relationship types are things like "isAuthorOfPublication" or "isProjectOfOrgUnit".
* MUST be tested with https://github.com/DSpace/DSpace/pull/3183 installed on your backend.