### PR TITLE
Remove menu options for disabled features

### DIFF
--- a/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
@@ -179,17 +179,18 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
             link: '/processes/new'
           } as LinkMenuItemModel,
         },
-        {
-          id: 'new_item_version',
-          parentID: 'new',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.new_item_version',
-            link: ''
-          } as LinkMenuItemModel,
-        },
+        // TODO: enable this menu item once the feature has been implemented
+        // {
+        //   id: 'new_item_version',
+        //   parentID: 'new',
+        //   active: false,
+        //   visible: true,
+        //   model: {
+        //     type: MenuItemType.LINK,
+        //     text: 'menu.section.new_item_version',
+        //     link: ''
+        //   } as LinkMenuItemModel,
+        // },
 
         /* Edit */
         {
@@ -244,32 +245,34 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         },
 
         /* Statistics */
-        {
-          id: 'statistics_task',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.statistics_task',
-            link: ''
-          } as LinkMenuItemModel,
-          icon: 'chart-bar',
-          index: 8
-        },
+        // TODO: enable this menu item once the feature has been implemented
+        // {
+        //   id: 'statistics_task',
+        //   active: false,
+        //   visible: true,
+        //   model: {
+        //     type: MenuItemType.LINK,
+        //     text: 'menu.section.statistics_task',
+        //     link: ''
+        //   } as LinkMenuItemModel,
+        //   icon: 'chart-bar',
+        //   index: 8
+        // },
 
         /* Control Panel */
-        {
-          id: 'control_panel',
-          active: false,
-          visible: isSiteAdmin,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.control_panel',
-            link: ''
-          } as LinkMenuItemModel,
-          icon: 'cogs',
-          index: 9
-        },
+        // TODO: enable this menu item once the feature has been implemented
+        // {
+        //   id: 'control_panel',
+        //   active: false,
+        //   visible: isSiteAdmin,
+        //   model: {
+        //     type: MenuItemType.LINK,
+        //     text: 'menu.section.control_panel',
+        //     link: ''
+        //   } as LinkMenuItemModel,
+        //   icon: 'cogs',
+        //   index: 9
+        // },
 
         /* Processes */
         {
@@ -310,42 +313,45 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         index: 3,
         shouldPersistOnRouteChange: true
       },
-      {
-        id: 'export_community',
-        parentID: 'export',
-        active: false,
-        visible: true,
-        model: {
-          type: MenuItemType.LINK,
-          text: 'menu.section.export_community',
-          link: ''
-        } as LinkMenuItemModel,
-        shouldPersistOnRouteChange: true
-      },
-      {
-        id: 'export_collection',
-        parentID: 'export',
-        active: false,
-        visible: true,
-        model: {
-          type: MenuItemType.LINK,
-          text: 'menu.section.export_collection',
-          link: ''
-        } as LinkMenuItemModel,
-        shouldPersistOnRouteChange: true
-      },
-      {
-        id: 'export_item',
-        parentID: 'export',
-        active: false,
-        visible: true,
-        model: {
-          type: MenuItemType.LINK,
-          text: 'menu.section.export_item',
-          link: ''
-        } as LinkMenuItemModel,
-        shouldPersistOnRouteChange: true
-      },
+      // TODO: enable this menu item once the feature has been implemented
+      // {
+      //   id: 'export_community',
+      //   parentID: 'export',
+      //   active: false,
+      //   visible: true,
+      //   model: {
+      //     type: MenuItemType.LINK,
+      //     text: 'menu.section.export_community',
+      //     link: ''
+      //   } as LinkMenuItemModel,
+      //   shouldPersistOnRouteChange: true
+      // },
+      // TODO: enable this menu item once the feature has been implemented
+      // {
+      //   id: 'export_collection',
+      //   parentID: 'export',
+      //   active: false,
+      //   visible: true,
+      //   model: {
+      //     type: MenuItemType.LINK,
+      //     text: 'menu.section.export_collection',
+      //     link: ''
+      //   } as LinkMenuItemModel,
+      //   shouldPersistOnRouteChange: true
+      // },
+      // TODO: enable this menu item once the feature has been implemented
+      // {
+      //   id: 'export_item',
+      //   parentID: 'export',
+      //   active: false,
+      //   visible: true,
+      //   model: {
+      //     type: MenuItemType.LINK,
+      //     text: 'menu.section.export_item',
+      //     link: ''
+      //   } as LinkMenuItemModel,
+      //   shouldPersistOnRouteChange: true
+      // },
     ];
     menuList.forEach((menuSection) => this.menuService.addSection(this.menuID, menuSection));
 
@@ -392,17 +398,18 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         icon: 'file-import',
         index: 2
       },
-      {
-        id: 'import_batch',
-        parentID: 'import',
-        active: false,
-        visible: true,
-        model: {
-          type: MenuItemType.LINK,
-          text: 'menu.section.import_batch',
-          link: ''
-        } as LinkMenuItemModel,
-      }
+      // TODO: enable this menu item once the feature has been implemented
+      // {
+      //   id: 'import_batch',
+      //   parentID: 'import',
+      //   active: false,
+      //   visible: true,
+      //   model: {
+      //     type: MenuItemType.LINK,
+      //     text: 'menu.section.import_batch',
+      //     link: ''
+      //   } as LinkMenuItemModel,
+      // }
     ];
     menuList.forEach((menuSection) => this.menuService.addSection(this.menuID, Object.assign(menuSection, {
       shouldPersistOnRouteChange: true
@@ -549,17 +556,18 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
             link: '/access-control/groups'
           } as LinkMenuItemModel,
         },
-        {
-          id: 'access_control_authorizations',
-          parentID: 'access_control',
-          active: false,
-          visible: authorized,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.access_control_authorizations',
-            link: ''
-          } as LinkMenuItemModel,
-        },
+        // TODO: enable this menu item once the feature has been implemented
+        // {
+        //   id: 'access_control_authorizations',
+        //   parentID: 'access_control',
+        //   active: false,
+        //   visible: authorized,
+        //   model: {
+        //     type: MenuItemType.LINK,
+        //     text: 'menu.section.access_control_authorizations',
+        //     link: ''
+        //   } as LinkMenuItemModel,
+        // },
         {
           id: 'access_control',
           active: false,

--- a/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
@@ -243,20 +243,6 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
           } as OnClickMenuItemModel,
         },
 
-        /* Curation tasks */
-        {
-          id: 'curation_tasks',
-          active: false,
-          visible: isCollectionAdmin,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.curation_task',
-            link: ''
-          } as LinkMenuItemModel,
-          icon: 'filter',
-          index: 7
-        },
-
         /* Statistics */
         {
           id: 'statistics_task',


### PR DESCRIPTION
## References
Fixes #1125
Fixes #1019 (by removing disabled features)
Fixes #1155 (by removing disabled features)

## Description
- Removed duplicate `curation_tasks` menu item because it would be overridden by [this item](https://github.com/atmire/dspace-angular/blob/fe4fe9e8d34fff27a9def8ad483f6170f09176d8/src/app/%2Badmin/admin-sidebar/admin-sidebar.component.ts#L497) anyway.
- Commented out all menu items that currently don't have a link defined.

## Instructions for Reviewers
Log into DSpace and verify that all disabled menu items are gone from the sidebar.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
