### PR TITLE
Remove references to Testathon & Beta 5 from Demo / Default theme

### DIFF
--- a/src/themes/dspace/app/+home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/+home-page/home-news/home-news.component.html
@@ -3,7 +3,7 @@
     <div class="jumbotron jumbotron-fluid">
       <div class="d-flex flex-wrap">
         <div>
-          <h1 class="display-3">DSpace 7 - Beta 5</h1>
+          <h1 class="display-3">DSpace 7</h1>
           <p class="lead">DSpace is the world leading open source repository platform that enables
             organisations to:</p>
         </div>
@@ -20,10 +20,7 @@
         </li>
       </ul>
       <p>Join an international community of <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Positioning" target="_blank">leading institutions using DSpace</a>.</p>
-      <p>Participate in the <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+7.0+Testathon+Page"
-          target="_blank">official community Testathon</a>
-        from <strong>April 19th through May 7th</strong>. The test user accounts below have their password set to the name of
-        this
+      <p>The test user accounts below have their password set to the name of this
         software in lowercase.</p>
       <ul>
         <li>Demo Site Administrator = dspacedemo+admin@gmail.com</li>


### PR DESCRIPTION
Tiny change to update `home-news.component.html` in our `dspace` theme to no longer reference Testathon or Beta 5.

I'll merge this right after the build succeeds as it's minor cleanup