### PR TITLE
Fix issue when switching submission's collection between those with different submission definition

### DIFF
--- a/src/app/submission/form/collection/submission-form-collection.component.spec.ts
+++ b/src/app/submission/form/collection/submission-form-collection.component.spec.ts
@@ -261,9 +261,10 @@ describe('SubmissionFormCollectionComponent Component', () => {
         expect(comp.toggled).toHaveBeenCalled();
       });
 
-      it('should ', () => {
+      it('should change collection properly', () => {
         spyOn(comp.collectionChange, 'emit').and.callThrough();
         jsonPatchOpServiceStub.jsonPatchByResourceID.and.returnValue(of(submissionRestResponse));
+        submissionServiceStub.retrieveSubmission.and.returnValue(createSuccessfulRemoteDataObject$(submissionRestResponse[0]));
         comp.ngOnInit();
         comp.onSelect(mockCollectionList[1]);
         fixture.detectChanges();

--- a/src/app/submission/form/collection/submission-form-collection.component.ts
+++ b/src/app/submission/form/collection/submission-form-collection.component.ts
@@ -13,7 +13,7 @@ import {
 import { BehaviorSubject, Observable, of as observableOf, Subscription } from 'rxjs';
 import {
   find,
-  map
+  map, mergeMap
 } from 'rxjs/operators';
 
 import { Collection } from '../../../core/shared/collection.model';
@@ -27,6 +27,7 @@ import { SubmissionJsonPatchOperationsService } from '../../../core/submission/s
 import { CollectionDataService } from '../../../core/data/collection-data.service';
 import { CollectionDropdownComponent } from '../../../shared/collection-dropdown/collection-dropdown.component';
 import { SectionsService } from '../../sections/sections.service';
+import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
 
 /**
  * This component allows to show the current collection the submission belonging to and to change it.
@@ -164,11 +165,17 @@ export class SubmissionFormCollectionComponent implements OnChanges, OnInit {
       this.submissionService.getSubmissionObjectLinkName(),
       this.submissionId,
       'sections',
-      'collection')
-      .subscribe((submissionObject: SubmissionObject[]) => {
+      'collection').pipe(
+        mergeMap((submissionObject: SubmissionObject[]) => {
+          // retrieve the full submission object with embeds
+          return this.submissionService.retrieveSubmission(submissionObject[0].id).pipe(
+            getFirstSucceededRemoteDataPayload()
+          );
+        })
+      ).subscribe((submissionObject: SubmissionObject) => {
         this.selectedCollectionId = event.collection.id;
         this.selectedCollectionName$ = observableOf(event.collection.name);
-        this.collectionChange.emit(submissionObject[0]);
+        this.collectionChange.emit(submissionObject);
         this.submissionService.changeSubmissionCollection(this.submissionId, event.collection.id);
         this.processingChange$.next(false);
         this.cdr.detectChanges();


### PR DESCRIPTION
## References
* Fixes #1234

## Description
Fix issue when switching submission's collection between those with different submission definition

## Instructions for Reviewers
Follow instruction present in the #1234 and check the issue is not present anymore

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
