### PR TITLE
Add support for legacy bitstream download URLs

### DIFF
--- a/src/app/+bitstream-page/bitstream-page-routing.module.ts
+++ b/src/app/+bitstream-page/bitstream-page-routing.module.ts
@@ -9,6 +9,7 @@ import { ResourcePolicyCreateComponent } from '../shared/resource-policies/creat
 import { ResourcePolicyResolver } from '../shared/resource-policies/resolvers/resource-policy.resolver';
 import { ResourcePolicyEditComponent } from '../shared/resource-policies/edit/resource-policy-edit.component';
 import { BitstreamAuthorizationsComponent } from './bitstream-authorizations/bitstream-authorizations.component';
+import { LegacyBitstreamUrlResolver } from './legacy-bitstream-url.resolver';
 
 const EDIT_BITSTREAM_PATH = ':id/edit';
 const EDIT_BITSTREAM_AUTHORIZATIONS_PATH = ':id/authorizations';
@@ -20,7 +21,24 @@ const EDIT_BITSTREAM_AUTHORIZATIONS_PATH = ':id/authorizations';
   imports: [
     RouterModule.forChild([
       {
-        path:':id/download',
+        // Resolve XMLUI bitstream download URLs
+        path: 'handle/:prefix/:suffix/:filename',
+        component: BitstreamDownloadPageComponent,
+        resolve: {
+          bitstream: LegacyBitstreamUrlResolver
+        },
+      },
+      {
+        // Resolve JSPUI bitstream download URLs
+        path: ':prefix/:suffix/:sequence_id/:filename',
+        component: BitstreamDownloadPageComponent,
+        resolve: {
+          bitstream: LegacyBitstreamUrlResolver
+        },
+      },
+      {
+        // Resolve angular bitstream download URLs
+        path: ':id/download',
         component: BitstreamDownloadPageComponent,
         resolve: {
           bitstream: BitstreamPageResolver

--- a/src/app/+bitstream-page/legacy-bitstream-url.resolver.spec.ts
+++ b/src/app/+bitstream-page/legacy-bitstream-url.resolver.spec.ts
@@ -1,0 +1,145 @@
+import { LegacyBitstreamUrlResolver } from './legacy-bitstream-url.resolver';
+import { of as observableOf, EMPTY } from 'rxjs';
+import { BitstreamDataService } from '../core/data/bitstream-data.service';
+import { RemoteData } from '../core/data/remote-data';
+import { RequestEntryState } from '../core/data/request.reducer';
+import { TestScheduler } from 'rxjs/testing';
+
+describe(`LegacyBitstreamUrlResolver`, () => {
+  let resolver: LegacyBitstreamUrlResolver;
+  let bitstreamDataService: BitstreamDataService;
+  let testScheduler;
+  let remoteDataMocks;
+  let route;
+  let state;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+
+    route = {
+      params: {},
+      queryParams: {}
+    };
+    state = {};
+    remoteDataMocks = {
+      RequestPending: new RemoteData(undefined, 0, 0, RequestEntryState.RequestPending, undefined, undefined, undefined),
+      ResponsePending: new RemoteData(undefined, 0, 0, RequestEntryState.ResponsePending, undefined, undefined, undefined),
+      Success: new RemoteData(0, 0, 0, RequestEntryState.Success, undefined, {}, 200),
+      Error: new RemoteData(0, 0, 0, RequestEntryState.Error, 'Internal server error', undefined, 500),
+    };
+    bitstreamDataService = {
+      findByItemHandle: () => undefined
+    } as any;
+    resolver = new LegacyBitstreamUrlResolver(bitstreamDataService);
+  });
+
+  describe(`resolve`, () => {
+    describe(`For JSPUI-style URLs`, () => {
+      beforeEach(() => {
+        spyOn(bitstreamDataService, 'findByItemHandle').and.returnValue(EMPTY);
+        route = Object.assign({}, route, {
+          params: {
+            prefix: '123456789',
+            suffix: '1234',
+            filename: 'some-file.pdf',
+            sequence_id: '5'
+          }
+        });
+      });
+      it(`should call findByItemHandle with the handle, sequence id, and filename from the route`, () => {
+        testScheduler.run(() => {
+          resolver.resolve(route, state);
+          expect(bitstreamDataService.findByItemHandle).toHaveBeenCalledWith(
+            `${route.params.prefix}/${route.params.suffix}`,
+            route.params.sequence_id,
+            route.params.filename
+          );
+        });
+      });
+    });
+
+    describe(`For XMLUI-style URLs`, () => {
+      describe(`when there is a sequenceId query parameter`, () => {
+        beforeEach(() => {
+          spyOn(bitstreamDataService, 'findByItemHandle').and.returnValue(EMPTY);
+          route = Object.assign({}, route, {
+            params: {
+              prefix: '123456789',
+              suffix: '1234',
+              filename: 'some-file.pdf',
+            },
+            queryParams: {
+              sequenceId: '5'
+            }
+          });
+        });
+        it(`should call findByItemHandle with the handle and filename from the route, and the sequence ID from the queryParams`, () => {
+          testScheduler.run(() => {
+            resolver.resolve(route, state);
+            expect(bitstreamDataService.findByItemHandle).toHaveBeenCalledWith(
+              `${route.params.prefix}/${route.params.suffix}`,
+              route.queryParams.sequenceId,
+              route.params.filename
+            );
+          });
+        });
+      });
+      describe(`when there's no sequenceId query parameter`, () => {
+        beforeEach(() => {
+          spyOn(bitstreamDataService, 'findByItemHandle').and.returnValue(EMPTY);
+          route = Object.assign({}, route, {
+            params: {
+              prefix: '123456789',
+              suffix: '1234',
+              filename: 'some-file.pdf',
+            },
+          });
+        });
+        it(`should call findByItemHandle with the handle, and filename from the route`, () => {
+          testScheduler.run(() => {
+            resolver.resolve(route, state);
+            expect(bitstreamDataService.findByItemHandle).toHaveBeenCalledWith(
+              `${route.params.prefix}/${route.params.suffix}`,
+              undefined,
+              route.params.filename
+            );
+          });
+        });
+      });
+    });
+    describe(`should return and complete after the remotedata has...`, () => {
+      it(`...failed`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(bitstreamDataService, 'findByItemHandle').and.returnValue(cold('a-b-c', {
+            a: remoteDataMocks.RequestPending,
+            b: remoteDataMocks.ResponsePending,
+            c: remoteDataMocks.Error,
+          }));
+          const expected = '----(c|)';
+          const values = {
+            c: remoteDataMocks.Error,
+          };
+
+          expectObservable(resolver.resolve(route, state)).toBe(expected, values);
+        });
+      });
+      it(`...succeeded`, () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(bitstreamDataService, 'findByItemHandle').and.returnValue(cold('a-b-c', {
+            a: remoteDataMocks.RequestPending,
+            b: remoteDataMocks.ResponsePending,
+            c: remoteDataMocks.Success,
+          }));
+          const expected = '----(c|)';
+          const values = {
+            c: remoteDataMocks.Success,
+          };
+
+          expectObservable(resolver.resolve(route, state)).toBe(expected, values);
+        });
+      });
+    });
+  });
+});

