### PR TITLE
Fix issue where the app wouldn't load for the first request in prod mode

### DIFF
--- a/src/app/core/dspace-rest/dspace-rest.service.ts
+++ b/src/app/core/dspace-rest/dspace-rest.service.ts
@@ -112,11 +112,15 @@ export class DspaceRestService {
         statusText: res.statusText
       })),
       catchError((err) => {
-        return observableThrowError({
-          statusCode: err.status,
-          statusText: err.statusText,
-          message: (hasValue(err.error) && isNotEmpty(err.error.message)) ? err.error.message : err.message
-        });
+        if (hasValue(err.status)) {
+          return observableThrowError({
+            statusCode: err.status,
+            statusText: err.statusText,
+            message: (hasValue(err.error) && isNotEmpty(err.error.message)) ? err.error.message : err.message
+          });
+        } else {
+          return observableThrowError(err);
+        }
       }));
   }
 

--- a/src/app/core/log/log.interceptor.ts
+++ b/src/app/core/log/log.interceptor.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { CookieService } from '../services/cookie.service';
+import { hasValue } from '../../shared/empty.util';
 
 /**
  * Log Interceptor intercepting Http Requests & Responses to
@@ -23,7 +24,9 @@ export class LogInterceptor implements HttpInterceptor {
 
     // Add headers from the intercepted request
     let headers = request.headers;
-    headers = headers.append('X-CORRELATION-ID', correlationId);
+    if (hasValue(correlationId)) {
+      headers = headers.append('X-CORRELATION-ID', correlationId);
+    }
     headers = headers.append('X-REFERRER', this.router.url);
 
     // Add new headers to the intercepted request


### PR DESCRIPTION
## References
* Fixes #1279 (most critical issue, the CORRELATION_ID empty issue will be moved to a new ticket)

## Description
This PR adds a check to see if the correlation id exists before adding it to the header.

It also improves the error handling of DSpaceRestService. JS errors (as opposed to error responses) are now thrown on unmodified. That will give us a stacktrace for these kinds of errors in the future.

## Instructions for Reviewers
- Open an incognito window, or clear your cookies
- Disable javascript
- Open this PR in prod mode
- Verify that the page loads properly

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
