### PR TITLE
fix the profile page component in the custom theme

### DIFF
--- a/src/app/profile-page/profile-page.module.ts
+++ b/src/app/profile-page/profile-page.module.ts
@@ -14,7 +14,8 @@ import { ThemedProfilePageComponent } from './themed-profile-page.component';
     SharedModule
   ],
   exports: [
-    ProfilePageSecurityFormComponent
+    ProfilePageSecurityFormComponent,
+    ProfilePageMetadataFormComponent
   ],
   declarations: [
     ProfilePageComponent,

--- a/src/themes/custom/app/profile-page/profile-page.component.ts
+++ b/src/themes/custom/app/profile-page/profile-page.component.ts
@@ -3,8 +3,10 @@ import { ProfilePageComponent as BaseComponent } from '../../../../app/profile-p
 
 @Component({
   selector: 'ds-profile-page',
-  styleUrls: ['./profile-page.component.scss'],
-  templateUrl: './profile-page.component.html'
+  // styleUrls: ['./profile-page.component.scss'],
+  styleUrls: ['../../../../app/profile-page/profile-page.component.scss'],
+  // templateUrl: './profile-page.component.html'
+  templateUrl: '../../../../app/profile-page/profile-page.component.html'
 })
 /**
  * Component for a user to edit their profile information


### PR DESCRIPTION
## References
* Fixes #1308

## Description
Changes the profile page component in the custom theme to use the template and scss file of the base theme by default, the same way all the other components in the custom theme do.

## Instructions for Reviewers
Test this PR by enabling the custom theme and verifying that the profile page works properly, without errors in the console.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
