### PR TITLE
Escape browse by author data requests

### DIFF
--- a/src/app/core/browse/browse.service.spec.ts
+++ b/src/app/core/browse/browse.service.spec.ts
@@ -127,7 +127,8 @@ describe('BrowseService', () => {
   });
 
   describe('getBrowseEntriesFor and findList', () => {
-    const mockAuthorName = 'Donald Smith';
+    // should contain special characters such that url encoding can be tested as well
+    const mockAuthorName = 'Donald Smith & Sons';
 
     beforeEach(() => {
       requestService = getMockRequestService(getRequestEntry$(true));
@@ -152,7 +153,7 @@ describe('BrowseService', () => {
 
     describe('when findList is called with a valid browse definition id', () => {
       it('should call hrefOnlyDataService.findAllByHref with the expected href', () => {
-        const expected = browseDefinitions[1]._links.items.href + '?filterValue=' + mockAuthorName;
+        const expected = browseDefinitions[1]._links.items.href + '?filterValue=' + encodeURIComponent(mockAuthorName);
 
         scheduler.schedule(() => service.getBrowseItemsFor(mockAuthorName, new BrowseEntrySearchOptions(browseDefinitions[1].id)).subscribe());
         scheduler.flush();

--- a/src/app/core/browse/browse.service.ts
+++ b/src/app/core/browse/browse.service.ts
@@ -130,7 +130,7 @@ export class BrowseService {
           args.push(`startsWith=${options.startsWith}`);
         }
         if (isNotEmpty(filterValue)) {
-          args.push(`filterValue=${filterValue}`);
+          args.push(`filterValue=${encodeURIComponent(filterValue)}`);
         }
         if (isNotEmpty(args)) {
           href = new URLCombiner(href, `?${args.join('&')}`).toString();


### PR DESCRIPTION
## References
Fixes DSpace/DSpace#3230 (Angular part)

## Description
Encode URI characters when constructing url in browse.service.ts.

## Instructions for Reviewers
Before this change, e.g. https://demo7.dspace.org/browse/author?bbm.rpp=100&value=Biomolecular%20%26%20Analytical%20Mass%20Spectrometry%20(BAMS) does not show any items.

After this change the same page should show 4 items.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
