### PR TITLE
fix bitstream download during submission

### DIFF
--- a/src/app/shared/file-download-link/file-download-link.component.html
+++ b/src/app/shared/file-download-link/file-download-link.component.html
@@ -1,5 +1,6 @@
-<a [href]="bitstreamPath"><ng-container *ngTemplateOutlet="content"></ng-container></a>
-
+<a [href]="bitstreamPath" [target]="isBlank ? '_blank': '_self'" [ngClass]="cssClasses">
+  <ng-container *ngTemplateOutlet="content"></ng-container>
+</a>
 
 <ng-template #content>
   <ng-content></ng-content>

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -25,7 +25,7 @@ export class FileDownloadLinkComponent implements OnInit {
   @Input() cssClasses = '';
 
   /**
-   * Optional bitstream link, show in same tab or a new tab.
+   * A boolean representing if link is shown in same tab or in a new one.
    */
   @Input() isBlank = false;
 

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -18,6 +18,17 @@ export class FileDownloadLinkComponent implements OnInit {
    * Optional bitstream instead of href and file name
    */
   @Input() bitstream: Bitstream;
+
+  /**
+   * Additional css classes to apply to link
+   */
+  @Input() cssClasses = '';
+
+  /**
+   * Optional bitstream link, show in same tab or a new tab.
+   */
+  @Input() isBlank = false;
+
   bitstreamPath: string;
 
   ngOnInit() {

--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -10,8 +10,9 @@
       </div>
       <div class="float-right w-15" [class.sticky-buttons]="!readMode">
         <ng-container *ngIf="readMode">
-          <button class="btn btn-link" (click)="downloadBitstreamFile(); $event.stopPropagation()"><i class="fa fa-download fa-2x text-normal" aria-hidden="true"></i></button>
-          <!--<a href="{{fileData.url}}"  title="Download file" target="_blank"><i class="fa fa-download text-normal mr-3" aria-hidden="true"></i></a>-->
+          <ds-file-download-link [cssClasses]="'btn btn-link'" [isBlank]="true" [bitstream]="getBitstream()">
+            <i class="fa fa-download fa-2x text-normal" aria-hidden="true"></i>
+          </ds-file-download-link>
           <button class="btn btn-link" (click)="$event.preventDefault();switchMode();"><i class="fa fa-edit fa-2x text-normal"></i></button>
           <button class="btn btn-link"
                   title="{{ 'submission.sections.upload.delete.confirm.title' | translate }}"

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -6,7 +6,6 @@ import { CommonModule } from '@angular/common';
 import { of as observableOf } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { FileService } from '../../../../core/shared/file.service';
 import { FormService } from '../../../../shared/form/form.service';
 import { getMockFormService } from '../../../../shared/mocks/form-service.mock';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
@@ -19,7 +18,6 @@ import { SubmissionSectionUploadFileComponent } from './section-upload-file.comp
 import { SubmissionServiceStub } from '../../../../shared/testing/submission-service.stub';
 import {
   mockFileFormData,
-  mockGroup,
   mockSubmissionCollectionId,
   mockSubmissionId,
   mockSubmissionObject,
@@ -35,16 +33,8 @@ import { POLICY_DEFAULT_WITH_LIST } from '../section-upload.component';
 import { JsonPatchOperationPathCombiner } from '../../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { getMockSectionUploadService } from '../../../../shared/mocks/section-upload.service.mock';
 import { FormFieldMetadataValueObject } from '../../../../shared/form/builder/models/form-field-metadata-value.model';
-import { Group } from '../../../../core/eperson/models/group.model';
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
-
-function getMockFileService(): FileService {
-  return jasmine.createSpyObj('FileService', {
-    retrieveFileDownloadLink: jasmine.createSpy('retrieveFileDownloadLink'),
-    getFileNameFromResponseContentDisposition: jasmine.createSpy('getFileNameFromResponseContentDisposition')
-  });
-}
 
 describe('SubmissionSectionUploadFileComponent test suite', () => {
 
@@ -53,7 +43,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
   let fixture: ComponentFixture<SubmissionSectionUploadFileComponent>;
   let submissionServiceStub: SubmissionServiceStub;
   let uploadService: any;
-  let fileService: any;
   let formService: any;
   let halService: any;
   let operationsBuilder: any;
@@ -64,10 +53,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
   const sectionId = 'upload';
   const collectionId = mockSubmissionCollectionId;
   const availableAccessConditionOptions = mockUploadConfigResponse.accessConditionOptions;
-  const availableGroupsMap: Map<string, Group[]> = new Map([
-    [mockUploadConfigResponse.accessConditionOptions[1].name, [mockGroup as any]],
-    [mockUploadConfigResponse.accessConditionOptions[2].name, [mockGroup as any]],
-  ]);
   const collectionPolicyType = POLICY_DEFAULT_WITH_LIST;
   const fileIndex = '0';
   const fileName = '123456-test-upload.jpg';
@@ -95,7 +80,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
         TestComponent
       ],
       providers: [
-        { provide: FileService, useValue: getMockFileService() },
         { provide: FormService, useValue: getMockFormService() },
         { provide: HALEndpointService, useValue: new HALEndpointServiceStub('workspaceitems') },
         { provide: JsonPatchOperationsBuilder, useValue: jsonPatchOpBuilder },
@@ -152,7 +136,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       compAsAny = comp;
       submissionServiceStub = TestBed.inject(SubmissionService as any);
       uploadService = TestBed.inject(SectionUploadService);
-      fileService = TestBed.inject(FileService);
       formService = TestBed.inject(FormService);
       halService = TestBed.inject(HALEndpointService);
       operationsBuilder = TestBed.inject(JsonPatchOperationsBuilder);
@@ -225,15 +208,6 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
         pathCombiner.rootElement,
         pathCombiner.subRootElement);
     });
-
-    it('should download Bitstream File properly', fakeAsync(() => {
-      comp.fileData = fileData;
-      comp.downloadBitstreamFile();
-
-      tick();
-
-      expect(fileService.retrieveFileDownloadLink).toHaveBeenCalled();
-    }));
 
     it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
       compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 
 import { BehaviorSubject, Subscription } from 'rxjs';
-import { filter, first, mergeMap, take } from 'rxjs/operators';
+import { filter, mergeMap, take } from 'rxjs/operators';
 import { DynamicFormControlModel, } from '@ng-dynamic-forms/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -14,12 +14,12 @@ import { WorkspaceitemSectionUploadFileObject } from '../../../../core/submissio
 import { SubmissionFormsModel } from '../../../../core/config/models/config-submission-forms.model';
 import { dateToISOFormat } from '../../../../shared/date.util';
 import { SubmissionService } from '../../../submission.service';
-import { FileService } from '../../../../core/shared/file.service';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { SubmissionJsonPatchOperationsService } from '../../../../core/submission/submission-json-patch-operations.service';
 import { SubmissionObject } from '../../../../core/submission/models/submission-object.model';
 import { WorkspaceitemSectionUploadObject } from '../../../../core/submission/models/workspaceitem-section-upload.model';
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
+import { Bitstream } from '../../../../core/shared/bitstream.model';
 
 /**
  * This component represents a single bitstream contained in the submission
@@ -139,7 +139,6 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
    * Initialize instance variables
    *
    * @param {ChangeDetectorRef} cdr
-   * @param {FileService} fileService
    * @param {FormService} formService
    * @param {HALEndpointService} halService
    * @param {NgbModal} modalService
@@ -149,7 +148,6 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
    * @param {SectionUploadService} uploadService
    */
   constructor(private cdr: ChangeDetectorRef,
-              private fileService: FileService,
               private formService: FormService,
               private halService: HALEndpointService,
               private modalService: NgbModal,
@@ -217,15 +215,14 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
   }
 
   /**
-   * Perform bitstream download
+   * Build a Bitstream object by the current file uuid
+   *
+   * @return Bitstream object
    */
-  public downloadBitstreamFile() {
-    this.halService.getEndpoint('bitstreams').pipe(
-      first())
-      .subscribe((url) => {
-        const fileUrl = `${url}/${this.fileData.uuid}/content`;
-        this.fileService.retrieveFileDownloadLink(fileUrl);
-      });
+  public getBitstream(): Bitstream {
+    return Object.assign(new Bitstream(), {
+      uuid: this.fileData.uuid
+    });
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #1265

## Description
Fix issue #1265

## Instructions for Reviewers
Follow steps described in the #1265 and check if all works properly

**List of changes in this PR** :
With this PR SubmissionSectionUploadFileComponent make use of the existing FileDownloadLinkComponent to allow downloading of the uploaded files

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
