### PR TITLE
Cannot map new items with Collection Admin

### DIFF
--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.html
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.html
@@ -42,6 +42,7 @@
                 [key]="'map'"
                 [dsoRD$]="mappedItemsRD$"
                 [paginationOptions]="(searchOptions$ | async)?.pagination"
+                [featureId]="FeatureIds.CanManageMappings"
                 [confirmButton]="'collection.edit.item-mapper.confirm'"
                 [cancelButton]="'collection.edit.item-mapper.cancel'"
                 (confirm)="mapItems($event)"

--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.spec.ts
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.spec.ts
@@ -40,6 +40,7 @@ import {
   createSuccessfulRemoteDataObject$
 } from '../../shared/remote-data.utils';
 import { createPaginatedList } from '../../shared/testing/utils.test';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 
 describe('CollectionItemMapperComponent', () => {
   let comp: CollectionItemMapperComponent;
@@ -136,6 +137,10 @@ describe('CollectionItemMapperComponent', () => {
     }
   };
 
+  const authorizationDataService = jasmine.createSpyObj('authorizationDataService', {
+    isAuthorized: observableOf(true)
+  });
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CommonModule, FormsModule, RouterTestingModule.withRoutes([]), TranslateModule.forRoot(), NgbModule],
@@ -152,6 +157,7 @@ describe('CollectionItemMapperComponent', () => {
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
         { provide: ObjectSelectService, useValue: new ObjectSelectServiceStub() },
         { provide: RouteService, useValue: routeServiceStub },
+        { provide: AuthorizationDataService, useValue: authorizationDataService }
       ]
     }).compileComponents();
   }));

