### PR TITLE
Remove duplicate author field

### DIFF
--- a/src/app/+item-page/simple/field-components/specific-field/author/item-page-author-field.component.ts
+++ b/src/app/+item-page/simple/field-components/specific-field/author/item-page-author-field.component.ts
@@ -8,7 +8,11 @@ import { ItemPageFieldComponent } from '../item-page-field.component';
   templateUrl: '../item-page-field.component.html'
 })
 /**
- * This component is used for displaying the author (dc.contributor.author, dc.creator and dc.contributor) metadata of an item
+ * This component is used for displaying the author (dc.contributor.author, dc.creator and
+ * dc.contributor) metadata of an item.
+ *
+ * Note that it purely deals with metadata. It won't turn related Person authors into links to their
+ * item page. For that use a {@link MetadataRepresentationListComponent} instead.
  */
 export class ItemPageAuthorFieldComponent extends ItemPageFieldComponent {
 

--- a/src/app/+item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.html
@@ -18,7 +18,12 @@
     </ng-container>
     <ds-item-page-file-section [item]="object"></ds-item-page-file-section>
     <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
-    <ds-item-page-author-field [item]="object"></ds-item-page-author-field>
+    <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
+      [parentItem]="object"
+      [itemType]="'Person'"
+      [metadataField]="'dc.contributor.author'"
+      [label]="'relationships.isAuthorOf' | translate">
+    </ds-metadata-representation-list>
     <ds-generic-item-page-field [item]="object"
       [fields]="['journal.title']"
       [label]="'publication.page.journal-title'">
@@ -37,12 +42,6 @@
     </ds-generic-item-page-field>
   </div>
   <div class="col-xs-12 col-md-6">
-    <ds-metadata-representation-list
-      [parentItem]="object"
-      [itemType]="'Person'"
-      [metadataField]="'dc.contributor.author'"
-      [label]="'relationships.isAuthorOf' | translate">
-    </ds-metadata-representation-list>
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isProjectOfPublication'"

--- a/src/app/+item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.html
@@ -21,7 +21,7 @@
     <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
       [parentItem]="object"
       [itemType]="'Person'"
-      [metadataField]="'dc.contributor.author'"
+      [metadataFields]="['dc.contributor.author', 'dc.creator']"
       [label]="'relationships.isAuthorOf' | translate">
     </ds-metadata-representation-list>
     <ds-generic-item-page-field [item]="object"

--- a/src/app/+item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/+item-page/simple/item-types/publication/publication.component.spec.ts
@@ -88,9 +88,14 @@ describe('PublicationComponent', () => {
     expect(fields.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should contain a component to display the author', () => {
+  it('should not contain a metadata only author field', () => {
     const fields = fixture.debugElement.queryAll(By.css('ds-item-page-author-field'));
-    expect(fields.length).toBeGreaterThanOrEqual(1);
+    expect(fields.length).toBe(0);
+  });
+
+  it('should contain a mixed metadata and relationship field for authors', () => {
+    const fields = fixture.debugElement.queryAll(By.css('.ds-item-page-mixed-author-field'));
+    expect(fields.length).toBe(1);
   });
 
   it('should contain a component to display the abstract', () => {

--- a/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -18,7 +18,12 @@
     </ng-container>
     <ds-item-page-file-section [item]="object"></ds-item-page-file-section>
     <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
-    <ds-item-page-author-field [item]="object"></ds-item-page-author-field>
+    <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
+      [parentItem]="object"
+      [itemType]="'Person'"
+      [metadataField]="'dc.contributor.author'"
+      [label]="'relationships.isAuthorOf' | translate">
+    </ds-metadata-representation-list>
     <ds-generic-item-page-field [item]="object"
       [fields]="['journal.title']"
       [label]="'item.page.journal-title'">
@@ -37,12 +42,6 @@
     </ds-generic-item-page-field>
   </div>
   <div class="col-xs-12 col-md-6">
-    <ds-metadata-representation-list
-      [parentItem]="object"
-      [itemType]="'Person'"
-      [metadataField]="'dc.contributor.author'"
-      [label]="'relationships.isAuthorOf' | translate">
-    </ds-metadata-representation-list>
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"

--- a/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -21,7 +21,7 @@
     <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
       [parentItem]="object"
       [itemType]="'Person'"
-      [metadataField]="'dc.contributor.author'"
+      [metadataFields]="['dc.contributor.author', 'dc.creator']"
       [label]="'relationships.isAuthorOf' | translate">
     </ds-metadata-representation-list>
     <ds-generic-item-page-field [item]="object"

--- a/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
+++ b/src/app/+item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
@@ -89,9 +89,14 @@ describe('UntypedItemComponent', () => {
     expect(fields.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should contain a component to display the author', () => {
+  it('should not contain a metadata only author field', () => {
     const fields = fixture.debugElement.queryAll(By.css('ds-item-page-author-field'));
-    expect(fields.length).toBeGreaterThanOrEqual(1);
+    expect(fields.length).toBe(0);
+  });
+
+  it('should contain a mixed metadata and relationship field for authors', () => {
+    const fields = fixture.debugElement.queryAll(By.css('.ds-item-page-mixed-author-field'));
+    expect(fields.length).toBe(1);
   });
 
   it('should contain a component to display the abstract', () => {

--- a/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
+++ b/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
@@ -11,7 +11,7 @@ import { VarDirective } from '../../../shared/utils/var.directive';
 import { of as observableOf } from 'rxjs';
 
 const itemType = 'Person';
-const metadataField = 'dc.contributor.author';
+const metadataFields = ['dc.contributor.author', 'dc.creator'];
 const parentItem: Item = Object.assign(new Item(), {
   id: 'parent-item',
   metadata: {
@@ -27,6 +27,14 @@ const parentItem: Item = Object.assign(new Item(), {
         value: 'Author without authority',
         place: 1
       }
+    ],
+    'dc.creator': [
+      {
+        language: null,
+        value: 'Related Creator with authority',
+        authority: 'virtual::related-creator',
+        place: 3,
+      },
     ],
     'dc.title': [
       {
@@ -81,13 +89,13 @@ describe('MetadataRepresentationListComponent', () => {
     comp = fixture.componentInstance;
     comp.parentItem = parentItem;
     comp.itemType = itemType;
-    comp.metadataField = metadataField;
+    comp.metadataFields = metadataFields;
     fixture.detectChanges();
   }));
 
-  it('should load 2 ds-metadata-representation-loader components', () => {
+  it('should load 3 ds-metadata-representation-loader components', () => {
     const fields = fixture.debugElement.queryAll(By.css('ds-metadata-representation-loader'));
-    expect(fields.length).toBe(2);
+    expect(fields.length).toBe(3);
   });
 
   it('should contain one page of items', () => {

--- a/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
+++ b/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
@@ -5,7 +5,7 @@ import { MetadataRepresentationListComponent } from './metadata-representation-l
 import { RelationshipService } from '../../../core/data/relationship.service';
 import { Item } from '../../../core/shared/item.model';
 import { Relationship } from '../../../core/shared/item-relationships/relationship.model';
-import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
+import { createSuccessfulRemoteDataObject$, createFailedRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { TranslateModule } from '@ngx-translate/core';
 import { VarDirective } from '../../../shared/utils/var.directive';
 import { of as observableOf } from 'rxjs';
@@ -35,6 +35,12 @@ const parentItem: Item = Object.assign(new Item(), {
         authority: 'virtual::related-creator',
         place: 3,
       },
+      {
+        language: null,
+        value: 'Related Creator with authority - unauthorized',
+        authority: 'virtual::related-creator-unauthorized',
+        place: 4,
+      },
     ],
     'dc.title': [
       {
@@ -55,21 +61,49 @@ const relatedAuthor: Item = Object.assign(new Item(), {
     ]
   }
 });
-const relation: Relationship = Object.assign(new Relationship(), {
+const relatedCreator: Item = Object.assign(new Item(), {
+  id: 'related-creator',
+  metadata: {
+    'dc.title': [
+      {
+        language: null,
+        value: 'Related Creator'
+      }
+    ],
+    'dspace.entity.type': 'Person',
+  }
+});
+const authorRelation: Relationship = Object.assign(new Relationship(), {
   leftItem: createSuccessfulRemoteDataObject$(parentItem),
   rightItem: createSuccessfulRemoteDataObject$(relatedAuthor)
 });
-let relationshipService: RelationshipService;
+const creatorRelation: Relationship = Object.assign(new Relationship(), {
+  leftItem: createSuccessfulRemoteDataObject$(parentItem),
+  rightItem: createSuccessfulRemoteDataObject$(relatedCreator),
+});
+const creatorRelationUnauthorized: Relationship = Object.assign(new Relationship(), {
+  leftItem: createSuccessfulRemoteDataObject$(parentItem),
+  rightItem: createFailedRemoteDataObject$('Unauthorized', 401),
+});
+let relationshipService;
 
 describe('MetadataRepresentationListComponent', () => {
   let comp: MetadataRepresentationListComponent;
   let fixture: ComponentFixture<MetadataRepresentationListComponent>;
 
-  relationshipService = jasmine.createSpyObj('relationshipService',
-    {
-      findById: createSuccessfulRemoteDataObject$(relation)
-    }
-  );
+  relationshipService = {
+    findById: (id: string) => {
+      if (id === 'related-author') {
+        return createSuccessfulRemoteDataObject$(authorRelation);
+      }
+      if (id === 'related-creator') {
+        return createSuccessfulRemoteDataObject$(creatorRelation);
+      }
+      if (id === 'related-creator-unauthorized') {
+        return createSuccessfulRemoteDataObject$(creatorRelationUnauthorized);
+      }
+    },
+  };
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -93,9 +127,9 @@ describe('MetadataRepresentationListComponent', () => {
     fixture.detectChanges();
   }));
 
-  it('should load 3 ds-metadata-representation-loader components', () => {
+  it('should load 4 ds-metadata-representation-loader components', () => {
     const fields = fixture.debugElement.queryAll(By.css('ds-metadata-representation-loader'));
-    expect(fields.length).toBe(3);
+    expect(fields.length).toBe(4);
   });
 
   it('should contain one page of items', () => {

--- a/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
+++ b/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
@@ -91,9 +91,11 @@ export class MetadataRepresentationListComponent extends AbstractIncrementalList
               getFirstSucceededRemoteData(),
               switchMap((relRD: RemoteData<Relationship>) =>
                 observableCombineLatest(relRD.payload.leftItem, relRD.payload.rightItem).pipe(
-                  filter(([leftItem, rightItem]) => leftItem.hasSucceeded && rightItem.hasSucceeded),
+                  filter(([leftItem, rightItem]) => leftItem.hasCompleted && rightItem.hasCompleted),
                   map(([leftItem, rightItem]) => {
-                    if (leftItem.payload.id === this.parentItem.id) {
+                    if (!leftItem.hasSucceeded || !rightItem.hasSucceeded) {
+                      return observableOf(Object.assign(new MetadatumRepresentation(this.itemType), metadatum));
+                    } else if (rightItem.hasSucceeded && leftItem.payload.id === this.parentItem.id) {
                       return rightItem.payload;
                     } else if (rightItem.payload.id === this.parentItem.id) {
                       return leftItem.payload;

--- a/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
+++ b/src/app/+item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
@@ -42,7 +42,7 @@ export class MetadataRepresentationListComponent extends AbstractIncrementalList
   /**
    * The metadata field to use for fetching metadata from the item
    */
-  @Input() metadataField: string;
+  @Input() metadataFields: string[];
 
   /**
    * An i18n label to use as a title for the list
@@ -70,7 +70,7 @@ export class MetadataRepresentationListComponent extends AbstractIncrementalList
    * @param page  The page to fetch
    */
   getPage(page: number): Observable<MetadataRepresentation[]> {
-    const metadata = this.parentItem.findMetadataSortedByPlace(this.metadataField);
+    const metadata = this.parentItem.findMetadataSortedByPlace(this.metadataFields);
     this.total = metadata.length;
     return this.resolveMetadataRepresentations(metadata, page);
   }

--- a/src/app/core/shared/dspace-object.model.ts
+++ b/src/app/core/shared/dspace-object.model.ts
@@ -163,8 +163,8 @@ export class DSpaceObject extends ListableObject implements CacheableObject {
    * Find metadata on a specific field and order all of them using their "place" property.
    * @param key
    */
-  findMetadataSortedByPlace(key: string): MetadataValue[] {
-    return this.allMetadata([key]).sort((a: MetadataValue, b: MetadataValue) => {
+  findMetadataSortedByPlace(keyOrKeys: string | string[]): MetadataValue[] {
+    return this.allMetadata(keyOrKeys).sort((a: MetadataValue, b: MetadataValue) => {
       if (hasNoValue(a.place) && hasNoValue(b.place)) {
         return 0;
       }

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.html
@@ -18,7 +18,7 @@
     <ds-metadata-representation-list
       [parentItem]="object"
       [itemType]="'OrgUnit'"
-      [metadataField]="'project.contributor.other'"
+      [metadataFields]="['project.contributor.other']"
       [label]="'project.page.contributor' | translate">
     </ds-metadata-representation-list>
     <ds-generic-item-page-field [item]="object"


### PR DESCRIPTION
## References
This PR fixes https://github.com/DSpace/dspace-angular/issues/1196

## Description

Currently the authors section appears twice on all item pages for untyped items and publications, once using a metadata only component (ItemPageAuthorField), and once using a component that renders related entities as links (MetadataRepresentationList).
The MetadataRepresentationList doesn't support multiple metadatafields yet, so it only lists 'dc.contributor.author' metadata now, while the ItemPageAuthorField also lists 'dc.creator' metadata.
While fixing this, we also discovered a bug in the MetadataRepresentationList: when the user is unauthorised for the related item, no author metadata is displayed.

## Instructions for Reviewers

List of changes in this PR:
* The MetadataRepresentationList component has been altered to support multiple metadata fields
* The item pages for publications and untyped items now only use the MetadataRepresentationList and no longer use the ItemPageAuthorField
* For these item pages, dc.creator has been added to the MetadataRepresentationList for the authors
* The MetadataRepresentationList.resolveMetadataRepresentations method has been altered to fix the above bug: when the related item did not properly resolve, a simple MetadatumRepresentation is used instead
* An example of a publication with a related item which returns a 401 (for an anonymous user) can be found on the 4science REST api ('api7.dspace.org/') with item id '047556d1-3d01-4c53-bc68-0cee7ad7ed4e'.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
