### PR TITLE
Fix hardcoded submission section IDs

### DIFF
--- a/src/app/shared/testing/sections-service.stub.ts
+++ b/src/app/shared/testing/sections-service.stub.ts
@@ -10,6 +10,8 @@ export class SectionsServiceStub {
   isSectionEnabled = jasmine.createSpy('isSectionEnabled');
   isSectionReadOnly = jasmine.createSpy('isSectionReadOnly');
   isSectionAvailable = jasmine.createSpy('isSectionAvailable');
+  isSectionTypeAvailable = jasmine.createSpy('isSectionTypeAvailable');
+  isSectionType = jasmine.createSpy('isSectionType');
   addSection = jasmine.createSpy('addSection');
   removeSection = jasmine.createSpy('removeSection');
   updateSectionData = jasmine.createSpy('updateSectionData');

--- a/src/app/submission/form/collection/submission-form-collection.component.spec.ts
+++ b/src/app/submission/form/collection/submission-form-collection.component.spec.ts
@@ -120,7 +120,7 @@ describe('SubmissionFormCollectionComponent Component', () => {
   });
 
   const sectionsService: any = jasmine.createSpyObj('sectionsService', {
-    isSectionAvailable: of(true)
+    isSectionTypeAvailable: of(true)
   });
 
   beforeEach(waitForAsync(() => {

--- a/src/app/submission/form/collection/submission-form-collection.component.ts
+++ b/src/app/submission/form/collection/submission-form-collection.component.ts
@@ -28,6 +28,7 @@ import { CollectionDataService } from '../../../core/data/collection-data.servic
 import { CollectionDropdownComponent } from '../../../shared/collection-dropdown/collection-dropdown.component';
 import { SectionsService } from '../../sections/sections.service';
 import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
+import { SectionsType } from '../../sections/sections-type';
 
 /**
  * This component allows to show the current collection the submission belonging to and to change it.
@@ -142,7 +143,7 @@ export class SubmissionFormCollectionComponent implements OnChanges, OnInit {
    */
   ngOnInit() {
     this.pathCombiner = new JsonPatchOperationPathCombiner('sections', 'collection');
-    this.available$ = this.sectionsService.isSectionAvailable(this.submissionId, 'collection');
+    this.available$ = this.sectionsService.isSectionTypeAvailable(this.submissionId, SectionsType.collection);
   }
 
   /**

--- a/src/app/submission/form/submission-form.component.html
+++ b/src/app/submission/form/submission-form.component.html
@@ -3,7 +3,6 @@
         <div *ngIf="(uploadEnabled$ | async)" class="w-100">
             <ds-submission-upload-files [submissionId]="submissionId"
                                         [collectionId]="collectionId"
-                                        [sectionId]="'upload'"
                                         [uploadFilesOptions]="uploadFilesOptions"></ds-submission-upload-files>
             <div class="clearfix"></div>
         </div>

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.spec.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.spec.ts
@@ -150,9 +150,7 @@ describe('SubmissionUploadFilesComponent Component', () => {
 
     describe('on upload complete', () => {
       beforeEach(() => {
-        sectionsServiceStub.isSectionType.and.callFake((submissionId, sectionId, sectionType) => {
-          return observableOf(sectionId === 'upload')
-        });
+        sectionsServiceStub.isSectionType.and.callFake((_, sectionId, __) => observableOf(sectionId === 'upload'));
         compAsAny.uploadEnabled = observableOf(true);
       });
 

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
@@ -13,6 +13,7 @@ import { UploaderOptions } from '../../../shared/uploader/uploader-options.model
 import parseSectionErrors from '../../utils/parseSectionErrors';
 import { SubmissionJsonPatchOperationsService } from '../../../core/submission/submission-json-patch-operations.service';
 import { WorkspaceItem } from '../../../core/submission/models/workspaceitem.model';
+import { SectionsType } from '../../sections/sections-type';
 
 /**
  * This component represents the drop zone that provides to add files to the submission.
@@ -34,12 +35,6 @@ export class SubmissionUploadFilesComponent implements OnChanges {
    * @type {string}
    */
   @Input() submissionId: string;
-
-  /**
-   * The upload section id
-   * @type {string}
-   */
-  @Input() sectionId: string;
 
   /**
    * The uploader configuration options
@@ -110,7 +105,7 @@ export class SubmissionUploadFilesComponent implements OnChanges {
    * Check if upload functionality is enabled
    */
   ngOnChanges() {
-    this.uploadEnabled = this.sectionService.isSectionAvailable(this.submissionId, this.sectionId);
+    this.uploadEnabled = this.sectionService.isSectionTypeAvailable(this.submissionId, SectionsType.Upload);
   }
 
   /**
@@ -136,14 +131,16 @@ export class SubmissionUploadFilesComponent implements OnChanges {
                 .forEach((sectionId) => {
                   const sectionData = normalizeSectionData(sections[sectionId]);
                   const sectionErrors = errorsList[sectionId];
-                  if (sectionId === 'upload') {
-                    // Look for errors on upload
-                    if ((isEmpty(sectionErrors))) {
-                      this.notificationsService.success(null, this.translate.get('submission.sections.upload.upload-successful'));
-                    } else {
-                      this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
+                  this.sectionService.isSectionType(this.submissionId, sectionId, SectionsType.Upload).subscribe((isUpload) => {
+                    if (isUpload) {
+                      // Look for errors on upload
+                      if ((isEmpty(sectionErrors))) {
+                        this.notificationsService.success(null, this.translate.get('submission.sections.upload.upload-successful'));
+                      } else {
+                        this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
+                      }
                     }
-                  }
+                  });
                   this.sectionService.updateSectionData(this.submissionId, sectionId, sectionData, sectionErrors);
                 });
             }

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, of as observableOf, Subscription } from 'rxjs';
-import { first } from 'rxjs/operators';
+import { first, take } from 'rxjs/operators';
 
 import { SectionsService } from '../../sections/sections.service';
 import { hasValue, isEmpty, isNotEmpty } from '../../../shared/empty.util';
@@ -131,16 +131,18 @@ export class SubmissionUploadFilesComponent implements OnChanges {
                 .forEach((sectionId) => {
                   const sectionData = normalizeSectionData(sections[sectionId]);
                   const sectionErrors = errorsList[sectionId];
-                  this.sectionService.isSectionType(this.submissionId, sectionId, SectionsType.Upload).subscribe((isUpload) => {
-                    if (isUpload) {
-                      // Look for errors on upload
-                      if ((isEmpty(sectionErrors))) {
-                        this.notificationsService.success(null, this.translate.get('submission.sections.upload.upload-successful'));
-                      } else {
-                        this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
-                      }
-                    }
-                  });
+                  this.sectionService.isSectionType(this.submissionId, sectionId, SectionsType.Upload)
+                      .pipe(take(1))
+                      .subscribe((isUpload) => {
+                        if (isUpload) {
+                          // Look for errors on upload
+                          if ((isEmpty(sectionErrors))) {
+                            this.notificationsService.success(null, this.translate.get('submission.sections.upload.upload-successful'));
+                          } else {
+                            this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
+                          }
+                        }
+                      });
                   this.sectionService.updateSectionData(this.submissionId, sectionId, sectionData, sectionErrors);
                 });
             }

--- a/src/app/submission/sections/sections.service.spec.ts
+++ b/src/app/submission/sections/sections.service.spec.ts
@@ -334,6 +334,38 @@ describe('SectionsService test suite', () => {
     });
   });
 
+  describe('isSectionType', () => {
+    it('should return true if the section matches the provided type', () => {
+      store.select.and.returnValue(observableOf(submissionState));
+
+      const expected = cold('(b|)', {
+        b: true
+      });
+
+      expect(service.isSectionType(submissionId, 'upload', SectionsType.Upload)).toBeObservable(expected);
+    });
+
+    it('should return false if the section doesn\'t match the provided type', () => {
+      store.select.and.returnValue(observableOf(submissionState));
+
+      const expected = cold('(b|)', {
+        b: false
+      });
+
+      expect(service.isSectionType(submissionId, sectionId, SectionsType.Upload)).toBeObservable(expected);
+    });
+
+    it('should return false if the provided sectionId doesn\'t exist', () => {
+      store.select.and.returnValue(observableOf(submissionState));
+
+      const expected = cold('(b|)', {
+        b: false
+      });
+
+      expect(service.isSectionType(submissionId, 'no-such-id', SectionsType.Upload)).toBeObservable(expected);
+    });
+  });
+
   describe('addSection', () => {
     it('should dispatch a new EnableSectionAction a move target to new section', () => {
 

--- a/src/app/submission/sections/sections.service.ts
+++ b/src/app/submission/sections/sections.service.ts
@@ -329,6 +329,22 @@ export class SectionsService {
   }
 
   /**
+   * Check if given section id is of a given section type
+   * @param submissionId
+   * @param sectionId
+   * @param sectionType
+   */
+  public isSectionType(submissionId: string, sectionId: string, sectionType: SectionsType): Observable<boolean> {
+    return this.store.select(submissionObjectFromIdSelector(submissionId)).pipe(
+      filter((submissionState: SubmissionObjectEntry) => isNotUndefined(submissionState)),
+      map((submissionState: SubmissionObjectEntry) => {
+        return isNotUndefined(submissionState.sections) && isNotUndefined(submissionState.sections[sectionId]
+          && submissionState.sections[sectionId].sectionType === sectionType );
+      }),
+      distinctUntilChanged());
+  }
+
+  /**
    * Dispatch a new [EnableSectionAction] to add a new section and move page target to it
    *
    * @param submissionId

--- a/src/app/submission/sections/sections.service.ts
+++ b/src/app/submission/sections/sections.service.ts
@@ -338,8 +338,8 @@ export class SectionsService {
     return this.store.select(submissionObjectFromIdSelector(submissionId)).pipe(
       filter((submissionState: SubmissionObjectEntry) => isNotUndefined(submissionState)),
       map((submissionState: SubmissionObjectEntry) => {
-        return isNotUndefined(submissionState.sections) && isNotUndefined(submissionState.sections[sectionId]
-          && submissionState.sections[sectionId].sectionType === sectionType );
+        return isNotUndefined(submissionState.sections) && isNotUndefined(submissionState.sections[sectionId])
+          && submissionState.sections[sectionId].sectionType === sectionType;
       }),
       distinctUntilChanged());
   }

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -291,14 +291,13 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
           this.pathCombiner.subRootElement);
       })
     ).subscribe((result: SubmissionObject[]) => {
-      if (result[0].sections.upload) {
-        Object.keys((result[0].sections.upload as WorkspaceitemSectionUploadObject).files)
-          .filter((key) => (result[0].sections.upload as WorkspaceitemSectionUploadObject).files[key].uuid === this.fileId)
+      if (result[0].sections[this.sectionId]) {
+        const uploadSection = (result[0].sections[this.sectionId] as WorkspaceitemSectionUploadObject);
+        Object.keys(uploadSection.files)
+          .filter((key) => uploadSection.files[key].uuid === this.fileId)
           .forEach((key) => this.uploadService.updateFileData(
-            this.submissionId,
-            this.sectionId,
-            this.fileId,
-            (result[0].sections.upload as WorkspaceitemSectionUploadObject).files[key]));
+            this.submissionId, this.sectionId, this.fileId, uploadSection.files[key])
+          );
       }
       this.switchMode();
     }));


### PR DESCRIPTION
## References

* A similar issue was brought up before: #844

## Description

Fixed some hardcoded submission section IDs. 
We came across this issue when debugging for an instance which had a custom ID for the upload section.

## Instructions for Reviewers

List of changes in this PR:

* Replaced `SectionsService#isSectionAvailable` calls with `SectionsService#isSectionTypeAvailable`
* Added `SectionsService#isSectionType` to replace hardcoded check for an upload section in `WorkspaceItem`

**Reviewing**

* No noticeable difference expected with the default configuration

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

