### PR TITLE
Handle redirect for items not working fix

### DIFF
--- a/src/app/+lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/+lookup-by-id/lookup-guard.spec.ts
@@ -22,7 +22,7 @@ describe('LookupGuard', () => {
       }
     };
     guard.canActivate(scopedRoute as any, undefined);
-    expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('123456789/1234', IdentifierType.HANDLE);
+    expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789/1234', IdentifierType.HANDLE);
   });
 
   it('should call findByIdAndIDType with handle params', () => {
@@ -33,7 +33,7 @@ describe('LookupGuard', () => {
       }
     };
     guard.canActivate(scopedRoute as any, undefined);
-    expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('123456789%2F1234', IdentifierType.HANDLE);
+    expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789%2F1234', IdentifierType.HANDLE);
   });
 
   it('should call findByIdAndIDType with UUID params', () => {

--- a/src/app/+lookup-by-id/lookup-guard.ts
+++ b/src/app/+lookup-by-id/lookup-guard.ts
@@ -35,11 +35,11 @@ export class LookupGuard implements CanActivate {
       type = IdentifierType.HANDLE;
       const prefix = route.params.idType;
       const handleId = route.params.id;
-      id = `${prefix}/${handleId}`;
+      id = `hdl:${prefix}/${handleId}`;
 
     } else if (route.params.idType === IdentifierType.HANDLE) {
       type = IdentifierType.HANDLE;
-      id = route.params.id;
+      id = 'hdl:' + route.params.id;
 
     } else {
       type = IdentifierType.UUID;


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3113

## Description
This PR fixes the handle redirect issue. This means that navigating to `http://localhost:4000/handle/{handle}` will now properly redirect to the Item page

## Instructions for Reviewers

List of changes in this PR:
* Added a "hdl:" prefix to the handle before being sent to the pid endpoint in REST

How to test this PR:
* Please set up this Angular branch
* Please set up the REST branch from this PR: https://github.com/DSpace/DSpace/pull/3194
* Navigate to {dspace.url}/handle/{handle} in Angular for a handle that's connected to an Item in the REST API
* Verify that you get redirected to the Item page

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
