### PR TITLE
Fix issue where stale RemoteData is emitted first

### DIFF
--- a/src/app/core/data/data.service.spec.ts
+++ b/src/app/core/data/data.service.spec.ts
@@ -20,6 +20,9 @@ import { getMockRequestService } from '../../shared/mocks/request.service.mock';
 import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service.stub';
 import { RequestParam } from '../cache/models/request-param.model';
 import { getMockRemoteDataBuildService } from '../../shared/mocks/remote-data-build.service.mock';
+import { TestScheduler } from 'rxjs/testing';
+import { RemoteData } from './remote-data';
+import { RequestEntryState } from './request.reducer';
 
 const endpoint = 'https://rest.api/core';
 
@@ -63,6 +66,10 @@ describe('DataService', () => {
   let comparator;
   let objectCache;
   let store;
+  let selfLink;
+  let linksToFollow;
+  let testScheduler;
+  let remoteDataMocks;
 
   function initTestService(): TestService {
     requestService = getMockRequestService();
@@ -81,6 +88,34 @@ describe('DataService', () => {
       }
     } as any;
     store = {} as Store<CoreState>;
+    selfLink = 'https://rest.api/endpoint/1698f1d3-be98-4c51-9fd8-6bfedcbd59b7';
+    linksToFollow = [
+      followLink('a'),
+      followLink('b')
+    ];
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      // asserting the two objects are equal
+      // e.g. using chai.
+      expect(actual).toEqual(expected);
+    });
+
+    const timeStamp = new Date().getTime();
+    const msToLive = 15 * 60 * 1000;
+    const payload = { foo: 'bar' };
+    const statusCodeSuccess = 200;
+    const statusCodeError = 404;
+    const errorMessage = 'not found';
+    remoteDataMocks = {
+      RequestPending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.RequestPending, undefined, undefined, undefined),
+      ResponsePending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.ResponsePending, undefined, undefined, undefined),
+      Success: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Success, undefined, payload, statusCodeSuccess),
+      SuccessStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.SuccessStale, undefined, payload, statusCodeSuccess),
+      Error: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Error, errorMessage, undefined, statusCodeError),
+      ErrorStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.ErrorStale, errorMessage, undefined, statusCodeError),
+    };
+
+
     return new TestService(
       requestService,
       rdbService,
@@ -307,14 +342,12 @@ describe('DataService', () => {
 
   describe('update', () => {
     let operations;
-    let selfLink;
     let dso;
     let dso2;
     const name1 = 'random string';
     const name2 = 'another random string';
     beforeEach(() => {
       operations = [{ op: 'replace', path: '/0/value', value: name2 } as Operation];
-      selfLink = 'https://rest.api/endpoint/1698f1d3-be98-4c51-9fd8-6bfedcbd59b7';
 
       dso = Object.assign(new DSpaceObject(), {
         _links: { self: { href: selfLink } },
@@ -338,6 +371,453 @@ describe('DataService', () => {
     it('should not call addPatch on the object cache with the right parameters when there are no differences', () => {
       service.update(dso).subscribe();
       expect(objectCache.addPatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(`reRequestStaleRemoteData`, () => {
+    let callback: jasmine.Spy<jasmine.Func>;
+
+    beforeEach(() => {
+      callback = jasmine.createSpy();
+    });
+
+
+    describe(`when shouldReRequest is false`, () => {
+      it(`shouldn't do anything`, () => {
+        testScheduler.run(({ cold, expectObservable, flush }) => {
+          const expected = 'a-b-c-d-e-f';
+          const values = {
+            a: remoteDataMocks.RequestPending,
+            b: remoteDataMocks.ResponsePending,
+            c: remoteDataMocks.Success,
+            d: remoteDataMocks.SuccessStale,
+            e: remoteDataMocks.Error,
+            f: remoteDataMocks.ErrorStale,
+          };
+
+          expectObservable((service as any).reRequestStaleRemoteData(false, callback)(cold(expected, values))).toBe(expected, values);
+          // since the callback happens in a tap(), flush to ensure it has been executed
+          flush();
+          expect(callback).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe(`when shouldReRequest is true`, () => {
+      it(`should call the callback for stale RemoteData objects, but still pass the source observable unmodified`, () => {
+        testScheduler.run(({ cold, expectObservable, flush }) => {
+          const expected = 'a-b';
+          const values = {
+            a: remoteDataMocks.SuccessStale,
+            b: remoteDataMocks.ErrorStale,
+          };
+
+          expectObservable((service as any).reRequestStaleRemoteData(true, callback)(cold(expected, values))).toBe(expected, values);
+          // since the callback happens in a tap(), flush to ensure it has been executed
+          flush();
+          expect(callback).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      it(`should only call the callback for stale RemoteData objects if something is subscribed to it`, (done) => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          const expected = 'a';
+          const values = {
+            a: remoteDataMocks.SuccessStale,
+          };
+
+          const result$ = (service as any).reRequestStaleRemoteData(true, callback)(cold(expected, values));
+          expectObservable(result$).toBe(expected, values);
+          expect(callback).not.toHaveBeenCalled();
+          result$.subscribe(() => {
+            expect(callback).toHaveBeenCalled();
+            done();
+          });
+        });
+      });
+
+      it(`shouldn't do anything for RemoteData objects that aren't stale`, () => {
+        testScheduler.run(({ cold, expectObservable, flush }) => {
+          const expected = 'a-b-c-d';
+          const values = {
+            a: remoteDataMocks.RequestPending,
+            b: remoteDataMocks.ResponsePending,
+            c: remoteDataMocks.Success,
+            d: remoteDataMocks.Error,
+          };
+
+          expectObservable((service as any).reRequestStaleRemoteData(true, callback)(cold(expected, values))).toBe(expected, values);
+          // since the callback happens in a tap(), flush to ensure it has been executed
+          flush();
+          expect(callback).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+  });
+
+  describe(`findByHref`, () => {
+    beforeEach(() => {
+      spyOn(service as any, 'createAndSendGetRequest').and.callFake((href$) => { href$.subscribe().unsubscribe(); });
+    });
+
+    it(`should call buildHrefFromFindOptions with href and linksToFollow`, () => {
+      testScheduler.run(({ cold }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findByHref(selfLink, true, true, ...linksToFollow);
+        expect(service.buildHrefFromFindOptions).toHaveBeenCalledWith(selfLink, {}, [], ...linksToFollow);
+      });
+    });
+
+    it(`should call createAndSendGetRequest with the result from buildHrefFromFindOptions and useCachedVersionIfAvailable`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue('bingo!');
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findByHref(selfLink, true, true, ...linksToFollow);
+        expect((service as any).createAndSendGetRequest).toHaveBeenCalledWith(jasmine.anything(), true);
+        expectObservable(rdbService.buildSingle.calls.argsFor(0)[0]).toBe('(a|)', { a: 'bingo!' });
+
+        service.findByHref(selfLink, false, true, ...linksToFollow);
+        expect((service as any).createAndSendGetRequest).toHaveBeenCalledWith(jasmine.anything(), false);
+        expectObservable(rdbService.buildSingle.calls.argsFor(1)[0]).toBe('(a|)', { a: 'bingo!' });
+      });
+    });
+
+    it(`should call rdbService.buildSingle with the result from buildHrefFromFindOptions and linksToFollow`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue('bingo!');
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findByHref(selfLink, true, true, ...linksToFollow);
+        expect(rdbService.buildSingle).toHaveBeenCalledWith(jasmine.anything() as any, ...linksToFollow);
+        expectObservable(rdbService.buildSingle.calls.argsFor(0)[0]).toBe('(a|)', { a: 'bingo!' });
+      });
+    });
+
+    it(`should return a the output from reRequestStaleRemoteData`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: 'bingo!' }));
+        const expected = 'a';
+        const values = {
+          a: 'bingo!',
+        };
+
+        expectObservable(service.findByHref(selfLink, true, true, ...linksToFollow)).toBe(expected, values);
+      });
+    });
+
+    it(`should call reRequestStaleRemoteData with reRequestOnStale and the exact same findByHref call as a callback`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', { a: remoteDataMocks.SuccessStale }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.SuccessStale }));
+
+        service.findByHref(selfLink, true, true, ...linksToFollow);
+        expect((service as any).reRequestStaleRemoteData.calls.argsFor(0)[0]).toBeTrue();
+        spyOn(service, 'findByHref').and.returnValue(cold('a', { a: remoteDataMocks.SuccessStale }));
+        // prove that the spy we just added hasn't been called yet
+        expect(service.findByHref).not.toHaveBeenCalled();
+        // call the callback passed to reRequestStaleRemoteData
+        (service as any).reRequestStaleRemoteData.calls.argsFor(0)[1]();
+        // verify that findByHref _has_ been called now, with the same params as the original call
+        expect(service.findByHref).toHaveBeenCalledWith(jasmine.anything(), true, true, ...linksToFollow);
+        // ... except for selflink, which will have been turned in to an observable.
+        expectObservable((service.findByHref as jasmine.Spy).calls.argsFor(0)[0]).toBe('(a|)', { a: selfLink });
+      });
+    });
+
+    describe(`when useCachedVersionIfAvailable is true`, () => {
+      beforeEach(() => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
+      });
+
+      it(`should emit a cached completed RemoteData immediately, and keep emitting if it gets rerequested`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = 'a-b-c-d-e';
+          const values = {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findByHref(selfLink, true, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it(`should not emit a cached stale RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.SuccessStale,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findByHref(selfLink, true, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+    });
+
+    describe(`when useCachedVersionIfAvailable is false`, () => {
+      beforeEach(() => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
+      });
+
+
+      it(`should not emit a cached completed RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findByHref(selfLink, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it(`should not emit a cached stale RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.SuccessStale,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findByHref(selfLink, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+    });
+
+  });
+
+  describe(`findAllByHref`, () => {
+    let findListOptions;
+    beforeEach(() => {
+      findListOptions = { currentPage: 5 };
+      spyOn(service as any, 'createAndSendGetRequest').and.callFake((href$) => { href$.subscribe().unsubscribe(); });
+    });
+
+    it(`should call buildHrefFromFindOptions with href and linksToFollow`, () => {
+      testScheduler.run(({ cold }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(rdbService, 'buildList').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow);
+        expect(service.buildHrefFromFindOptions).toHaveBeenCalledWith(selfLink, findListOptions, [], ...linksToFollow);
+      });
+    });
+
+    it(`should call createAndSendGetRequest with the result from buildHrefFromFindOptions and useCachedVersionIfAvailable`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue('bingo!');
+        spyOn(rdbService, 'buildList').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow);
+        expect((service as any).createAndSendGetRequest).toHaveBeenCalledWith(jasmine.anything(), true);
+        expectObservable(rdbService.buildList.calls.argsFor(0)[0]).toBe('(a|)', { a: 'bingo!' });
+
+        service.findAllByHref(selfLink, findListOptions, false, true, ...linksToFollow);
+        expect((service as any).createAndSendGetRequest).toHaveBeenCalledWith(jasmine.anything(), false);
+        expectObservable(rdbService.buildList.calls.argsFor(1)[0]).toBe('(a|)', { a: 'bingo!' });
+      });
+    });
+
+    it(`should call rdbService.buildList with the result from buildHrefFromFindOptions and linksToFollow`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue('bingo!');
+        spyOn(rdbService, 'buildList').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.Success }));
+
+        service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow);
+        expect(rdbService.buildList).toHaveBeenCalledWith(jasmine.anything() as any, ...linksToFollow);
+        expectObservable(rdbService.buildList.calls.argsFor(0)[0]).toBe('(a|)', { a: 'bingo!' });
+      });
+    });
+
+    it(`should call reRequestStaleRemoteData with reRequestOnStale and the exact same findAllByHref call as a callback`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue('bingo!');
+        spyOn(rdbService, 'buildList').and.returnValue(cold('a', { a: remoteDataMocks.SuccessStale }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: remoteDataMocks.SuccessStale }));
+
+        service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow);
+        expect((service as any).reRequestStaleRemoteData.calls.argsFor(0)[0]).toBeTrue();
+        spyOn(service, 'findAllByHref').and.returnValue(cold('a', { a: remoteDataMocks.SuccessStale }));
+        // prove that the spy we just added hasn't been called yet
+        expect(service.findAllByHref).not.toHaveBeenCalled();
+        // call the callback passed to reRequestStaleRemoteData
+        (service as any).reRequestStaleRemoteData.calls.argsFor(0)[1]();
+        // verify that findAllByHref _has_ been called now, with the same params as the original call
+        expect(service.findAllByHref).toHaveBeenCalledWith(jasmine.anything(), findListOptions, true, true, ...linksToFollow);
+        // ... except for selflink, which will have been turned in to an observable.
+        expectObservable((service.findAllByHref as jasmine.Spy).calls.argsFor(0)[0]).toBe('(a|)', { a: selfLink });
+      });
+    });
+
+    it(`should return a the output from reRequestStaleRemoteData`, () => {
+      testScheduler.run(({ cold, expectObservable }) => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(rdbService, 'buildList').and.returnValue(cold('a', { a: remoteDataMocks.Success }));
+        spyOn(service as any, 'reRequestStaleRemoteData').and.returnValue(() => cold('a', { a: 'bingo!' }));
+        const expected = 'a';
+        const values = {
+          a: 'bingo!',
+        };
+
+        expectObservable(service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow)).toBe(expected, values);
+      });
+    });
+
+    describe(`when useCachedVersionIfAvailable is true`, () => {
+      beforeEach(() => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
+      });
+
+      it(`should emit a cached completed RemoteData immediately, and keep emitting if it gets rerequested`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildList').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = 'a-b-c-d-e';
+          const values = {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it(`should not emit a cached stale RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildList').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.SuccessStale,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findAllByHref(selfLink, findListOptions, true, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+    });
+
+    describe(`when useCachedVersionIfAvailable is false`, () => {
+      beforeEach(() => {
+        spyOn(service, 'buildHrefFromFindOptions').and.returnValue(selfLink);
+        spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
+      });
+
+
+      it(`should not emit a cached completed RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildList').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findAllByHref(selfLink, findListOptions, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it(`should not emit a cached stale RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildList').and.returnValue(cold('a-b-c-d-e', {
+            a: remoteDataMocks.SuccessStale,
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          }));
+          const expected = '--b-c-d-e';
+          const values = {
+            b: remoteDataMocks.RequestPending,
+            c: remoteDataMocks.ResponsePending,
+            d: remoteDataMocks.Success,
+            e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findAllByHref(selfLink, findListOptions, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
     });
   });
 });

--- a/src/app/core/tasks/tasks.service.ts
+++ b/src/app/core/tasks/tasks.service.ts
@@ -110,7 +110,6 @@ export abstract class TasksService<T extends CacheableObject> extends DataServic
       find((href: string) => hasValue(href)),
       mergeMap((href) => this.findByHref(href, false, true).pipe(
         getAllCompletedRemoteData(),
-        filter((rd: RemoteData<T>) => !rd.isSuccessStale),
         tap(() => this.requestService.setStaleByHrefSubstring(href)))
       )
     );


### PR DESCRIPTION
## References
* Fixes #1027

## Description
If you try to retrieve an object that is cached but stale. It will automatically be re-retrieved and the stale version in the cache will be overwritten. However currently it is possible in rare circumstances to still get that stale object returned first, before you the re-retrieved version. That means that if you add e.g. the getFirstCompletedRemoteData operator in line, that first stale object is the only one that you'll ever get.

This PR ensures that a stale object can no longer be emitted first from a findBy method on a dataservice. When useCachedIfAvailable is false, it also ensures a cached, completed (but not stale) object can't be emitted first.


## Instructions for Reviewers
This issue is hard to recreate, because in most cases the new request replaces the old one in the store almost immediately. So the best way to verify that it works the way it should is using the unit tests

You always have [the remotedata objects emitted from the rdbservice at the top](https://github.com/atmire/dspace-angular/blob/stale-issue/src/app/core/data/data.service.spec.ts#L770-L776) and [the expected ones emitted from the findBy method at the bottom](https://github.com/atmire/dspace-angular/blob/stale-issue/src/app/core/data/data.service.spec.ts#L777-L783). So in the linked test that means that the stale RemoteData `a` that was emitted first is omitted in the expected values, but the next stale remotedata `e` _is_ allowed through.

If you remove [the `skipWhile` lines](https://github.com/atmire/dspace-angular/blob/stale-issue/src/app/core/data/data.service.ts#L386) I added in DataService these tests should fail. With those lines the tests should succeed.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
