### PR TITLE
edit item metadata fix

### DIFF
--- a/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.html
+++ b/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.html
@@ -1,10 +1,10 @@
 <td>
     <div class="metadata-field">
         <div *ngIf="!(editable | async)">
-            <span>{{metadata?.key?.split('.').join('.&#8203;')}}</span>
+            <span disabled="true">{{metadata?.key?.split('.').join('.&#8203;')}}</span>
         </div>
         <div *ngIf="(editable | async)" class="field-container">
-            <ds-validation-suggestions [suggestions]="(metadataFieldSuggestions | async)"
+            <ds-validation-suggestions [disable]="fieldUpdate.changeType != 1" [suggestions]="(metadataFieldSuggestions | async)"
                                          [(ngModel)]="metadata.key"
                                          [url]="this.url"
                                          [metadata]="this.metadata"

--- a/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.spec.ts
@@ -463,4 +463,40 @@ describe('EditInPlaceFieldComponent', () => {
     });
 
   });
+
+  describe('canEditMetadataField', () => {
+    describe('when the fieldUpdate\'s changeType is currently ADD', () => {
+      beforeEach(() => {
+        objectUpdatesService.isEditable.and.returnValue(observableOf(true));
+        comp.fieldUpdate.changeType = FieldChangeType.ADD;
+        fixture.detectChanges();
+      });
+      it('can edit metadata field', () => {
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+       expect(disabledMetadataField).toBe(false);
+      });
+    });
+    describe('when the fieldUpdate\'s changeType is currently REMOVE', () => {
+      beforeEach(() => {
+        objectUpdatesService.isEditable.and.returnValue(observableOf(true));
+        comp.fieldUpdate.changeType = FieldChangeType.REMOVE;
+        fixture.detectChanges();
+      });
+      it('can edit metadata field', () => {
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+        expect(disabledMetadataField).toBe(true);
+      });
+    });
+    describe('when the fieldUpdate\'s changeType is currently UPDATE', () => {
+      beforeEach(() => {
+        objectUpdatesService.isEditable.and.returnValue(observableOf(true));
+        comp.fieldUpdate.changeType = FieldChangeType.UPDATE;
+        fixture.detectChanges();
+      });
+      it('can edit metadata field', () => {
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+        expect(disabledMetadataField).toBe(true);
+      });
+    });
+  });
 });

--- a/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-metadata/edit-in-place-field/edit-in-place-field.component.spec.ts
@@ -472,7 +472,8 @@ describe('EditInPlaceFieldComponent', () => {
         fixture.detectChanges();
       });
       it('can edit metadata field', () => {
-        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions'))
+          .componentInstance.disable;
        expect(disabledMetadataField).toBe(false);
       });
     });
@@ -483,7 +484,8 @@ describe('EditInPlaceFieldComponent', () => {
         fixture.detectChanges();
       });
       it('can edit metadata field', () => {
-        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions'))
+          .componentInstance.disable;
         expect(disabledMetadataField).toBe(true);
       });
     });
@@ -494,7 +496,8 @@ describe('EditInPlaceFieldComponent', () => {
         fixture.detectChanges();
       });
       it('can edit metadata field', () => {
-        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions')).componentInstance.disable
+        const disabledMetadataField = fixture.debugElement.query(By.css('ds-validation-suggestions'))
+          .componentInstance.disable;
         expect(disabledMetadataField).toBe(true);
       });
     });

--- a/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.html
+++ b/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.html
@@ -3,7 +3,7 @@
       (keydown.arrowdown)="shiftFocusDown($event)"
       (keydown.arrowup)="shiftFocusUp($event)" (keydown.esc)="close()"
       (dsClickOutside)="checkIfValidInput(form);close();">
