### PR TITLE
Language attribute on HTML tag

### DIFF
--- a/src/app/core/locale/locale.service.spec.ts
+++ b/src/app/core/locale/locale.service.spec.ts
@@ -21,6 +21,7 @@ describe('LocaleService test suite', () => {
   let spyOnSet;
   let authService;
   let routeService;
+  let document;
 
   authService = jasmine.createSpyObj('AuthService', {
     isAuthenticated: jasmine.createSpy('isAuthenticated'),
@@ -43,6 +44,7 @@ describe('LocaleService test suite', () => {
         { provide: CookieService, useValue: new CookieServiceMock() },
         { provide: AuthService, userValue: authService },
         { provide: RouteService, useValue: routeServiceStub },
+        { provide: Document, useValue: document },
       ]
     });
   }));
@@ -52,7 +54,8 @@ describe('LocaleService test suite', () => {
     translateService = TestBed.inject(TranslateService);
     routeService = TestBed.inject(RouteService);
     window = new NativeWindowRef();
-    service = new LocaleService(window, cookieService, translateService, authService, routeService);
+    document = { documentElement: { lang: 'en' } };
+    service = new LocaleService(window, cookieService, translateService, authService, routeService, document);
     serviceAsAny = service;
     spyOnGet = spyOn(cookieService, 'get');
     spyOnSet = spyOn(cookieService, 'set');
@@ -113,6 +116,12 @@ describe('LocaleService test suite', () => {
       service.setCurrentLanguageCode();
       expect(translateService.use).toHaveBeenCalledWith('es');
       expect(service.saveLanguageCodeToCookie).toHaveBeenCalledWith('es');
+    });
+
+    it('should set the current language on the html tag', () => {
+      spyOn(service, 'getCurrentLanguageCode').and.returnValue('es');
+      service.setCurrentLanguageCode();
+      expect((service as any).document.documentElement.lang).toEqual('es');
     });
   });
 

--- a/src/app/core/locale/locale.service.ts
+++ b/src/app/core/locale/locale.service.ts
@@ -10,6 +10,7 @@ import { combineLatest, Observable, of as observableOf } from 'rxjs';
 import { map, mergeMap, take } from 'rxjs/operators';
 import { NativeWindowRef, NativeWindowService } from '../services/window.service';
 import { RouteService } from '../services/route.service';
+import { DOCUMENT } from '@angular/common';
 
 export const LANG_COOKIE = 'dsLanguage';
 
@@ -38,7 +39,9 @@ export class LocaleService {
     protected cookie: CookieService,
     protected translate: TranslateService,
     protected authService: AuthService,
-    protected routeService: RouteService) {
+    protected routeService: RouteService,
+    @Inject(DOCUMENT) private document: any
+  ) {
   }
 
   /**
@@ -148,6 +151,7 @@ export class LocaleService {
     }
     this.translate.use(lang);
     this.saveLanguageCodeToCookie(lang);
+    this.document.documentElement.lang = lang;
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #1188

## Description
This PR adds the "lang" attribute to the html tag with the current language.

## Instructions for Reviewers
Start the angular front-end and check if the html has the correct language attribute. 
Change the language and check if the attribute changes accordingly. 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
