### PR TITLE
Fixed edit item bitstreams

### DIFF
--- a/src/app/item-page/bitstreams/upload/upload-bitstream.component.spec.ts
+++ b/src/app/item-page/bitstreams/upload/upload-bitstream.component.spec.ts
@@ -21,6 +21,7 @@ import { createPaginatedList } from '../../../shared/testing/utils.test';
 import { RouterStub } from '../../../shared/testing/router.stub';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 import { AuthServiceStub } from '../../../shared/testing/auth-service.stub';
+import { getTestScheduler } from 'jasmine-marbles';
 
 describe('UploadBistreamComponent', () => {
   let comp: UploadBitstreamComponent;
@@ -76,7 +77,8 @@ describe('UploadBistreamComponent', () => {
   const restEndpoint = 'fake-rest-endpoint';
   const mockItemDataService = jasmine.createSpyObj('mockItemDataService', {
     getBitstreamsEndpoint: observableOf(restEndpoint),
-    createBundle: createSuccessfulRemoteDataObject$(createdBundle)
+    createBundle: createSuccessfulRemoteDataObject$(createdBundle),
+    getBundles: createSuccessfulRemoteDataObject$([bundle])
   });
   const bundleService = jasmine.createSpyObj('bundleService', {
     getBitstreamsEndpoint: observableOf(restEndpoint),
@@ -90,6 +92,22 @@ describe('UploadBistreamComponent', () => {
   const uploaderComponent = jasmine.createSpyObj('uploaderComponent', ['ngOnInit', 'ngAfterViewInit']);
   const requestService = jasmine.createSpyObj('requestService', {
     removeByHrefSubstring: {}
+  });
+
+
+  describe('on init', () => {
+    beforeEach(waitForAsync(() => {
+      createUploadBitstreamTestingModule({
+        bundle: bundle.id
+      });
+    }));
+    beforeEach(() => {
+      loadFixtureAndComp();
+    });
+    it('should initialize the bundles', () => {
+      expect(comp.bundlesRD$).toBeDefined();
+      getTestScheduler().expectObservable(comp.bundlesRD$).toBe('(a|)', {a: createSuccessfulRemoteDataObject([bundle])});
+    });
   });
 
   describe('when a file is uploaded', () => {

--- a/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
+++ b/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
@@ -108,9 +108,7 @@ export class UploadBitstreamComponent implements OnInit, OnDestroy {
     this.itemId = this.route.snapshot.params.id;
     this.entityType = this.route.snapshot.params['entity-type'];
     this.itemRD$ = this.route.data.pipe(map((data) => data.dso));
-    this.bundlesRD$ = this.itemRD$.pipe(
-      switchMap((itemRD: RemoteData<Item>) => itemRD.payload.bundles)
-    );
+    this.bundlesRD$ = this.itemService.getBundles(this.itemId);
     this.selectedBundleId = this.route.snapshot.queryParams.bundle;
     if (isNotEmpty(this.selectedBundleId)) {
       this.bundleService.findById(this.selectedBundleId).pipe(

--- a/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
+++ b/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { Item } from '../../../core/shared/item.model';
-import { map, switchMap, take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UploaderOptions } from '../../../shared/uploader/uploader-options.model';
 import { hasValue, isEmpty, isNotEmpty } from '../../../shared/empty.util';


### PR DESCRIPTION
## References
* Fixes #1286 

## Description
This PR fixes the issue where new bitstreams couldn't be uploaded in the UI on the edit item page anymore.

## Instructions for Reviewers
Go to an edit item page and select the Bitstreams tab.
Upload a new bitstream to this item and make sure it is working again.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).