--- a/src/app/+bitstream-page/legacy-bitstream-url.resolver.ts
+++ b/src/app/+bitstream-page/legacy-bitstream-url.resolver.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+import { RemoteData } from '../core/data/remote-data';
+import { Bitstream } from '../core/shared/bitstream.model';
+import { getFirstCompletedRemoteData } from '../core/shared/operators';
+import { hasNoValue } from '../shared/empty.util';
+import { BitstreamDataService } from '../core/data/bitstream-data.service';
+
+/**
+ * This class resolves a bitstream based on the DSpace 6 XMLUI or JSPUI bitstream download URLs
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class LegacyBitstreamUrlResolver implements Resolve<RemoteData<Bitstream>> {
+  constructor(protected bitstreamDataService: BitstreamDataService) {
+  }
+
+  /**
+   * Resolve a bitstream based on the handle of the item, and the sequence id or the filename of the
+   * bitstream
+   *
+   * @param {ActivatedRouteSnapshot} route The current ActivatedRouteSnapshot
+   * @param {RouterStateSnapshot} state The current RouterStateSnapshot
+   * @returns Observable<<RemoteData<Item>> Emits the found bitstream based on the parameters in
+   * current route, or an error if something went wrong
+   */
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
+    Observable<RemoteData<Bitstream>> {
+      const prefix = route.params.prefix;
+      const suffix = route.params.suffix;
+      const filename = route.params.filename;
+
+      let sequenceId = route.params.sequence_id;
+      if (hasNoValue(sequenceId)) {
+        sequenceId = route.queryParams.sequenceId;
+      }
+
+      return this.bitstreamDataService.findByItemHandle(
+        `${prefix}/${suffix}`,
+        sequenceId,
+        filename,
+      ).pipe(
+        getFirstCompletedRemoteData()
+      );
+  }
+}

