### PR TITLE
improve positioning of buttons in the submission form

### DIFF
--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -1,42 +1,51 @@
 <div class="row" *ngIf="!!submissionId">
   <div class="col">
-    <!-- a class="btn btn-outline-primary" role="button" href="#"><i class="fas fa-times"></i> {{'submission.general.cancel' |translate}}</a -->
-  </div>
-  <div *ngIf="(processingSaveStatus | async) || (processingDepositStatus | async)" class="col d-flex justify-content-end align-items-center">
-    <div class="progress w-75">
-      <div *ngIf="(processingSaveStatus | async)" class="progress-bar progress-bar-striped progress-bar-animated bg-info" [style.width]="'100%'" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">Saving...</div>
-      <div *ngIf="(processingDepositStatus | async)" class="progress-bar progress-bar-striped progress-bar-animated bg-info" [style.width]="'100%'" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">Depositing...</div>
-    </div>
-  </div>
-  <div *ngIf="!(processingSaveStatus | async) && !(processingDepositStatus | async)" class="col text-right">
-    <button type="button"
-            class="btn btn-secondary"
-            id="save"
-            [disabled]="(processingSaveStatus | async) || !(hasUnsavedModification | async)"
-            (click)="save($event)">
-      <span><i class="fas fa-save"></i> {{'submission.general.save' | translate}}</span>
-    </button>
-    <button type="button"
-            [class.btn-primary]="!(showDepositAndDiscard | async)"
-            [class.btn-secondary]="(showDepositAndDiscard | async)"
-            class="btn"
-            id="saveForLater"
-            [disabled]="(processingSaveStatus | async)"
-            (click)="saveLater($event)">
-      <span><i class="fas fa-save"></i> {{'submission.general.save-later' | translate}}</span>
-    </button>
-    <button *ngIf="(showDepositAndDiscard | async)"
-            type="button"
-            class="btn btn-primary"
-            [disabled]="(submissionIsInvalid | async)" (click)="deposit($event)">
-      <span><i class="fas fa-plus"></i> {{'submission.general.deposit' | translate}}</span>
-    </button>
     <button *ngIf="(showDepositAndDiscard | async)"
             type="button"
             class="btn btn-danger"
+            [disabled]="(processingSaveStatus | async) || (processingDepositStatus | async)"
             (click)="$event.preventDefault();confirmDiscard(content)">
       <i class="fas fa-trash"></i> {{'submission.general.discard.submit' | translate}}
     </button>
+  </div>
+  <div class="col text-right d-flex justify-content-end align-items-center">
+    <span *ngIf="!(hasUnsavedModification | async) && !(processingSaveStatus | async) && !(processingDepositStatus | async)">
+      <i class="fas fa-check-circle"></i> {{'submission.general.info.saved' | translate}}
+    </span>
+    <span *ngIf="(hasUnsavedModification | async) && !(processingSaveStatus | async) && !(processingDepositStatus | async)">
+      <i class="fas fa-exclamation-circle"></i> {{'submission.general.info.pending-changes' | translate}}
+    </span>
+    <div *ngIf="(processingSaveStatus | async) || (processingDepositStatus | async)" class="col d-flex justify-content-end align-items-center">
+      <div class="progress w-75">
+        <div *ngIf="(processingSaveStatus | async)" class="progress-bar progress-bar-striped progress-bar-animated bg-info" [style.width]="'100%'" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">Saving...</div>
+        <div *ngIf="(processingDepositStatus | async)" class="progress-bar progress-bar-striped progress-bar-animated bg-info" [style.width]="'100%'" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">Depositing...</div>
+      </div>
+    </div>
+    <div class="ml-2">
+      <button type="button"
+              class="btn btn-secondary"
+              id="save"
+              [disabled]="(processingSaveStatus | async) || !(hasUnsavedModification | async)"
+              (click)="save($event)">
+        <span><i class="fas fa-save"></i> {{'submission.general.save' | translate}}</span>
+      </button>
+      <button type="button"
+              [class.btn-primary]="!(showDepositAndDiscard | async)"
+              [class.btn-secondary]="(showDepositAndDiscard | async)"
+              class="btn"
+              id="saveForLater"
+              [disabled]="(processingSaveStatus | async) || (processingDepositStatus | async)"
+              (click)="saveLater($event)">
+        <span><i class="fas fa-save"></i> {{'submission.general.save-later' | translate}}</span>
+      </button>
+      <button *ngIf="(showDepositAndDiscard | async)"
+              type="button"
+              class="btn btn-success"
+              [disabled]="(submissionIsInvalid | async) || (processingSaveStatus | async) || (processingDepositStatus | async)"
+              (click)="deposit($event)">
+        <span><i class="fas fa-plus"></i> {{'submission.general.deposit' | translate}}</span>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/src/app/submission/form/footer/submission-form-footer.component.spec.ts
+++ b/src/app/submission/form/footer/submission-form-footer.component.spec.ts
@@ -205,7 +205,7 @@ describe('SubmissionFormFooterComponent Component', () => {
       comp.showDepositAndDiscard = observableOf(true);
       compAsAny.submissionIsInvalid = observableOf(true);
       fixture.detectChanges();
-      const depositBtn: any = fixture.debugElement.query(By.css('.btn-primary'));
+      const depositBtn: any = fixture.debugElement.query(By.css('.btn-success'));
 
       expect(depositBtn.nativeElement.disabled).toBeTruthy();
     });
@@ -214,7 +214,7 @@ describe('SubmissionFormFooterComponent Component', () => {
       comp.showDepositAndDiscard = observableOf(true);
       compAsAny.submissionIsInvalid = observableOf(false);
       fixture.detectChanges();
-      const depositBtn: any = fixture.debugElement.query(By.css('.btn-primary'));
+      const depositBtn: any = fixture.debugElement.query(By.css('.btn-success'));
 
       expect(depositBtn.nativeElement.disabled).toBeFalsy();
     });

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3172,6 +3172,10 @@
 
   "submission.general.discard.submit": "Discard",
 
+  "submission.general.info.saved": "Saved",
+
+  "submission.general.info.pending-changes": "Unsaved changes",
+
   "submission.general.save": "Save",
 
   "submission.general.save-later": "Save for later",
@@ -3198,7 +3202,7 @@
   "submission.import-external.source.loading": "Loading ...",
 
   "submission.import-external.source.sherpaJournal": "SHERPA Journals",
-  
+
   "submission.import-external.source.sherpaJournalIssn": "SHERPA Journals by ISSN",
 
   "submission.import-external.source.sherpaPublisher": "SHERPA Publishers",


### PR DESCRIPTION
## References
* Fixes #1207 

## Description
this PR tries to solve usability issue on submission form reported in #1207 


### List of changes in this PR:
* Place the discard button, as the previous versions, on the left in the button bar separated from the other ones.
* Change deposit button's class 
* Add a text describing the saving status of the submission

![Schermata da 2021-07-12 14-31-53](https://user-images.githubusercontent.com/2486489/125288795-d2cb6080-e31e-11eb-8100-dffc0d96bf31.png)


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
