### PR TITLE
Improve session timeout UX

### DIFF
--- a/src/app/+browse-by/+browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/+browse-by/+browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -167,7 +167,6 @@ export class BrowseByMetadataPageComponent implements OnInit {
    * @param value          The value of the browse-entry to display items for
    */
   updatePageWithItems(searchOptions: BrowseEntrySearchOptions, value: string) {
-    console.log('updatePAge', searchOptions);
     this.items$ = this.browseService.getBrowseItemsFor(value, searchOptions);
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { delay, distinctUntilChanged, filter, take } from 'rxjs/operators';
+import { delay, distinctUntilChanged, filter, take, withLatestFrom } from 'rxjs/operators';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { NavigationCancel, NavigationEnd, NavigationStart, Router } from '@angular/router';
 
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, of } from 'rxjs';
 import { select, Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
@@ -38,6 +38,8 @@ import { ThemeService } from './shared/theme-support/theme.service';
 import { BASE_THEME_NAME } from './shared/theme-support/theme.constants';
 import { DEFAULT_THEME_CONFIG } from './shared/theme-support/theme.effects';
 import { BreadcrumbsService } from './breadcrumbs/breadcrumbs.service';
+import { IdleModalComponent } from './shared/idle-modal/idle-modal.component';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ds-app',
@@ -70,6 +72,11 @@ export class AppComponent implements OnInit, AfterViewInit {
   isThemeLoading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
 
+  /**
+   * Whether or not the idle modal is is currently open
+   */
+  idleModalOpen: boolean;
+
   constructor(
     @Inject(NativeWindowService) private _window: NativeWindowRef,
     @Inject(DOCUMENT) private document: any,
@@ -87,6 +94,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     private windowService: HostWindowService,
     private localeService: LocaleService,
     private breadcrumbsService: BreadcrumbsService,
+    private modalService: NgbModal,
     @Optional() private cookiesService: KlaroService,
     @Optional() private googleAnalyticsService: GoogleAnalyticsService,
   ) {
@@ -107,6 +115,11 @@ export class AppComponent implements OnInit, AfterViewInit {
         this.setThemeCss(BASE_THEME_NAME);
       }
     });
+
+    if (isPlatformBrowser(this.platformId)) {
+      this.authService.trackTokenExpiration();
+      this.trackIdleModal();
+    }
 
     // Load all the languages that are defined as active from the config file
     translate.addLangs(environment.languages.filter((LangConfig) => LangConfig.active === true).map((a) => a.code));
@@ -130,7 +143,6 @@ export class AppComponent implements OnInit, AfterViewInit {
       console.info(environment);
     }
     this.storeCSSVariables();
-    this.authService.trackTokenExpiration();
   }
 
   ngOnInit() {
@@ -228,5 +240,24 @@ export class AppComponent implements OnInit, AfterViewInit {
       this.isThemeLoading$.next(false);
     };
     head.appendChild(link);
+  }
+
+  private trackIdleModal() {
+    const isIdle$ = this.authService.isUserIdle();
+    const isAuthenticated$ = this.authService.isAuthenticated();
+    isIdle$.pipe(withLatestFrom(isAuthenticated$))
+      .subscribe(([userIdle, authenticated]) => {
+        if (userIdle && authenticated) {
+          if (!this.idleModalOpen) {
+            const modalRef = this.modalService.open(IdleModalComponent);
+            this.idleModalOpen = true;
+            modalRef.componentInstance.response.pipe(take(1)).subscribe((closed: boolean) => {
+              if (closed) {
+                this.idleModalOpen = false;
+              }
+            });
+          }
+        }
+      });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -130,7 +130,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       console.info(environment);
     }
     this.storeCSSVariables();
-
+    this.authService.trackTokenExpiration();
   }
 
   ngOnInit() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -249,7 +249,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       .subscribe(([userIdle, authenticated]) => {
         if (userIdle && authenticated) {
           if (!this.idleModalOpen) {
-            const modalRef = this.modalService.open(IdleModalComponent);
+            const modalRef = this.modalService.open(IdleModalComponent, { ariaLabelledBy: 'idle-modal.header' });
             this.idleModalOpen = true;
             modalRef.componentInstance.response.pipe(take(1)).subscribe((closed: boolean) => {
               if (closed) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { NavigationCancel, NavigationEnd, NavigationStart, Router } from '@angular/router';
 
-import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { select, Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { ThemedHeaderComponent } from './header/themed-header.component';
 import { ThemedFooterComponent } from './footer/themed-footer.component';
 import { ThemedBreadcrumbsComponent } from './breadcrumbs/themed-breadcrumbs.component';
 import { ThemedHeaderNavbarWrapperComponent } from './header-nav-wrapper/themed-header-navbar-wrapper.component';
+import { IdleModalComponent } from './shared/idle-modal/idle-modal.component';
 
 export function getBase() {
   return environment.ui.nameSpace;
@@ -144,6 +145,7 @@ const DECLARATIONS = [
   ThemedBreadcrumbsComponent,
   ForbiddenComponent,
   ThemedForbiddenComponent,
+  IdleModalComponent
 ];
 
 const EXPORTS = [

--- a/src/app/core/auth/auth.actions.ts
+++ b/src/app/core/auth/auth.actions.ts
@@ -34,7 +34,9 @@ export const AuthActionTypes = {
   RETRIEVE_AUTHENTICATED_EPERSON: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON'),
   RETRIEVE_AUTHENTICATED_EPERSON_SUCCESS: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON_SUCCESS'),
   RETRIEVE_AUTHENTICATED_EPERSON_ERROR: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON_ERROR'),
-  REDIRECT_AFTER_LOGIN_SUCCESS: type('dspace/auth/REDIRECT_AFTER_LOGIN_SUCCESS')
+  REDIRECT_AFTER_LOGIN_SUCCESS: type('dspace/auth/REDIRECT_AFTER_LOGIN_SUCCESS'),
+  SET_USER_AS_IDLE: type('dspace/auth/SET_USER_AS_IDLE'),
+  UNSET_USER_AS_IDLE: type('dspace/auth/UNSET_USER_AS_IDLE')
 };
 
 /* tslint:disable:max-classes-per-file */
@@ -404,6 +406,24 @@ export class RetrieveAuthenticatedEpersonErrorAction implements Action {
     this.payload = payload ;
   }
 }
+
+/**
+ * Set the current user as being idle.
+ * @class SetUserAsIdleAction
+ * @implements {Action}
+ */
+export class SetUserAsIdleAction implements Action {
+  public type: string = AuthActionTypes.SET_USER_AS_IDLE;
+}
+
+/**
+ * Unset the current user as being idle.
+ * @class UnsetUserAsIdleAction
+ * @implements {Action}
+ */
+export class UnsetUserAsIdleAction implements Action {
+  public type: string = AuthActionTypes.UNSET_USER_AS_IDLE;
+}
 /* tslint:enable:max-classes-per-file */
 
 /**
@@ -434,4 +454,7 @@ export type AuthActions
   | RetrieveAuthenticatedEpersonErrorAction
   | RetrieveAuthenticatedEpersonSuccessAction
   | SetRedirectUrlAction
-  | RedirectAfterLoginSuccessAction;
+  | RedirectAfterLoginSuccessAction
+  | SetUserAsIdleAction
+  | UnsetUserAsIdleAction;
+

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -263,7 +263,6 @@ export class AuthEffects {
     filter((action: Action) => !IDLE_TIMER_IGNORE_TYPES.includes(action.type)),
     // Using switchMap the timer will be interrupted and restarted if a new action comes in, so idleness timer restarts
     switchMap(() => {
-      this.authService.isAuthenticated();
       return timer(environment.auth.ui.timeUntilIdle);
     }),
     map(() => {

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -1,6 +1,6 @@
 import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 
-import { catchError, filter, map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { Injectable, Injector } from '@angular/core';
 import {
   HttpErrorResponse,
@@ -12,14 +12,13 @@ import {
   HttpResponse,
   HttpResponseBase
 } from '@angular/common/http';
-import { find } from 'lodash';
 
 import { AppState } from '../../app.reducer';
 import { AuthService } from './auth.service';
 import { AuthStatus } from './models/auth-status.model';
 import { AuthTokenInfo } from './models/auth-token-info.model';
-import { hasValue, isNotEmpty, isNotNull, isUndefined } from '../../shared/empty.util';
-import { RedirectWhenTokenExpiredAction, RefreshTokenAction } from './auth.actions';
+import { hasValue, isNotEmpty, isNotNull } from '../../shared/empty.util';
+import { RedirectWhenTokenExpiredAction } from './auth.actions';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
 import { AuthMethod } from './models/auth.method';

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -28,7 +28,7 @@ import { AuthMethodType } from './models/auth.method-type';
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
 
-  // Intercetor is called twice per request,
+  // Interceptor is called twice per request,
   // so to prevent RefreshTokenAction is dispatched twice
   // we're creating a refresh token request list
   protected refreshTokenRequestUrls = [];
@@ -216,23 +216,8 @@ export class AuthInterceptor implements HttpInterceptor {
     let authorization: string;
 
     if (authService.isTokenExpired()) {
-      authService.setRedirectUrl(this.router.url);
-      // The access token is expired
-      // Redirect to the login route
-      this.store.dispatch(new RedirectWhenTokenExpiredAction('auth.messages.expired'));
       return observableOf(null);
     } else if ((!this.isAuthRequest(req) || this.isLogoutResponse(req)) && isNotEmpty(token)) {
-      // Intercept a request that is not to the authentication endpoint
-      authService.isTokenExpiring().pipe(
-        filter((isExpiring) => isExpiring))
-        .subscribe(() => {
-          // If the current request url is already in the refresh token request list, skip it
-          if (isUndefined(find(this.refreshTokenRequestUrls, req.url))) {
-            // When a token is about to expire, refresh it
-            this.store.dispatch(new RefreshTokenAction(token));
-            this.refreshTokenRequestUrls.push(req.url);
-          }
-        });
       // Get the auth header from the service.
       authorization = authService.buildAuthHeader(token);
       let newHeaders = req.headers.set('authorization', authorization);

--- a/src/app/core/auth/auth.reducer.spec.ts
+++ b/src/app/core/auth/auth.reducer.spec.ts
@@ -610,7 +610,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: false,
-      authMethods: authMethods
+      authMethods: authMethods,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -621,7 +622,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
 
     const action = new RetrieveAuthMethodsErrorAction(false);
@@ -685,7 +687,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
 
     const action = new RetrieveAuthMethodsErrorAction(true);
@@ -695,7 +698,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: false,
-      authMethods: [new AuthMethod(AuthMethodType.Password)]
+      authMethods: [new AuthMethod(AuthMethodType.Password)],
+      idle: false
     };
     expect(newState).toEqual(state);
   });

--- a/src/app/core/auth/auth.reducer.spec.ts
+++ b/src/app/core/auth/auth.reducer.spec.ts
@@ -23,7 +23,7 @@ import {
   RetrieveAuthMethodsAction,
   RetrieveAuthMethodsErrorAction,
   RetrieveAuthMethodsSuccessAction,
-  SetRedirectUrlAction
+  SetRedirectUrlAction, SetUserAsIdleAction, UnsetUserAsIdleAction
 } from './auth.actions';
 import { AuthTokenInfo } from './models/auth-token-info.model';
 import { EPersonMock } from '../../shared/testing/eperson.mock';
@@ -44,6 +44,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: false,
+      idle: false
     };
     const action = new AuthenticateAction('user', 'password');
     const newState = authReducer(initialState, action);
@@ -53,7 +54,8 @@ describe('authReducer', () => {
       blocking: true,
       error: undefined,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
 
     expect(newState).toEqual(state);
@@ -66,7 +68,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new AuthenticationSuccessAction(mockTokenInfo);
     const newState = authReducer(initialState, action);
@@ -81,7 +84,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new AuthenticationErrorAction(mockError);
     const newState = authReducer(initialState, action);
@@ -92,7 +96,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       authToken: undefined,
-      error: 'Test error message'
+      error: 'Test error message',
+      idle: false
     };
 
     expect(newState).toEqual(state);
@@ -105,7 +110,8 @@ describe('authReducer', () => {
       loaded: false,
       error: undefined,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new AuthenticatedAction(mockTokenInfo);
     const newState = authReducer(initialState, action);
@@ -115,7 +121,8 @@ describe('authReducer', () => {
       loaded: false,
       error: undefined,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -127,7 +134,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new AuthenticatedSuccessAction(true, mockTokenInfo, EPersonMock._links.self.href);
     const newState = authReducer(initialState, action);
@@ -138,7 +146,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -150,7 +159,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new AuthenticatedErrorAction(mockError);
     const newState = authReducer(initialState, action);
@@ -161,7 +171,8 @@ describe('authReducer', () => {
       loaded: true,
       blocking: false,
       loading: false,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -172,6 +183,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
+      idle: false
     };
     const action = new CheckAuthenticationTokenAction();
     const newState = authReducer(initialState, action);
@@ -180,6 +192,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -190,6 +203,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: true,
+      idle: false
     };
     const action = new CheckAuthenticationTokenCookieAction();
     const newState = authReducer(initialState, action);
@@ -198,6 +212,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -211,7 +226,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
 
     const action = new LogOutAction();
@@ -229,7 +245,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
 
     const action = new LogOutSuccessAction();
@@ -243,7 +260,8 @@ describe('authReducer', () => {
       loading: true,
       info: undefined,
       refreshing: false,
-      userId: undefined
+      userId: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -257,7 +275,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
 
     const action = new LogOutErrorAction(mockError);
@@ -270,7 +289,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -283,7 +303,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new RetrieveAuthenticatedEpersonSuccessAction(EPersonMock.id);
     const newState = authReducer(initialState, action);
@@ -295,7 +316,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -307,7 +329,8 @@ describe('authReducer', () => {
       error: undefined,
       blocking: true,
       loading: true,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     const action = new RetrieveAuthenticatedEpersonErrorAction(mockError);
     const newState = authReducer(initialState, action);
@@ -318,7 +341,8 @@ describe('authReducer', () => {
       loaded: true,
       blocking: false,
       loading: false,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -332,7 +356,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
     const newTokenInfo = new AuthTokenInfo('Refreshed token');
     const action = new RefreshTokenAction(newTokenInfo);
@@ -346,7 +371,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       userId: EPersonMock.id,
-      refreshing: true
+      refreshing: true,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -361,7 +387,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       userId: EPersonMock.id,
-      refreshing: true
+      refreshing: true,
+      idle: false
     };
     const newTokenInfo = new AuthTokenInfo('Refreshed token');
     const action = new RefreshTokenSuccessAction(newTokenInfo);
@@ -375,7 +402,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       userId: EPersonMock.id,
-      refreshing: false
+      refreshing: false,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -390,7 +418,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       userId: EPersonMock.id,
-      refreshing: true
+      refreshing: true,
+      idle: false
     };
     const action = new RefreshTokenErrorAction();
     const newState = authReducer(initialState, action);
@@ -403,7 +432,8 @@ describe('authReducer', () => {
       loading: false,
       info: undefined,
       refreshing: false,
-      userId: undefined
+      userId: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -417,7 +447,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       info: undefined,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
 
     state = {
@@ -428,7 +459,8 @@ describe('authReducer', () => {
       loading: false,
       error: undefined,
       info: 'Message',
-      userId: undefined
+      userId: undefined,
+      idle: false
     };
   });
 
@@ -450,6 +482,7 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
+      idle: false
     };
     const action = new AddAuthenticationMessageAction('Message');
     const newState = authReducer(initialState, action);
@@ -458,7 +491,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
-      info: 'Message'
+      info: 'Message',
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -470,7 +504,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       error: 'Error',
-      info: 'Message'
+      info: 'Message',
+      idle: false
     };
     const action = new ResetAuthenticationMessagesAction();
     const newState = authReducer(initialState, action);
@@ -480,7 +515,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: false,
       error: undefined,
-      info: undefined
+      info: undefined,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -490,7 +526,8 @@ describe('authReducer', () => {
       authenticated: false,
       loaded: false,
       blocking: false,
-      loading: false
+      loading: false,
+      idle: false
     };
     const action = new SetRedirectUrlAction('redirect.url');
     const newState = authReducer(initialState, action);
@@ -499,7 +536,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
-      redirectUrl: 'redirect.url'
+      redirectUrl: 'redirect.url',
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -510,7 +548,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
     const action = new RetrieveAuthMethodsAction(new AuthStatus(), true);
     const newState = authReducer(initialState, action);
@@ -519,7 +558,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -530,7 +570,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
     const authMethods = [
       new AuthMethod(AuthMethodType.Password),
@@ -543,7 +584,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
-      authMethods: authMethods
+      authMethods: authMethods,
+      idle: false
     };
     expect(newState).toEqual(state);
   });
@@ -554,7 +596,8 @@ describe('authReducer', () => {
       loaded: false,
       blocking: true,
       loading: true,
-      authMethods: []
+      authMethods: [],
+      idle: false
     };
     const authMethods = [
       new AuthMethod(AuthMethodType.Password),
@@ -588,7 +631,50 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: false,
-      authMethods: [new AuthMethod(AuthMethodType.Password)]
+      authMethods: [new AuthMethod(AuthMethodType.Password)],
+      idle: false
+    };
+    expect(newState).toEqual(state);
+  });
+
+  it('should properly set the state, in response to a SET_USER_AS_IDLE action', () => {
+    initialState = {
+      authenticated: true,
+      loaded: true,
+      blocking: false,
+      loading: false,
+      idle: false
+    };
+
+    const action = new SetUserAsIdleAction();
+    const newState = authReducer(initialState, action);
+    state = {
+      authenticated: true,
+      loaded: true,
+      blocking: false,
+      loading: false,
+      idle: true
+    };
+    expect(newState).toEqual(state);
+  });
+
+  it('should properly set the state, in response to a UNSET_USER_AS_IDLE action', () => {
+    initialState = {
+      authenticated: true,
+      loaded: true,
+      blocking: false,
+      loading: false,
+      idle: true
+    };
+
+    const action = new UnsetUserAsIdleAction();
+    const newState = authReducer(initialState, action);
+    state = {
+      authenticated: true,
+      loaded: true,
+      blocking: false,
+      loading: false,
+      idle: false
     };
     expect(newState).toEqual(state);
   });

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -193,6 +193,7 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
       return Object.assign({}, state, {
         authToken: (action as RefreshTokenSuccessAction).payload,
         refreshing: false,
+        blocking: false
       });
 
     case AuthActionTypes.ADD_MESSAGE:

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -240,15 +240,9 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
       });
 
     case AuthActionTypes.SET_USER_AS_IDLE:
-      if (state.authenticated) {
-        return Object.assign({}, state, {
-          idle: true,
-        });
-      } else {
-        return Object.assign({}, state, {
-          idle: false,
-        });
-      }
+      return Object.assign({}, state, {
+        idle: true,
+      });
 
     case AuthActionTypes.UNSET_USER_AS_IDLE:
       return Object.assign({}, state, {

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -59,6 +59,9 @@ export interface AuthState {
   // all authentication Methods enabled at the backend
   authMethods?: AuthMethod[];
 
+  // true when the current user is idle
+  idle: boolean;
+
 }
 
 /**
@@ -69,7 +72,8 @@ const initialState: AuthState = {
   loaded: false,
   blocking: true,
   loading: false,
-  authMethods: []
+  authMethods: [],
+  idle: false
 };
 
 /**
@@ -232,6 +236,22 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
       return Object.assign({}, state, {
         loading: true,
         blocking: true,
+      });
+
+    case AuthActionTypes.SET_USER_AS_IDLE:
+      if (state.authenticated) {
+        return Object.assign({}, state, {
+          idle: true,
+        });
+      } else {
+        return Object.assign({}, state, {
+          idle: false,
+        });
+      }
+
+    case AuthActionTypes.UNSET_USER_AS_IDLE:
+      return Object.assign({}, state, {
+        idle: false,
       });
 
     default:

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -27,6 +27,10 @@ import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.util
 import { authMethodsMock } from '../../shared/testing/auth-service.stub';
 import { AuthMethod } from './models/auth.method';
 import { HardRedirectService } from '../services/hard-redirect.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { TranslateService } from '@ngx-translate/core';
+import { getMockTranslateService } from '../../shared/mocks/translate.service.mock';
+import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 
 describe('AuthService test', () => {
 
@@ -107,6 +111,8 @@ describe('AuthService test', () => {
           { provide: Store, useValue: mockStore },
           { provide: EPersonDataService, useValue: mockEpersonDataService },
           { provide: HardRedirectService, useValue: hardRedirectService },
+          { provide: NotificationsService, useValue: NotificationsServiceStub },
+          { provide: TranslateService, useValue: getMockTranslateService() },
           CookieService,
           AuthService
         ],
@@ -207,13 +213,13 @@ describe('AuthService test', () => {
       }).compileComponents();
     }));
 
-    beforeEach(inject([CookieService, AuthRequestService, Store, Router, RouteService], (cookieService: CookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService) => {
+    beforeEach(inject([CookieService, AuthRequestService, Store, Router, RouteService], (cookieService: CookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService, notificationsService: NotificationsService, translateService: TranslateService) => {
       store
         .subscribe((state) => {
           (state as any).core = Object.create({});
           (state as any).core.auth = authenticatedState;
         });
-      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService);
+      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService, notificationsService, translateService);
     }));
 
     it('should return true when user is logged in', () => {
@@ -277,7 +283,7 @@ describe('AuthService test', () => {
       }).compileComponents();
     }));
 
-    beforeEach(inject([ClientCookieService, AuthRequestService, Store, Router, RouteService], (cookieService: ClientCookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService) => {
+    beforeEach(inject([ClientCookieService, AuthRequestService, Store, Router, RouteService], (cookieService: ClientCookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService, notificationsService: NotificationsService, translateService: TranslateService) => {
       const expiredToken: AuthTokenInfo = new AuthTokenInfo('test_token');
       expiredToken.expires = Date.now() - (1000 * 60 * 60);
       authenticatedState = {
@@ -292,7 +298,7 @@ describe('AuthService test', () => {
           (state as any).core = Object.create({});
           (state as any).core.auth = authenticatedState;
         });
-      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService);
+      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService, notificationsService, translateService);
       storage = (authService as any).storage;
       routeServiceMock = TestBed.inject(RouteService);
       routerStub = TestBed.inject(Router);
@@ -493,13 +499,13 @@ describe('AuthService test', () => {
       }).compileComponents();
     }));
 
-    beforeEach(inject([CookieService, AuthRequestService, Store, Router, RouteService], (cookieService: CookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService) => {
+    beforeEach(inject([CookieService, AuthRequestService, Store, Router, RouteService], (cookieService: CookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService, notificationsService: NotificationsService, translateService: TranslateService) => {
       store
         .subscribe((state) => {
           (state as any).core = Object.create({});
           (state as any).core.auth = unAuthenticatedState;
         });
-      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService);
+      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService, notificationsService, translateService);
     }));
 
     it('should return null for the shortlived token', () => {

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -31,6 +31,7 @@ import { NotificationsService } from '../../shared/notifications/notifications.s
 import { TranslateService } from '@ngx-translate/core';
 import { getMockTranslateService } from '../../shared/mocks/translate.service.mock';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import { SetUserAsIdleAction, UnsetUserAsIdleAction } from './auth.actions';
 
 describe('AuthService test', () => {
 
@@ -51,6 +52,7 @@ describe('AuthService test', () => {
   let token: AuthTokenInfo;
   let authenticatedState;
   let unAuthenticatedState;
+  let idleState;
   let linkService;
   let hardRedirectService;
 
@@ -68,14 +70,24 @@ describe('AuthService test', () => {
       loaded: true,
       loading: false,
       authToken: token,
-      user: EPersonMock
+      user: EPersonMock,
+      idle: false
     };
     unAuthenticatedState = {
       authenticated: false,
       loaded: true,
       loading: false,
       authToken: undefined,
-      user: undefined
+      user: undefined,
+      idle: false
+    };
+    idleState = {
+      authenticated: true,
+      loaded: true,
+      loading: false,
+      authToken: token,
+      user: EPersonMock,
+      idle: true
     };
     authRequest = new AuthRequestServiceStub();
     routeStub = new ActivatedRouteStub();
@@ -186,6 +198,26 @@ describe('AuthService test', () => {
         expect(authMethods.length).toBe(2);
       });
     });
+
+    describe('setIdle true', () => {
+      beforeEach(() => {
+        authService.setIdle(true);
+      });
+
+      it('store should dispatch SetUserAsIdleAction', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith(new SetUserAsIdleAction());
+      });
+    });
+
+    describe('setIdle false', () => {
+      beforeEach(() => {
+        authService.setIdle(false);
+      });
+
+      it('store should dispatch UnsetUserAsIdleAction', () => {
+        expect(mockStore.dispatch).toHaveBeenCalledWith(new UnsetUserAsIdleAction());
+      });
+    });
   });
 
   describe('', () => {
@@ -253,6 +285,12 @@ describe('AuthService test', () => {
     it('should return true when authentication is loaded', () => {
       authService.isAuthenticationLoaded().subscribe((status: boolean) => {
         expect(status).toBe(true);
+      });
+    });
+
+    it('isUserIdle should return false when user is not yet idle', () => {
+      authService.isUserIdle().subscribe((status: boolean) => {
+        expect(status).toBe(false);
       });
     });
 
@@ -511,6 +549,46 @@ describe('AuthService test', () => {
     it('should return null for the shortlived token', () => {
       authService.getShortlivedToken().subscribe((shortlivedToken: string) => {
         expect(shortlivedToken).toBeNull();
+      });
+    });
+  });
+
+  describe('when user is idle', () => {
+    beforeEach(waitForAsync(() => {
+      init();
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot({ authReducer }, {
+            runtimeChecks: {
+              strictStateImmutability: false,
+              strictActionImmutability: false
+            }
+          })
+        ],
+        providers: [
+          { provide: AuthRequestService, useValue: authRequest },
+          { provide: REQUEST, useValue: {} },
+          { provide: Router, useValue: routerStub },
+          { provide: RouteService, useValue: routeServiceStub },
+          { provide: RemoteDataBuildService, useValue: linkService },
+          CookieService,
+          AuthService
+        ]
+      }).compileComponents();
+    }));
+
+    beforeEach(inject([CookieService, AuthRequestService, Store, Router, RouteService], (cookieService: CookieService, authReqService: AuthRequestService, store: Store<AppState>, router: Router, routeService: RouteService, notificationsService: NotificationsService, translateService: TranslateService) => {
+      store
+        .subscribe((state) => {
+          (state as any).core = Object.create({});
+          (state as any).core.auth = idleState;
+        });
+      authService = new AuthService({}, window, undefined, authReqService, mockEpersonDataService, router, routeService, cookieService, store, hardRedirectService, notificationsService, translateService);
+    }));
+
+    it('isUserIdle should return true when user is not idle', () => {
+      authService.isUserIdle().subscribe((status: boolean) => {
+        expect(status).toBe(true);
       });
     });
   });

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -282,7 +282,7 @@ export class AuthService {
     // Send a request that sign end the session
     let headers = new HttpHeaders();
     headers = headers.append('Content-Type', 'application/x-www-form-urlencoded');
-    const options: HttpOptions = Object.create({headers, responseType: 'text'});
+    const options: HttpOptions = Object.create({ headers, responseType: 'text' });
     return this.authRequestService.postToEndpoint('logout', options).pipe(
       map((rd: RemoteData<AuthStatus>) => {
         const status = rd.payload;
@@ -447,11 +447,14 @@ export class AuthService {
    * @param redirectUrl
    */
   public navigateToRedirectUrl(redirectUrl: string) {
-    let url = `/reload/${new Date().getTime()}`;
-    if (isNotEmpty(redirectUrl) && !redirectUrl.startsWith(LOGIN_ROUTE)) {
-      url += `?redirect=${encodeURIComponent(redirectUrl)}`;
+    // Don't do redirect if already on reload url
+    if (!hasValue(redirectUrl) || !redirectUrl.includes('/reload/')) {
+      let url = `/reload/${new Date().getTime()}`;
+      if (isNotEmpty(redirectUrl) && !redirectUrl.startsWith(LOGIN_ROUTE)) {
+        url += `?redirect=${encodeURIComponent(redirectUrl)}`;
+      }
+      this.hardRedirectService.redirect(url);
     }
-    this.hardRedirectService.redirect(url);
   }
 
   /**

--- a/src/app/core/auth/selectors.ts
+++ b/src/app/core/auth/selectors.ts
@@ -116,6 +116,14 @@ const _getRedirectUrl = (state: AuthState) => state.redirectUrl;
 const _getAuthenticationMethods = (state: AuthState) => state.authMethods;
 
 /**
+ * Returns true if the user is idle.
+ * @function _isIdle
+ * @param {State} state
+ * @returns {boolean}
+ */
+const _isIdle = (state: AuthState) => state.idle;
+
+/**
  * Returns the authentication methods enabled at the backend
  * @function getAuthenticationMethods
  * @param {AuthState} state
@@ -231,3 +239,12 @@ export const getRegistrationError = createSelector(getAuthState, _getRegistratio
  * @return {string}
  */
 export const getRedirectUrl = createSelector(getAuthState, _getRedirectUrl);
+
+/**
+ * Returns true if the user is idle
+ * @function isIdle
+ * @param {AuthState} state
+ * @param {any} props
+ * @return {boolean}
+ */
+export const isIdle = createSelector(getAuthState, _isIdle);

--- a/src/app/core/utilities/enter-zone.scheduler.ts
+++ b/src/app/core/utilities/enter-zone.scheduler.ts
@@ -1,0 +1,19 @@
+import { SchedulerLike, Subscription } from 'rxjs';
+import { NgZone } from '@angular/core';
+
+/**
+ *  An RXJS scheduler that will re-enter the Angular zone to run what's scheduled
+ */
+export class EnterZoneScheduler implements SchedulerLike {
+  constructor(private zone: NgZone, private scheduler: SchedulerLike) { }
+
+  schedule(...args: any[]): Subscription {
+    return this.zone.run(() =>
+      this.scheduler.schedule.apply(this.scheduler, args)
+    );
+  }
+
+  now (): number {
+    return this.scheduler.now();
+  }
+}

--- a/src/app/core/utilities/leave-zone.scheduler.ts
+++ b/src/app/core/utilities/leave-zone.scheduler.ts
@@ -1,0 +1,19 @@
+import { SchedulerLike, Subscription } from 'rxjs';
+import { NgZone } from '@angular/core';
+
+/**
+ * An RXJS scheduler that will run what's scheduled outside of the Angular zone
+ */
+export class LeaveZoneScheduler implements SchedulerLike {
+  constructor(private zone: NgZone, private scheduler: SchedulerLike) { }
+
+  schedule(...args: any[]): Subscription {
+    return this.zone.runOutsideAngular(() =>
+      this.scheduler.schedule.apply(this.scheduler, args)
+    );
+  }
+
+  now (): number {
+    return this.scheduler.now();
+  }
+}

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -1,13 +1,8 @@
-import { map, take } from 'rxjs/operators';
-import { Component, Inject, OnInit, Optional, Input } from '@angular/core';
+import { map } from 'rxjs/operators';
+import { Component, Inject, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 
-import {
-  combineLatest as observableCombineLatest,
-  combineLatest as combineLatestObservable,
-  Observable,
-  of
-} from 'rxjs';
+import { combineLatest as combineLatestObservable, Observable, of } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
@@ -23,11 +18,7 @@ import { HostWindowService } from '../shared/host-window.service';
 import { ThemeConfig } from '../../config/theme.model';
 import { Angulartics2DSpace } from '../statistics/angulartics/dspace-provider';
 import { environment } from '../../environments/environment';
-import { LocaleService } from '../core/locale/locale.service';
-import { KlaroService } from '../shared/cookies/klaro.service';
 import { slideSidebarPadding } from '../shared/animations/slide';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { IdleModalComponent } from '../shared/idle-modal/idle-modal.component';
 
 @Component({
   selector: 'ds-root',
@@ -54,11 +45,6 @@ export class RootComponent implements OnInit {
    */
   @Input() shouldShowRouteLoader: boolean;
 
-  /**
-   * Whether or not the idle modal is is currently open
-   */
-  idleModalOpen: boolean;
-
   constructor(
     @Inject(NativeWindowService) private _window: NativeWindowRef,
     private translate: TranslateService,
@@ -70,10 +56,7 @@ export class RootComponent implements OnInit {
     private router: Router,
     private cssService: CSSVariableService,
     private menuService: MenuService,
-    private windowService: HostWindowService,
-    private localeService: LocaleService,
-    @Optional() private cookiesService: KlaroService,
-    private modalService: NgbModal
+    private windowService: HostWindowService
   ) {
   }
 
@@ -88,20 +71,5 @@ export class RootComponent implements OnInit {
       .pipe(
         map(([collapsed, mobile]) => collapsed || mobile)
       );
-
-    observableCombineLatest([this.authService.isUserIdle(), this.authService.isAuthenticated()])
-      .subscribe(([userIdle, authenticated]) => {
-        if (userIdle && authenticated) {
-          if (!this.idleModalOpen) {
-            const modalRef = this.modalService.open(IdleModalComponent);
-            this.idleModalOpen = true;
-            modalRef.componentInstance.response.pipe(take(1)).subscribe((closed: boolean) => {
-              if (closed) {
-                this.idleModalOpen = false;
-              }
-            });
-          }
-        }
-    });
   }
 }

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -2,7 +2,12 @@ import { map, take } from 'rxjs/operators';
 import { Component, Inject, OnInit, Optional, Input } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { combineLatest as combineLatestObservable, Observable, of } from 'rxjs';
+import {
+  combineLatest as observableCombineLatest,
+  combineLatest as combineLatestObservable,
+  Observable,
+  of
+} from 'rxjs';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
@@ -84,18 +89,19 @@ export class RootComponent implements OnInit {
         map(([collapsed, mobile]) => collapsed || mobile)
       );
 
-    this.authService.isUserIdle().subscribe((userIdle: boolean) => {
-      if (userIdle) {
-        if (!this.idleModalOpen) {
-          const modalRef = this.modalService.open(IdleModalComponent);
-          this.idleModalOpen = true;
-          modalRef.componentInstance.response.pipe(take(1)).subscribe((closed: boolean) => {
-            if (closed) {
-              this.idleModalOpen = false;
-            }
-          });
+    observableCombineLatest([this.authService.isUserIdle(), this.authService.isAuthenticated()])
+      .subscribe(([userIdle, authenticated]) => {
+        if (userIdle && authenticated) {
+          if (!this.idleModalOpen) {
+            const modalRef = this.modalService.open(IdleModalComponent);
+            this.idleModalOpen = true;
+            modalRef.componentInstance.response.pipe(take(1)).subscribe((closed: boolean) => {
+              if (closed) {
+                this.idleModalOpen = false;
+              }
+            });
+          }
         }
-      }
     });
   }
 }

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
@@ -44,7 +44,8 @@ describe('AuthNavMenuComponent', () => {
       authenticated: false,
       loaded: false,
       blocking: false,
-      loading: false
+      loading: false,
+      idle: false
     };
     authState = {
       authenticated: true,
@@ -52,7 +53,8 @@ describe('AuthNavMenuComponent', () => {
       blocking: false,
       loading: false,
       authToken: new AuthTokenInfo('test_token'),
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
   }
 

--- a/src/app/shared/auth-nav-menu/user-menu/user-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/user-menu/user-menu.component.spec.ts
@@ -37,7 +37,8 @@ describe('UserMenuComponent', () => {
       blocking: false,
       loading: false,
       authToken: new AuthTokenInfo('test_token'),
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
     authStateLoading = {
       authenticated: true,
@@ -45,7 +46,8 @@ describe('UserMenuComponent', () => {
       blocking: false,
       loading: true,
       authToken: null,
-      userId: EPersonMock.id
+      userId: EPersonMock.id,
+      idle: false
     };
   }
 

--- a/src/app/shared/idle-modal/idle-modal.component.html
+++ b/src/app/shared/idle-modal/idle-modal.component.html
@@ -1,0 +1,18 @@
+<div>
+  <div class="modal-header">{{ "idle-modal.header" | translate }}
+    <button type="button" class="close" (click)="closePressed()" aria-label="Close">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <p>{{ "idle-modal.info" | translate:{timeToExpire: timeToExpire} }}</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="cancel btn btn-danger" (click)="logOutPressed()" aria-label="Log out">
+      <i class="fas fa-times"></i> {{ "idle-modal.log-out" | translate }}
+    </button>
+    <button type="button" class="confirm btn btn-outline-secondary" (click)="extendSessionPressed()" aria-label="Extend session" ngbAutofocus>
+      {{ "idle-modal.extend-session" | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/shared/idle-modal/idle-modal.component.html
+++ b/src/app/shared/idle-modal/idle-modal.component.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="modal-header">{{ "idle-modal.header" | translate }}
+  <div class="modal-header" id="idle-modal.header">{{ "idle-modal.header" | translate }}
     <button type="button" class="close" (click)="closePressed()" aria-label="Close">
       <span aria-hidden="true">×</span>
     </button>

--- a/src/app/shared/idle-modal/idle-modal.component.html
+++ b/src/app/shared/idle-modal/idle-modal.component.html
@@ -9,10 +9,10 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="cancel btn btn-danger" (click)="logOutPressed()" aria-label="Log out">
-      <i class="fas fa-times"></i> {{ "idle-modal.log-out" | translate }}
+      <i class="fas fa-sign-out-alt"></i> {{ "idle-modal.log-out" | translate }}
     </button>
-    <button type="button" class="confirm btn btn-outline-secondary" (click)="extendSessionPressed()" aria-label="Extend session" ngbAutofocus>
-      {{ "idle-modal.extend-session" | translate }}
+    <button type="button" class="confirm btn btn-primary" (click)="extendSessionPressed()" aria-label="Extend session" ngbAutofocus>
+      <i class="fas fa-redo-alt"></i> {{ "idle-modal.extend-session" | translate }}
     </button>
   </div>
 </div>

--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -1,0 +1,128 @@
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+import { IdleModalComponent } from './idle-modal.component';
+import { AuthService } from '../../core/auth/auth.service';
+import { By } from '@angular/platform-browser';
+
+describe('IdleModalComponent', () => {
+  let component: IdleModalComponent;
+  let fixture: ComponentFixture<IdleModalComponent>;
+  let debugElement: DebugElement;
+
+  const modalStub = jasmine.createSpyObj('modalStub', ['close']);
+  const authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'logout']);
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [IdleModalComponent],
+      providers: [
+        { provide: NgbActiveModal, useValue: modalStub },
+        { provide: AuthService, useValue: authServiceStub }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IdleModalComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('extendSessionPressed', () => {
+    beforeEach(fakeAsync(() => {
+      spyOn(component.response, 'next');
+      component.extendSessionPressed();
+    }));
+    it('should set idle to false', () => {
+      expect(authServiceStub.setIdle).toHaveBeenCalledWith(false);
+    });
+    it('should close the modal', () => {
+      expect(modalStub.close).toHaveBeenCalled();
+    });
+    it('response \'closed\' should have true as next', () => {
+      expect(component.response.next).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('logOutPressed', () => {
+    beforeEach(() => {
+      component.logOutPressed();
+    });
+    it('should logout', () => {
+      expect(authServiceStub.logout).toHaveBeenCalled();
+    });
+    it('should close the modal', () => {
+      expect(modalStub.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('closePressed', () => {
+    beforeEach(fakeAsync(() => {
+      spyOn(component.response, 'next');
+      component.closePressed();
+    }));
+    it('should set idle to false', () => {
+      expect(authServiceStub.setIdle).toHaveBeenCalledWith(false);
+    });
+    it('should close the modal', () => {
+      expect(modalStub.close).toHaveBeenCalled();
+    });
+    it('response \'closed\' should have true as next', () => {
+      expect(component.response.next).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('when the click method emits on extend session button', () => {
+    beforeEach(fakeAsync(() => {
+      spyOn(component, 'extendSessionPressed');
+      debugElement.query(By.css('button.confirm')).triggerEventHandler('click', {
+        preventDefault: () => {/**/
+        }
+      });
+      tick();
+      fixture.detectChanges();
+    }));
+    it('should call the extendSessionPressed method on the component', () => {
+      expect(component.extendSessionPressed).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the click method emits on log out button', () => {
+    beforeEach(fakeAsync(() => {
+      spyOn(component, 'logOutPressed');
+      debugElement.query(By.css('button.cancel')).triggerEventHandler('click', {
+        preventDefault: () => {/**/
+        }
+      });
+      tick();
+      fixture.detectChanges();
+    }));
+    it('should call the logOutPressed method on the component', () => {
+      expect(component.logOutPressed).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the click method emits on close button', () => {
+    beforeEach(fakeAsync(() => {
+      spyOn(component, 'closePressed');
+      debugElement.query(By.css('.close')).triggerEventHandler('click', {
+        preventDefault: () => {/**/
+        }
+      });
+      tick();
+      fixture.detectChanges();
+    }));
+    it('should call the closePressed method on the component', () => {
+      expect(component.closePressed).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -5,26 +5,29 @@ import { TranslateModule } from '@ngx-translate/core';
 import { IdleModalComponent } from './idle-modal.component';
 import { AuthService } from '../../core/auth/auth.service';
 import { By } from '@angular/platform-browser';
-import { HardRedirectService } from '../../core/services/hard-redirect.service';
+import { Store } from '@ngrx/store';
+import { LogOutAction } from '../../core/auth/auth.actions';
 
 describe('IdleModalComponent', () => {
   let component: IdleModalComponent;
   let fixture: ComponentFixture<IdleModalComponent>;
   let debugElement: DebugElement;
 
-  const modalStub = jasmine.createSpyObj('modalStub', ['close']);
-  const authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'logout', 'navigateToRedirectUrl']);
-  let hardRedirectService;
+  let modalStub;
+  let authServiceStub;
+  let storeStub;
 
   beforeEach(waitForAsync(() => {
-    hardRedirectService = jasmine.createSpyObj('hardRedirectService', ['getCurrentRoute']);
+    modalStub = jasmine.createSpyObj('modalStub', ['close']);
+    authServiceStub = jasmine.createSpyObj('authService', ['setIdle']);
+    storeStub = jasmine.createSpyObj('store', ['dispatch']);
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
       declarations: [IdleModalComponent],
       providers: [
         { provide: NgbActiveModal, useValue: modalStub },
         { provide: AuthService, useValue: authServiceStub },
-        { provide: HardRedirectService, useValue: hardRedirectService }
+        { provide: Store, useValue: storeStub }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -61,15 +64,11 @@ describe('IdleModalComponent', () => {
     beforeEach(() => {
       component.logOutPressed();
     });
-    it('should logout', () => {
-      expect(authServiceStub.logout).toHaveBeenCalled();
-    });
     it('should close the modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
     });
-    it('should reload', () => {
-      expect(hardRedirectService.getCurrentRoute).toHaveBeenCalled();
-      expect(authServiceStub.navigateToRedirectUrl).toHaveBeenCalled();
+    it('should send logout action', () => {
+      expect(storeStub.dispatch).toHaveBeenCalledWith(new LogOutAction());
     });
   });
 

--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { IdleModalComponent } from './idle-modal.component';
 import { AuthService } from '../../core/auth/auth.service';
 import { By } from '@angular/platform-browser';
+import { HardRedirectService } from '../../core/services/hard-redirect.service';
 
 describe('IdleModalComponent', () => {
   let component: IdleModalComponent;
@@ -12,15 +13,18 @@ describe('IdleModalComponent', () => {
   let debugElement: DebugElement;
 
   const modalStub = jasmine.createSpyObj('modalStub', ['close']);
-  const authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'logout']);
+  const authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'logout', 'navigateToRedirectUrl']);
+  let hardRedirectService;
 
   beforeEach(waitForAsync(() => {
+    hardRedirectService = jasmine.createSpyObj('hardRedirectService', ['getCurrentRoute']);
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
       declarations: [IdleModalComponent],
       providers: [
         { provide: NgbActiveModal, useValue: modalStub },
-        { provide: AuthService, useValue: authServiceStub }
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: HardRedirectService, useValue: hardRedirectService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -62,6 +66,10 @@ describe('IdleModalComponent', () => {
     });
     it('should close the modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
+    });
+    it('should reload', () => {
+      expect(hardRedirectService.getCurrentRoute).toHaveBeenCalled();
+      expect(authServiceStub.navigateToRedirectUrl).toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -4,6 +4,7 @@ import { environment } from '../../../environments/environment';
 import { AuthService } from '../../core/auth/auth.service';
 import { Subject } from 'rxjs';
 import { hasValue } from '../empty.util';
+import { HardRedirectService } from '../../core/services/hard-redirect.service';
 
 @Component({
   selector: 'ds-idle-modal',
@@ -29,7 +30,8 @@ export class IdleModalComponent implements OnInit {
   response: Subject<boolean> = new Subject();
 
   constructor(private activeModal: NgbActiveModal,
-              private authService: AuthService) {
+              private authService: AuthService,
+              protected hardRedirectService: HardRedirectService) {
     this.timeToExpire = (environment.auth.ui.timeUntilIdle + environment.auth.ui.idleGracePeriod) / 1000 / 60; // ms => min
   }
 
@@ -53,8 +55,9 @@ export class IdleModalComponent implements OnInit {
    * Close modal and logout
    */
   logOutPressed() {
-    this.authService.logout();
     this.closeModal();
+    this.authService.logout();
+    this.authService.navigateToRedirectUrl(this.hardRedirectService.getCurrentRoute());
   }
 
   /**

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -4,7 +4,9 @@ import { environment } from '../../../environments/environment';
 import { AuthService } from '../../core/auth/auth.service';
 import { Subject } from 'rxjs';
 import { hasValue } from '../empty.util';
-import { HardRedirectService } from '../../core/services/hard-redirect.service';
+import { Store } from '@ngrx/store';
+import { AppState } from '../../app.reducer';
+import { LogOutAction } from '../../core/auth/auth.actions';
 
 @Component({
   selector: 'ds-idle-modal',
@@ -31,7 +33,7 @@ export class IdleModalComponent implements OnInit {
 
   constructor(private activeModal: NgbActiveModal,
               private authService: AuthService,
-              protected hardRedirectService: HardRedirectService) {
+              private store: Store<AppState>) {
     this.timeToExpire = (environment.auth.ui.timeUntilIdle + environment.auth.ui.idleGracePeriod) / 1000 / 60; // ms => min
   }
 
@@ -56,8 +58,7 @@ export class IdleModalComponent implements OnInit {
    */
   logOutPressed() {
     this.closeModal();
-    this.authService.logout();
-    this.authService.navigateToRedirectUrl(this.hardRedirectService.getCurrentRoute());
+    this.store.dispatch(new LogOutAction());
   }
 
   /**

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit, Output } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { environment } from '../../../environments/environment';
+import { AuthService } from '../../core/auth/auth.service';
+import { Subject } from 'rxjs';
+import { hasValue } from '../empty.util';
+
+@Component({
+  selector: 'ds-idle-modal',
+  templateUrl: 'idle-modal.component.html',
+})
+export class IdleModalComponent implements OnInit {
+
+  /**
+   * Total time of idleness before session expires (in minutes)
+   * (environment.auth.ui.timeUntilIdle + environment.auth.ui.idleGracePeriod / 1000 / 60)
+   */
+  timeToExpire: number;
+
+  /**
+   * Timer to track time grace period
+   */
+  private graceTimer;
+
+  /**
+   * An event fired when the modal is closed
+   */
+  @Output()
+  response: Subject<boolean> = new Subject();
+
+  constructor(private activeModal: NgbActiveModal,
+              private authService: AuthService) {
+    this.timeToExpire = (environment.auth.ui.timeUntilIdle + environment.auth.ui.idleGracePeriod) / 1000 / 60; // ms => min
+  }
+
+  ngOnInit() {
+    if (hasValue(this.graceTimer)) {
+      clearTimeout(this.graceTimer);
+    }
+    this.graceTimer = setTimeout(() => {
+      this.logOutPressed();
+    }, environment.auth.ui.idleGracePeriod);
+  }
+
+  /**
+   * When extend session is pressed
+   */
+  extendSessionPressed() {
+    this.extendSessionAndCloseModal();
+  }
+
+  /**
+   * Close modal and logout
+   */
+  logOutPressed() {
+    this.authService.logout();
+    this.closeModal();
+  }
+
+  /**
+   * When close is pressed
+   */
+  closePressed() {
+    this.extendSessionAndCloseModal();
+  }
+
+  /**
+   * Close the modal and extend session
+   */
+  extendSessionAndCloseModal() {
+    if (hasValue(this.graceTimer)) {
+      clearTimeout(this.graceTimer);
+    }
+    this.authService.setIdle(false);
+    this.closeModal();
+  }
+
+  /**
+   * Close the modal and set the response to true so RootComponent knows the modal was closed
+   */
+  closeModal() {
+    this.activeModal.close();
+    this.response.next(true);
+  }
+}

--- a/src/app/shared/mocks/auth.service.mock.ts
+++ b/src/app/shared/mocks/auth.service.mock.ts
@@ -19,4 +19,11 @@ export class AuthServiceMock {
 
   public setRedirectUrl(url: string) {
   }
+
+  public trackTokenExpiration(): void {
+  }
+
+  public isUserIdle(): Observable<boolean> {
+    return observableOf(false);
+  }
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -526,6 +526,8 @@
 
   "auth.messages.expired": "Your session has expired. Please log in again.",
 
+  "auth.messages.token-refresh-failed": "Refreshing your session token failed. Please log in again.",
+
 
 
   "bitstream.download.page": "Now downloading {{bitstream}}..." ,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3691,5 +3691,15 @@
 
   "workflow-item.send-back.button.cancel": "Cancel",
 
-  "workflow-item.send-back.button.confirm": "Send back"
+  "workflow-item.send-back.button.confirm": "Send back",
+
+
+
+  "idle-modal.header": "Session will expire soon",
+
+  "idle-modal.info": "For security reasons, user sessions expire after {{ timeToExpire }} minutes of inactivity. Your session will expire soon. Would you like to extend it or log out?”",
+
+  "idle-modal.log-out": "Log out",
+
+  "idle-modal.extend-session": "Extend session"
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3697,7 +3697,7 @@
 
   "idle-modal.header": "Session will expire soon",
 
-  "idle-modal.info": "For security reasons, user sessions expire after {{ timeToExpire }} minutes of inactivity. Your session will expire soon. Would you like to extend it or log out?”",
+  "idle-modal.info": "For security reasons, user sessions expire after {{ timeToExpire }} minutes of inactivity. Your session will expire soon. Would you like to extend it or log out?",
 
   "idle-modal.log-out": "Log out",
 

--- a/src/config/auth-config.interfaces.ts
+++ b/src/config/auth-config.interfaces.ts
@@ -6,5 +6,18 @@ export interface AuthTarget {
 }
 
 export interface AuthConfig extends Config {
-  target: AuthTarget;
+  target?: AuthTarget;
+
+  ui: {
+    // The amount of time before the idle warning is shown
+    timeUntilIdle: number;
+    // The amount of time the user has to react after the idle warning is shown before they are logged out.
+    idleGracePeriod: number;
+  };
+
+  rest: {
+    // If the rest token expires in less than this amount of time, it will be refreshed automatically.
+    // This is independent from the idle warning.
+    timeLeftBeforeTokenRefresh: number;
+  };
 }

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -2,7 +2,6 @@ import { GlobalConfig } from '../config/global-config.interface';
 import { NotificationAnimationsType } from '../app/shared/notifications/models/notification-animations-type';
 import { BrowseByType } from '../app/+browse-by/+browse-by-switcher/browse-by-decorator';
 import { RestRequestMethod } from '../app/core/data/rest-request-method';
-import { BASE_THEME_NAME } from '../app/shared/theme-support/theme.constants';
 
 export const environment: GlobalConfig = {
   production: true,
@@ -42,6 +41,25 @@ export const environment: GlobalConfig = {
       maxBufferSize: 100,
       timePerMethod: {[RestRequestMethod.PATCH]: 3} as any // time in seconds
     }
+  },
+  // Authority settings
+  auth: {
+    // Authority UI settings
+    ui: {
+      // the amount of time before the idle warning is shown
+      // timeUntilIdle: 15 * 60 * 1000, // 15 minutes
+      timeUntilIdle: 1 * 60 * 1000, // 1 minutes
+      // the amount of time the user has to react after the idle warning is shown before they are logged out.
+      // idleGracePeriod: 5 * 60 * 1000, // 5 minutes
+      idleGracePeriod: 1 * 60 * 1000, // 1 minutes
+    },
+    // Authority REST settings
+    rest: {
+      // If the rest token expires in less than this amount of time, it will be refreshed automatically.
+      // This is independent from the idle warning.
+      // timeLeftBeforeTokenRefresh: 2 * 60 * 1000, // 2 minutes
+      timeLeftBeforeTokenRefresh: 0.25 * 60 * 1000, // 25 seconds
+    },
   },
   // Form settings
   form: {
@@ -267,8 +285,8 @@ export const environment: GlobalConfig = {
   ],
   // Whether the UI should rewrite file download URLs to match its domain. Only necessary to enable when running UI and REST API on separate domains
   rewriteDownloadUrls: false,
-  // Whether to enable media viewer for image and/or video Bitstreams (i.e. Bitstreams whose MIME type starts with "image" or "video").  
-  // For images, this enables a gallery viewer where you can zoom or page through images. 
+  // Whether to enable media viewer for image and/or video Bitstreams (i.e. Bitstreams whose MIME type starts with "image" or "video").
+  // For images, this enables a gallery viewer where you can zoom or page through images.
   // For videos, this enables embedded video streaming
   mediaViewer: {
     image: false,

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -42,16 +42,16 @@ export const environment: GlobalConfig = {
       timePerMethod: {[RestRequestMethod.PATCH]: 3} as any // time in seconds
     }
   },
-  // Authority settings
+  // Authentication settings
   auth: {
-    // Authority UI settings
+    // Authentication UI settings
     ui: {
       // the amount of time before the idle warning is shown
       timeUntilIdle: 15 * 60 * 1000, // 15 minutes
       // the amount of time the user has to react after the idle warning is shown before they are logged out.
       idleGracePeriod: 5 * 60 * 1000, // 5 minutes
     },
-    // Authority REST settings
+    // Authentication REST settings
     rest: {
       // If the rest token expires in less than this amount of time, it will be refreshed automatically.
       // This is independent from the idle warning.

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -47,11 +47,9 @@ export const environment: GlobalConfig = {
     // Authority UI settings
     ui: {
       // the amount of time before the idle warning is shown
-      // timeUntilIdle: 15 * 60 * 1000, // 15 minutes
-      timeUntilIdle: 30 * 1000, // 30 seconds
+      timeUntilIdle: 15 * 60 * 1000, // 15 minutes
       // the amount of time the user has to react after the idle warning is shown before they are logged out.
-      // idleGracePeriod: 5 * 60 * 1000, // 5 minutes
-      idleGracePeriod: 1 * 60 * 1000, // 1 minute
+      idleGracePeriod: 5 * 60 * 1000, // 5 minutes
     },
     // Authority REST settings
     rest: {

--- a/src/environments/environment.common.ts
+++ b/src/environments/environment.common.ts
@@ -48,17 +48,16 @@ export const environment: GlobalConfig = {
     ui: {
       // the amount of time before the idle warning is shown
       // timeUntilIdle: 15 * 60 * 1000, // 15 minutes
-      timeUntilIdle: 1 * 60 * 1000, // 1 minutes
+      timeUntilIdle: 30 * 1000, // 30 seconds
       // the amount of time the user has to react after the idle warning is shown before they are logged out.
       // idleGracePeriod: 5 * 60 * 1000, // 5 minutes
-      idleGracePeriod: 1 * 60 * 1000, // 1 minutes
+      idleGracePeriod: 1 * 60 * 1000, // 1 minute
     },
     // Authority REST settings
     rest: {
       // If the rest token expires in less than this amount of time, it will be refreshed automatically.
       // This is independent from the idle warning.
-      // timeLeftBeforeTokenRefresh: 2 * 60 * 1000, // 2 minutes
-      timeLeftBeforeTokenRefresh: 0.25 * 60 * 1000, // 25 seconds
+      timeLeftBeforeTokenRefresh: 2 * 60 * 1000, // 2 minutes
     },
   },
   // Form settings

--- a/src/environments/mock-environment.ts
+++ b/src/environments/mock-environment.ts
@@ -35,16 +35,16 @@ export const environment: Partial<GlobalConfig> = {
       timePerMethod: {[RestRequestMethod.PATCH]: 3} as any // time in seconds
     }
   },
-  // Authority settings
+  // Authentication settings
   auth: {
-    // Authority UI settings
+    // Authentication UI settings
     ui: {
       // the amount of time before the idle warning is shown
       timeUntilIdle: 20000, // 20 sec
       // the amount of time the user has to react after the idle warning is shown before they are logged out.
       idleGracePeriod: 20000, // 20 sec
     },
-    // Authority REST settings
+    // Authentication REST settings
     rest: {
       // If the rest token expires in less than this amount of time, it will be refreshed automatically.
       // This is independent from the idle warning.

--- a/src/environments/mock-environment.ts
+++ b/src/environments/mock-environment.ts
@@ -35,6 +35,22 @@ export const environment: Partial<GlobalConfig> = {
       timePerMethod: {[RestRequestMethod.PATCH]: 3} as any // time in seconds
     }
   },
+  // Authority settings
+  auth: {
+    // Authority UI settings
+    ui: {
+      // the amount of time before the idle warning is shown
+      timeUntilIdle: 20000, // 20 sec
+      // the amount of time the user has to react after the idle warning is shown before they are logged out.
+      idleGracePeriod: 20000, // 20 sec
+    },
+    // Authority REST settings
+    rest: {
+      // If the rest token expires in less than this amount of time, it will be refreshed automatically.
+      // This is independent from the idle warning.
+      timeLeftBeforeTokenRefresh: 20000, // 20 sec
+    },
+  },
   // Form settings
   form: {
     // NOTE: Map server-side validators to comparative Angular form validators


### PR DESCRIPTION
## References
* Fixes #1173 ('[Deque Analysis] User is not warned of session timeout')

## Description
There are two timers introduced, one for the token refresh, and one for the session time.

The first timer starts when a token is stored, a configurable time later, this token is refreshed and the timer restarts. If something goes wrong with the token refresh a notification is shown and the user is logged out. Whether or not the token needs to be refreshed, which is checked with any change on the authToken, is dependent on the `expires` property given to the token, based on REST config `jwt.login.token.expiration`, subtracted the UI configurable `auth.rest.time-left-before-token-refresh` (and current date, since the `token.expires` is `{currentTimeInMillisecondsAtTokenCreation}+jwt.login.token.expiration`).

The second timer restarts any time an ngrx action occurs (with a few exceptions) to check 'idleness' of the user. If the user hasn't interacted for a configurable time (`auth.ui.time-until-idle`), i.e. no new action has occurred, then a modal is shown indicating the user's session is about to expire. The user can do 1 of 4 things: extend session or close model with x, which extends the sessions (so timer restarts), or they can either choose log out option or ignore the model for a configurable time (`auth.ui.idle-grace-period`) after which the user is logged out and the page reloads.

### Config options

- `auth.ui.time-until-idle`:
   - the amount of time before the idle warning is shown
   - default to 15 minutes
- `auth.ui.idle-grace-period`:
   - the amount of time the user has to react after the idle warning is shown before they are logged out.
   - default to 5 minutes
- `auth.rest.time-left-before-token-refresh`:
   - If the rest token expires in less than this amount of time, it will be refreshed automatically. This is independent from the idle warning.
   - default to 2 minutes (which means that with the default `jwt.login.token.expiration` on the REST side of 30 minutes, it will automatically refresh 28 minutes after logging in or refreshing)

## Instructions for Reviewers

### Token refresh

- As the token timer expires, you should see a (successful) refresh in the network tab (if there is no interaction which makes it so a new token is sent, token should refresh every `jwt.login.token.expiration` - `auth.rest.time-left-before-token-refresh`, which is 28 minutes if you leave them at the default values).
- To simulate the token refresh failing you can temp turn of your backend before the timer runs out and you should see a notification of the token refresh failing and should log you out and refresh page

### Idle modal

- If not logged in => No idle modal appears
- Login => Idle time => Modal appears
   - Extend session => Modal closes => Idle time => Modal appears again
   - Press x to close modal => Modal closes => Idle time => Modal appears again
   - Don’t do anything => Grace time => Modal closes, logs out, page refreshes & is logged out => Modal doesn’t appear again after idle time
   - Press log out => Modal closes, logs out, page refreshes & is logged out => Modal doesn’t appear again after idle time

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
