### PR TITLE
 UI sends wrong request when creating new metadata field without qualifier

### DIFF
--- a/src/app/core/registry/registry.service.spec.ts
+++ b/src/app/core/registry/registry.service.spec.ts
@@ -326,6 +326,25 @@ describe('RegistryService', () => {
     });
   });
 
+  describe('when createMetadataField is called with a blank qualifier', () => {
+    let result: Observable<MetadataField>;
+    let metadataField: MetadataField;
+
+    beforeEach(() => {
+      metadataField = mockFieldsList[0];
+      metadataField.qualifier = '';
+      result = registryService.createMetadataField(metadataField, mockSchemasList[0]);
+    });
+
+    it('should return the created metadata field with a null qualifier', (done) => {
+      metadataField.qualifier = null;
+      result.subscribe((field: MetadataField) => {
+        expect(field).toEqual(metadataField);
+        done();
+      });
+    });
+  });
+
   describe('when updateMetadataField is called', () => {
     let result: Observable<MetadataField>;
 
@@ -336,6 +355,25 @@ describe('RegistryService', () => {
     it('should return the updated metadata field', (done) => {
       result.subscribe((field: MetadataField) => {
         expect(field).toEqual(mockFieldsList[0]);
+        done();
+      });
+    });
+  });
+
+  describe('when updateMetadataField is called with a blank qualifier', () => {
+    let result: Observable<MetadataField>;
+    let metadataField: MetadataField;
+
+    beforeEach(() => {
+      metadataField = mockFieldsList[0];
+      metadataField.qualifier = '';
+      result = registryService.updateMetadataField(metadataField);
+    });
+
+    it('should return the updated metadata field with a null qualifier', (done) => {
+      metadataField.qualifier = null;
+      result.subscribe((field: MetadataField) => {
+        expect(field).toEqual(metadataField);
         done();
       });
     });

--- a/src/app/core/registry/registry.service.ts
+++ b/src/app/core/registry/registry.service.ts
@@ -245,6 +245,9 @@ export class RegistryService {
    * @param schema   The MetadataSchema to create the field in
    */
   public createMetadataField(field: MetadataField, schema: MetadataSchema): Observable<MetadataField> {
+    if (!field.qualifier) {
+      field.qualifier = null;
+    }
     return this.metadataFieldService.create(field, new RequestParam('schemaId', schema.id)).pipe(
       getFirstSucceededRemoteDataPayload(),
       hasValueOperator(),
@@ -260,6 +263,9 @@ export class RegistryService {
    * @param field    The MetadataField to update
    */
   public updateMetadataField(field: MetadataField): Observable<MetadataField> {
+    if (!field.qualifier) {
+      field.qualifier = null;
+    }
     return this.metadataFieldService.put(field).pipe(
       getFirstSucceededRemoteDataPayload(),
       hasValueOperator(),


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1067
* Angular counterpart of REST PR: https://github.com/DSpace/DSpace/pull/3205

## Description
The call to create a new metadatafield previously sent an empty string for the qualifier if no value was provided.
This leads the backend to create a metadatafield with an empty string, instead of the customary `null` value.
On the backend side -> This is currently being addressed in the PR mentioned above as well (So that other UI-specific solutions don't need to specifically 'know' not to send an empty qualifier)
On the Angular side, we make sure to 'transform' the empty qualifier to a `null` value

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* When an empty qualifier is being sent to the REST, it's subsequently transformed to a `null` value

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
* Setup the latest main REST codebase (Without the REST PR)
* Setup the Angular code from this PR
* Use the UI to create a new metadata field. Leave the qualifier blank.
    * Observe that the qualifier being sent to REST is transformed to `null` 
* Use the UI to create a new metadata field. Fill in the qualifier.
    * Observe that the qualifier being sent to REST is the same 
    
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
