### PR TITLE
Update metadata import export script params

### DIFF
--- a/src/app/+admin/admin-import-metadata-page/metadata-import-page.component.spec.ts
+++ b/src/app/+admin/admin-import-metadata-page/metadata-import-page.component.spec.ts
@@ -6,10 +6,7 @@ import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { of as observableOf } from 'rxjs';
-import { AuthService } from '../../core/auth/auth.service';
 import { METADATA_IMPORT_SCRIPT_NAME, ScriptDataService } from '../../core/data/processes/script-data.service';
-import { EPerson } from '../../core/eperson/models/eperson.model';
 import { ProcessParameter } from '../../process-page/processes/process-parameter.model';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
@@ -22,12 +19,9 @@ describe('MetadataImportPageComponent', () => {
   let comp: MetadataImportPageComponent;
   let fixture: ComponentFixture<MetadataImportPageComponent>;
 
-  let user;
-
   let notificationService: NotificationsServiceStub;
   let scriptService: any;
   let router;
-  let authService;
   let locationStub;
 
   function init() {
@@ -37,13 +31,6 @@ describe('MetadataImportPageComponent', () => {
         invoke: createSuccessfulRemoteDataObject$({ processId: '45' })
       }
     );
-    user = Object.assign(new EPerson(), {
-      id: 'userId',
-      email: 'user@test.com'
-    });
-    authService = jasmine.createSpyObj('authService', {
-      getAuthenticatedUserFromStore: observableOf(user)
-    });
     router = jasmine.createSpyObj('router', {
       navigateByUrl: jasmine.createSpy('navigateByUrl')
     });
@@ -65,7 +52,6 @@ describe('MetadataImportPageComponent', () => {
         { provide: NotificationsService, useValue: notificationService },
         { provide: ScriptDataService, useValue: scriptService },
         { provide: Router, useValue: router },
-        { provide: AuthService, useValue: authService },
         { provide: Location, useValue: locationStub },
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -107,9 +93,8 @@ describe('MetadataImportPageComponent', () => {
         proceed.click();
         fixture.detectChanges();
       }));
-      it('metadata-import script is invoked with its -e currentUserEmail, -f fileName and the mockFile', () => {
+      it('metadata-import script is invoked with -f fileName and the mockFile', () => {
         const parameterValues: ProcessParameter[] = [
-          Object.assign(new ProcessParameter(), { name: '-e', value: user.email }),
           Object.assign(new ProcessParameter(), { name: '-f', value: 'filename.txt' }),
         ];
         expect(scriptService.invoke).toHaveBeenCalledWith(METADATA_IMPORT_SCRIPT_NAME, parameterValues, [fileMock]);

--- a/src/app/+admin/admin-import-metadata-page/metadata-import-page.component.ts
+++ b/src/app/+admin/admin-import-metadata-page/metadata-import-page.component.ts
@@ -23,20 +23,14 @@ import { getProcessDetailRoute } from '../../process-page/process-page-routing.p
 /**
  * Component that represents a metadata import page for administrators
  */
-export class MetadataImportPageComponent implements OnInit {
+export class MetadataImportPageComponent {
 
   /**
    * The current value of the file
    */
   fileObject: File;
 
-  /**
-   * The authenticated user's email
-   */
-  private currentUserEmail$: Observable<string>;
-
-  public constructor(protected authService: AuthService,
-                     private location: Location,
+  public constructor(private location: Location,
                      protected translate: TranslateService,
                      protected notificationsService: NotificationsService,
                      private scriptDataService: ScriptDataService,
@@ -52,15 +46,6 @@ export class MetadataImportPageComponent implements OnInit {
   }
 
   /**
-   * Method provided by Angular. Invoked after the constructor.
-   */
-  ngOnInit() {
-    this.currentUserEmail$ = this.authService.getAuthenticatedUserFromStore().pipe(
-      map((user: EPerson) => user.email)
-    );
-  }
-
-  /**
    * When return button is pressed go to previous location
    */
   public onReturn() {
@@ -68,22 +53,17 @@ export class MetadataImportPageComponent implements OnInit {
   }
 
   /**
-   * Starts import-metadata script with -e currentUserEmail -f fileName (and the selected file)
+   * Starts import-metadata script with -f fileName (and the selected file)
    */
   public importMetadata() {
     if (this.fileObject == null) {
       this.notificationsService.error(this.translate.get('admin.metadata-import.page.error.addFile'));
     } else {
-      this.currentUserEmail$.pipe(
-        switchMap((email: string) => {
-          if (isNotEmpty(email)) {
-            const parameterValues: ProcessParameter[] = [
-              Object.assign(new ProcessParameter(), { name: '-e', value: email }),
-              Object.assign(new ProcessParameter(), { name: '-f', value: this.fileObject.name }),
-            ];
-            return this.scriptDataService.invoke(METADATA_IMPORT_SCRIPT_NAME, parameterValues, [this.fileObject]);
-          }
-        }),
+      const parameterValues: ProcessParameter[] = [
+        Object.assign(new ProcessParameter(), { name: '-f', value: this.fileObject.name }),
+      ];
+
+      this.scriptDataService.invoke(METADATA_IMPORT_SCRIPT_NAME, parameterValues, [this.fileObject]).pipe(
         getFirstCompletedRemoteData(),
       ).subscribe((rd: RemoteData<Process>) => {
         if (rd.hasSucceeded) {

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
@@ -51,12 +51,14 @@ describe('ExportMetadataSelectorComponent', () => {
 
   const mockItem = Object.assign(new Item(), {
     id: 'fake-id',
+    uuid: 'fake-id',
     handle: 'fake/handle',
     lastModified: '2018'
   });
 
   const mockCollection: Collection = Object.assign(new Collection(), {
     id: 'test-collection-1-1',
+    uuid: 'test-collection-1-1',
     name: 'test-collection-1',
     metadata: {
       'dc.identifier.uri': [
@@ -70,6 +72,7 @@ describe('ExportMetadataSelectorComponent', () => {
 
   const mockCommunity = Object.assign(new Community(), {
     id: 'test-uuid',
+    uuid: 'test-uuid',
     metadata: {
       'dc.identifier.uri': [
         {
@@ -157,7 +160,7 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('metadata-export script is invoked with its -i handle', () => {
+    it('should invoke the metadata-export script with option -i uuid', () => {
       const parameterValues: ProcessParameter[] = [
         Object.assign(new ProcessParameter(), { name: '-i', value: mockCollection.uuid }),
       ];
@@ -181,7 +184,7 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('metadata-export script is invoked with its -i handle', () => {
+    it('should invoke the metadata-export script with option -i uuid', () => {
       const parameterValues: ProcessParameter[] = [
         Object.assign(new ProcessParameter(), { name: '-i', value: mockCommunity.uuid }),
       ];

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
@@ -157,10 +157,9 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('metadata-export script is invoked with its -i handle and -f uuid.csv', () => {
+    it('metadata-export script is invoked with its -i handle', () => {
       const parameterValues: ProcessParameter[] = [
-        Object.assign(new ProcessParameter(), { name: '-i', value: mockCollection.handle }),
-        Object.assign(new ProcessParameter(), { name: '-f', value: mockCollection.uuid + '.csv' }),
+        Object.assign(new ProcessParameter(), { name: '-i', value: mockCollection.uuid }),
       ];
       expect(scriptService.invoke).toHaveBeenCalledWith(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
     });
@@ -182,10 +181,9 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('metadata-export script is invoked with its -i handle and -f uuid.csv', () => {
+    it('metadata-export script is invoked with its -i handle', () => {
       const parameterValues: ProcessParameter[] = [
-        Object.assign(new ProcessParameter(), { name: '-i', value: mockCommunity.handle }),
-        Object.assign(new ProcessParameter(), { name: '-f', value: mockCommunity.uuid + '.csv' }),
+        Object.assign(new ProcessParameter(), { name: '-i', value: mockCommunity.uuid }),
       ];
       expect(scriptService.invoke).toHaveBeenCalledWith(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
     });

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
@@ -56,7 +56,7 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
       modalRef.componentInstance.confirmIcon = 'fas fa-file-export';
       const resp$ =  modalRef.componentInstance.response.pipe(switchMap((confirm: boolean) => {
         if (confirm) {
-          const startScriptSucceeded$ = this.startScriptNotifyAndRedirect(dso, dso.handle);
+          const startScriptSucceeded$ = this.startScriptNotifyAndRedirect(dso);
           return startScriptSucceeded$.pipe(
             switchMap((r: boolean) => {
               return observableOf(r);
@@ -78,12 +78,10 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
    * Start export-metadata script of dso & navigate to process if successful
    * Otherwise show error message
    * @param dso    Dso to export
-   * @param handle Dso handle to export
    */
-  private startScriptNotifyAndRedirect(dso: DSpaceObject, handle: string): Observable<boolean> {
+  private startScriptNotifyAndRedirect(dso: DSpaceObject): Observable<boolean> {
     const parameterValues: ProcessParameter[] = [
-      Object.assign(new ProcessParameter(), { name: '-i', value: handle }),
-      Object.assign(new ProcessParameter(), { name: '-f', value: dso.uuid + '.csv' }),
+      Object.assign(new ProcessParameter(), { name: '-i', value: dso.uuid }),
     ];
     return this.scriptDataService.invoke(METADATA_EXPORT_SCRIPT_NAME, parameterValues, [])
       .pipe(


### PR DESCRIPTION
## References
- Fixes #1132
- Fixes #1133
- Depends on https://github.com/DSpace/DSpace/pull/3276

## Description
- Remove `-e` option from `MetadataImportPageComponent`, fix tests and simplify code.
- Remove `-f` option from `ExportMetadataSelectorComponent`, fix tests and simplify code.
- Pass uuid (instead of handle) to `ExportMetadataSelectorComponent`

## Instructions for Reviewers
Make sure metadata import and export work again.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
