### PR TITLE
Temporarily disable a11y check until random failure for color contrast can be fixed

### DIFF
--- a/cypress/integration/homepage.spec.ts
+++ b/cypress/integration/homepage.spec.ts
@@ -20,18 +20,18 @@ describe('Homepage', () => {
     cy.url().should('include', 'query=' + encodeURI(queryString));
   });
 
-  it('should pass accessibility tests', () => {
-    // first must inject Axe into current page
-    cy.injectAxe();
+  // it('should pass accessibility tests', () => {
+  //   // first must inject Axe into current page
+  //   cy.injectAxe();
 
-    // Analyze entire page for accessibility issues
-    // NOTE: this test checks accessibility of header/footer as well
-    cy.checkA11y({
-      exclude: [
-        ['#klaro'],                   // Klaro plugin (privacy policy popup) has color contrast issues
-        ['#search-navbar-container'], // search in navbar has duplicative ID. Will be fixed in #1174
-        ['.dropdownLogin']            // "Log in" link in header has color contrast issues
-      ],
-    });
-  });
+  //   // Analyze entire page for accessibility issues
+  //   // NOTE: this test checks accessibility of header/footer as well
+  //   cy.checkA11y({
+  //     exclude: [
+  //       ['#klaro'],                   // Klaro plugin (privacy policy popup) has color contrast issues
+  //       ['#search-navbar-container'], // search in navbar has duplicative ID. Will be fixed in #1174
+  //       ['.dropdownLogin']            // "Log in" link in header has color contrast issues
+  //     ],
+  //   });
+  // });
 });


### PR DESCRIPTION
Immediately after merging #1301, I noticed that the accessibility check in `homepage.spec.ts` seems to randomly *fail* for color contrast issues.  This sort of inconsistency in color contrast has also been reported in cypress-axe tool we are using, see component-driven/cypress-axe#98

As I'm currently working on a PR to run automated accessibility checks, I'll look into this issue in that work & ensure the new PR doesn't result in randomish failures, even if it means we don't automate tests for color contrast.

Therefore, this PR is just temporarily disabling that accessibility check until it is fixed in follow-up work.  That way this random failure doesn't get in the way of other development.
