### PR TITLE
Fix edit group navigation bug

### DIFF
--- a/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
@@ -210,4 +210,11 @@ describe('GroupFormComponent', () => {
     });
   });
 
+  describe('ngOnDestroy', () => {
+    it('does NOT call router.navigate', () => {
+      component.ngOnDestroy();
+      expect(router.navigate).toHaveBeenCalledTimes(0);
+    });
+  });
+
 });

--- a/src/app/access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.ts
@@ -405,7 +405,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
    */
   @HostListener('window:beforeunload')
   ngOnDestroy(): void {
-    this.onCancel();
+    this.groupDataService.cancelEditGroup();
     this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
   }
 


### PR DESCRIPTION
## References
Fixes #1127

## Description
When navigating away from an "edit group" page (Access Control), the group list would be shown, regardless of user intentions. This PR eliminates a call to `router.navigate` such that navigation works again as intended.

## Instructions for Reviewers
- Log into DSpace
- Open the group list (sidebar > Access Control > Groups)
- Open the edit page of any group
- Navigate to any page and observe that the expected page is opened. (Without this PR, the group list would always open.)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
