### PR TITLE
Fix forgot password page

### DIFF
--- a/src/app/core/data/eperson-registration.service.spec.ts
+++ b/src/app/core/data/eperson-registration.service.spec.ts
@@ -98,9 +98,10 @@ describe('EpersonRegistrationService', () => {
       }));
     });
 
+    // tslint:disable:no-shadowed-variable
     it('should use cached responses and /registrations/search/findByToken?', () => {
-      testScheduler.run(({ tscold, expectObservable }) => {
-        rdbService.buildSingle.and.returnValue(tscold('a', { a: rd }));
+      testScheduler.run(({ cold, expectObservable }) => {
+        rdbService.buildSingle.and.returnValue(cold('a', { a: rd }));
 
         service.searchByToken('test-token');
 

--- a/src/app/core/data/eperson-registration.service.spec.ts
+++ b/src/app/core/data/eperson-registration.service.spec.ts
@@ -99,8 +99,8 @@ describe('EpersonRegistrationService', () => {
     });
 
     it('should use cached responses and /registrations/search/findByToken?', () => {
-      testScheduler.run(({ cold, expectObservable }) => {
-        rdbService.buildSingle.and.returnValue(cold('a', { a: rd }));
+      testScheduler.run(({ tscold, expectObservable }) => {
+        rdbService.buildSingle.and.returnValue(tscold('a', { a: rd }));
 
         service.searchByToken('test-token');
 
@@ -119,3 +119,4 @@ describe('EpersonRegistrationService', () => {
   });
 
 });
+/**/

--- a/src/app/core/data/eperson-registration.service.ts
+++ b/src/app/core/data/eperson-registration.service.ts
@@ -84,7 +84,7 @@ export class EpersonRegistrationService {
 
     const href$ = this.getTokenSearchEndpoint(token).pipe(
       find((href: string) => hasValue(href)),
-    )
+    );
 
     href$.subscribe((href: string) => {
       const request = new GetRequest(requestId, href);

--- a/src/app/core/data/eperson-registration.service.ts
+++ b/src/app/core/data/eperson-registration.service.ts
@@ -3,7 +3,7 @@ import { RequestService } from './request.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { GetRequest, PostRequest } from './request.models';
 import { Observable } from 'rxjs';
-import { filter, find, map, skipWhile, take } from 'rxjs/operators';
+import { filter, find, map, skipWhile } from 'rxjs/operators';
 import { hasValue, isNotEmpty } from '../../shared/empty.util';
 import { Registration } from '../shared/registration.model';
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteData } from '../shared/operators';

--- a/src/app/core/data/eperson-registration.service.ts
+++ b/src/app/core/data/eperson-registration.service.ts
@@ -3,7 +3,7 @@ import { RequestService } from './request.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { GetRequest, PostRequest } from './request.models';
 import { Observable } from 'rxjs';
-import { filter, find, map, take } from 'rxjs/operators';
+import { filter, find, map, skipWhile, take } from 'rxjs/operators';
 import { hasValue, isNotEmpty } from '../../shared/empty.util';
 import { Registration } from '../shared/registration.model';
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteData } from '../shared/operators';
@@ -60,9 +60,9 @@ export class EpersonRegistrationService {
 
     const requestId = this.requestService.generateRequestId();
 
-    const hrefObs = this.getRegistrationEndpoint();
+    const href$ = this.getRegistrationEndpoint();
 
-    hrefObs.pipe(
+    href$.pipe(
       find((href: string) => hasValue(href)),
       map((href: string) => {
         const request = new PostRequest(requestId, href, registration);
@@ -82,27 +82,28 @@ export class EpersonRegistrationService {
   searchByToken(token: string): Observable<Registration> {
     const requestId = this.requestService.generateRequestId();
 
-    const hrefObs = this.getTokenSearchEndpoint(token);
-
-    hrefObs.pipe(
+    const href$ = this.getTokenSearchEndpoint(token).pipe(
       find((href: string) => hasValue(href)),
-      map((href: string) => {
-        const request = new GetRequest(requestId, href);
-        Object.assign(request, {
-          getResponseParser(): GenericConstructor<ResponseParsingService> {
-            return RegistrationResponseParsingService;
-          }
-        });
-        this.requestService.send(request, true);
-      })
-    ).subscribe();
+    )
 
-    return this.rdbService.buildFromRequestUUID<Registration>(requestId).pipe(
+    href$.subscribe((href: string) => {
+      const request = new GetRequest(requestId, href);
+      Object.assign(request, {
+        getResponseParser(): GenericConstructor<ResponseParsingService> {
+          return RegistrationResponseParsingService;
+        }
+      });
+      this.requestService.send(request, true);
+    });
+
+    return this.rdbService.buildSingle<Registration>(href$).pipe(
+      skipWhile((rd: RemoteData<Registration>) => rd.isStale),
       getFirstSucceededRemoteData(),
       map((restResponse: RemoteData<Registration>) => {
-        return Object.assign(new Registration(), {email: restResponse.payload.email, token: token, user: restResponse.payload.user});
+        return Object.assign(new Registration(), {
+          email: restResponse.payload.email, token: token, user: restResponse.payload.user
+        });
       }),
-      take(1),
     );
 
   }

--- a/src/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
+++ b/src/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
@@ -11,6 +11,7 @@ import { Store } from '@ngrx/store';
 import { CoreState } from '../../core/core.reducers';
 import { RemoteData } from '../../core/data/remote-data';
 import { EPerson } from '../../core/eperson/models/eperson.model';
+import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 
 @Component({
   selector: 'ds-forgot-password-form',
@@ -70,7 +71,9 @@ export class ForgotPasswordFormComponent {
    */
   submit() {
     if (!this.isInValid) {
-      this.ePersonDataService.patchPasswordWithToken(this.user, this.token, this.password).subscribe((response: RemoteData<EPerson>) => {
+      this.ePersonDataService.patchPasswordWithToken(this.user, this.token, this.password).pipe(
+        getFirstCompletedRemoteData()
+      ).subscribe((response: RemoteData<EPerson>) => {
         if (response.hasSucceeded) {
           this.notificationsService.success(
             this.translateService.instant(this.NOTIFICATIONS_PREFIX + '.success.title'),


### PR DESCRIPTION
## References

- Fixes #1113



## Description

Fixed "Forgot Password" page getting replaced with (stuck) loading animation



## Instructions for Reviewers

List of changes in this PR:

- Fixed issue in `EpersonRegistrationService#searchByToken` 
  - Requests for cached `Registration` objects don't get sent
  - The method tried to use the UUID of these unsent requests to retrieve the `Registration`
- Added a unit test to cover this scenario
- Fixed a double notification when submitting the form



**Reviewing:**

1. Create a new account (if needed) at https://demo7.dspace.org/ (or locally)
2. Use the "Forgot Password" page.
3. Password reset link will be sent via email
4. Click the link. The Forgot Password page should appear (and stay up).



## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for *all new (or modified) public methods and classes*. It also includes TypeDoc for large or complex private methods.
- [x]  My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.