### PR TITLE
Quick win: Allow html in license section of submission form

### DIFF
--- a/src/app/submission/sections/license/section-license.component.html
+++ b/src/app/submission/sections/license/section-license.component.html
@@ -1,4 +1,4 @@
-<span class="mb-5">{{ licenseText$ | async }}</span>
+<span class="mb-5" [innerHTML]="licenseText$ | async"></span>
 <br> <br>
 <ds-form *ngIf="formModel" #formRef="formComponent"
          [formId]="formId"


### PR DESCRIPTION
## Description
Render html in the license section of the submission form.

## Instructions for Reviewers
1. Change `dspace/config/default.license` to contain html.
2. Submit a new item. The html should be rendered correctly in the license section of the form.

**Before**
<img width="989" alt="Screenshot 2021-04-14 at 11 47 02" src="https://user-images.githubusercontent.com/72436758/114690601-2675e000-9d17-11eb-92da-157ecb856e5f.png">

**After**
<img width="994" alt="Screenshot 2021-04-14 at 11 43 06" src="https://user-images.githubusercontent.com/72436758/114690161-bc5d3b00-9d16-11eb-80fc-18e39545db8d.png">

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
