### PR TITLE
Fix CI build by downloading latest Chrome

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install latest Chrome (for e2e tests)
+      # Install latest stable Chrome from Google's repository (this gets updates before Ubuntu)
+      # See also https://www.ubuntuupdates.org/ppa/google_chrome
+      - name: Install latest Chrome from Google (for e2e tests)
         run: |
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
           sudo apt-get update
-          sudo apt-get --only-upgrade install google-chrome-stable -y
+          sudo apt-get install google-chrome-stable
           google-chrome --version
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Install latest stable Chrome from Google's repository (this gets updates before Ubuntu)
-      # See also https://www.ubuntuupdates.org/ppa/google_chrome
-      - name: Install latest Chrome from Google (for e2e tests)
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-          sudo apt-get update
-          sudo apt-get install google-chrome-stable
-          google-chrome --version
+      # Install latest stable Chrome & ChromeDriver which matches it
+      # https://github.com/nanasess/setup-chromedriver
+      - name: Install latest Chrome & corresponding ChromeDriver (for e2e tests)
+        uses: nanasess/setup-chromedriver@v1.0.1
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get Yarn cache directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: '/server'
       DSPACE_REST_SSL: false
+      # Force ChromeDriver to always match version of Chrome installed
+      # See https://www.npmjs.com/package/chromedriver#detect-chromedriver-version
+      DETECT_CHROMEDRIVER_VERSION: true
     strategy:
       # Create a matrix of Node versions to test against (in parallel)
       matrix:
@@ -34,10 +37,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Install latest stable Chrome & ChromeDriver which matches it
-      # https://github.com/nanasess/setup-chromedriver
-      - name: Install latest Chrome & corresponding ChromeDriver (for e2e tests)
-        uses: nanasess/setup-chromedriver@v1.0.1
+      - name: Install latest Chrome (for e2e tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get --only-upgrade install google-chrome-stable -y
+          google-chrome --version
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get Yarn cache directory


### PR DESCRIPTION
## Description
Currently our Build/CI is failing in the e2e test phase with the following error:
```
[20:36:40] E/launcher - SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 90
Current browser version is 89.0.4389.114 with binary path /usr/bin/google-chrome
```

~~This is a tiny PR which ensures we have the latest version of Chrome in our CI environment by adding the Google repository (as v90 is not yet available in standard Ubuntu repositories).~~

This PR was updated to just use this action https://github.com/nanasess/setup-chromedriver which downloads the version of ChromeDriver based on the current version of Chrome.

As the current `main` branch is [failing CI with this error](https://github.com/DSpace/dspace-angular/actions/runs/745457687), if this PR fixes it then it should be merged immediately.