--- a/src/app/app-routing-paths.ts
+++ b/src/app/app-routing-paths.ts
@@ -10,6 +10,11 @@ import { URLCombiner } from './core/url-combiner/url-combiner';
 
 export const BITSTREAM_MODULE_PATH = 'bitstreams';
 
+/**
+ * The bitstream module path to resolve XMLUI and JSPUI bitstream download URLs
+ */
+export const LEGACY_BITSTREAM_MODULE_PATH = 'bitstream';
+
 export function getBitstreamModuleRoute() {
   return `/${BITSTREAM_MODULE_PATH}`;
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import {
   PROFILE_MODULE_PATH,
   REGISTER_PATH,
   WORKFLOW_ITEM_MODULE_PATH,
+  LEGACY_BITSTREAM_MODULE_PATH,
 } from './app-routing-paths';
 import { COLLECTION_MODULE_PATH } from './+collection-page/collection-page-routing-paths';
 import { COMMUNITY_MODULE_PATH } from './+community-page/community-page-routing-paths';
@@ -91,6 +92,12 @@ import { GroupAdministratorGuard } from './core/data/feature-authorization/featu
           { path: 'entities/:entity-type',
             loadChildren: () => import('./+item-page/item-page.module')
               .then((m) => m.ItemPageModule),
+            canActivate: [EndUserAgreementCurrentUserGuard]
+          },
+          {
+            path: LEGACY_BITSTREAM_MODULE_PATH,
+            loadChildren: () => import('./+bitstream-page/bitstream-page.module')
+              .then((m) => m.BitstreamPageModule),
             canActivate: [EndUserAgreementCurrentUserGuard]
           },
           {


### PR DESCRIPTION
## References
* Fixes #1147
* Requires DSpace/DSpace#3294

## Description
This PR adds support for JSPUI and XMLUI-style bitstream download URLs

## Instructions for Reviewers
It adds route paths for XMLUI and JSPUI style bitstream download URLs to the bitstream page module, and uses the new LegacyBitstreamUrlResolver, to resolve those routes to be reusable by the existing bitstream-download page.

**Note** we went over the 4 hour estimate by 3 hours (7 total), because we tried to do the redirect using guards first, which is the way angular recommends. However it is currently not possible to do so without replacing the URL (which is not ideal: if your link contains one small mistake, e.g. your copy/paste didn't include the last character, you want to be able to fix it, not have the URL change to `/404`). This angular issue tracks the problem, and offers a few workarounds, but they didn't work for our use case: https://github.com/angular/angular/issues/27148

You can test this PR by trying to download a few bitstreams using their legacy URLs:
- XMLUI:
    - `/bitstream/handle/[prefix]/[suffix]/[filename]?sequence=[sequence_id]&isAllowed=y`
    - or `/bitstream/handle/[prefix]/[suffix]/[filename]`
- JSPUI:
    - `/bitstream/[prefix]/[suffix]/[sequence_id]/[filename]`

The following SQL query can be useful to retrieve the legacy params you need based on the DSpace 7 bitstream UUID

```sql
select handle, text_value, sequence_id
from bitstream
    join metadatavalue on dspace_object_id = uuid
    join bundle2bitstream on bundle2bitstream.bitstream_id = uuid
    join item2bundle using(bundle_id)
    join handle on item_id = resource_id
where metadata_field_id = 70
  and uuid = 'your-bitstream-uuid-here';
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
