### PR TITLE
Fix trail not showing on item pages

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ import { DOCUMENT } from '@angular/common';
 import { ThemeService } from './shared/theme-support/theme.service';
 import { BASE_THEME_NAME } from './shared/theme-support/theme.constants';
 import { DEFAULT_THEME_CONFIG } from './shared/theme-support/theme.effects';
+import { BreadcrumbsService } from './breadcrumbs/breadcrumbs.service';
 
 @Component({
   selector: 'ds-app',
@@ -73,6 +74,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     private menuService: MenuService,
     private windowService: HostWindowService,
     private localeService: LocaleService,
+    private breadcrumbsService: BreadcrumbsService,
     @Optional() private cookiesService: KlaroService,
     @Optional() private googleAnalyticsService: GoogleAnalyticsService,
   ) {
@@ -106,6 +108,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     angulartics2DSpace.startTracking();
 
     metadata.listenForRouteChange();
+    breadcrumbsService.listenForRouteChanges();
 
     if (environment.debug) {
       console.info(environment);

--- a/src/app/breadcrumbs/breadcrumb/breadcrumb-config.model.ts
+++ b/src/app/breadcrumbs/breadcrumb/breadcrumb-config.model.ts
@@ -1,4 +1,4 @@
-import { BreadcrumbsService } from '../../core/breadcrumbs/breadcrumbs.service';
+import { BreadcrumbsProviderService } from '../../core/breadcrumbs/breadcrumbsProviderService';
 
 /**
  * Interface for breadcrumb configuration objects
@@ -7,7 +7,7 @@ export interface BreadcrumbConfig<T> {
     /**
      * The service used to calculate the breadcrumb object
      */
-    provider: BreadcrumbsService<T>;
+    provider: BreadcrumbsProviderService<T>;
 
     /**
      * The key that is used to calculate the breadcrumb display value

--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
-    <nav *ngIf="showBreadcrumbs" aria-label="breadcrumb">
+    <nav *ngIf="(showBreadcrumbs$ | async)" aria-label="breadcrumb">
         <ol class="breadcrumb">
             <ng-container
                     *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -12,7 +12,6 @@ import { Breadcrumb } from './breadcrumb/breadcrumb.model';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { VarDirective } from '../shared/utils/var.directive';
-import { getTestScheduler } from 'jasmine-marbles';
 
 class TestBreadcrumbsService implements BreadcrumbsProviderService<string> {
   getBreadcrumbs(key: string, url: string): Observable<Breadcrumb[]> {
@@ -92,24 +91,24 @@ describe('BreadcrumbsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('ngOnInit', () => {
-    beforeEach(() => {
-      spyOn(component, 'resolveBreadcrumbs').and.returnValue(observableOf([]));
-    });
-
-    it('should call resolveBreadcrumb on init', () => {
-      router.events = observableOf(new NavigationEnd(0, '', ''));
-      component.ngOnInit();
-      fixture.detectChanges();
-
-      expect(component.resolveBreadcrumbs).toHaveBeenCalledWith(route.root);
-    });
-  });
-
-  describe('resolveBreadcrumbs', () => {
-    it('should return the correct breadcrumbs', () => {
-      const breadcrumbs = component.resolveBreadcrumbs(route.root);
-      getTestScheduler().expectObservable(breadcrumbs).toBe('(a|)', { a: expectedBreadcrumbs });
-    });
-  });
+  // describe('ngOnInit', () => {
+  //   beforeEach(() => {
+  //     spyOn(component, 'resolveBreadcrumbs').and.returnValue(observableOf([]));
+  //   });
+  //
+  //   it('should call resolveBreadcrumb on init', () => {
+  //     router.events = observableOf(new NavigationEnd(0, '', ''));
+  //     component.ngOnInit();
+  //     fixture.detectChanges();
+  //
+  //     expect(component.resolveBreadcrumbs).toHaveBeenCalledWith(route.root);
+  //   });
+  // });
+  //
+  // describe('resolveBreadcrumbs', () => {
+  //   it('should return the correct breadcrumbs', () => {
+  //     const breadcrumbs = component.resolveBreadcrumbs(route.root);
+  //     getTestScheduler().expectObservable(breadcrumbs).toBe('(a|)', { a: expectedBreadcrumbs });
+  //   });
+  // });
 });

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -7,14 +7,14 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateLoaderMock } from '../shared/testing/translate-loader.mock';
 import { BreadcrumbConfig } from './breadcrumb/breadcrumb-config.model';
-import { BreadcrumbsService } from '../core/breadcrumbs/breadcrumbs.service';
+import { BreadcrumbsProviderService } from '../core/breadcrumbs/breadcrumbsProviderService';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { VarDirective } from '../shared/utils/var.directive';
 import { getTestScheduler } from 'jasmine-marbles';
 
-class TestBreadcrumbsService implements BreadcrumbsService<string> {
+class TestBreadcrumbsService implements BreadcrumbsProviderService<string> {
   getBreadcrumbs(key: string, url: string): Observable<Breadcrumb[]> {
     return observableOf([new Breadcrumb(key, url)]);
   }

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,114 +1,78 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { BreadcrumbsComponent } from './breadcrumbs.component';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { Observable, of as observableOf } from 'rxjs';
-import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbsService } from './breadcrumbs.service';
+import { Breadcrumb } from './breadcrumb/breadcrumb.model';
+import { VarDirective } from '../shared/utils/var.directive';
+import { By } from '@angular/platform-browser';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateLoaderMock } from '../shared/testing/translate-loader.mock';
-import { BreadcrumbConfig } from './breadcrumb/breadcrumb-config.model';
-import { BreadcrumbsProviderService } from '../core/breadcrumbs/breadcrumbsProviderService';
-import { Breadcrumb } from './breadcrumb/breadcrumb.model';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { VarDirective } from '../shared/utils/var.directive';
-
-class TestBreadcrumbsService implements BreadcrumbsProviderService<string> {
-  getBreadcrumbs(key: string, url: string): Observable<Breadcrumb[]> {
-    return observableOf([new Breadcrumb(key, url)]);
-  }
-}
+import { RouterTestingModule } from '@angular/router/testing';
+import { of as observableOf } from 'rxjs/internal/observable/of';
+import { DebugElement } from '@angular/core';
 
 describe('BreadcrumbsComponent', () => {
   let component: BreadcrumbsComponent;
   let fixture: ComponentFixture<BreadcrumbsComponent>;
-  let router: any;
-  let route: any;
-  let breadcrumbProvider;
-  let breadcrumbConfigA: BreadcrumbConfig<string>;
-  let breadcrumbConfigB: BreadcrumbConfig<string>;
-  let expectedBreadcrumbs;
+  let breadcrumbsServiceMock: BreadcrumbsService;
 
-  function init() {
-    breadcrumbProvider = new TestBreadcrumbsService();
+  const expectBreadcrumb = (listItem: DebugElement, text: string, url: string) => {
+    const anchor = listItem.query(By.css('a'));
 
-    breadcrumbConfigA = { provider: breadcrumbProvider, key: 'example.path', url: 'example.com' };
-    breadcrumbConfigB = { provider: breadcrumbProvider, key: 'another.path', url: 'another.com' };
-
-    route = {
-      root: {
-        snapshot: {
-          data: { breadcrumb: breadcrumbConfigA },
-          routeConfig: { resolve: { breadcrumb: {} } }
-        },
-        firstChild: {
-          snapshot: {
-            // Example without resolver should be ignored
-            data: { breadcrumb: breadcrumbConfigA },
-          },
-          firstChild: {
-            snapshot: {
-              data: { breadcrumb: breadcrumbConfigB },
-              routeConfig: { resolve: { breadcrumb: {} } }
-            }
-          }
-        }
-      }
-    };
-
-    expectedBreadcrumbs = [
-      new Breadcrumb(breadcrumbConfigA.key, breadcrumbConfigA.url),
-      new Breadcrumb(breadcrumbConfigB.key, breadcrumbConfigB.url)
-    ];
-
-  }
+    if (url == null) {
+      expect(anchor).toBeNull();
+      expect(listItem.nativeElement.innerHTML).toEqual(text);
+    } else {
+      expect(anchor).toBeInstanceOf(DebugElement);
+      expect(anchor.attributes.href).toEqual(url);
+      expect(anchor.nativeElement.innerHTML).toEqual(text);
+    }
+  };
 
   beforeEach(waitForAsync(() => {
-    init();
-    TestBed.configureTestingModule({
-      declarations: [BreadcrumbsComponent, VarDirective],
-      imports: [RouterTestingModule.withRoutes([]), TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: TranslateLoaderMock
-        }
-      }), NgbModule],
-      providers: [
-        {provide: ActivatedRoute, useValue: route}
-      ], schemas: [NO_ERRORS_SCHEMA]
-    })
-      .compileComponents();
-  }));
+    breadcrumbsServiceMock = {
+      breadcrumbs$: observableOf([
+        // NOTE: a root breadcrumb is automatically rendered
+        new Breadcrumb('bc 1', 'example.com'),
+        new Breadcrumb('bc 2', 'another.com'),
+      ]),
+      showBreadcrumbs$: observableOf(true),
+    } as BreadcrumbsService;
 
-  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        BreadcrumbsComponent,
+        VarDirective,
+      ],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          }
+        }),
+      ],
+      providers: [
+        { provide: BreadcrumbsService, useValue: breadcrumbsServiceMock },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(BreadcrumbsComponent);
     component = fixture.componentInstance;
-    router = TestBed.inject(Router);
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // describe('ngOnInit', () => {
-  //   beforeEach(() => {
-  //     spyOn(component, 'resolveBreadcrumbs').and.returnValue(observableOf([]));
-  //   });
-  //
-  //   it('should call resolveBreadcrumb on init', () => {
-  //     router.events = observableOf(new NavigationEnd(0, '', ''));
-  //     component.ngOnInit();
-  //     fixture.detectChanges();
-  //
-  //     expect(component.resolveBreadcrumbs).toHaveBeenCalledWith(route.root);
-  //   });
-  // });
-  //
-  // describe('resolveBreadcrumbs', () => {
-  //   it('should return the correct breadcrumbs', () => {
-  //     const breadcrumbs = component.resolveBreadcrumbs(route.root);
-  //     getTestScheduler().expectObservable(breadcrumbs).toBe('(a|)', { a: expectedBreadcrumbs });
-  //   });
-  // });
+  it('should render the breadcrumbs', () => {
+    const breadcrumbs = fixture.debugElement.queryAll(By.css('.breadcrumb-item'));
+    expect(breadcrumbs.length).toBe(3);
+    expectBreadcrumb(breadcrumbs[0], 'home.breadcrumbs', '/');
+    expectBreadcrumb(breadcrumbs[1], 'bc 1', '/example.com');
+    expectBreadcrumb(breadcrumbs[2], 'bc 2', null);
+  });
+
 });

--- a/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -1,9 +1,8 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
-import { hasNoValue, hasValue, isUndefined } from '../shared/empty.util';
-import { filter, map, switchMap, tap } from 'rxjs/operators';
-import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { BreadcrumbsService } from './breadcrumbs.service';
+import { Observable } from 'rxjs/internal/Observable';
 
 /**
  * Component representing the breadcrumbs of a page
@@ -13,7 +12,8 @@ import { combineLatest, Observable, of as observableOf } from 'rxjs';
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss']
 })
-export class BreadcrumbsComponent implements OnInit {
+export class BreadcrumbsComponent {
+
   /**
    * Observable of the list of breadcrumbs for this page
    */
@@ -22,61 +22,15 @@ export class BreadcrumbsComponent implements OnInit {
   /**
    * Whether or not to show breadcrumbs on this page
    */
-  showBreadcrumbs: boolean;
+  showBreadcrumbs$: Observable<boolean>;
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private breadcrumbsService: BreadcrumbsService,
   ) {
+    this.breadcrumbs$ = breadcrumbsService.breadcrumbs$;
+    this.showBreadcrumbs$ = breadcrumbsService.showBreadcrumbs$;
   }
 
-  /**
-   * Sets the breadcrumbs on init for this page
-   */
-  ngOnInit(): void {
-    this.breadcrumbs$ = this.router.events.pipe(
-      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-      tap(() => this.reset()),
-      switchMap(() => this.resolveBreadcrumbs(this.route.root)),
-    );
-  }
-
-  /**
-   * Method that recursively resolves breadcrumbs
-   * @param route The route to get the breadcrumb from
-   */
-  resolveBreadcrumbs(route: ActivatedRoute): Observable<Breadcrumb[]> {
-    const data = route.snapshot.data;
-    const routeConfig = route.snapshot.routeConfig;
-
-    const last: boolean = hasNoValue(route.firstChild);
-    if (last) {
-      if (hasValue(data.showBreadcrumbs)) {
-        this.showBreadcrumbs = data.showBreadcrumbs;
-      } else if (isUndefined(data.breadcrumb)) {
-        this.showBreadcrumbs = false;
-      }
-    }
-
-    if (
-      hasValue(data) && hasValue(data.breadcrumb) &&
-      hasValue(routeConfig) && hasValue(routeConfig.resolve) && hasValue(routeConfig.resolve.breadcrumb)
-    ) {
-      const { provider, key, url } = data.breadcrumb;
-      if (!last) {
-        return combineLatest(provider.getBreadcrumbs(key, url), this.resolveBreadcrumbs(route.firstChild))
-          .pipe(map((crumbs) => [].concat.apply([], crumbs)));
-      } else {
-        return provider.getBreadcrumbs(key, url);
-      }
-    }
-    return !last ? this.resolveBreadcrumbs(route.firstChild) : observableOf([]);
-  }
-
-  /**
-   * Resets the state of the breadcrumbs
-   */
-  reset() {
-    this.showBreadcrumbs = true;
-  }
 }

--- a/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
 import { BreadcrumbsService } from './breadcrumbs.service';
 import { Observable } from 'rxjs/internal/Observable';
@@ -25,8 +24,6 @@ export class BreadcrumbsComponent {
   showBreadcrumbs$: Observable<boolean>;
 
   constructor(
-    private route: ActivatedRoute,
-    private router: Router,
     private breadcrumbsService: BreadcrumbsService,
   ) {
     this.breadcrumbs$ = breadcrumbsService.breadcrumbs$;

--- a/src/app/breadcrumbs/breadcrumbs.service.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.spec.ts
@@ -1,0 +1,116 @@
+/* tslint:disable:max-classes-per-file */
+import { TestBed } from '@angular/core/testing';
+
+import { BreadcrumbsService } from './breadcrumbs.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRouteSnapshot, Resolve, Route, Router } from '@angular/router';
+import { Component } from '@angular/core';
+import { BreadcrumbConfig } from './breadcrumb/breadcrumb-config.model';
+import { BreadcrumbsProviderService } from '../core/breadcrumbs/breadcrumbsProviderService';
+import { Observable, of as observableOf } from 'rxjs';
+import { Breadcrumb } from './breadcrumb/breadcrumb.model';
+
+/**
+ * Create the breadcrumbs
+ */
+class TestBreadcrumbsProviderService implements BreadcrumbsProviderService<string> {
+  getBreadcrumbs(key: string, url: string): Observable<Breadcrumb[]> {
+    return observableOf([new Breadcrumb(key, url)]);
+  }
+}
+
+/**
+ * Empty component used for every route
+ */
+@Component({ template: '' })
+class DummyComponent {}
+
+/**
+ * {@link BreadcrumbsService#resolveBreadcrumbs} requires that a breadcrumb resolver is present,
+ * or data.breadcrumb will be ignored.
+ * This class satisfies the requirement and sets data.breadcrumb.
+ */
+class TestBreadcrumbResolver implements Resolve<BreadcrumbConfig<string>> {
+  resolve(route: ActivatedRouteSnapshot): BreadcrumbConfig<string> {
+    console.log('route:', route);
+    return route.data.returnValueForTestBreadcrumbResolver;
+  }
+}
+
+describe('BreadcrumbsService', () => {
+  let service: BreadcrumbsService;
+  let router: any;
+  let breadcrumbProvider;
+  let breadcrumbConfigA: BreadcrumbConfig<string>;
+  let breadcrumbConfigB: BreadcrumbConfig<string>;
+
+  const initRoute = (path: string, showBreadcrumbs: boolean, breadcrumbConfig: BreadcrumbConfig<string>): Route => ({
+    path: path,
+    component: DummyComponent,
+    data: {
+      showBreadcrumbs: showBreadcrumbs,
+      returnValueForTestBreadcrumbResolver: breadcrumbConfig,
+    },
+    resolve: {
+      breadcrumb: TestBreadcrumbResolver,
+    }
+  });
+
+  const initBreadcrumbs = () => {
+    breadcrumbProvider = new TestBreadcrumbsProviderService();
+    breadcrumbConfigA = { provider: breadcrumbProvider, key: 'example.path', url: 'example.com' };
+    breadcrumbConfigB = { provider: breadcrumbProvider, key: 'another.path', url: 'another.com' };
+  };
+
+  beforeEach(() => {
+    initBreadcrumbs();
+    TestBed.configureTestingModule({
+      providers: [
+        TestBreadcrumbResolver,
+      ],
+      imports: [
+        RouterTestingModule.withRoutes([
+          initRoute('route-1', undefined, undefined),
+          initRoute('route-2', false, breadcrumbConfigA),
+          initRoute('route-3', true, breadcrumbConfigB),
+        ]),
+      ],
+    });
+    router = TestBed.inject(Router);
+    service = TestBed.inject(BreadcrumbsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('breadcrumbs$', () => {
+    it('should return a breadcrumb corresponding to the current route', () => {
+      // TODO
+      service.breadcrumbs$.subscribe((value) => {
+        console.log('TEST');
+        console.log(value);
+      });
+      router.navigate(['route-3']);
+    });
+
+    it('should change when the route changes', () => {
+      // TODO
+    });
+  });
+
+  describe('showBreadcrumbs$', () => {
+    describe('when the last part of the route has showBreadcrumbs in its data', () => {
+      it('should return that value', () => {
+        // TODO
+      });
+    });
+
+    describe('when the last part of the route has no breadcrumb in its data', () => {
+      it('should return false', () => {
+        // TODO
+      });
+    });
+  });
+
+});

--- a/src/app/breadcrumbs/breadcrumbs.service.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.ts
@@ -23,7 +23,13 @@ export class BreadcrumbsService {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-  ) {
+  ) {}
+
+  /**
+   * Called by {@link AppComponent#constructor} (i.e. before routing)
+   * such that no routing events are missed.
+   */
+  listenForRouteChanges() {
     // supply events to this.breadcrumbs$
     this.router.events.pipe(
       filter((e): e is NavigationEnd => e instanceof NavigationEnd),

--- a/src/app/breadcrumbs/breadcrumbs.service.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import {combineLatest, Observable, of as observableOf, ReplaySubject} from 'rxjs';
+import {Breadcrumb} from './breadcrumb/breadcrumb.model';
+import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
+import {filter, map, switchMap, tap} from 'rxjs/operators';
+import {hasNoValue, hasValue, isUndefined} from '../shared/empty.util';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BreadcrumbsService {
+
+  /**
+   * Observable of the list of breadcrumbs for this page
+   */
+  breadcrumbs$: ReplaySubject<Breadcrumb[]> = new ReplaySubject(1);
+
+  /**
+   * Whether or not to show breadcrumbs on this page
+   */
+  showBreadcrumbs$: ReplaySubject<boolean> = new ReplaySubject(1);
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {
+    // supply events to this.breadcrumbs$
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      tap(() => this.reset()),
+      switchMap(() => this.resolveBreadcrumbs(this.route.root)),
+    ).subscribe(this.breadcrumbs$);
+  }
+
+  /**
+   * Method that recursively resolves breadcrumbs
+   * @param route The route to get the breadcrumb from
+   */
+  private resolveBreadcrumbs(route: ActivatedRoute): Observable<Breadcrumb[]> {
+    const data = route.snapshot.data;
+    const routeConfig = route.snapshot.routeConfig;
+
+    const last: boolean = hasNoValue(route.firstChild);
+    if (last) {
+      if (hasValue(data.showBreadcrumbs)) {
+        this.showBreadcrumbs$.next(data.showBreadcrumbs);
+      } else if (isUndefined(data.breadcrumb)) {
+        this.showBreadcrumbs$.next(false);
+      }
+    }
+
+    if (
+      hasValue(data) && hasValue(data.breadcrumb) &&
+      hasValue(routeConfig) && hasValue(routeConfig.resolve) && hasValue(routeConfig.resolve.breadcrumb)
+    ) {
+      const { provider, key, url } = data.breadcrumb;
+      if (!last) {
+        return combineLatest(provider.getBreadcrumbs(key, url), this.resolveBreadcrumbs(route.firstChild))
+          .pipe(map((crumbs) => [].concat.apply([], crumbs)));
+      } else {
+        return provider.getBreadcrumbs(key, url);
+      }
+    }
+    return !last ? this.resolveBreadcrumbs(route.firstChild) : observableOf([]);
+  }
+
+  /**
+   * Resets the state of the breadcrumbs
+   */
+  private reset() {
+    this.showBreadcrumbs$.next(true);
+  }
+
+}

--- a/src/app/core/breadcrumbs/breadcrumbsProviderService.ts
+++ b/src/app/core/breadcrumbs/breadcrumbsProviderService.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 /**
  * Service to calculate breadcrumbs for a single part of the route
  */
-export interface BreadcrumbsService<T> {
+export interface BreadcrumbsProviderService<T> {
 
   /**
    * Method to calculate the breadcrumbs for a part of the route

--- a/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
+++ b/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
@@ -1,5 +1,5 @@
 import { Breadcrumb } from '../../breadcrumbs/breadcrumb/breadcrumb.model';
-import { BreadcrumbsService } from './breadcrumbs.service';
+import { BreadcrumbsProviderService } from './breadcrumbsProviderService';
 import { DSONameService } from './dso-name.service';
 import { Observable, of as observableOf } from 'rxjs';
 import { ChildHALResource } from '../shared/child-hal-resource.model';
@@ -18,7 +18,7 @@ import { getDSORoute } from '../../app-routing-paths';
 @Injectable({
   providedIn: 'root'
 })
-export class DSOBreadcrumbsService implements BreadcrumbsService<ChildHALResource & DSpaceObject> {
+export class DSOBreadcrumbsService implements BreadcrumbsProviderService<ChildHALResource & DSpaceObject> {
   constructor(
     private linkService: LinkService,
     private dsoNameService: DSONameService

--- a/src/app/core/breadcrumbs/i18n-breadcrumbs.service.ts
+++ b/src/app/core/breadcrumbs/i18n-breadcrumbs.service.ts
@@ -1,5 +1,5 @@
 import { Breadcrumb } from '../../breadcrumbs/breadcrumb/breadcrumb.model';
-import { BreadcrumbsService } from './breadcrumbs.service';
+import { BreadcrumbsProviderService } from './breadcrumbsProviderService';
 import { Observable, of as observableOf } from 'rxjs';
 import { Injectable } from '@angular/core';
 
@@ -14,7 +14,7 @@ export const BREADCRUMB_MESSAGE_POSTFIX = '.breadcrumbs';
 @Injectable({
   providedIn: 'root'
 })
-export class I18nBreadcrumbsService implements BreadcrumbsService<string> {
+export class I18nBreadcrumbsService implements BreadcrumbsProviderService<string> {
 
   /**
    * Method to calculate the breadcrumbs

--- a/src/app/process-page/process-breadcrumbs.service.ts
+++ b/src/app/process-page/process-breadcrumbs.service.ts
@@ -1,6 +1,6 @@
 import { Observable, of as observableOf } from 'rxjs';
 import { Injectable } from '@angular/core';
-import { BreadcrumbsService } from '../core/breadcrumbs/breadcrumbs.service';
+import { BreadcrumbsProviderService } from '../core/breadcrumbs/breadcrumbsProviderService';
 import { Breadcrumb } from '../breadcrumbs/breadcrumb/breadcrumb.model';
 import { Process } from './processes/process.model';
 
@@ -8,7 +8,7 @@ import { Process } from './processes/process.model';
  * Service to calculate process breadcrumbs for a single part of the route
  */
 @Injectable()
-export class ProcessBreadcrumbsService implements BreadcrumbsService<Process> {
+export class ProcessBreadcrumbsService implements BreadcrumbsProviderService<Process> {
 
   /**
    * Method to calculate the breadcrumbs


### PR DESCRIPTION
## References
Fixes #982

## Description
Because `ngOnInit` for `BreadcrumbsComponent` was called after the component was created (so as part of the routing operation), there was a race condition between the component and the first routing event. Most of the time `ngOnInit` got called before the `NavigationEnd` event. But sometimes it didn’t. It most frequently didn’t for the first client-side page render because all the data needed for the route is already in cache. That makes the first client-side routing operation a lot faster than average.

The solution was to listen for route changes _before_ routing.

Most logic of `BreadcrumbsComponent` was moved to a new service `BreadcrumbsService`. The init code of this service is called in `AppComponent`, such that it is run before routing, hence no routing events are missed.

## Instructions for Reviewers
List of changes in this PR:
* Rename `BreadcrumbsService` to `BreadcrumbsProviderService`
* create new service: `BreadcrumbsService`
* call `BreadcrumbsService#listenForRouteChanges()` in `AppComponent`
* move logic from `BreadcrumbsComponent` to `BreadcrumbsService`
* turn `showBreadcrumbs` into observable
* add tests for observables of `BreadcrumbsService` (they replace the original tests of `BreadcrumbsComponent`)
* add new test for `BreadcrumbsComponent`: should render the breadcrumbs
* add new test for `AppComponent`: the constructor should call breadcrumbsService.listenForRouteChanges

**How to test/review this PR**
* run the UI in dev mode and confirm that the breadcrumbs bar still hides/appears like it did before the PR. This PR should not affect the appearance and/or functionality of the breadcrumb bar.
* run the UI in production mode and verify that issue #982 is gone. In particular: verify that the breadcrumb bar consistently shows when refreshing any item summary page. (See #982 for a screen recording of the issue.)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
