### PR TITLE
Fix contrast issues with grays

### DIFF
--- a/src/app/shared/object-collection/shared/mydspace-item-submitter/item-submitter.component.html
+++ b/src/app/shared/object-collection/shared/mydspace-item-submitter/item-submitter.component.html
@@ -1,3 +1,3 @@
 <div class="mt-2 mb-2">
-  <span class="text-muted">{{'submission.workflow.tasks.generic.submitter' | translate}} : <span class="badge badge-light">{{(submitter$ | async)?.name}}</span></span>
+  <span class="text-muted">{{'submission.workflow.tasks.generic.submitter' | translate}} : <span class="badge badge-info">{{(submitter$ | async)?.name}}</span></span>
 </div>

--- a/src/app/shared/object-list/type-badge/type-badge.component.html
+++ b/src/app/shared/object-list/type-badge/type-badge.component.html
@@ -1,3 +1,3 @@
 <div *ngIf="typeMessage">
-  <span class="badge badge-light">{{ typeMessage | translate }}</span>
+  <span class="badge badge-info">{{ typeMessage | translate }}</span>
 </div>

--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -12,12 +12,6 @@ $image-path: "../assets/images" !default;
 
 /** Bootstrap Variables **/
 /* Colors */
-$gray-base: #000 !default;
-$gray-900: lighten($gray-base, 13.5%) !default; // #222
-$gray-800: lighten($gray-base, 26.6%) !default; // #444
-$gray-700: lighten($gray-base, 46.6%) !default; // #777
-$gray-600: lighten($gray-base, 73.3%) !default; // #bbb
-$gray-100: lighten($gray-base, 93.5%) !default; // #eee
 
 /* Reassign color vars to semantic color scheme */
 $blue:   #2B4E72 !default;
@@ -29,12 +23,12 @@ $dark:   darken($blue, 17%) !default;
 
 $theme-colors: (
         primary: $blue,
-        secondary: $gray-700,
+        secondary: #495057,   // Bootstrap $gray-700
         success: $green,
         info: $cyan,
         warning: $yellow,
         danger: $red,
-        light: $gray-100,
+        light: #f8f9fa,       // Bootstrap $gray-100
         dark: $dark
 ) !default;
 /* Fonts */

--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -12,8 +12,8 @@ $image-path: "../assets/images" !default;
 
 /** Bootstrap Variables **/
 /* Colors */
-$gray-700: #495057; !default  // Bootstrap $gray-700
-$gray-100: #f8f9fa; !default  //           $gray-100
+$gray-700: #495057 !default;  // Bootstrap $gray-700
+$gray-100: #f8f9fa !default;  //           $gray-100
 
 /* Reassign color vars to semantic color scheme */
 $blue:   #2B4E72 !default;

--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -12,6 +12,8 @@ $image-path: "../assets/images" !default;
 
 /** Bootstrap Variables **/
 /* Colors */
+$gray-700: #495057; !default  // Bootstrap $gray-700
+$gray-100: #f8f9fa; !default  //           $gray-100
 
 /* Reassign color vars to semantic color scheme */
 $blue:   #2B4E72 !default;
@@ -23,12 +25,12 @@ $dark:   darken($blue, 17%) !default;
 
 $theme-colors: (
         primary: $blue,
-        secondary: #495057,   // Bootstrap $gray-700
+        secondary: $gray-700,
         success: $green,
         info: $cyan,
         warning: $yellow,
         danger: $red,
-        light: #f8f9fa,       // Bootstrap $gray-100
+        light: $gray-100,
         dark: $dark
 ) !default;
 /* Fonts */

--- a/src/themes/custom/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/custom/styles/_theme_sass_variable_overrides.scss
@@ -5,13 +5,6 @@
 
 // $font-family-sans-serif:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 //
-// $gray-base: #000 !default;
-// $gray-900: lighten($gray-base, 13.5%) !default; // #222
-// $gray-800: lighten($gray-base, 26.6%) !default; // #444
-// $gray-700: lighten($gray-base, 46.6%) !default; // #777
-// $gray-600: lighten($gray-base, 73.3%) !default; // #bbb
-// $gray-100: lighten($gray-base, 93.5%) !default; // #eee
-//
 // $blue:   #2B4E72 !default;
 // $green:  #94BA65 !default;
 // $cyan:   #006666 !default;
@@ -21,12 +14,12 @@
 //
 // $theme-colors: (
 //   primary: $blue,
-//   secondary: $gray-700,
+//   secondary: #495057,   // Bootstrap $gray-700
 //   success: $green,
 //   info: $cyan,
 //   warning: $yellow,
 //   danger: $red,
-//   light: $gray-100,
+//   light: #f8f9fa,       // Bootstrap $gray-100
 //   dark: $dark
 // ) !default;
 //

