### PR TITLE
Disable community/collection delete button while the delete operation is being processed

### DIFF
--- a/src/app/+collection-page/delete-collection-page/delete-collection-page.component.html
+++ b/src/app/+collection-page/delete-collection-page/delete-collection-page.component.html
@@ -6,11 +6,12 @@
                 <p class="pb-2">{{ 'collection.delete.text' | translate:{ dso: dso.name } }}</p>
                 <div class="form-group row">
                   <div class="col text-right">
-                    <button class="btn btn-outline-secondary" (click)="onCancel(dso)">
+                    <button class="btn btn-outline-secondary" (click)="onCancel(dso)" [disabled]="(processing$ | async)">
                       <i class="fas fa-times"></i> {{'collection.delete.cancel' | translate}}
                     </button>
-                    <button class="btn btn-danger mr-2" (click)="onConfirm(dso)">
-                      <i class="fas fa-trash"></i> {{'collection.delete.confirm' | translate}}
+                    <button class="btn btn-danger mr-2" (click)="onConfirm(dso)" [disabled]="(processing$ | async)">
+                      <span *ngIf="processing$ | async"><i class='fas fa-circle-notch fa-spin'></i> {{'collection.delete.processing' | translate}}</span>
+                      <span *ngIf="!(processing$ | async)"><i class="fas fa-trash"></i> {{'collection.delete.confirm' | translate}}</span>
                     </button>
                   </div>
                 </div>

--- a/src/app/+community-page/delete-community-page/delete-community-page.component.html
+++ b/src/app/+community-page/delete-community-page/delete-community-page.component.html
@@ -6,11 +6,12 @@
                 <p class="pb-2">{{ 'community.delete.text' | translate:{ dso: dso.name } }}</p>
                 <div class="form-group row">
                     <div class="col text-right">
-                        <button class="btn btn-outline-secondary" (click)="onCancel(dso)">
+                        <button class="btn btn-outline-secondary" (click)="onCancel(dso)" [disabled]="(processing$ | async)">
                             <i class="fas fa-times"></i> {{'community.delete.cancel' | translate}}
                         </button>
-                        <button class="btn btn-danger mr-2" (click)="onConfirm(dso)">
-                            <i class="fas fa-trash"></i> {{'community.delete.confirm' | translate}}
+                        <button class="btn btn-danger mr-2" (click)="onConfirm(dso)" [disabled]="(processing$ | async)">
+                            <span *ngIf="processing$ | async"><i class='fas fa-circle-notch fa-spin'></i> {{'community.delete.processing' | translate}}</span>
+                            <span *ngIf="!(processing$ | async)"><i class="fas fa-trash"></i> {{'community.delete.confirm' | translate}}</span>
                         </button>
                     </div>
                 </div>

--- a/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RemoteData } from '../../../core/data/remote-data';
 import { first, map } from 'rxjs/operators';
@@ -29,6 +29,12 @@ export class DeleteComColPageComponent<TDomain extends Community | Collection> i
    */
   public dsoRD$: Observable<RemoteData<TDomain>>;
 
+  /**
+   * A boolean representing if a delete operation is pending
+   * @type {BehaviorSubject<boolean>}
+   */
+  public processing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
   public constructor(
     protected dsoDataService: ComColDataService<TDomain>,
     protected router: Router,
@@ -48,6 +54,7 @@ export class DeleteComColPageComponent<TDomain extends Community | Collection> i
    * Deletes an existing DSO and redirects to the home page afterwards, showing a notification that states whether or not the deletion was successful
    */
   onConfirm(dso: TDomain) {
+    this.processing$.next(true);
     this.dsoDataService.delete(dso.id)
       .pipe(getFirstCompletedRemoteData())
       .subscribe((response: RemoteData<NoContent>) => {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -661,6 +661,8 @@
 
   "collection.delete.confirm": "Confirm",
 
+  "collection.delete.processing": "Deleting",
+
   "collection.delete.head": "Delete Collection",
 
   "collection.delete.notification.fail": "Collection could not be deleted",
@@ -898,6 +900,8 @@
   "community.delete.cancel": "Cancel",
 
   "community.delete.confirm": "Confirm",
+
+  "community.delete.processing": "Deleting...",
 
   "community.delete.head": "Delete Community",
 


### PR DESCRIPTION
## References
* Fixes #1122

## Description
Disable community/collection delete button while the delete operation is being processed

## Instructions for Reviewers
- go to community/collection delete page
- confirm deletion 
- check the delete button is disabled and it can't be clicked again

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
