### PR TITLE
Delete pending json patch operations

### DIFF
--- a/src/app/core/json-patch/json-patch-operations.actions.ts
+++ b/src/app/core/json-patch/json-patch-operations.actions.ts
@@ -20,6 +20,7 @@ export const JsonPatchOperationsActionTypes = {
   ROLLBACK_JSON_PATCH_OPERATIONS: type('dspace/core/patch/ROLLBACK_JSON_PATCH_OPERATIONS'),
   FLUSH_JSON_PATCH_OPERATIONS: type('dspace/core/patch/FLUSH_JSON_PATCH_OPERATIONS'),
   START_TRANSACTION_JSON_PATCH_OPERATIONS: type('dspace/core/patch/START_TRANSACTION_JSON_PATCH_OPERATIONS'),
+  DELETE_PENDING_JSON_PATCH_OPERATIONS: type('dspace/core/patch/DELETE_PENDING_JSON_PATCH_OPERATIONS'),
 };
 
 /* tslint:disable:max-classes-per-file */
@@ -261,6 +262,13 @@ export class NewPatchReplaceOperationAction implements Action {
   }
 }
 
+/**
+ * An ngrx action to delete all pending JSON Patch Operations.
+ */
+export class DeletePendingJsonPatchOperationsAction implements Action {
+  type = JsonPatchOperationsActionTypes.DELETE_PENDING_JSON_PATCH_OPERATIONS;
+}
+
 /* tslint:enable:max-classes-per-file */
 
 /**
@@ -276,4 +284,5 @@ export type PatchOperationsActions
   | NewPatchRemoveOperationAction
   | NewPatchReplaceOperationAction
   | RollbacktPatchOperationsAction
-  | StartTransactionPatchOperationsAction;
+  | StartTransactionPatchOperationsAction
+  | DeletePendingJsonPatchOperationsAction;

--- a/src/app/core/json-patch/json-patch-operations.reducer.spec.ts
+++ b/src/app/core/json-patch/json-patch-operations.reducer.spec.ts
@@ -1,7 +1,7 @@
 import * as deepFreeze from 'deep-freeze';
 
 import {
-  CommitPatchOperationsAction,
+  CommitPatchOperationsAction, DeletePendingJsonPatchOperationsAction,
   FlushPatchOperationsAction,
   NewPatchAddOperationAction,
   NewPatchRemoveOperationAction,
@@ -321,6 +321,21 @@ describe('jsonPatchOperationsReducer test suite', () => {
       expect(newState[testJsonPatchResourceType].children[testJsonPatchResourceAnotherId].body).toEqual([]);
     });
 
+  });
+
+  describe('When DeletePendingJsonPatchOperationsAction has been dispatched', () => {
+    it('should set set the JsonPatchOperationsState to null ', () => {
+      const action = new DeletePendingJsonPatchOperationsAction();
+      initState = Object.assign({}, testState, {
+        [testJsonPatchResourceType]: Object.assign({}, testState[testJsonPatchResourceType], {
+          transactionStartTime: startTimestamp,
+          commitPending: true
+        })
+      });
+      const newState = jsonPatchOperationsReducer(initState, action);
+
+      expect(newState).toBeNull();
+    });
   });
 
 });

--- a/src/app/core/json-patch/json-patch-operations.reducer.ts
+++ b/src/app/core/json-patch/json-patch-operations.reducer.ts
@@ -11,7 +11,8 @@ import {
   NewPatchReplaceOperationAction,
   CommitPatchOperationsAction,
   StartTransactionPatchOperationsAction,
-  RollbacktPatchOperationsAction
+  RollbacktPatchOperationsAction,
+  DeletePendingJsonPatchOperationsAction
 } from './json-patch-operations.actions';
 import { JsonPatchOperationModel, JsonPatchOperationType } from './json-patch.model';
 
@@ -101,6 +102,10 @@ export function jsonPatchOperationsReducer(state = initialState, action: PatchOp
       return startTransactionPatchOperations(state, action as StartTransactionPatchOperationsAction);
     }
 
+    case JsonPatchOperationsActionTypes.DELETE_PENDING_JSON_PATCH_OPERATIONS: {
+      return deletePendingOperations(state, action as DeletePendingJsonPatchOperationsAction);
+    }
+
     default: {
       return state;
     }
@@ -176,6 +181,20 @@ function rollbackOperations(state: JsonPatchOperationsState, action: RollbacktPa
   } else {
     return state;
   }
+}
+
+/**
+ * Set the JsonPatchOperationsState to its initial value.
+ *
+ * @param state
+ *    the current state
+ * @param action
+ *    an DeletePendingJsonPatchOperationsAction
+ * @return JsonPatchOperationsState
+ *    the new state.
+ */
+function deletePendingOperations(state: JsonPatchOperationsState, action: DeletePendingJsonPatchOperationsAction): JsonPatchOperationsState {
+  return null;
 }
 
 /**

--- a/src/app/core/json-patch/json-patch-operations.service.spec.ts
+++ b/src/app/core/json-patch/json-patch-operations.service.spec.ts
@@ -17,6 +17,7 @@ import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { JsonPatchOperationsEntry, JsonPatchOperationsResourceEntry } from './json-patch-operations.reducer';
 import {
   CommitPatchOperationsAction,
+  DeletePendingJsonPatchOperationsAction,
   RollbacktPatchOperationsAction,
   StartTransactionPatchOperationsAction
 } from './json-patch-operations.actions';
@@ -285,6 +286,21 @@ describe('JsonPatchOperationsService test suite', () => {
 
         expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
       });
+    });
+  });
+
+  describe('deletePendingJsonPatchOperations', () => {
+    beforeEach(() => {
+      store.dispatch.and.callFake(() => { /* */ });
+    });
+
+    it('should dispatch a new DeletePendingJsonPatchOperationsAction', () => {
+
+      const expectedAction = new DeletePendingJsonPatchOperationsAction();
+      scheduler.schedule(() => service.deletePendingJsonPatchOperations());
+      scheduler.flush();
+
+      expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
     });
   });
 