--- a/src/themes/custom/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/custom/styles/_theme_sass_variable_overrides.scss
@@ -5,8 +5,8 @@
 
 // $font-family-sans-serif:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 //
-// $gray-700: #495057; !default  // Bootstrap $gray-700
-// $gray-100: #f8f9fa; !default  //           $gray-100
+// $gray-700: #495057 !default;  // Bootstrap $gray-700
+// $gray-100: #f8f9fa !default;  //           $gray-100
 //
 // $blue:   #2B4E72 !default;
 // $green:  #94BA65 !default;

--- a/src/themes/custom/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/custom/styles/_theme_sass_variable_overrides.scss
@@ -5,6 +5,9 @@
 
 // $font-family-sans-serif:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 //
+// $gray-700: #495057; !default  // Bootstrap $gray-700
+// $gray-100: #f8f9fa; !default  //           $gray-100
+//
 // $blue:   #2B4E72 !default;
 // $green:  #94BA65 !default;
 // $cyan:   #006666 !default;
@@ -14,12 +17,12 @@
 //
 // $theme-colors: (
 //   primary: $blue,
-//   secondary: #495057,   // Bootstrap $gray-700
+//   secondary: $gray-700,
 //   success: $green,
 //   info: $cyan,
 //   warning: $yellow,
 //   danger: $red,
-//   light: #f8f9fa,       // Bootstrap $gray-100
+//   light: $gray-100,
 //   dark: $dark
 // ) !default;
 //

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -17,9 +17,9 @@ $yellow: #ec9433 !default;
 $red: #CF4444 !default;
 $dark: #43515f !default;
 
-$gray-800: #343a40; !default
-$gray-400: #ced4da; !default
-$gray-100: #f8f9fa; !default
+$gray-800: #343a40 !default;
+$gray-400: #ced4da !default;
+$gray-100: #f8f9fa !default;
 
 $body-color: $gray-800 !default;                    // Bootstrap $gray-800
 

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -6,10 +6,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;1,200;1,300;1,400;1,600;1,700;1,800&display=swap');
 
 $font-family-sans-serif: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-$gray-100: #e8ebf3 !default;
-$gray-400: #ced4da !default;
-$gray-600: #959595 !default;
-$gray-800: #444444 !default;
 
 $navbar-dark-color: #FFFFFF;
 
@@ -21,10 +17,10 @@ $yellow: #ec9433 !default;
 $red: #CF4444 !default;
 $dark: #43515f !default;
 
-$body-color: $gray-800 !default;
+$body-color: #343a40 !default;                    // Bootstrap $gray-800
 
-$table-accent-bg:             $gray-100 !default;
-$table-hover-bg:              $gray-400 !default;
+$table-accent-bg:             #f8f9fa !default;   // Bootstrap $gray-100
+$table-hover-bg:              #ced4da !default;   // Bootstrap $gray-400
 
 $yiq-contrasted-threshold:  170 !default;
 

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -17,10 +17,13 @@ $yellow: #ec9433 !default;
 $red: #CF4444 !default;
 $dark: #43515f !default;
 
-$body-color: #343a40 !default;                    // Bootstrap $gray-800
+$gray-800: #343a40; !default
+$gray-400: #ced4da; !default
+$gray-100: #f8f9fa; !default
 
-$table-accent-bg:             #f8f9fa !default;   // Bootstrap $gray-100
-$table-hover-bg:              #ced4da !default;   // Bootstrap $gray-400
+$body-color: $gray-800 !default;                    // Bootstrap $gray-800
+
+$table-accent-bg: $gray-100 !default;   // Bootstrap $gray-100
+$table-hover-bg: $gray-400 !default;   // Bootstrap $gray-400
 
 $yiq-contrasted-threshold:  170 !default;
-


### PR DESCRIPTION
## References
* Fixes #1151 
* Fixes #1154 
* Fixes #1156 
* Fixes #1160
* ~Depends on #1221~
  

## Description

Reverted to Bootstrap's `$gray-` values to fix contrast issues

## Instructions for Reviewers

List of changes in this PR:

* Set `$gray-` values back to Bootstrap defaults in `src/styles/_bootstrap_variables.scss` as well as `src/themes/*/styles/_theme_sass_variable_overrides.scss`

* With the default `$gray-100`, `badge-light` becomes too light; changed badge classes to `badge-info`

  * Now blue instead of gray
    <img width="600" alt="image-20210622092503842" src="https://user-images.githubusercontent.com/31547038/122881945-f876d280-d33b-11eb-871d-d1c07f49c7f3.png">


    

**Include guidance for how to test or review your PR.**

* Deque analysis / go over the contrast problems listed in the issues referenced above

~**This PR seems bigger than it is, because it depends on #1221 You can see only the changes in this PR [here](https://github.com/atmire/dspace-angular/compare/move-header-changes-to-dspace-theme...w2p-80154_Fix-contrast-issues-with-grays)**~

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

