### PR TITLE
Bugs on Collection Item Template fix

### DIFF
--- a/src/app/+collection-page/collection-page-routing-paths.ts
+++ b/src/app/+collection-page/collection-page-routing-paths.ts
@@ -24,6 +24,10 @@ export function getCollectionEditRolesRoute(id) {
   return new URLCombiner(getCollectionPageRoute(id), COLLECTION_EDIT_PATH, COLLECTION_EDIT_ROLES_PATH).toString();
 }
 
+export function getCollectionItemTemplateRoute(id) {
+  return new URLCombiner(getCollectionPageRoute(id), ITEMTEMPLATE_PATH).toString();
+}
+
 export const COLLECTION_CREATE_PATH = 'create';
 export const COLLECTION_EDIT_PATH = 'edit';
 export const COLLECTION_EDIT_ROLES_PATH = 'roles';

--- a/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.html
+++ b/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.html
@@ -6,6 +6,8 @@
         <ds-item-metadata [updateService]="itemTemplateService" [item]="itemRD?.payload"></ds-item-metadata>
         <button [routerLink]="getCollectionEditUrl(collection)" class="btn btn-outline-secondary">{{ 'collection.edit.template.cancel' | translate }}</button>
       </ng-container>
+      <ds-loading *ngIf="itemRD?.isLoading" [message]="'collection.edit.template.loading' | translate"></ds-loading>
+      <ds-alert *ngIf="itemRD?.hasFailed" [type]="AlertTypeEnum.Error" [content]="'collection.edit.template.error' | translate"></ds-alert>
     </div>
   </div>
 </div>

--- a/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.html
+++ b/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.html
@@ -1,9 +1,11 @@
 <div class="container" *ngVar="(collectionRD$ | async)?.payload as collection">
   <div class="row">
-    <div class="col-12">
-      <h2 class="border-bottom">{{ 'collection.edit.template.head' | translate:{ collection: collection?.name } }}</h2>
-      <ds-item-metadata [updateService]="itemTemplateService"></ds-item-metadata>
-      <button [routerLink]="getCollectionEditUrl(collection)" class="btn btn-outline-secondary">{{ 'collection.edit.template.cancel' | translate }}</button>
+    <div class="col-12" *ngVar="(itemRD$ | async) as itemRD">
+      <ng-container *ngIf="itemRD?.hasSucceeded">
+        <h2 class="border-bottom">{{ 'collection.edit.template.head' | translate:{ collection: collection?.name } }}</h2>
+        <ds-item-metadata [updateService]="itemTemplateService" [item]="itemRD?.payload"></ds-item-metadata>
+        <button [routerLink]="getCollectionEditUrl(collection)" class="btn btn-outline-secondary">{{ 'collection.edit.template.cancel' | translate }}</button>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.spec.ts
+++ b/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.spec.ts
@@ -9,7 +9,7 @@ import { ActivatedRoute } from '@angular/router';
 import { of as observableOf } from 'rxjs';
 import { Collection } from '../../core/shared/collection.model';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { createSuccessfulRemoteDataObject } from '../../shared/remote-data.utils';
+import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { getCollectionEditRoute } from '../collection-page-routing-paths';
 
 describe('EditItemTemplatePageComponent', () => {
@@ -24,11 +24,14 @@ describe('EditItemTemplatePageComponent', () => {
       id: 'collection-id',
       name: 'Fake Collection'
     });
+    itemTemplateService = jasmine.createSpyObj('itemTemplateService', {
+      findByCollectionID: createSuccessfulRemoteDataObject$({})
+    });
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), SharedModule, CommonModule, RouterTestingModule],
       declarations: [EditItemTemplatePageComponent],
       providers: [
-        { provide: ItemTemplateDataService, useValue: {} },
+        { provide: ItemTemplateDataService, useValue: itemTemplateService },
         { provide: ActivatedRoute, useValue: { parent: { data: observableOf({ dso: createSuccessfulRemoteDataObject(collection) }) } } }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -38,7 +41,6 @@ describe('EditItemTemplatePageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(EditItemTemplatePageComponent);
     comp = fixture.componentInstance;
-    itemTemplateService = (comp as any).itemTemplateService;
     fixture.detectChanges();
   });
 

--- a/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.ts
+++ b/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.ts
@@ -3,9 +3,11 @@ import { Observable } from 'rxjs';
 import { RemoteData } from '../../core/data/remote-data';
 import { Collection } from '../../core/shared/collection.model';
 import { ActivatedRoute } from '@angular/router';
-import { first, map } from 'rxjs/operators';
+import { first, map, switchMap } from 'rxjs/operators';
 import { ItemTemplateDataService } from '../../core/data/item-template-data.service';
 import { getCollectionEditRoute } from '../collection-page-routing-paths';
+import { Item } from '../../core/shared/item.model';
+import { getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
 
 @Component({
   selector: 'ds-edit-item-template-page',
@@ -21,12 +23,21 @@ export class EditItemTemplatePageComponent implements OnInit {
    */
   collectionRD$: Observable<RemoteData<Collection>>;
 
+  /**
+   * The template item
+   */
+  itemRD$: Observable<RemoteData<Item>>;
+
   constructor(protected route: ActivatedRoute,
               public itemTemplateService: ItemTemplateDataService) {
   }
 
   ngOnInit(): void {
     this.collectionRD$ = this.route.parent.data.pipe(first(), map((data) => data.dso));
+    this.itemRD$ = this.collectionRD$.pipe(
+      getFirstSucceededRemoteDataPayload(),
+      switchMap((collection) => this.itemTemplateService.findByCollectionID(collection.id)),
+    );
   }
 
   /**

--- a/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.ts
+++ b/src/app/+collection-page/edit-item-template-page/edit-item-template-page.component.ts
@@ -8,6 +8,7 @@ import { ItemTemplateDataService } from '../../core/data/item-template-data.serv
 import { getCollectionEditRoute } from '../collection-page-routing-paths';
 import { Item } from '../../core/shared/item.model';
 import { getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
+import { AlertType } from '../../shared/alert/aletr-type';
 
 @Component({
   selector: 'ds-edit-item-template-page',
@@ -27,6 +28,12 @@ export class EditItemTemplatePageComponent implements OnInit {
    * The template item
    */
   itemRD$: Observable<RemoteData<Item>>;
+
+  /**
+   * The AlertType enumeration
+   * @type {AlertType}
+   */
+  AlertTypeEnum = AlertType;
 
   constructor(protected route: ActivatedRoute,
               public itemTemplateService: ItemTemplateDataService) {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -777,9 +777,13 @@
 
   "collection.edit.template.edit-button": "Edit",
 
+  "collection.edit.template.error": "An error occurred retrieving the template item",
+
   "collection.edit.template.head": "Edit Template Item for Collection \"{{ collection }}\"",
 
   "collection.edit.template.label": "Template item",
+
+  "collection.edit.template.loading": "Loading template item...",
 
   "collection.edit.template.notifications.delete.error": "Failed to delete the item template",
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1034

## Description
This PR fixes all the bugs listed in the above mentioned issue with regards to the Collection's item template

## Instructions for Reviewers

List of changes in this PR:
* Ensured that the Item template is getting used in the edit template item screen instead of the collection's metadata
* Ensured that adding/deleting metadata works properly without errors
* Ensured that the delete call only returns one notification

How to test this PR
* Build this Angular branch
* Go to a collection and create an Item template
* Add and delete metadatavalues, ensure that it works
* Delete the item template afterwards, ensure that only one notification is shown

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