--- a/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
+++ b/src/app/+collection-page/collection-item-mapper/collection-item-mapper.component.ts
@@ -28,6 +28,7 @@ import { PaginatedSearchOptions } from '../../shared/search/paginated-search-opt
 import { SearchService } from '../../core/shared/search/search.service';
 import { followLink } from '../../shared/utils/follow-link-config.model';
 import { NoContent } from '../../core/shared/NoContent.model';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
 
 @Component({
   selector: 'ds-collection-item-mapper',
@@ -49,6 +50,8 @@ import { NoContent } from '../../core/shared/NoContent.model';
  * Component used to map items to a collection
  */
 export class CollectionItemMapperComponent implements OnInit {
+
+  FeatureIds = FeatureID;
 
   /**
    * A view on the tabset element

--- a/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
+++ b/src/app/+item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
@@ -40,6 +40,7 @@ import {
   createSuccessfulRemoteDataObject$
 } from '../../../shared/remote-data.utils';
 import { createPaginatedList } from '../../../shared/testing/utils.test';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 
 describe('ItemCollectionMapperComponent', () => {
   let comp: ItemCollectionMapperComponent;
@@ -110,6 +111,10 @@ describe('ItemCollectionMapperComponent', () => {
     onDefaultLangChange: new EventEmitter()
   };
 
+  const authorizationDataService = jasmine.createSpyObj('authorizationDataService', {
+    isAuthorized: observableOf(true)
+  });
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CommonModule, FormsModule, RouterTestingModule.withRoutes([]), TranslateModule.forRoot(), NgbModule],
@@ -124,7 +129,8 @@ describe('ItemCollectionMapperComponent', () => {
         { provide: ObjectSelectService, useValue: new ObjectSelectServiceStub() },
         { provide: TranslateService, useValue: translateServiceStub },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
-        { provide: CollectionDataService, useValue: collectionDataServiceStub }
+        { provide: CollectionDataService, useValue: collectionDataServiceStub },
+        { provide: AuthorizationDataService, useValue: authorizationDataService }
       ]
     }).compileComponents();
   }));

--- a/src/app/shared/object-select/collection-select/collection-select.component.spec.ts
+++ b/src/app/shared/object-select/collection-select/collection-select.component.spec.ts
@@ -13,11 +13,10 @@ import { CollectionSelectComponent } from './collection-select.component';
 import { Collection } from '../../../core/shared/collection.model';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
 import { createPaginatedList } from '../../testing/utils.test';
-import { SortDirection, SortOptions } from '../../../core/cache/models/sort-options.model';
-import { FindListOptions } from '../../../core/data/request.models';
-import { of as observableOf } from 'rxjs';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../testing/pagination-service.stub';
+import { of as observableOf } from 'rxjs/internal/observable/of';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 
 describe('CollectionSelectComponent', () => {
   let comp: CollectionSelectComponent;
@@ -41,6 +40,10 @@ describe('CollectionSelectComponent', () => {
     currentPage: 1
   });
 
+  const authorizationDataService = jasmine.createSpyObj('authorizationDataService', {
+    isAuthorized: observableOf(true)
+  });
+
   const paginationService = new PaginationServiceStub();
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -49,7 +52,8 @@ describe('CollectionSelectComponent', () => {
       providers: [
         { provide: ObjectSelectService, useValue: new ObjectSelectServiceStub([mockCollectionList[1].id]) },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: AuthorizationDataService, useValue: authorizationDataService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/object-select/collection-select/collection-select.component.ts
+++ b/src/app/shared/object-select/collection-select/collection-select.component.ts
@@ -3,6 +3,7 @@ import { Collection } from '../../../core/shared/collection.model';
 import { ObjectSelectComponent } from '../object-select/object-select.component';
 import { isNotEmpty } from '../../empty.util';
 import { ObjectSelectService } from '../object-select.service';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 
 @Component({
   selector: 'ds-collection-select',
@@ -14,8 +15,9 @@ import { ObjectSelectService } from '../object-select.service';
  */
 export class CollectionSelectComponent extends ObjectSelectComponent<Collection> {
 
-  constructor(protected objectSelectService: ObjectSelectService) {
-    super(objectSelectService);
+  constructor(protected objectSelectService: ObjectSelectService,
+              protected authorizationService: AuthorizationDataService) {
+    super(objectSelectService, authorizationService);
   }
 
   ngOnInit(): void {

--- a/src/app/shared/object-select/item-select/item-select.component.html
+++ b/src/app/shared/object-select/item-select/item-select.component.html
@@ -19,7 +19,7 @@
         </thead>
         <tbody>
         <tr *ngFor="let item of itemsRD?.payload?.page">
-          <td><input class="item-checkbox" [ngModel]="getSelected(item.id) | async" (change)="switch(item.id)" type="checkbox" name="{{item.id}}"></td>
+          <td><input [disabled]="!(canSelect(item) | async)" class="item-checkbox" [ngModel]="getSelected(item.id) | async" (change)="switch(item.id)" type="checkbox" name="{{item.id}}"></td>
           <td *ngIf="!hideCollection">
             <span *ngVar="(item.owningCollection | async)?.payload as collection">
               <a *ngIf="collection" [routerLink]="['/collections', collection?.id]">{{collection?.name}}</a>

--- a/src/app/shared/object-select/item-select/item-select.component.spec.ts
+++ b/src/app/shared/object-select/item-select/item-select.component.spec.ts
@@ -156,13 +156,15 @@ describe('ItemSelectComponent', () => {
     beforeEach(() => {
       comp.featureId = FeatureID.CanManageMappings;
       spyOn(authorizationDataService, 'isAuthorized').and.returnValue(of(false));
-      fixture.detectChanges();
     });
 
-    it('should disable the checkbox', () => {
-      const checkbox = fixture.debugElement.query(By.css('input.item-checkbox')).nativeElement;
-      expect(authorizationDataService.isAuthorized).toHaveBeenCalled();
-      expect(checkbox.checked).toBeFalsy();
-    });
+    it('should disable the checkbox', waitForAsync(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        const checkbox = fixture.debugElement.query(By.css('input.item-checkbox')).nativeElement;
+        expect(authorizationDataService.isAuthorized).toHaveBeenCalled();
+        expect(checkbox.disabled).toBeTrue();
+      });
+    }));
   });
 });

--- a/src/app/shared/object-select/item-select/item-select.component.spec.ts
+++ b/src/app/shared/object-select/item-select/item-select.component.spec.ts
@@ -11,13 +11,13 @@ import { HostWindowService } from '../../host-window.service';
 import { HostWindowServiceStub } from '../../testing/host-window-service.stub';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { of as observableOf, of } from 'rxjs';
+import { of } from 'rxjs';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
 import { createPaginatedList } from '../../testing/utils.test';
 import { PaginationService } from '../../../core/pagination/pagination.service';
-import { SortDirection, SortOptions } from '../../../core/cache/models/sort-options.model';
-import { FindListOptions } from '../../../core/data/request.models';
 import { PaginationServiceStub } from '../../testing/pagination-service.stub';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 
 describe('ItemSelectComponent', () => {
   let comp: ItemSelectComponent;
@@ -39,7 +39,8 @@ describe('ItemSelectComponent', () => {
           key: 'dc.type',
           language: null,
           value: 'Article'
-        }]
+        }],
+      _links: { self: { href: 'selfId1' } }
     }),
     Object.assign(new Item(), {
       id: 'id2',
@@ -54,7 +55,8 @@ describe('ItemSelectComponent', () => {
           key: 'dc.type',
           language: null,
           value: 'Article'
-        }]
+        }],
+      _links: { self: { href: 'selfId2' } }
     })
   ];
   const mockItems = createSuccessfulRemoteDataObject$(createPaginatedList(mockItemList));
