### PR TITLE
Fix the rel name for the submissioncclicenseUrls-search link

### DIFF
--- a/src/app/core/submission/submission-cc-license-url-data.service.ts
+++ b/src/app/core/submission/submission-cc-license-url-data.service.ts
@@ -22,7 +22,7 @@ import { isNotEmpty } from '../../shared/empty.util';
 @dataService(SUBMISSION_CC_LICENSE_URL)
 export class SubmissionCcLicenseUrlDataService extends DataService<SubmissionCcLicenceUrl> {
 
-  protected linkPath = 'submissioncclicenseUrl-search';
+  protected linkPath = 'submissioncclicenseUrls-search';
 
   constructor(
     protected comparator: DefaultChangeAnalyzer<SubmissionCcLicenceUrl>,


### PR DESCRIPTION
## References
* Fixes #1208 

## Description
Fix the name of the search link from submissioncclicenseUrls

## Instructions for Reviewers
Enable the cclicense step and try to use it. Without this fix anwers to the cc questions will not lead to a license selection.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
