### PR TITLE
Ensure REST API is up/available for e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,12 @@ jobs:
       - name: Wait for DSpace REST Backend to be ready (for e2e tests)
         uses: nev7n/wait_for_response@v1
         with:
-            url: 'http://localhost:8080/server/api'
+            # We use the 'sites' endpoint to also ensure the database is ready
+            url: 'http://localhost:8080/server/api/core/sites'
             responseCode: 200
             timeout: 30000
 
-      - name: Check DSpace REST Backend response (for e2e tests)
+      - name: Get DSpace REST Backend info/properties
         run: curl http://localhost:8080/server/api
 
       - name: Run e2e tests (integration tests)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,16 @@ jobs:
           docker-compose -f ./docker/cli.yml -f ./docker/cli.assetstore.yml run --rm dspace-cli
           docker container ls
 
-      - name: Check DSpace REST Backend available (for e2e tests)
+      # Wait until the REST API returns a 200 response (or for a max of 30 seconds)
+      # https://github.com/nev7n/wait_for_response
+      - name: Wait for DSpace REST Backend to be ready (for e2e tests)
+        uses: nev7n/wait_for_response@v1
+        with:
+            url: 'http://localhost:8080/server/api'
+            responseCode: 200
+            timeout: 30000
+
+      - name: Check DSpace REST Backend response (for e2e tests)
         run: curl http://localhost:8080/server/api
 
       - name: Run e2e tests (integration tests)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,9 @@ jobs:
           docker-compose -f ./docker/cli.yml -f ./docker/cli.assetstore.yml run --rm dspace-cli
           docker container ls
 
+      - name: Check DSpace REST Backend available (for e2e tests)
+        run: curl http://localhost:8080/server/api
+
       - name: Run e2e tests (integration tests)
         run: yarn run e2e:ci
 


### PR DESCRIPTION
## Description

After some testing, I've realized the issues with the e2e tests randomly timing out **are related to the REST API backend** which is kicked off via Docker.

The e2e timeouts appear to occur when the e2e tests start running **before** the REST API backend has completed it's startup process.  In other words, there is a small window where the Docker container has already successfully started, but the REST API is not yet available at http://localhost:8080/server/ because Tomcat has not finished booting up.   

I was able to verify this by adding a simple `curl http://localhost:8080/server/api' (see https://github.com/DSpace/dspace-angular/pull/1068/commits/12f8e82aa23b6236ce447377a64d1732c00d20cb). I found that command returns a Tomcat 404 error when e2e tests end up timing out, but it returns 200 when they run successfully (here's [an early build which shows that behavior](https://github.com/tdonohue/dspace-angular/actions/runs/661992824)) However, this is difficult to reproduce because it is dependent on how long it takes for Tomcat to start/deploy the REST API.

In order to fix this issue, I've found a [`wait_for_response`](https://github.com/nev7n/wait_for_response) GitHub Action, which waits until a given URL returns a 200 before allowing following CI steps to proceed. (see https://github.com/DSpace/dspace-angular/pull/1068/commits/ba4c7a8e88cf78fd2fa5748dda90a5adac7b4d65)