--- a/src/app/core/json-patch/json-patch-operations.service.ts
+++ b/src/app/core/json-patch/json-patch-operations.service.ts
@@ -10,7 +10,7 @@ import { CoreState } from '../core.reducers';
 import { jsonPatchOperationsByResourceType } from './selectors';
 import { JsonPatchOperationsResourceEntry } from './json-patch-operations.reducer';
 import {
-  CommitPatchOperationsAction,
+  CommitPatchOperationsAction, DeletePendingJsonPatchOperationsAction,
   RollbacktPatchOperationsAction,
   StartTransactionPatchOperationsAction
 } from './json-patch-operations.actions';
@@ -103,6 +103,13 @@ export abstract class JsonPatchOperationsService<ResponseDefinitionDomain, Patch
         );
         }))
     );
+  }
+
+  /**
+   * Dispatch an action to delete all pending JSON patch Operations.
+   */
+  public deletePendingJsonPatchOperations() {
+    this.store.dispatch(new DeletePendingJsonPatchOperationsAction());
   }
 
   /**

--- a/src/app/shared/testing/submission-json-patch-operations-service.stub.ts
+++ b/src/app/shared/testing/submission-json-patch-operations-service.stub.ts
@@ -6,5 +6,6 @@ export class SubmissionJsonPatchOperationsServiceStub {
 
   jsonPatchByResourceType = jasmine.createSpy('jsonPatchByResourceType');
   jsonPatchByResourceID = jasmine.createSpy('jsonPatchByResourceID');
+  deletePendingJsonPatchOperations = jasmine.createSpy('deletePendingJsonPatchOperations');
 
 }

--- a/src/app/submission/edit/submission-edit.component.spec.ts
+++ b/src/app/submission/edit/submission-edit.component.spec.ts
@@ -18,6 +18,8 @@ import { ActivatedRouteStub } from '../../shared/testing/active-router.stub';
 import { mockSubmissionObject } from '../../shared/mocks/submission.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { ItemDataService } from '../../core/data/item-data.service';
+import { SubmissionJsonPatchOperationsServiceStub } from '../../shared/testing/submission-json-patch-operations-service.stub';
+import { SubmissionJsonPatchOperationsService } from '../../core/submission/submission-json-patch-operations.service';
 
 describe('SubmissionEditComponent Component', () => {
 
@@ -25,6 +27,7 @@ describe('SubmissionEditComponent Component', () => {
   let fixture: ComponentFixture<SubmissionEditComponent>;
   let submissionServiceStub: SubmissionServiceStub;
   let itemDataService: ItemDataService;
+  let submissionJsonPatchOperationsServiceStub: SubmissionJsonPatchOperationsServiceStub;
   let router: RouterStub;
 
   const submissionId = '826';
@@ -46,6 +49,7 @@ describe('SubmissionEditComponent Component', () => {
       providers: [
         { provide: NotificationsService, useClass: NotificationsServiceStub },
         { provide: SubmissionService, useClass: SubmissionServiceStub },
+        { provide: SubmissionJsonPatchOperationsService, useClass: SubmissionJsonPatchOperationsServiceStub },
         { provide: ItemDataService, useValue: itemDataService },
         { provide: TranslateService, useValue: getMockTranslateService() },
         { provide: Router, useValue: new RouterStub() },
@@ -60,6 +64,7 @@ describe('SubmissionEditComponent Component', () => {
     fixture = TestBed.createComponent(SubmissionEditComponent);
     comp = fixture.componentInstance;
     submissionServiceStub = TestBed.inject(SubmissionService as any);
+    submissionJsonPatchOperationsServiceStub = TestBed.inject(SubmissionJsonPatchOperationsService as any);
     router = TestBed.inject(Router as any);
   });
 
@@ -111,5 +116,17 @@ describe('SubmissionEditComponent Component', () => {
     expect(comp.sections).toBeUndefined();
     expect(comp.submissionDefinition).toBeUndefined();
   });
+
+  describe('ngOnDestroy', () => {
+    it('should call delete pending json patch operations', fakeAsync(() => {
+
+      submissionJsonPatchOperationsServiceStub.deletePendingJsonPatchOperations.and.callFake(() => { /* */ });
+      comp.ngOnDestroy();
+
+      expect(submissionJsonPatchOperationsServiceStub.deletePendingJsonPatchOperations).toHaveBeenCalled();
+    }));
+
+  });
+
 
 });

