### PR TITLE
Fix relationship modal on item page

### DIFF
--- a/src/app/+item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/+item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -18,7 +18,7 @@ import { RelationshipType } from '../../../../core/shared/item-relationships/rel
 import {
   getAllSucceededRemoteData,
   getRemoteDataPayload,
-  getFirstSucceededRemoteData,
+  getFirstSucceededRemoteData, getFirstSucceededRemoteDataPayload,
 } from '../../../../core/shared/operators';
 import { ItemType } from '../../../../core/shared/item-relationships/item-type.model';
 import { DsDynamicLookupRelationModalComponent } from '../../../../shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
@@ -29,6 +29,7 @@ import { SearchResult } from '../../../../shared/search/search-result.model';
 import { followLink } from '../../../../shared/utils/follow-link-config.model';
 import { PaginatedList } from '../../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../../core/data/remote-data';
+import { Collection } from '../../../../core/shared/collection.model';
 
 @Component({
   selector: 'ds-edit-relationship-list',
@@ -146,6 +147,11 @@ export class EditRelationshipListComponent implements OnInit {
     modalComp.repeatable = true;
     modalComp.listId = this.listId;
     modalComp.item = this.item;
+    this.item.owningCollection.pipe(
+      getFirstSucceededRemoteDataPayload()
+    ).subscribe((collection: Collection) => {
+      modalComp.collection = collection;
+    });
     modalComp.select = (...selectableObjects: SearchResult<Item>[]) => {
       selectableObjects.forEach((searchResult) => {
         const relatedItem: Item = searchResult.indexableObject;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -21,8 +21,6 @@ import { createPaginatedList } from '../../../../testing/utils.test';
 import { ExternalSourceService } from '../../../../../core/data/external-source.service';
 import { LookupRelationService } from '../../../../../core/data/lookup-relation.service';
 import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
-import { SubmissionService } from '../../../../../submission/submission.service';
-import { SubmissionObjectDataService } from '../../../../../core/submission/submission-object-data.service';
 import { WorkspaceItem } from '../../../../../core/submission/models/workspaceitem.model';
 import { Collection } from '../../../../../core/shared/collection.model';
 
@@ -46,8 +44,6 @@ describe('DsDynamicLookupRelationModalComponent', () => {
   let lookupRelationService;
   let rdbService;
   let submissionId;
-  let submissionService;
-  let submissionObjectDataService;
 
   const externalSources = [
     Object.assign(new ExternalSource(), {
@@ -99,12 +95,6 @@ describe('DsDynamicLookupRelationModalComponent', () => {
     rdbService = jasmine.createSpyObj('rdbService', {
       aggregate: createSuccessfulRemoteDataObject$(externalSources)
     });
-    submissionService = jasmine.createSpyObj('SubmissionService', {
-      dispatchSave: jasmine.createSpy('dispatchSave')
-    });
-    submissionObjectDataService = jasmine.createSpyObj('SubmissionObjectDataService', {
-      findById: createSuccessfulRemoteDataObject$(testWSI)
-    });
     submissionId = '1234';
   }
 
@@ -129,8 +119,6 @@ describe('DsDynamicLookupRelationModalComponent', () => {
         },
         { provide: RelationshipTypeService, useValue: {} },
         { provide: RemoteDataBuildService, useValue: rdbService },
-        { provide: SubmissionService, useValue: submissionService },
-        { provide: SubmissionObjectDataService, useValue: submissionObjectDataService },
         {
           provide: Store, useValue: {
             // tslint:disable-next-line:no-empty

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -12,11 +12,8 @@ import { RelationshipOptions } from '../../models/relationship-options.model';
 import { SearchResult } from '../../../../search/search-result.model';
 import { Item } from '../../../../../core/shared/item.model';
 import {
-  getAllSucceededRemoteData,
-  getAllSucceededRemoteDataPayload,
-  getRemoteDataPayload
-} from '../../../../../core/shared/operators';
-import { AddRelationshipAction, RemoveRelationshipAction, UpdateRelationshipNameVariantAction } from './relationship.actions';
+  AddRelationshipAction, RemoveRelationshipAction, UpdateRelationshipNameVariantAction,
+} from './relationship.actions';
 import { RelationshipService } from '../../../../../core/data/relationship.service';
 import { RelationshipTypeService } from '../../../../../core/data/relationship-type.service';
 import { Store } from '@ngrx/store';
@@ -27,12 +24,7 @@ import { ExternalSource } from '../../../../../core/shared/external-source.model
 import { ExternalSourceService } from '../../../../../core/data/external-source.service';
 import { Router } from '@angular/router';
 import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
-import { followLink } from '../../../../utils/follow-link-config.model';
-import { SubmissionObject } from '../../../../../core/submission/models/submission-object.model';
-import { Collection } from '../../../../../core/shared/collection.model';
-import { SubmissionService } from '../../../../../submission/submission.service';
-import { SubmissionObjectDataService } from '../../../../../core/submission/submission-object-data.service';
-import { RemoteData } from '../../../../../core/data/remote-data';
+import { getAllSucceededRemoteDataPayload } from '../../../../../core/shared/operators';
 
 @Component({
   selector: 'ds-dynamic-lookup-relation-modal',
@@ -122,10 +114,6 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
    */
   totalExternal$: Observable<number[]>;
 
-  /**
-   * List of subscriptions to unsubscribe from
-   */
-  private subs: Subscription[] = [];
 
   constructor(
     public modal: NgbActiveModal,
@@ -136,17 +124,14 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     private lookupRelationService: LookupRelationService,
     private searchConfigService: SearchConfigurationService,
     private rdbService: RemoteDataBuildService,
-    private submissionService: SubmissionService,
-    private submissionObjectService: SubmissionObjectDataService,
     private zone: NgZone,
     private store: Store<AppState>,
-    private router: Router
+    private router: Router,
   ) {
 
   }
 
   ngOnInit(): void {
-    this.setItem();
     this.selection$ = this.selectableListService
       .getSelectableList(this.listId)
       .pipe(map((listState: SelectableListState) => hasValue(listState) && hasValue(listState.selection) ? listState.selection : []));
@@ -207,24 +192,6 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   }
 
   /**
-   *  Initialize this.item$ based on this.model.submissionId
-   */
-  private setItem() {
-    const submissionObject$ = this.submissionObjectService
-      .findById(this.submissionId, true, true, followLink('item'), followLink('collection')).pipe(
-        getAllSucceededRemoteData(),
-        getRemoteDataPayload()
-      );
-
-    const item$ = submissionObject$.pipe(switchMap((submissionObject: SubmissionObject) => (submissionObject.item as Observable<RemoteData<Item>>).pipe(getAllSucceededRemoteData(), getRemoteDataPayload())));
-    const collection$ = submissionObject$.pipe(switchMap((submissionObject: SubmissionObject) => (submissionObject.collection as Observable<RemoteData<Collection>>).pipe(getAllSucceededRemoteData(), getRemoteDataPayload())));
-
-    this.subs.push(item$.subscribe((item) => this.item = item));
-    this.subs.push(collection$.subscribe((collection) => this.collection = collection));
-
-  }
-
-  /**
    * Add a subscription updating relationships with name variants
    * @param sri The search result to track name variants for
    */
@@ -279,8 +246,5 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   ngOnDestroy() {
     this.router.navigate([], {});
     Object.values(this.subMap).forEach((subscription) => subscription.unsubscribe());
-    this.subs
-      .filter((sub) => hasValue(sub))
-      .forEach((sub) => sub.unsubscribe());
   }
 }


### PR DESCRIPTION
## References

* Fixes #1103

## Description

Remove submission-based initialization of `DsDynamicLookupRelationModalComponent#item`

## Instructions for Reviewers

* Removed `DsDynamicLookupRelationModalComponent#setItem` 
  * Along with calls, services & `subs` attribute
  * Removed services from unit tests
* When opening a relationship lookup modal from `EditRelationShipListComponent`, set the modal's `collection` to the owning Collection of the Item being edited

**Reviewing**

1. Authenticate as an admin

2. Edit an item. Open its "Relationships" tab. Click on any of the "Add" buttons. 

   The relationship lookup modal should open (and not get stuck in the "loading" animation)

3. Open a submission in a collection with lookup enabled. Click on the lookup button next to the field

   The relationship lookup modal should open (and not get stuck in the "loading" animation)

   

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.