### PR TITLE
Reload of My Dspace results is broken

### DIFF
--- a/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.spec.ts
+++ b/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.spec.ts
@@ -48,6 +48,7 @@ describe('ListableObjectComponentLoaderComponent', () => {
     comp.viewMode = testViewMode;
     comp.context = testContext;
     spyOn(comp, 'getComponent').and.returnValue(ItemListElementComponent as any);
+    spyOn(comp as any, 'connectInputsAndOutputs').and.callThrough();
     fixture.detectChanges();
 
   }));
@@ -55,6 +56,10 @@ describe('ListableObjectComponentLoaderComponent', () => {
   describe('When the component is rendered', () => {
     it('should call the getListableObjectComponent function with the right types, view mode and context', () => {
       expect(comp.getComponent).toHaveBeenCalledWith([testType], testViewMode, testContext);
+    });
+
+    it('should connectInputsAndOutputs of loaded component', () => {
+      expect((comp as any).connectInputsAndOutputs).toHaveBeenCalled();
     });
   });
 
@@ -121,20 +126,20 @@ describe('ListableObjectComponentLoaderComponent', () => {
     let reloadedObject: any;
 
     beforeEach(() => {
-      spyOn((comp as any), 'connectInputsAndOutputs').and.returnValue(null);
+      spyOn((comp as any), 'instantiateComponent').and.returnValue(null);
       spyOn((comp as any).contentChange, 'emit').and.returnValue(null);
 
       listableComponent = fixture.debugElement.query(By.css('ds-item-list-element')).componentInstance;
       reloadedObject = 'object';
     });
 
-    it('should pass it on connectInputsAndOutputs', fakeAsync(() => {
-      expect((comp as any).connectInputsAndOutputs).not.toHaveBeenCalled();
+    it('should re-instantiate the listable component', fakeAsync(() => {
+      expect((comp as any).instantiateComponent).not.toHaveBeenCalled();
 
       (listableComponent as any).reloadedObject.emit(reloadedObject);
       tick();
 
-      expect((comp as any).connectInputsAndOutputs).toHaveBeenCalled();
+      expect((comp as any).instantiateComponent).toHaveBeenCalledWith(reloadedObject);
     }));
 
     it('should re-emit it as a contentChange', fakeAsync(() => {

--- a/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
+++ b/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.ts
@@ -184,7 +184,7 @@ export class ListableObjectComponentLoaderComponent implements OnInit, OnChanges
         if (reloadedObject) {
           this.compRef.destroy();
           this.object = reloadedObject;
-          this.connectInputsAndOutputs();
+          this.instantiateComponent(reloadedObject);
           this.contentChange.emit(reloadedObject);
         }
       });


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1320

## Instructions for Reviewers
Claim a pool search result and check the reloaded claimed object is actually rendered.

The code responsible to reload the object has been restored (it was completely removed in this [commit](https://github.com/DSpace/dspace-angular/pull/1247/commits/b586a264ca06de1ccbedb68fefa35323bf25d383)).
I've also reintroduced the unit test of this functionality.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
