### PR TITLE
Fix theme switching issues

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -47,6 +47,7 @@
               "src/robots.txt"
             ],
             "styles": [
+              "src/styles/startup.scss",
               {
                 "input": "src/styles/base-theme.scss",
                 "inject": false,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,3 @@
-<ds-themed-root [isNotAuthBlocking]="isNotAuthBlocking$ | async" [isLoading]="isLoading$ | async"></ds-themed-root>
+<ds-themed-root
+  [shouldShowFullscreenLoader]="(isAuthBlocking$ | async) || (isThemeLoading$ | async)"
+  [shouldShowRouteLoader]="isRouteLoading$ | async"></ds-themed-root>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { delay, map, distinctUntilChanged, filter, take } from 'rxjs/operators';
+import { delay, distinctUntilChanged, filter, take } from 'rxjs/operators';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -7,6 +7,7 @@ import {
   Inject,
   OnInit,
   Optional,
+  PLATFORM_ID,
 } from '@angular/core';
 import { NavigationCancel, NavigationEnd, NavigationStart, Router } from '@angular/router';
 
@@ -32,7 +33,7 @@ import { LocaleService } from './core/locale/locale.service';
 import { hasValue, isNotEmpty } from './shared/empty.util';
 import { KlaroService } from './shared/cookies/klaro.service';
 import { GoogleAnalyticsService } from './statistics/google-analytics.service';
-import { DOCUMENT } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { ThemeService } from './shared/theme-support/theme.service';
 import { BASE_THEME_NAME } from './shared/theme-support/theme.constants';
 import { DEFAULT_THEME_CONFIG } from './shared/theme-support/theme.effects';
@@ -45,7 +46,6 @@ import { BreadcrumbsService } from './breadcrumbs/breadcrumbs.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent implements OnInit, AfterViewInit {
-  isLoading$: BehaviorSubject<boolean> = new BehaviorSubject(true);
   sidebarVisible: Observable<boolean>;
   slideSidebarOver: Observable<boolean>;
   collapsedSidebarWidth: Observable<string>;
@@ -57,11 +57,23 @@ export class AppComponent implements OnInit, AfterViewInit {
   /**
    * Whether or not the authentication is currently blocking the UI
    */
-  isNotAuthBlocking$: Observable<boolean>;
+  isAuthBlocking$: Observable<boolean>;
+
+  /**
+   * Whether or not the app is in the process of rerouting
+   */
+  isRouteLoading$: BehaviorSubject<boolean> = new BehaviorSubject(true);
+
+  /**
+   * Whether or not the theme is in the process of being swapped
+   */
+  isThemeLoading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
 
   constructor(
     @Inject(NativeWindowService) private _window: NativeWindowRef,
-      @Inject(DOCUMENT) private document: any,
+    @Inject(DOCUMENT) private document: any,
+    @Inject(PLATFORM_ID) private platformId: any,
     private themeService: ThemeService,
     private translate: TranslateService,
     private store: Store<HostWindowState>,
@@ -83,6 +95,10 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.models = models;
 
     this.themeService.getThemeName$().subscribe((themeName: string) => {
+      if (isPlatformBrowser(this.platformId)) {
+        // the theme css will never download server side, so this should only happen on the browser
+        this.isThemeLoading$.next(true);
+      }
       if (hasValue(themeName)) {
         this.setThemeCss(themeName);
       } else if (hasValue(DEFAULT_THEME_CONFIG)) {
@@ -118,13 +134,12 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-    this.isNotAuthBlocking$ = this.store.pipe(select(isAuthenticationBlocking)).pipe(
-      map((isBlocking: boolean) => isBlocking === false),
+    this.isAuthBlocking$ = this.store.pipe(select(isAuthenticationBlocking)).pipe(
       distinctUntilChanged()
     );
-    this.isNotAuthBlocking$
+    this.isAuthBlocking$
       .pipe(
-        filter((notBlocking: boolean) => notBlocking),
+        filter((isBlocking: boolean) => isBlocking === false),
         take(1)
       ).subscribe(() => this.initializeKlaro());
 
@@ -156,12 +171,12 @@ export class AppComponent implements OnInit, AfterViewInit {
       delay(0)
     ).subscribe((event) => {
       if (event instanceof NavigationStart) {
-        this.isLoading$.next(true);
+        this.isRouteLoading$.next(true);
       } else if (
         event instanceof NavigationEnd ||
         event instanceof NavigationCancel
       ) {
-        this.isLoading$.next(false);
+        this.isRouteLoading$.next(false);
       }
     });
   }
@@ -209,6 +224,8 @@ export class AppComponent implements OnInit, AfterViewInit {
           }
         });
       }
+      // the fact that this callback is used, proves we're on the browser.
+      this.isThemeLoading$.next(false);
     };
     head.appendChild(link);
   }

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -24,7 +24,7 @@
   </div>
 </div>
 <ng-template #authLoader>
-  <div class="text-center ds-full-screen-loader d-flex align-items-center flex-column justify-content-center">
+  <div class="ds-full-screen-loader">
     <ds-loading [showMessage]="false"></ds-loading>
   </div>
 </ng-template>

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -1,4 +1,4 @@
-<div class="outer-wrapper" *ngIf="isNotAuthBlocking; else authLoader">
+<div class="outer-wrapper" *ngIf="!shouldShowFullscreenLoader; else fullScreenLoader">
   <ds-admin-sidebar></ds-admin-sidebar>
   <div class="inner-wrapper"  [@slideSidebarPadding]="{
      value: (!(sidebarVisible | async) ? 'hidden' : (slideSidebarOver | async) ? 'shown' : 'expanded'),
@@ -12,10 +12,10 @@
     <main class="main-content">
       <ds-themed-breadcrumbs></ds-themed-breadcrumbs>
 
-      <div class="container d-flex justify-content-center align-items-center h-100" *ngIf="isLoading">
+      <div class="container d-flex justify-content-center align-items-center h-100" *ngIf="shouldShowRouteLoader">
         <ds-loading [showMessage]="false"></ds-loading>
       </div>
-      <div [class.d-none]="isLoading">
+      <div [class.d-none]="shouldShowRouteLoader">
         <router-outlet></router-outlet>
       </div>
     </main>
@@ -23,7 +23,7 @@
     <ds-themed-footer></ds-themed-footer>
   </div>
 </div>
-<ng-template #authLoader>
+<ng-template #fullScreenLoader>
   <div class="ds-full-screen-loader">
     <ds-loading [showMessage]="false"></ds-loading>
   </div>

--- a/src/app/root/root.component.spec.ts
+++ b/src/app/root/root.component.spec.ts
@@ -27,6 +27,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { RouteService } from '../core/services/route.service';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { MenuServiceStub } from '../shared/testing/menu-service.stub';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('RootComponent', () => {
   let component: RootComponent;
@@ -36,6 +37,7 @@ describe('RootComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         CommonModule,
+        NoopAnimationsModule,
         StoreModule.forRoot(authReducer, storeModuleConfig),
         TranslateModule.forRoot({
           loader: {

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -38,14 +38,14 @@ export class RootComponent implements OnInit {
   models;
 
   /**
-   * Whether or not the authentication is currently blocking the UI
+   * Whether or not to show a full screen loader
    */
-  @Input() isNotAuthBlocking: boolean;
+  @Input() shouldShowFullscreenLoader: boolean;
 
   /**
-   * Whether or not the the application is loading;
+   * Whether or not to show a loader across the router outlet
    */
-  @Input() isLoading: boolean;
+  @Input() shouldShowRouteLoader: boolean;
 
   constructor(
     @Inject(NativeWindowService) private _window: NativeWindowRef,

--- a/src/app/root/themed-root.component.ts
+++ b/src/app/root/themed-root.component.ts
@@ -11,14 +11,14 @@ export class ThemedRootComponent extends ThemedComponent<RootComponent> {
   /**
    * Whether or not the authentication is currently blocking the UI
    */
-  @Input() isNotAuthBlocking: boolean;
+  @Input() shouldShowFullscreenLoader: boolean;
 
   /**
    * Whether or not the the application is loading;
    */
-  @Input() isLoading: boolean;
+  @Input() shouldShowRouteLoader: boolean;
 
-  protected inAndOutputNames: (keyof RootComponent & keyof this)[] = ['isLoading', 'isNotAuthBlocking'];
+  protected inAndOutputNames: (keyof RootComponent & keyof this)[] = ['shouldShowRouteLoader', 'shouldShowFullscreenLoader'];
 
   protected getComponentName(): string {
     return 'RootComponent';

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
   <title>DSpace</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico" />
-  <link class="theme-css" rel="stylesheet" href="/dspace-theme.css">
 </head>
 
 <body>

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -40,10 +40,6 @@ ds-admin-sidebar {
   z-index: var(--ds-sidebar-z-index);
 }
 
-.ds-full-screen-loader {
-  height: 100vh;
-}
-
 .sticky-top {
   z-index: 0;
 }

--- a/src/styles/startup.scss
+++ b/src/styles/startup.scss
@@ -1,0 +1,8 @@
+.ds-full-screen-loader {
+  height: 100vh;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}


### PR DESCRIPTION
## References
* Fixes #1093
* Fixes #1134

## Description
This PR creates a separate dedicated css file that contains only the style needed to render the full screen loader. That's all that's shown before the theme is loaded by angular, so this way we no longer have to hardcode any theme into index.html, fixing #1093 

It also shows the full screen loader when themes are switched, preventing the brief flash showing the header in the old theme reported in #1134

## Instructions for Reviewers
To test this PR: 
- configure two themes that have noticeably different background colors for the header. 
- confiture one (Theme A) to match a specific route, the other (Theme B) to be the fallback for all other routes
- open the route that matches Theme A
- navigate to a route that matches theme B
- Verify that you see all components in Theme A, followed by a full screen loader, followed by all components in Theme B

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.