-  <input #inputField type="text" formControlName="metadataNameField" attr.aria-labelledby="fieldName" [(ngModel)]="value" id="name" [name]="name"
+  <input [readonly]="disable" #inputField type="text" formControlName="metadataNameField" attr.aria-labelledby="fieldName" [(ngModel)]="value" id="name" [name]="name"
          class="form-control suggestion_input"
          [ngClass]="{'is-invalid': !valid}"
          [dsDebounce]="debounceTime" (onDebounce)="find($event)"

--- a/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.spec.ts
+++ b/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.spec.ts
@@ -60,4 +60,30 @@ describe('ValidationSuggestionsComponent', () => {
       expect(comp.onClickSuggestion).toHaveBeenCalledWith(suggestions[clickedIndex].value);
     });
   });
+  describe('can edit input', () => {
+    describe('test input field readonly property when input disable is true', () => {
+      beforeEach(() => {
+        comp.disable = true;
+        fixture.detectChanges();
+      });
+      it('it should be true', () => {
+        fixture.detectChanges();
+        let input = fixture.debugElement.query(By.css('input'));
+        let el = input.nativeElement;
+        expect(el.readOnly).toBe(true)
+      });
+    })
+    describe('test input field readonly property when input disable is false', () => {
+      beforeEach(() => {
+        comp.disable = false;
+        fixture.detectChanges();
+      });
+      it('it should be true', () => {
+        fixture.detectChanges();
+        let input = fixture.debugElement.query(By.css('input'));
+        let el = input.nativeElement;
+        expect(el.readOnly).toBe(false)
+      });
+    })
+  })
 });

--- a/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.spec.ts
+++ b/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.spec.ts
@@ -68,11 +68,11 @@ describe('ValidationSuggestionsComponent', () => {
       });
       it('it should be true', () => {
         fixture.detectChanges();
-        let input = fixture.debugElement.query(By.css('input'));
-        let el = input.nativeElement;
-        expect(el.readOnly).toBe(true)
+        const input = fixture.debugElement.query(By.css('input'));
+        const element = input.nativeElement;
+        expect(element.readOnly).toBe(true);
       });
-    })
+    });
     describe('test input field readonly property when input disable is false', () => {
       beforeEach(() => {
         comp.disable = false;
@@ -80,10 +80,10 @@ describe('ValidationSuggestionsComponent', () => {
       });
       it('it should be true', () => {
         fixture.detectChanges();
-        let input = fixture.debugElement.query(By.css('input'));
-        let el = input.nativeElement;
-        expect(el.readOnly).toBe(false)
+        const input = fixture.debugElement.query(By.css('input'));
+        const element = input.nativeElement;
+        expect(element.readOnly).toBe(false);
       });
-    })
-  })
+    });
+  });
 });

--- a/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.ts
+++ b/src/app/shared/input-suggestions/validation-suggestions/validation-suggestions.component.ts
@@ -42,7 +42,10 @@ export class ValidationSuggestionsComponent extends InputSuggestionsComponent im
    * The suggestions that should be shown
    */
   @Input() suggestions: InputSuggestion[] = [];
-
+  /**
+   * The possibility to edit metadata
+   */
+  @Input() disable;
   constructor(private metadataFieldValidator: MetadataFieldValidator,
               private objectUpdatesService: ObjectUpdatesService) {
     super();


### PR DESCRIPTION
## References
* Fixes #1317

## Description
When editing an item metadata, it is not possible change metadata field name since its input field is disabled. 
This to prevent errors reported in issue #1317. 
Despite of what estimated, this update took us 2 hours.

## Instructions for Reviewers

List of changes in this PR:
* added disable input to ValidationSuggestionComponent
* edit-in-place-field-component html changed so that its ds-validation-suggestion is disabled, using above input field, during metadata update and deletion operations, this change 

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
* Log in into dspace7
* from left menu select edit -> item and choose an item to edit
* go to "metadata" tab
* Click the right column toggle to edit an existing metadata
* Verify that input field for metadata name is blocked 
* Click on Add button
* Verify that it is possible to define a name for metadata to be added, and suggestion works.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
