### PR TITLE
Header Accessibility Fix: Allow enter key or spacebar to expand or contract menu based on current active status

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,17 @@ Once you have tested the Pull Request, please add a comment and/or approval to t
 
 ### Unit Tests
 
-Unit tests use Karma. You can find the configuration file at the same level of this README file:`./karma.conf.js` If you are going to use a remote test environment you need to edit the `./karma.conf.js`. Follow the instructions you will find inside it. To executing tests whenever any file changes you can modify the 'autoWatch' option to 'true' and 'singleRun' option to 'false'. A coverage report is also available at: http://localhost:9876/ after you run: `yarn run coverage`.
+Unit tests use the [Jasmine test framework](https://jasmine.github.io/), and are run via [Karma](https://karma-runner.github.io/).
+
+You can find the Karma configuration file at the same level of this README file:`./karma.conf.js` If you are going to use a remote test environment you need to edit the `./karma.conf.js`. Follow the instructions you will find inside it. To executing tests whenever any file changes you can modify the 'autoWatch' option to 'true' and 'singleRun' option to 'false'. A coverage report is also available at: http://localhost:9876/ after you run: `yarn run coverage`.
 
 The default browser is Google Chrome.
 
-Place your tests in the same location of the application source code files that they test.
+Place your tests in the same location of the application source code files that they test, e.g. ending with `*.component.spec.ts`
 
-and run: `yarn run test`
+and run: `yarn test`
+
+If you run into odd test errors, see the Angular guide to debugging tests: https://angular.io/guide/test-debugging
 
 ### E2E Tests
 
@@ -257,6 +261,10 @@ All E2E tests must be created under the `./cypress/integration/` folder, and mus
 _Hint: Creating e2e tests is easiest in an IDE (like Visual Studio), as it can help prompt/autocomplete your Cypress commands._
 
 More Information: [docs.cypress.io](https://docs.cypress.io/) has great guides & documentation helping you learn more about writing/debugging e2e tests in Cypress.
+
+### Learning how to build tests
+
+See our [DSpace Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide) for more hints/tips.
 
 Documentation
 --------------

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,6 +1,7 @@
 <div class="nav-item dropdown expandable-navbar-section"
     *ngVar="(active | async) as isActive"
     (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keyup.space)="isActive ? deactivateSection($event) : activateSection($event)"
     (mouseenter)="activateSection($event)"
     (mouseleave)="deactivateSection($event)">
     <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,7 +1,7 @@
 <div class="nav-item dropdown expandable-navbar-section"
     *ngVar="(active | async) as isActive"
-    (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
-    (keyup.space)="$event.stopPropagation(); isActive ? deactivateSection($event) : activateSection($event)"
+    (keydown.enter)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keydown.space)="isActive ? deactivateSection($event) : activateSection($event)"
     (mouseenter)="activateSection($event)"
     (mouseleave)="deactivateSection($event)">
     <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,18 +1,20 @@
-<div class="nav-item dropdown expandable-navbar-section"
-    (keyup.enter)="activateSection($event)"
-    (mouseenter)="activateSection($event)"
-    (mouseleave)="deactivateSection($event)">
-    <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"
-       id="browseDropdown" (click)="toggleSection($event)"
-       data-toggle="dropdown">
-        <ng-container
-                *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
-    </a>
-    <ul @slide *ngIf="(active | async)" (click)="deactivateSection($event)"
-        class="m-0 shadow-none border-top-0 dropdown-menu show">
-        <ng-container *ngFor="let subSection of (subSections$ | async)">
+<ng-container *ngVar="(active | async) as isActive">
+    <div class="nav-item dropdown expandable-navbar-section"
+        (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
+        (mouseenter)="activateSection($event)"
+        (mouseleave)="deactivateSection($event)">
+        <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"
+        id="browseDropdown" (click)="toggleSection($event)"
+        data-toggle="dropdown">
             <ng-container
-                    *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
-        </ng-container>
-    </ul>
-</div>
+                    *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
+        </a>
+        <ul @slide *ngIf="(active | async)" (click)="deactivateSection($event)"
+            class="m-0 shadow-none border-top-0 dropdown-menu show">
+            <ng-container *ngFor="let subSection of (subSections$ | async)">
+                <ng-container
+                        *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
+            </ng-container>
+        </ul>
+    </div>
+</ng-container>

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,7 +1,8 @@
 <div class="nav-item dropdown expandable-navbar-section"
     *ngVar="(active | async) as isActive"
-    (keydown.enter)="isActive ? deactivateSection($event) : activateSection($event)"
-    (keydown.space)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keyup.space)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keydown.space)="$event.preventDefault()"
     (mouseenter)="activateSection($event)"
     (mouseleave)="deactivateSection($event)">
     <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,7 +1,7 @@
 <div class="nav-item dropdown expandable-navbar-section"
     *ngVar="(active | async) as isActive"
     (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
-    (keyup.space)="isActive ? deactivateSection($event) : activateSection($event)"
+    (keyup.space)="$event.stopPropagation(); isActive ? deactivateSection($event) : activateSection($event)"
     (mouseenter)="activateSection($event)"
     (mouseleave)="deactivateSection($event)">
     <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,20 +1,19 @@
-<ng-container *ngVar="(active | async) as isActive">
-    <div class="nav-item dropdown expandable-navbar-section"
-        (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
-        (mouseenter)="activateSection($event)"
-        (mouseleave)="deactivateSection($event)">
-        <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"
-        id="browseDropdown" (click)="toggleSection($event)"
-        data-toggle="dropdown">
+<div class="nav-item dropdown expandable-navbar-section"
+    *ngVar="(active | async) as isActive"
+    (keyup.enter)="isActive ? deactivateSection($event) : activateSection($event)"
+    (mouseenter)="activateSection($event)"
+    (mouseleave)="deactivateSection($event)">
+    <a href="#" class="nav-link dropdown-toggle" routerLinkActive="active"
+       id="browseDropdown" (click)="toggleSection($event)"
+       data-toggle="dropdown">
+        <ng-container
+                *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
+    </a>
+    <ul @slide *ngIf="(active | async)" (click)="deactivateSection($event)"
+        class="m-0 shadow-none border-top-0 dropdown-menu show">
+        <ng-container *ngFor="let subSection of (subSections$ | async)">
             <ng-container
-                    *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
-        </a>
-        <ul @slide *ngIf="(active | async)" (click)="deactivateSection($event)"
-            class="m-0 shadow-none border-top-0 dropdown-menu show">
-            <ng-container *ngFor="let subSection of (subSections$ | async)">
-                <ng-container
-                        *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
-            </ng-container>
-        </ul>
-    </div>
-</ng-container>
+                    *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
+        </ng-container>
+    </ul>
+</div>

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -9,6 +9,7 @@ import { HostWindowService } from '../../shared/host-window.service';
 import { MenuService } from '../../shared/menu/menu.service';
 import { HostWindowServiceStub } from '../../shared/testing/host-window-service.stub';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { VarDirective } from '../../shared/utils/var.directive';
 
 describe('ExpandableNavbarSectionComponent', () => {
   let component: ExpandableNavbarSectionComponent;
@@ -19,7 +20,7 @@ describe('ExpandableNavbarSectionComponent', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-        declarations: [ExpandableNavbarSectionComponent, TestComponent],
+        declarations: [ExpandableNavbarSectionComponent, TestComponent, VarDirective],
         providers: [
           { provide: 'sectionDataProvider', useValue: {} },
           { provide: MenuService, useValue: menuService },
@@ -76,6 +77,42 @@ describe('ExpandableNavbarSectionComponent', () => {
       });
     });
 
+    describe('when Enter key is pressed on section header (while inactive)', () => {
+      beforeEach(() => {
+        spyOn(menuService, 'activateSection');
+        // Make sure section is 'inactive'. Requires calling ngOnInit() to update component 'active' property.
+        spyOn(menuService, 'isSectionActive').and.returnValue(observableOf(false));
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
+        // dispatch the (keyup.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+      });
+
+      it('should call activateSection on the menuService', () => {
+        expect(menuService.activateSection).toHaveBeenCalled();
+      });
+    });
+
+    describe('when Enter key is pressed on section header (while active)', () => {
+      beforeEach(() => {
+        spyOn(menuService, 'deactivateSection');
+        // Make sure section is 'active'. Requires calling ngOnInit() to update component 'active' property.
+        spyOn(menuService, 'isSectionActive').and.returnValue(observableOf(true));
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
+        // dispatch the (keyup.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+      });
+
+      it('should call deactivateSection on the menuService', () => {
+        expect(menuService.deactivateSection).toHaveBeenCalled();
+      });
+    });
+
     describe('when a click occurs on the section header', () => {
       beforeEach(() => {
         spyOn(menuService, 'toggleActiveSection');
@@ -96,7 +133,7 @@ describe('ExpandableNavbarSectionComponent', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-        declarations: [ExpandableNavbarSectionComponent, TestComponent],
+        declarations: [ExpandableNavbarSectionComponent, TestComponent, VarDirective],
         providers: [
           { provide: 'sectionDataProvider', useValue: {} },
           { provide: MenuService, useValue: menuService },

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -113,6 +113,42 @@ describe('ExpandableNavbarSectionComponent', () => {
       });
     });
 
+    describe('when spacebar is pressed on section header (while inactive)', () => {
+      beforeEach(() => {
+        spyOn(menuService, 'activateSection');
+        // Make sure section is 'inactive'. Requires calling ngOnInit() to update component 'active' property.
+        spyOn(menuService, 'isSectionActive').and.returnValue(observableOf(false));
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
+        // dispatch the (keyup.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+      });
+
+      it('should call activateSection on the menuService', () => {
+        expect(menuService.activateSection).toHaveBeenCalled();
+      });
+    });
+
+    describe('when spacebar is pressed on section header (while active)', () => {
+      beforeEach(() => {
+        spyOn(menuService, 'deactivateSection');
+        // Make sure section is 'active'. Requires calling ngOnInit() to update component 'active' property.
+        spyOn(menuService, 'isSectionActive').and.returnValue(observableOf(true));
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
+        // dispatch the (keyup.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+      });
+
+      it('should call deactivateSection on the menuService', () => {
+        expect(menuService.deactivateSection).toHaveBeenCalled();
+      });
+    });
+
     describe('when a click occurs on the section header', () => {
       beforeEach(() => {
         spyOn(menuService, 'toggleActiveSection');

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -86,8 +86,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keyup.enter) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+        // dispatch the (keydown.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       });
 
       it('should call activateSection on the menuService', () => {
@@ -104,8 +104,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keyup.enter) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+        // dispatch the (keydown.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       });
 
       it('should call deactivateSection on the menuService', () => {
@@ -122,8 +122,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keyup.space) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+        // dispatch the (keydown.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
       });
 
       it('should call activateSection on the menuService', () => {
@@ -140,8 +140,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keyup.space) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+        // dispatch the (keydown.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
       });
 
       it('should call deactivateSection on the menuService', () => {

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -86,8 +86,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keydown.enter) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        // dispatch the (keyup.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
       });
 
       it('should call activateSection on the menuService', () => {
@@ -104,8 +104,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keydown.enter) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        // dispatch the (keyup.enter) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
       });
 
       it('should call deactivateSection on the menuService', () => {
@@ -122,8 +122,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keydown.space) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+        // dispatch the (keyup.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
       });
 
       it('should call activateSection on the menuService', () => {
@@ -140,8 +140,8 @@ describe('ExpandableNavbarSectionComponent', () => {
         fixture.detectChanges();
 
         const sidebarToggler = fixture.debugElement.query(By.css('div.nav-item.dropdown'));
-        // dispatch the (keydown.space) action used in our component HTML
-        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+        // dispatch the (keyup.space) action used in our component HTML
+        sidebarToggler.nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
       });
 
       it('should call deactivateSection on the menuService', () => {

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -42,6 +42,7 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param {Event} event The user event that triggered this function
    */
   activateSection(event): void {
+    event.preventDefault();
     this.windowService.isXsOrSm().pipe(
       first()
     ).subscribe((isMobile) => {
@@ -57,6 +58,7 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param {Event} event The user event that triggered this function
    */
   deactivateSection(event): void {
+    event.preventDefault();
     this.windowService.isXsOrSm().pipe(
       first()
     ).subscribe((isMobile) => {

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -42,7 +42,6 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param {Event} event The user event that triggered this function
    */
   activateSection(event): void {
-    event.preventDefault();
     this.windowService.isXsOrSm().pipe(
       first()
     ).subscribe((isMobile) => {
@@ -58,7 +57,6 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param {Event} event The user event that triggered this function
    */
   deactivateSection(event): void {
-    event.preventDefault();
     this.windowService.isXsOrSm().pipe(
       first()
     ).subscribe((isMobile) => {


### PR DESCRIPTION
## References
Small improvement to the fixes to #1167 in PR #1252

## Description
Deque retested those header fixes, and found one issue was only partially fixed. 

* If you use a Keyboard to select the "All of DSpace" menu in the Header, you can open it by pressing "Enter"
* However, once it is open, there is no way to close it using only the keyboard.  

This PR fixes that issue by ensuring pressing "Enter" will open/close that menu based on the current status. 

## Instructions for Reviewers
* Review code changes
* Test keyboard interaction of header menu
    * Tab to the "All of DSpace" menu, press "Enter" (or spacebar).  It should open
    * Click Tab again, reselecting "All of DSpace".  press "Enter" (or spacebar) again. Now it should close.
    * Verify you can still tab to a submenu (e.g. "By Subject") and press "Enter" to go to that browse by page.