### PR TITLE
Access Control - Groups only editable by Com/Col admin if group related to com/col & Only site admin access to access control epeople

### DIFF
--- a/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/+admin/admin-sidebar/admin-sidebar.component.ts
@@ -531,14 +531,17 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
    * Create menu sections dependent on whether or not the current user can manage access control groups
    */
   createAccessControlMenuSections() {
-    this.authorizationService.isAuthorized(FeatureID.CanManageGroups).subscribe((authorized) => {
+    observableCombineLatest(
+      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
+      this.authorizationService.isAuthorized(FeatureID.CanManageGroups)
+    ).subscribe(([isSiteAdmin, canManageGroups]) => {
       const menuList = [
         /* Access Control */
         {
           id: 'access_control_people',
           parentID: 'access_control',
           active: false,
-          visible: authorized,
+          visible: isSiteAdmin,
           model: {
             type: MenuItemType.LINK,
             text: 'menu.section.access_control_people',
@@ -549,7 +552,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
           id: 'access_control_groups',
           parentID: 'access_control',
           active: false,
-          visible: authorized,
+          visible: canManageGroups,
           model: {
             type: MenuItemType.LINK,
             text: 'menu.section.access_control_groups',
@@ -571,7 +574,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         {
           id: 'access_control',
           active: false,
-          visible: authorized,
+          visible: canManageGroups || isSiteAdmin,
           model: {
             type: MenuItemType.TEXT,
             text: 'menu.section.access_control'

--- a/src/app/access-control/access-control-routing-paths.ts
+++ b/src/app/access-control/access-control-routing-paths.ts
@@ -3,6 +3,10 @@ import { getAccessControlModuleRoute } from '../app-routing-paths';
 
 export const GROUP_EDIT_PATH = 'groups';
 
+export function getGroupsRoute() {
+  return new URLCombiner(getAccessControlModuleRoute(), GROUP_EDIT_PATH).toString();
+}
+
 export function getGroupEditRoute(id: string) {
   return new URLCombiner(getAccessControlModuleRoute(), GROUP_EDIT_PATH, id).toString();
 }

--- a/src/app/access-control/access-control-routing.module.ts
+++ b/src/app/access-control/access-control-routing.module.ts
@@ -5,6 +5,7 @@ import { GroupFormComponent } from './group-registry/group-form/group-form.compo
 import { GroupsRegistryComponent } from './group-registry/groups-registry.component';
 import { GROUP_EDIT_PATH } from './access-control-routing-paths';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
+import { GroupPageGuard } from './group-registry/group-page.guard';
 
 @NgModule({
   imports: [
@@ -39,7 +40,8 @@ import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.reso
         resolve: {
           breadcrumb: I18nBreadcrumbResolver
         },
-        data: { title: 'admin.access-control.groups.title.singleGroup', breadcrumbKey: 'admin.access-control.groups.singleGroup' }
+        data: { title: 'admin.access-control.groups.title.singleGroup', breadcrumbKey: 'admin.access-control.groups.singleGroup' },
+        canActivate: [GroupPageGuard]
       }
     ])
   ]

--- a/src/app/access-control/access-control-routing.module.ts
+++ b/src/app/access-control/access-control-routing.module.ts
@@ -6,6 +6,8 @@ import { GroupsRegistryComponent } from './group-registry/groups-registry.compon
 import { GROUP_EDIT_PATH } from './access-control-routing-paths';
 import { I18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 import { GroupPageGuard } from './group-registry/group-page.guard';
+import { GroupAdministratorGuard } from '../core/data/feature-authorization/feature-authorization-guard/group-administrator.guard';
+import { SiteAdministratorGuard } from '../core/data/feature-authorization/feature-authorization-guard/site-administrator.guard';
 
 @NgModule({
   imports: [
@@ -16,7 +18,8 @@ import { GroupPageGuard } from './group-registry/group-page.guard';
         resolve: {
           breadcrumb: I18nBreadcrumbResolver
         },
-        data: { title: 'admin.access-control.epeople.title', breadcrumbKey: 'admin.access-control.epeople' }
+        data: { title: 'admin.access-control.epeople.title', breadcrumbKey: 'admin.access-control.epeople' },
+        canActivate: [SiteAdministratorGuard]
       },
       {
         path: GROUP_EDIT_PATH,
@@ -24,7 +27,8 @@ import { GroupPageGuard } from './group-registry/group-page.guard';
         resolve: {
           breadcrumb: I18nBreadcrumbResolver
         },
-        data: { title: 'admin.access-control.groups.title', breadcrumbKey: 'admin.access-control.groups' }
+        data: { title: 'admin.access-control.groups.title', breadcrumbKey: 'admin.access-control.groups' },
+        canActivate: [GroupAdministratorGuard]
       },
       {
         path: `${GROUP_EDIT_PATH}/newGroup`,
@@ -32,7 +36,8 @@ import { GroupPageGuard } from './group-registry/group-page.guard';
         resolve: {
           breadcrumb: I18nBreadcrumbResolver
         },
-        data: { title: 'admin.access-control.groups.title.addGroup', breadcrumbKey: 'admin.access-control.groups.addGroup' }
+        data: { title: 'admin.access-control.groups.title.addGroup', breadcrumbKey: 'admin.access-control.groups.addGroup' },
+        canActivate: [GroupAdministratorGuard]
       },
       {
         path: `${GROUP_EDIT_PATH}/:groupId`,

--- a/src/app/access-control/group-registry/group-page.guard.spec.ts
+++ b/src/app/access-control/group-registry/group-page.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GroupPageGuard } from './group-page.guard';
+
+describe('GroupPageGuard', () => {
+  let guard: GroupPageGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(GroupPageGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/access-control/group-registry/group-page.guard.spec.ts
+++ b/src/app/access-control/group-registry/group-page.guard.spec.ts
@@ -1,16 +1,83 @@
-import { TestBed } from '@angular/core/testing';
-
 import { GroupPageGuard } from './group-page.guard';
+import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { of as observableOf } from 'rxjs';
+import { AuthService } from '../../core/auth/auth.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
 
 describe('GroupPageGuard', () => {
+  const groupsEndpointUrl = 'https://test.org/api/eperson/groups';
+  const groupUuid = '0d6f89df-f95a-4829-943c-f21f434fb892';
+  const groupEndpointUrl = `${groupsEndpointUrl}/${groupUuid}`;
+  const routeSnapshotWithGroupId = {
+    params: {
+      groupId: groupUuid,
+    }
+  } as unknown as ActivatedRouteSnapshot;
+
   let guard: GroupPageGuard;
+  let halEndpointService: HALEndpointService;
+  let authorizationService: AuthorizationDataService;
+  let router: Router;
+  let authService: AuthService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    guard = TestBed.inject(GroupPageGuard);
+    halEndpointService = jasmine.createSpyObj(['getEndpoint']);
+    (halEndpointService as any).getEndpoint.and.returnValue(observableOf(groupsEndpointUrl));
+
+    authorizationService = jasmine.createSpyObj(['isAuthorized']);
+    // NOTE: value is set in beforeEach
+
+    router = jasmine.createSpyObj(['parseUrl']);
+    (router as any).parseUrl.and.returnValue = {};
+
+    authService = jasmine.createSpyObj(['isAuthenticated']);
+    (authService as any).isAuthenticated.and.returnValue(observableOf(true));
+
+    guard = new GroupPageGuard(halEndpointService, authorizationService, router, authService);
   });
 
   it('should be created', () => {
     expect(guard).toBeTruthy();
   });
+
+  describe('canActivate', () => {
+    describe('when the current user can manage the group', () => {
+      beforeEach(() => {
+        (authorizationService as any).isAuthorized.and.returnValue(observableOf(true));
+      });
+
+      it('should return true', (done) => {
+        guard.canActivate(
+          routeSnapshotWithGroupId, { url: 'current-url'} as any
+        ).subscribe((result) => {
+          expect(authorizationService.isAuthorized).toHaveBeenCalledWith(
+            FeatureID.CanManageGroup, groupEndpointUrl, undefined
+          );
+          expect(result).toBeTrue();
+          done();
+        });
+      });
+    });
+
+    describe('when the current user can not manage the group', () => {
+      beforeEach(() => {
+        (authorizationService as any).isAuthorized.and.returnValue(observableOf(false));
+      });
+
+      it('should not return true', (done) => {
+        guard.canActivate(
+          routeSnapshotWithGroupId, { url: 'current-url'} as any
+        ).subscribe((result) => {
+          expect(authorizationService.isAuthorized).toHaveBeenCalledWith(
+            FeatureID.CanManageGroup, groupEndpointUrl, undefined
+          );
+          expect(result).not.toBeTrue();
+          done();
+        });
+      });
+    });
+  });
+
 });

--- a/src/app/access-control/group-registry/group-page.guard.ts
+++ b/src/app/access-control/group-registry/group-page.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { Observable, of as observableOf } from 'rxjs';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { AuthService } from '../../core/auth/auth.service';
+import { SomeFeatureAuthorizationGuard } from '../../core/data/feature-authorization/feature-authorization-guard/some-feature-authorization.guard';
+import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GroupPageGuard extends SomeFeatureAuthorizationGuard {
+
+  protected groupsEndpoint = 'groups';
+
+  constructor(protected halEndpointService: HALEndpointService,
+              protected authorizationService: AuthorizationDataService,
+              protected router: Router,
+              protected authService: AuthService) {
+    super(authorizationService, router, authService);
+  }
+
+  getFeatureIDs(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureID[]> {
+    return observableOf([FeatureID.CanManageGroup]);
+  }
+
+  getObjectUrl(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<string> {
+    return this.halEndpointService.getEndpoint(this.groupsEndpoint).pipe(
+      map(groupsUrl => `${groupsUrl}/${route?.params?.groupId}`)
+    );
+  }
+
+}

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -62,14 +62,14 @@
                   <ng-container [ngSwitch]="groupDto.ableToEdit">
                     <button *ngSwitchCase="true"
                       [routerLink]="groupService.getGroupEditPageRouterLink(groupDto.group)"
-                      class="btn btn-outline-primary btn-sm"
+                      class="btn btn-outline-primary btn-sm btn-edit"
                       title="{{messagePrefix + 'table.edit.buttons.edit' | translate: {name: groupDto.group.name} }}"
                     >
                       <i class="fas fa-edit fa-fw"></i>
                     </button>
                     <button *ngSwitchCase="false"
                       [disabled]="true"
-                      class="btn btn-outline-primary btn-sm"
+                      class="btn btn-outline-primary btn-sm btn-edit"
                       placement="left"
                       [ngbTooltip]="'admin.access-control.epeople.table.edit.buttons.edit-disabled' | translate"
                     >

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -59,11 +59,23 @@
               <td>{{groupDto.epersons?.totalElements + groupDto.subgroups?.totalElements}}</td>
               <td>
                 <div class="btn-group edit-field">
-                  <button [routerLink]="groupService.getGroupEditPageRouterLink(groupDto.group)"
-                          class="btn btn-outline-primary btn-sm"
-                          title="{{messagePrefix + 'table.edit.buttons.edit' | translate: {name: groupDto.group.name} }}">
-                    <i class="fas fa-edit fa-fw"></i>
-                  </button>
+                  <ng-container [ngSwitch]="groupDto.ableToEdit">
+                    <button *ngSwitchCase="true"
+                      [routerLink]="groupService.getGroupEditPageRouterLink(groupDto.group)"
+                      class="btn btn-outline-primary btn-sm"
+                      title="{{messagePrefix + 'table.edit.buttons.edit' | translate: {name: groupDto.group.name} }}"
+                    >
+                      <i class="fas fa-edit fa-fw"></i>
+                    </button>
+                    <button *ngSwitchCase="false"
+                      [disabled]="true"
+                      class="btn btn-outline-primary btn-sm"
+                      placement="left"
+                      [ngbTooltip]="'admin.access-control.epeople.table.edit.buttons.edit-disabled' | translate"
+                    >
+                      <i class="fas fa-edit fa-fw"></i>
+                    </button>
+                  </ng-container>
                   <button *ngIf="!groupDto.group?.permanent && groupDto.ableToDelete"
                           (click)="deleteGroup(groupDto)" class="btn btn-outline-danger btn-sm"
                           title="{{messagePrefix + 'table.edit.buttons.remove' | translate: {name: groupDto.group.name} }}">

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -33,9 +33,9 @@
         </div>
       </form>
 
-      <ds-loading *ngIf="searching$ | async"></ds-loading>
+      <ds-loading *ngIf="loading$ | async"></ds-loading>
       <ds-pagination
-        *ngIf="(pageInfoState$ | async)?.totalElements > 0 && !(searching$ | async)"
+        *ngIf="(pageInfoState$ | async)?.totalElements > 0 && !(loading$ | async)"
         [paginationOptions]="config"
         [pageInfoState]="pageInfoState$"
         [collectionSize]="(pageInfoState$ | async)?.totalElements"

--- a/src/app/access-control/group-registry/groups-registry.component.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.ts
@@ -9,7 +9,7 @@ import {
   of as observableOf,
   Subscription
 } from 'rxjs';
-import { catchError, map, switchMap, take } from 'rxjs/operators';
+import { catchError, map, switchMap, take, tap } from 'rxjs/operators';
 import { DSpaceObjectDataService } from '../../core/data/dspace-object-data.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '../../core/data/feature-authorization/feature-id';
@@ -118,12 +118,12 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
    * @param data  Contains query param
    */
   search(data: any) {
-    this.loading$.next(true);
     if (hasValue(this.searchSub)) {
       this.searchSub.unsubscribe();
       this.subs = this.subs.filter((sub: Subscription) => sub !== this.searchSub);
     }
     this.searchSub = this.paginationService.getCurrentPagination(this.config.id, this.config).pipe(
+      tap(() => this.loading$.next(true)),
       switchMap((paginationOptions) => {
         const query: string = data.query;
         if (query != null && this.currentSearchQuery !== query) {

--- a/src/app/access-control/group-registry/groups-registry.component.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.ts
@@ -75,7 +75,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
   /**
    * A boolean representing if a search is pending
    */
-  searching$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  loading$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   // Current search in groups registry
   currentSearchQuery: string;
@@ -118,7 +118,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
    * @param data  Contains query param
    */
   search(data: any) {
-    this.searching$.next(true);
+    this.loading$.next(true);
     if (hasValue(this.searchSub)) {
       this.searchSub.unsubscribe();
       this.subs = this.subs.filter((sub: Subscription) => sub !== this.searchSub);
@@ -174,7 +174,7 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
     ).subscribe((value: PaginatedList<GroupDtoModel>) => {
       this.groupsDto$.next(value);
       this.pageInfoState$.next(value.pageInfo);
-      this.searching$.next(false);
+      this.loading$.next(false);
     });
 
     this.subs.push(this.searchSub);

--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -10,6 +10,7 @@ export enum FeatureID {
   ReinstateItem = 'reinstateItem',
   EPersonRegistration = 'epersonRegistration',
   CanManageGroups = 'canManageGroups',
+  CanManageGroup = 'canManageGroup',
   IsCollectionAdmin = 'isCollectionAdmin',
   IsCommunityAdmin = 'isCommunityAdmin',
   CanDownload = 'canDownload',

--- a/src/app/core/eperson/models/group-dto.model.ts
+++ b/src/app/core/eperson/models/group-dto.model.ts
@@ -18,6 +18,11 @@ export class GroupDtoModel {
   public ableToDelete: boolean;
 
   /**
+   * Whether or not the current user is able to edit the linked group
+   */
+  public ableToEdit: boolean;
+
+  /**
    * List of subgroups of this group
    */
   public subgroups: PaginatedList<Group>;

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -238,6 +238,8 @@
 
   "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",
 
+  "admin.access-control.epeople.table.edit.buttons.edit-disabled": "You are not authorized to edit this group",
+
   "admin.access-control.epeople.table.edit.buttons.remove": "Delete \"{{name}}\"",
 
   "admin.access-control.epeople.no-items": "No EPeople to show.",


### PR DESCRIPTION
## References
* Fixes #1124
* Requires DSpace/DSpace#3293

## Description
A community or collection admin now no longer has access to `/access-control/epeople`, only site admin do.
Community/Collection admins can now only edit the groups on which they have `canManageGroup` authorization (see DSpace/DSpace#3293). This gets checked for every group in the groups list view, and check by guard on a group edit page. If the user is a site admin, this authorization check is not done for every group since they can edit any group.

## Instructions for Reviewers
### EPeople access control only for site admins
- Logged in as general/site admin
    * Sidebar => Access control => People is visible
    * Direct navigation to `/access-control/epeople` is possible

- Logged in as community or collection admin
    * Sidebar => Access control => Only Groups is visible
    * Direct navigation to `/access-control/epeople` is Not possible => 403 Forbidden

### Groups only edit function possible if `canManageGroup` authorization
- Logged in as general admin
    * All groups are editable
        * in group list overview (`access-control/groups`)
        * on single group page (`access-control/groups/{uuid}`)
    * There are no requests done to the server with `canManageGroup` in network tab

- Logged in as collection admin
    * Non-collection/community related groups are not editable by this user
        * Not in list overview
        * Not on single group page
    * Collection/Community groups that are Not linked to the collection the user is admin for (ex COLLECTION_{other-collection-than-admin-uuid}_SUBMIT) are Not editable by this user
        * Not in list overview
        * Not on single group page
    * Groups that are linked to the collection the user is admin for (ex COLLECTION_{collection-of-which-admin-uuid}_WORKFLOW_ROLE_editor) Are editable by this user
        * Both in list overview
        * And single group page

- Logged in as community admin
    * Non-collection/community related groups are not editable by this user
        * Not in list overview
        * Not on single group page
    * Collection/Community groups that are Not linked (or not linked to its subcoms/collections) to the community the user is admin for are Not editable by this user
        * Both in list overview
        * And single group page
    * Groups that are linked to the community the user is admin for (ex COMMUNITY{community-of-which-admin-uuid}_ADMIN) Are editable by this user
        * Both in list overview
        * And single group page
    * Groups that are linked to the subcoms of the community the user is admin for (ex COMMUNITY{subcommunity-of-community-of-which-admin-uuid}_ADMIN) Are editable by this user
        * Both in list overview
        * And single group page
    * Groups that are linked to the collections of the community the user is admin for (ex COLLECTION_{collection-of-community-of-which-admin-uuid}_ADMIN) Are editable by this user
        * Both in list overview
        * And single group page

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
