### PR TITLE
Minor updates to base and dspace theme for Testathon.

### DIFF
--- a/src/app/+home-page/home-news/home-news.component.html
+++ b/src/app/+home-page/home-news/home-news.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="d-flex flex-wrap">
       <div>
-        <h1 class="display-3">Welcome to the DSpace 7 Preview</h1>
+        <h1 class="display-3">DSpace 7</h1>
         <p class="lead">DSpace is the world leading open source repository platform that enables organisations to:</p>
       </div>
     </div>
@@ -13,6 +13,8 @@
       </li>
       <li>issue permanent urls and trustworthy identifiers, including optional integrations with handle.net and DataCite DOI</li>
     </ul>
-    <p>Join an international community of <A HREF="https://wiki.duraspace.org/display/DSPACE/DSpace+Positioning" TARGET="_NEW">leading institutions using DSpace</A>.</p>
+    <p>Join an international community of <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Positioning"
+        target="_blank">leading institutions using DSpace</a>.
+    </p>
   </div>
 </div>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -56,7 +56,7 @@
       <p class="m-0">
         <a class="text-white" href="http://www.dspace.org/">{{ 'footer.link.dspace' | translate}}</a>
         {{ 'footer.copyright' | translate:{year: dateObj | date:'y'} }}
-        <a class="text-white" href="http://www.duraspace.org/">{{ 'footer.link.duraspace' | translate}}</a>
+        <a class="text-white" href="https://www.lyrasis.org/">{{ 'footer.link.lyrasis' | translate}}</a>
       </p>
       <ul class="footer-info list-unstyled small d-flex justify-content-center mb-0">
         <li>

--- a/src/app/shared/lang-switch/lang-switch.component.spec.ts
+++ b/src/app/shared/lang-switch/lang-switch.component.spec.ts
@@ -23,7 +23,7 @@ class CustomLoader implements TranslateLoader {
       'footer': {
         'copyright': 'copyright © 2002-{{ year }}',
         'link.dspace': 'DSpace software',
-        'link.duraspace': 'DuraSpace'
+        'link.lyrasis': 'LYRASIS'
       }
     });
   }

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -2287,9 +2287,9 @@
   // TODO New key - Add a translation
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
   // TODO New key - Add a translation
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2245,8 +2245,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "software DSpace",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -2014,8 +2014,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace Software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1241,7 +1241,7 @@
 
   "footer.link.dspace": "DSpace software",
 
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
 
   "footer.link.cookies": "Cookie settings",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -2081,8 +2081,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "Software DSpace",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -1891,8 +1891,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace-ohjelmisto",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -2082,8 +2082,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -1748,8 +1748,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace szoftver",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   "footer.link.cookies": "Süti beállítások",

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -2287,9 +2287,9 @@
   // TODO New key - Add a translation
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
   // TODO New key - Add a translation
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -1886,8 +1886,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -2080,8 +2080,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -2287,9 +2287,9 @@
   // TODO New key - Add a translation
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
   // TODO New key - Add a translation
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -2037,8 +2037,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -2037,8 +2037,8 @@
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
-  "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -2287,9 +2287,9 @@
   // TODO New key - Add a translation
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
   // TODO New key - Add a translation
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -2287,9 +2287,9 @@
   // TODO New key - Add a translation
   "footer.link.dspace": "DSpace software",
   
-  // "footer.link.duraspace": "DuraSpace",
+  // "footer.link.lyrasis": "LYRASIS",
   // TODO New key - Add a translation
-  "footer.link.duraspace": "DuraSpace",
+  "footer.link.lyrasis": "LYRASIS",
   
   // "footer.link.cookies": "Cookie settings",
   // TODO New key - Add a translation

--- a/src/themes/dspace/app/+home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/+home-page/home-news/home-news.component.html
@@ -3,7 +3,7 @@
     <div class="jumbotron jumbotron-fluid">
       <div class="d-flex flex-wrap">
         <div>
-          <h1 class="display-3">DSpace 7</h1>
+          <h1 class="display-3">DSpace 7 - Beta 5</h1>
           <p class="lead">DSpace is the world leading open source repository platform that enables
             organisations to:</p>
         </div>
@@ -20,6 +20,17 @@
         </li>
       </ul>
       <p>Join an international community of <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Positioning" target="_blank">leading institutions using DSpace</a>.</p>
+      <p>Participate in the <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+7.0+Testathon+Page"
+          target="_blank">official community Testathon</a>
+        from <strong>April 19th through May 7th</strong>. The test user accounts below have their password set to the name of
+        this
+        software in lowercase.</p>
+      <ul>
+        <li>Demo Site Administrator = dspacedemo+admin@gmail.com</li>
+        <li>Demo Community Administrator = dspacedemo+commadmin@gmail.com</li>
+        <li>Demo Collection Administrator = dspacedemo+colladmin@gmail.com</li>
+        <li>Demo Submitter = dspacedemo+submit@gmail.com</li>
+      </ul>
     </div>
   </div>
   <small class="credits">Photo by <a href="https://www.pexels.com/@inspiredimages">@inspiredimages</a></small>


### PR DESCRIPTION
Replaces #1089.

This makes minor updates to the "base" theme to replace usages of DuraSpace with LYRASIS.

It also updates our "dspace" theme to display the Testathon message that @bram-atmire created in #1089.  I simply moved this code into the "dspace" theme so that it would be used by default (as that's the default theme).