### PR TITLE
Fix hardcoded reference to 'upload' section

### DIFF
--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -288,14 +288,13 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
           this.pathCombiner.subRootElement);
       })
     ).subscribe((result: SubmissionObject[]) => {
-      if (result[0].sections.upload) {
-        Object.keys((result[0].sections.upload as WorkspaceitemSectionUploadObject).files)
-          .filter((key) => (result[0].sections.upload as WorkspaceitemSectionUploadObject).files[key].uuid === this.fileId)
+      if (result[0].sections[this.sectionId]) {
+        const uploadSection = (result[0].sections[this.sectionId] as WorkspaceitemSectionUploadObject);
+        Object.keys(uploadSection.files)
+          .filter((key) => uploadSection.files[key].uuid === this.fileId)
           .forEach((key) => this.uploadService.updateFileData(
-            this.submissionId,
-            this.sectionId,
-            this.fileId,
-            (result[0].sections.upload as WorkspaceitemSectionUploadObject).files[key]));
+            this.submissionId, this.sectionId, this.fileId, uploadSection.files[key])
+          );
       }
       this.switchMode();
     }));


### PR DESCRIPTION
## References
* Leftover from #1239

## Description
Fixes a tiny issue that I missed in the previous PR. 
Leads to data loss when editing file metadata in a submission upload section with an ID that's not exactly `'upload'`

## List of changes in this PR
* Use `this.sectionId` instead of `'upload'` when updating the upload section

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
