### PR TITLE
Fix date filter bugs

### DIFF
--- a/src/app/+my-dspace-page/my-dspace-configuration.service.spec.ts
+++ b/src/app/+my-dspace-page/my-dspace-configuration.service.spec.ts
@@ -27,7 +27,10 @@ describe('MyDSpaceConfigurationService', () => {
     scope: ''
   });
 
-  const backendFilters = [new SearchFilter('f.namedresourcetype', ['another value']), new SearchFilter('f.dateSubmitted', ['[2013 TO 2018]'])];
+  const backendFilters = [
+    new SearchFilter('f.namedresourcetype', ['another value']),
+    new SearchFilter('f.dateSubmitted', ['[2013 TO 2018]'], 'equals')
+  ];
 
   const spy = jasmine.createSpyObj('RouteService', {
     getQueryParameterValue: observableOf(value1),

--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -23,7 +23,10 @@ describe('SearchConfigurationService', () => {
     scope: ''
   });
 
-  const backendFilters = [new SearchFilter('f.author', ['another value']), new SearchFilter('f.date', ['[2013 TO 2018]'])];
+  const backendFilters = [
+    new SearchFilter('f.author', ['another value']),
+    new SearchFilter('f.date', ['[2013 TO 2018]'], 'equals')
+  ];
 
   const routeService = jasmine.createSpyObj('RouteService', {
     getQueryParameterValue: observableOf(value1),

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -168,7 +168,7 @@ export class SearchConfigurationService implements OnDestroy {
             if (hasNoValue(filters.find((f) => f.key === realKey))) {
               const min = filterParams[realKey + '.min'] ? filterParams[realKey + '.min'][0] : '*';
               const max = filterParams[realKey + '.max'] ? filterParams[realKey + '.max'][0] : '*';
-              filters.push(new SearchFilter(realKey, ['[' + min + ' TO ' + max + ']']));
+              filters.push(new SearchFilter(realKey, ['[' + min + ' TO ' + max + ']'], 'equals'));
             }
           } else {
             filters.push(new SearchFilter(key, filterParams[key]));

--- a/src/app/shared/search/paginated-search-options.model.spec.ts
+++ b/src/app/shared/search/paginated-search-options.model.spec.ts
@@ -13,6 +13,7 @@ describe('PaginatedSearchOptions', () => {
     new SearchFilter('f.example', ['another value', 'second value']),
     new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
   ];
+  const fixedFilter = 'f.fixed=1234 5678,equals';
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
@@ -23,7 +24,8 @@ describe('PaginatedSearchOptions', () => {
       filters: filters,
       query: query,
       scope: scope,
-      dsoTypes: [DSpaceObjectType.ITEM]
+      dsoTypes: [DSpaceObjectType.ITEM],
+      fixedFilter: fixedFilter,
     });
   });
 
@@ -35,6 +37,7 @@ describe('PaginatedSearchOptions', () => {
         'sort=test.field,DESC&' +
         'page=0&' +
         'size=40&' +
+        'f.fixed=1234%205678,equals&' +
         'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +

--- a/src/app/shared/search/paginated-search-options.model.spec.ts
+++ b/src/app/shared/search/paginated-search-options.model.spec.ts
@@ -10,10 +10,10 @@ describe('PaginatedSearchOptions', () => {
   const pageOptions = Object.assign(new PaginationComponentOptions(), { pageSize: 40, page: 1 });
   const filters = [
     new SearchFilter('f.test', ['value']),
-    new SearchFilter('f.example', ['another value', 'second value']),
-    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
+    new SearchFilter('f.example', ['another value', 'second value']), // should be split into two arguments, spaces should be URI-encoded
+    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),        // value should be URI-encoded, ',equals' should not
   ];
-  const fixedFilter = 'f.fixed=1234 5678,equals';
+  const fixedFilter = 'f.fixed=1234,5678,equals';                     // '=' and ',equals' should not be URI-encoded
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
@@ -37,7 +37,7 @@ describe('PaginatedSearchOptions', () => {
         'sort=test.field,DESC&' +
         'page=0&' +
         'size=40&' +
-        'f.fixed=1234%205678,equals&' +
+        'f.fixed=1234%2C5678,equals&' +
         'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +

--- a/src/app/shared/search/paginated-search-options.model.spec.ts
+++ b/src/app/shared/search/paginated-search-options.model.spec.ts
@@ -8,7 +8,11 @@ describe('PaginatedSearchOptions', () => {
   let options: PaginatedSearchOptions;
   const sortOptions = new SortOptions('test.field', SortDirection.DESC);
   const pageOptions = Object.assign(new PaginationComponentOptions(), { pageSize: 40, page: 1 });
-  const filters = [new SearchFilter('f.test', ['value']), new SearchFilter('f.example', ['another value', 'second value'])];
+  const filters = [
+    new SearchFilter('f.test', ['value']),
+    new SearchFilter('f.example', ['another value', 'second value']),
+    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
+  ];
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
@@ -31,12 +35,13 @@ describe('PaginatedSearchOptions', () => {
         'sort=test.field,DESC&' +
         'page=0&' +
         'size=40&' +
-        'query=search query&' +
+        'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +
         'f.test=value&' +
-        'f.example=another value&' +
-        'f.example=second value'
+        'f.example=another%20value&' +
+        'f.example=second%20value&' +
+        'f.range=%5B2002%20TO%202021%5D,equals'
       );
     });
 

--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.ts
@@ -35,7 +35,7 @@ export class SearchFilterComponent implements OnInit {
   /**
    * True when the filter is 100% collapsed in the UI
    */
-  closed = true;
+  closed: boolean;
 
   /**
    * Emits true when the filter is currently collapsed in the store

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.scss
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.scss
@@ -8,18 +8,16 @@
 
 ::ng-deep
 {
-  --ds-slider-handle-width: 18px;
-
     html:not([dir=rtl]) .noUi-horizontal .noUi-handle {
         right: calc(var(--ds-slider-handle-width) / -2);
     }
     .noUi-horizontal .noUi-handle {
         width: var(--ds-slider-handle-width);
         &:before {
-            left: calc(calc(calc(var(--ds-slider-handle-width) - 2) / 2) - 2);
+            left: calc(((var(--ds-slider-handle-width) - 2px) / 2) - 2px);
         }
         &:after {
-            left: calc(calc(calc(var(--ds-slider-handle-width) - 2) / 2) + 2);
+            left: calc(((var(--ds-slider-handle-width) - 2px) / 2) + 2px);
         }
         &:focus {
             outline: none;

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
@@ -56,7 +56,7 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   /**
    * Fallback maximum for the range
    */
-  max = 2018;
+  max = new Date().getFullYear();
 
   /**
    * The current range of the filter

--- a/src/app/shared/search/search-options.model.spec.ts
+++ b/src/app/shared/search/search-options.model.spec.ts
@@ -8,10 +8,10 @@ describe('SearchOptions', () => {
 
   const filters = [
     new SearchFilter('f.test', ['value']),
-    new SearchFilter('f.example', ['another value', 'second value']),
-    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
+    new SearchFilter('f.example', ['another value', 'second value']), // should be split into two arguments, spaces should be URI-encoded
+    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),        // value should be URI-encoded, ',equals' should not
   ];
-  const fixedFilter = 'f.fixed=1234 5678,equals';
+  const fixedFilter = 'f.fixed=1234,5678,equals';                    // '=' and ',equals' should not be URI-encoded
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
@@ -30,7 +30,7 @@ describe('SearchOptions', () => {
     it('should generate a string with all parameters that are present', () => {
       const outcome = options.toRestUrl(baseUrl);
       expect(outcome).toEqual('www.rest.com?' +
-        'f.fixed=1234%205678,equals&' +
+        'f.fixed=1234%2C5678,equals&' +
         'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +

--- a/src/app/shared/search/search-options.model.spec.ts
+++ b/src/app/shared/search/search-options.model.spec.ts
@@ -4,8 +4,13 @@ import { SearchFilter } from './search-filter.model';
 import { DSpaceObjectType } from '../../core/shared/dspace-object-type.model';
 
 describe('SearchOptions', () => {
-  let options: PaginatedSearchOptions;
-  const filters = [new SearchFilter('f.test', ['value']), new SearchFilter('f.example', ['another value', 'second value'])];
+  let options: SearchOptions;
+
+  const filters = [
+    new SearchFilter('f.test', ['value']),
+    new SearchFilter('f.example', ['another value', 'second value']),
+    new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
+  ];
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
@@ -18,12 +23,13 @@ describe('SearchOptions', () => {
     it('should generate a string with all parameters that are present', () => {
       const outcome = options.toRestUrl(baseUrl);
       expect(outcome).toEqual('www.rest.com?' +
-        'query=search query&' +
+        'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +
         'f.test=value&' +
-        'f.example=another value&' +
-        'f.example=second value'
+        'f.example=another%20value&' +
+        'f.example=second%20value&' +
+        'f.range=%5B2002%20TO%202021%5D,equals'
       );
     });
 

--- a/src/app/shared/search/search-options.model.spec.ts
+++ b/src/app/shared/search/search-options.model.spec.ts
@@ -11,11 +11,18 @@ describe('SearchOptions', () => {
     new SearchFilter('f.example', ['another value', 'second value']),
     new SearchFilter('f.range', ['[2002 TO 2021]'], 'equals'),
   ];
+  const fixedFilter = 'f.fixed=1234 5678,equals';
   const query = 'search query';
   const scope = '0fde1ecb-82cc-425a-b600-ac3576d76b47';
   const baseUrl = 'www.rest.com';
   beforeEach(() => {
-    options = new SearchOptions({ filters: filters, query: query, scope: scope, dsoTypes: [DSpaceObjectType.ITEM] });
+    options = new SearchOptions({
+      filters: filters,
+      query: query,
+      scope: scope,
+      dsoTypes: [DSpaceObjectType.ITEM],
+      fixedFilter: fixedFilter,
+    });
   });
 
   describe('when toRestUrl is called', () => {
@@ -23,6 +30,7 @@ describe('SearchOptions', () => {
     it('should generate a string with all parameters that are present', () => {
       const outcome = options.toRestUrl(baseUrl);
       expect(outcome).toEqual('www.rest.com?' +
+        'f.fixed=1234%205678,equals&' +
         'query=search%20query&' +
         'scope=0fde1ecb-82cc-425a-b600-ac3576d76b47&' +
         'dsoType=ITEM&' +

--- a/src/app/shared/search/search-options.model.ts
+++ b/src/app/shared/search/search-options.model.ts
@@ -13,10 +13,15 @@ export class SearchOptions {
   scope?: string;
   query?: string;
   dsoTypes?: DSpaceObjectType[];
-  filters?: any;
-  fixedFilter?: any;
+  filters?: SearchFilter[];
+  fixedFilter?: string;
 
-  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any}) {
+  constructor(
+    options: {
+      configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[],
+      fixedFilter?: string
+    }
+  ) {
       this.configuration = options.configuration;
       this.scope = options.scope;
       this.query = options.query;

--- a/src/app/shared/search/search-options.model.ts
+++ b/src/app/shared/search/search-options.model.ts
@@ -38,27 +38,38 @@ export class SearchOptions {
    */
   toRestUrl(url: string, args: string[] = []): string {
     if (isNotEmpty(this.configuration)) {
-      args.push(`configuration=${this.configuration}`);
+      args.push(`configuration=${encodeURIComponent(this.configuration)}`);
     }
     if (isNotEmpty(this.fixedFilter)) {
-      args.push(this.fixedFilter);
+      let fixedFilter: string;
+      const match = this.fixedFilter.match(/^([^=]+=)(.+)$/);
+
+      if (match) {
+        fixedFilter = match[1] + encodeURIComponent(match[2]);
+      } else {
+        fixedFilter = encodeURIComponent(this.fixedFilter);
+      }
+
+      args.push(fixedFilter);
     }
     if (isNotEmpty(this.query)) {
-      args.push(`query=${this.query}`);
+      args.push(`query=${encodeURIComponent(this.query)}`);
     }
     if (isNotEmpty(this.scope)) {
-      args.push(`scope=${this.scope}`);
+      args.push(`scope=${encodeURIComponent(this.scope)}`);
     }
     if (isNotEmpty(this.dsoTypes)) {
       this.dsoTypes.forEach((dsoType: string) => {
-        args.push(`dsoType=${dsoType}`);
+        args.push(`dsoType=${encodeURIComponent(dsoType)}`);
       });
     }
     if (isNotEmpty(this.filters)) {
       this.filters.forEach((filter: SearchFilter) => {
         filter.values.forEach((value) => {
           const filterValue = value.includes(',') ? `${value}` : value + (filter.operator ? ',' + filter.operator : '');
-          args.push(`${filter.key}=${filterValue}`);
+
+          // we don't want commas to get URI-encoded
+          args.push(`${filter.key}=${encodeURIComponent(filterValue).replace(/%2C/g, ',')}`);
         });
       });
     }

--- a/src/app/shared/search/search-options.model.ts
+++ b/src/app/shared/search/search-options.model.ts
@@ -45,7 +45,7 @@ export class SearchOptions {
       const match = this.fixedFilter.match(/^([^=]+=)(.+)$/);
 
       if (match) {
-        fixedFilter = match[1] + encodeURIComponent(match[2]);
+        fixedFilter = match[1] + encodeURIComponent(match[2]).replace(/%2C/g, ',');
       } else {
         fixedFilter = encodeURIComponent(this.fixedFilter);
       }

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -78,4 +78,5 @@
   --ds-breadcrumb-link-active-color: #{darken($cyan, 30%)};
 
   --ds-slider-color: #{$green};
+  --ds-slider-handle-width: 18px;
 }


### PR DESCRIPTION
## References

* Fixes #1112

## Description

Fix filtering by date range

## Instructions for Reviewers

List of changes in this PR:

* `_custom_variables.scss`: Initialize `--ds-slider-handle-width: 18px; ` so the handles show up as handles instead of just lines

* Add an `'equals'` operator to range filters. 

  This used to be optional, but now the backend returns 422 if no operator is specified.

* Set the fallback max date to the current year (used to be 2018)

* Fix horizontal position of vertical lines in range handles (were forced all the way to the left)

* Fix `.search-filter-wrapper` getting stuck with `.closed` when actually in open state

**Reviewing**

1. Search on https://demo7.dspace.org/ or a local instance
2. Filter by date (range) -- results should load and be filtered by the specified date (range).
3. Drag the 'max' handle all the way to the right -- the right input box should show the current year

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.