@@ -66,6 +68,7 @@ describe('ItemSelectComponent', () => {
 
   paginationService = new PaginationServiceStub(mockPaginationOptions);
 
+  const authorizationDataService = new AuthorizationDataService(null, null, null, null, null, null, null, null, null, null);
 
 
   beforeEach(waitForAsync(() => {
@@ -75,7 +78,8 @@ describe('ItemSelectComponent', () => {
       providers: [
         { provide: ObjectSelectService, useValue: new ObjectSelectServiceStub([mockItemList[1].id]) },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: AuthorizationDataService, useValue: authorizationDataService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -144,6 +148,21 @@ describe('ItemSelectComponent', () => {
     it('should emit a cancel event', () => {
       cancelButton.click();
       expect(comp.cancel.emit).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the authorize feature is not authorized', () => {
+
+    beforeEach(() => {
+      comp.featureId = FeatureID.CanManageMappings;
+      spyOn(authorizationDataService, 'isAuthorized').and.returnValue(of(false));
+      fixture.detectChanges();
+    });
+
+    it('should disable the checkbox', () => {
+      const checkbox = fixture.debugElement.query(By.css('input.item-checkbox')).nativeElement;
+      expect(authorizationDataService.isAuthorized).toHaveBeenCalled();
+      expect(checkbox.checked).toBeFalsy();
     });
   });
 });

--- a/src/app/shared/object-select/item-select/item-select.component.ts
+++ b/src/app/shared/object-select/item-select/item-select.component.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { getAllSucceededRemoteDataPayload } from '../../../core/shared/operators';
 import { map } from 'rxjs/operators';
 import { getItemPageRoute } from '../../../+item-page/item-page-routing-paths';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 
 @Component({
   selector: 'ds-item-select',
@@ -33,8 +34,9 @@ export class ItemSelectComponent extends ObjectSelectComponent<Item> {
     [itemId: string]: string
   }>;
 
-  constructor(protected objectSelectService: ObjectSelectService) {
-    super(objectSelectService);
+  constructor(protected objectSelectService: ObjectSelectService,
+              protected authorizationService: AuthorizationDataService ) {
+    super(objectSelectService, authorizationService);
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## References
* Fixes #1203

## Description
The Object Selector component has been enhanced. Is now possible to pass a FeatureID to check against to decide whether an item is selectable or not according to this authorization check.

## Instructions for Reviewers
The CollectionItemMapperComponent now inject the feature `canManageMappings` to the inner object selector component. This way only those items on which the user has that authorization will be selectable to be part of the mapping request.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
