### PR TITLE
Error deleting an item when its entity type has no relations

### DIFF
--- a/src/app/+item-page/edit-item-page/item-delete/item-delete.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-delete/item-delete.component.spec.ts
@@ -173,6 +173,19 @@ describe('ItemDeleteComponent', () => {
         .toHaveBeenCalledWith(mockItem.id, types.filter((type) => typesSelection[type]).map((type) => type.id));
       expect(comp.notify).toHaveBeenCalled();
     });
+
+    it('should call delete function from the ItemDataService with empty types', () => {
+
+      spyOn(comp, 'notify');
+      jasmine.getEnv().allowRespy(true);
+      spyOn(entityTypeService, 'getEntityTypeRelationships').and.returnValue([]);
+      comp.ngOnInit();
+
+      comp.performAction();
+
+      expect(mockItemDataService.delete).toHaveBeenCalledWith(mockItem.id, []);
+      expect(comp.notify).toHaveBeenCalled();
+    });
   });
   describe('notify', () => {
     it('should navigate to the homepage on successful deletion of the item', () => {

--- a/src/app/+item-page/edit-item-page/item-delete/item-delete.component.ts
+++ b/src/app/+item-page/edit-item-page/item-delete/item-delete.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { defaultIfEmpty, filter, map, switchMap, take } from 'rxjs/operators';
+import {defaultIfEmpty, filter, map, switchMap, take} from 'rxjs/operators';
 import { AbstractSimpleItemActionComponent } from '../simple-item-action/abstract-simple-item-action.component';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -121,8 +121,11 @@ export class ItemDeleteComponent
         getFirstSucceededRemoteData(),
         getRemoteDataPayload(),
         map((relationshipTypes) => relationshipTypes.page),
-        switchMap((types) =>
-          combineLatest(types.map((type) => this.getRelationships(type))).pipe(
+        switchMap((types) => {
+          if (types.length === 0) {
+            return observableOf(types);
+          }
+          return combineLatest(types.map((type) => this.getRelationships(type))).pipe(
             map((relationships) =>
               types.reduce<RelationshipType[]>((includedTypes, type, index) => {
                 if (!includedTypes.some((includedType) => includedType.id === type.id)
@@ -133,8 +136,8 @@ export class ItemDeleteComponent
                 }
               }, [])
             ),
-          )
-        ),
+          );
+        })
       );
     } else {
       this.types$ = observableOf([]);


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1054

## Description
When an entity type has no existent relations the item deletion is not executed. This case has been handled and we can now proceed further even without related types.

## Instructions for Reviewers
To validate this PR the steps to reproduce the behavior can be followed as described in the related issue https://github.com/DSpace/dspace-angular/issues/1054

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
