### PR TITLE
Ensure we are always using UTC dates in the UI, as the backend expects/uses UTC-based dates

### DIFF
--- a/src/app/+browse-by/+browse-by-date-page/browse-by-date-page.component.spec.ts
+++ b/src/app/+browse-by/+browse-by-date-page/browse-by-date-page.component.spec.ts
@@ -107,6 +107,6 @@ describe('BrowseByDatePageComponent', () => {
   });
 
   it('should create a list of startsWith options with the current year first', () => {
-    expect(comp.startsWithOptions[0]).toEqual(new Date().getFullYear());
+    expect(comp.startsWithOptions[0]).toEqual(new Date().getUTCFullYear());
   });
 });

--- a/src/app/+browse-by/+browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/+browse-by/+browse-by-date-page/browse-by-date-page.component.ts
@@ -92,7 +92,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
           }
         }
         const options = [];
-        const currentYear = new Date().getFullYear();
+        const currentYear = new Date().getUTCFullYear();
         const oneYearBreak = Math.floor((currentYear - environment.browseBy.oneYearLimit) / 5) * 5;
         const fiveYearBreak = Math.floor((currentYear - environment.browseBy.fiveYearLimit) / 10) * 10;
         if (lowerLimit <= fiveYearBreak) {

--- a/src/app/shared/date.util.ts
+++ b/src/app/shared/date.util.ts
@@ -57,7 +57,7 @@ export function dateToISOFormat(date: Date | NgbDateStruct | string): string {
  *    the Date object
  */
 export function ngbDateStructToDate(date: NgbDateStruct): Date {
-  return new Date(date.year, (date.month - 1), date.day);
+  return new Date(Date.UTC(date.year, (date.month - 1), date.day));
 }
 
 /**

--- a/src/app/shared/date.util.ts
+++ b/src/app/shared/date.util.ts
@@ -31,9 +31,9 @@ export function dateToISOFormat(date: Date | NgbDateStruct | string): string {
   const dateObj: Date = (date instanceof Date) ? date :
     ((typeof date === 'string') ? ngbDateStructToDate(stringToNgbDateStruct(date)) : ngbDateStructToDate(date));
 
-  let year = dateObj.getFullYear().toString();
-  let month = (dateObj.getMonth() + 1).toString();
-  let day = dateObj.getDate().toString();
+  let year = dateObj.getUTCFullYear().toString();
+  let month = (dateObj.getUTCMonth() + 1).toString();
+  let day = dateObj.getUTCDate().toString();
   let hour = dateObj.getHours().toString();
   let min = dateObj.getMinutes().toString();
   let sec = dateObj.getSeconds().toString();
@@ -86,9 +86,9 @@ export function dateToNgbDateStruct(date?: Date): NgbDateStruct {
   }
 
   return {
-    year: date.getFullYear(),
-    month: date.getMonth() + 1,
-    day: date.getDate()
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate()
   };
 }
 
@@ -103,9 +103,9 @@ export function dateToNgbDateStruct(date?: Date): NgbDateStruct {
 export function dateToString(date: Date | NgbDateStruct): string {
   const dateObj: Date = (date instanceof Date) ? date : ngbDateStructToDate(date);
 
-  let year = dateObj.getFullYear().toString();
-  let month = (dateObj.getMonth() + 1).toString();
-  let day = dateObj.getDate().toString();
+  let year = dateObj.getUTCFullYear().toString();
+  let month = (dateObj.getUTCMonth() + 1).toString();
+  let day = dateObj.getUTCDate().toString();
 
   year = (year.length === 1) ? '0' + year : year;
   month = (month.length === 1) ? '0' + month : month;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
@@ -57,9 +57,9 @@ export class DsDatePickerComponent extends DynamicFormControlComponent implement
 
   ngOnInit() {
     const now = new Date();
-    this.initialYear = now.getFullYear();
-    this.initialMonth = now.getMonth() + 1;
-    this.initialDay = now.getDate();
+    this.initialYear = now.getUTCFullYear();
+    this.initialMonth = now.getUTCMonth() + 1;
+    this.initialDay = now.getUTCDate();
 
     if (this.model && this.model.value !== null) {
       const values = this.model.value.toString().split(DS_DATE_PICKER_SEPARATOR);

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
@@ -56,7 +56,7 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   /**
    * Fallback maximum for the range
    */
-  max = new Date().getFullYear();
+  max = new Date().getUTCFullYear();
 
   /**
    * The current range of the filter

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -244,9 +244,9 @@ export class SubmissionSectionUploadFileEditComponent implements OnChanges {
             if (metadataModel.type === DYNAMIC_FORM_CONTROL_TYPE_DATEPICKER) {
               const date = new Date(accessCondition[key]);
               metadataModel.value = {
-                year: date.getFullYear(),
-                month: date.getMonth() + 1,
-                day: date.getDate()
+                year: date.getUTCFullYear(),
+                month: date.getUTCMonth() + 1,
+                day: date.getUTCDate()
               };
             } else {
               metadataModel.value = accessCondition[key];
@@ -302,9 +302,9 @@ export class SubmissionSectionUploadFileEditComponent implements OnChanges {
 
           const min = new Date(accessCondition.maxStartDate);
           startDateModel.max = {
-            year: min.getFullYear(),
-            month: min.getMonth() + 1,
-            day: min.getDate()
+            year: min.getUTCFullYear(),
+            month: min.getUTCMonth() + 1,
+            day: min.getUTCDate()
           };
         }
         if (accessCondition.hasEndDate) {
@@ -314,9 +314,9 @@ export class SubmissionSectionUploadFileEditComponent implements OnChanges {
 
           const max = new Date(accessCondition.maxEndDate);
           endDateModel.max = {
-            year: max.getFullYear(),
-            month: max.getMonth() + 1,
-            day: max.getDate()
+            year: max.getUTCFullYear(),
+            month: max.getUTCMonth() + 1,
+            day: max.getUTCDate()
           };
         }
       }


### PR DESCRIPTION
## References
* Fixes #1256

## Description
In several areas of the UI (especially related to embargo dates) we use localized versions of dates (e.g. `getFullYear()`, `getMonth()`, `getDate()`).  This causes odd behavior when using the UI from a location with a vastly different time than UTC, and results in the UI sometimes accidentally changing embargo dates, etc.

This PR fixes those issues by ensuring we are always using UTC dates when interacting with Typescript `Date` object.  While the main bug is with the embargo date, I decided to do a find & replace on these methods, as I expect odd behavior would occur elsewhere as well.

## More Background 
As a sidenote, we should keep in mind that this behavior is in line with DSpace v6 (and below). In older versions of DSpace, both the UI and Backend used UTC dates only. So, this PR is reverting to that behavior. 

If we wanted the UI to use localized dates (while the backend uses UTC), then we'd need to do more significant work here. Likely, at a minimum, we would need embargoes to have a *time* associated with them. Currently, an embargo is treated as just a date in the UI, with the assumed time of `00:00:00`.  [See this comment on the initial issue for an example](https://github.com/DSpace/dspace-angular/issues/1256#issuecomment-873011938).