### PR TITLE
Fix timezone issue with test dates

### DIFF
--- a/src/app/shared/resource-policies/form/resource-policy-form.component.spec.ts
+++ b/src/app/shared/resource-policies/form/resource-policy-form.component.spec.ts
@@ -25,7 +25,7 @@ import { getMockFormService } from '../../mocks/form-service.mock';
 import { FormBuilderService } from '../../form/builder/form-builder.service';
 import { EpersonGroupListComponent } from './eperson-group-list/eperson-group-list.component';
 import { FormComponent } from '../../form/form.component';
-import { stringToNgbDateStruct } from '../../date.util';
+import { stringToNgbDateStruct, dateToISOFormat } from '../../date.util';
 import { ResourcePolicy } from '../../../core/resource-policy/models/resource-policy.model';
 import { RESOURCE_POLICY } from '../../../core/resource-policy/models/resource-policy.resource-type';
 import { EPersonMock } from '../../testing/eperson.mock';
@@ -107,8 +107,8 @@ export const submittedResourcePolicy = Object.assign(new ResourcePolicy(), {
   description: 'description',
   policyType: PolicyType.TYPE_WORKFLOW,
   action: ActionType.WRITE,
-  startDate: '2019-04-14T00:00:00Z',
-  endDate: '2020-04-14T00:00:00Z',
+  startDate: dateToISOFormat('2019-04-14T00:00:00Z'),
+  endDate: dateToISOFormat('2020-04-14T00:00:00Z'),
   type: RESOURCE_POLICY
 });
 

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -35,6 +35,7 @@ import { getMockSectionUploadService } from '../../../../shared/mocks/section-up
 import { FormFieldMetadataValueObject } from '../../../../shared/form/builder/models/form-field-metadata-value.model';
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
+import { dateToISOFormat } from '../../../../shared/date.util';
 
 describe('SubmissionSectionUploadFileComponent test suite', () => {
 
@@ -232,8 +233,8 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
 
       const accessConditionsToSave = [
         { name: 'openaccess' },
-        { name: 'lease', endDate: '2019-01-16T00:00:00Z' },
-        { name: 'embargo', startDate: '2019-01-16T00:00:00Z' },
+        { name: 'lease', endDate: dateToISOFormat('2019-01-16T00:00:00Z') },
+        { name: 'embargo', startDate: dateToISOFormat('2019-01-16T00:00:00Z') },
       ];
       comp.saveBitstreamData(event);
       tick();


### PR DESCRIPTION
## References
* Fixes issue introduced by #1262

## Description
Ever since #1262 was merged, a number of tests involving dates fail on my machine, but don't on github. When dates were compared the expected dates were always 2 hours off the actual result.

This PR addresses this by using the dateToISOFormat function on the expected dates.

## Instructions for Reviewers
Please verify that with this PR the tests work in your timezone and on github

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