--- a/src/app/submission/edit/submission-edit.component.ts
+++ b/src/app/submission/edit/submission-edit.component.ts
@@ -17,6 +17,7 @@ import { Item } from '../../core/shared/item.model';
 import { getAllSucceededRemoteData } from '../../core/shared/operators';
 import { ItemDataService } from '../../core/data/item-data.service';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
+import { SubmissionJsonPatchOperationsService } from '../../core/submission/submission-json-patch-operations.service';
 
 /**
  * This component allows to edit an existing workspaceitem/workflowitem.
@@ -92,7 +93,8 @@ export class SubmissionEditComponent implements OnDestroy, OnInit {
               private router: Router,
               private itemDataService: ItemDataService,
               private submissionService: SubmissionService,
-              private translate: TranslateService) {
+              private translate: TranslateService,
+              private submissionJsonPatchOperationsService: SubmissionJsonPatchOperationsService) {
   }
 
   /**
@@ -149,5 +151,7 @@ export class SubmissionEditComponent implements OnDestroy, OnInit {
     this.subs
       .filter((sub) => hasValue(sub))
       .forEach((sub) => sub.unsubscribe());
+
+    this.submissionJsonPatchOperationsService.deletePendingJsonPatchOperations();
   }
 }


### PR DESCRIPTION
## References
* Fixes #1217

## Description
When the user leaves the submission page the state related to the aborted submission must be totally erased.

## Instructions for Reviewers
To achieve the goal a new NgRx Action has been added (`DELETE_PENDING_JSON_PATCH_OPERATIONS`). This action is dispatched on the _OnDestroy_ hook of the `SubmissionEditComponent`. The reducer destroy every data related to the aborted submission.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
