### PR TITLE
Control collection harvest from the UI

### DIFF
--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.html
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.html
@@ -1,0 +1,35 @@
+<div *ngVar="(contentSource$ |async) as contentSource">
+    <div class="container-fluid" *ngIf="shouldShow">
+        <h4>{{ 'collection.source.controls.head' | translate }}</h4>
+        <div>
+            <span class="font-weight-bold">{{'collection.source.controls.harvest.status' | translate}}</span>
+            <span>{{contentSource?.harvestStatus}}</span>
+        </div>
+        <div>
+            <span class="font-weight-bold">{{'collection.source.controls.harvest.start' | translate}}</span>
+            <span>{{contentSource?.harvestStartTime ? contentSource?.harvestStartTime : 'collection.source.controls.harvest.no-information'|translate }}</span>
+        </div>
+        <div>
+            <span class="font-weight-bold">{{'collection.source.controls.harvest.last' | translate}}</span>
+            <span>{{contentSource?.lastHarvested ? contentSource?.lastHarvested : 'collection.source.controls.harvest.no-information'|translate }}</span>
+        </div>
+
+        <button class=" btn btn-secondary"
+                [disabled]="!(isEnabled)"
+                (click)="testConfiguration(contentSource)">
+            <span class="d-none d-sm-inline">{{'collection.source.controls.test.submit' | translate}}</span>
+        </button>
+        <button class="btn btn-primary"
+                [disabled]="!(isEnabled)"
+                (click)="importNow()">
+            <span class="d-none d-sm-inline">{{'collection.source.controls.import.submit' | translate}}</span>
+        </button>
+        <button class="btn btn-primary"
+                [disabled]="!(isEnabled)"
+                (click)="resetAndReimport()">
+            <span class="d-none d-sm-inline">&nbsp;{{'collection.source.controls.reset.submit' | translate}}</span>
+        </button>
+
+
+    </div>
+</div>

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.ts
@@ -1,0 +1,150 @@
+import { Component, Input, OnDestroy } from '@angular/core';
+import { ScriptDataService } from '../../../../core/data/processes/script-data.service';
+import { ContentSource } from '../../../../core/shared/content-source.model';
+import { ProcessDataService } from '../../../../core/data/processes/process-data.service';
+import {
+  getAllCompletedRemoteData,
+  getAllSucceededRemoteDataPayload,
+  getFirstCompletedRemoteData,
+  getFirstSucceededRemoteDataPayload
+} from '../../../../core/shared/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { hasValue, hasValueOperator } from '../../../../shared/empty.util';
+import { ProcessStatus } from '../../../../process-page/processes/process-status.model';
+import { Subscription } from 'rxjs/internal/Subscription';
+import { RequestService } from '../../../../core/data/request.service';
+import { NotificationsService } from '../../../../shared/notifications/notifications.service';
+import { Collection } from '../../../../core/shared/collection.model';
+import { CollectionDataService } from '../../../../core/data/collection-data.service';
+import { Observable } from 'rxjs/internal/Observable';
+import { Process } from '../../../../process-page/processes/process.model';
+import { TranslateService } from '@ngx-translate/core';
+import { HttpClient } from '@angular/common/http';
+import { BitstreamDataService } from '../../../../core/data/bitstream-data.service';
+
+@Component({
+  selector: 'ds-collection-source-controls',
+  templateUrl: './collection-source-controls.component.html',
+})
+export class CollectionSourceControlsComponent implements OnDestroy {
+
+  @Input() isEnabled: boolean;
+  @Input() collection: Collection;
+  @Input() shouldShow: boolean;
+
+  contentSource$: Observable<ContentSource>;
+  private subs: Subscription[] = [];
+
+  constructor(private scriptDataService: ScriptDataService,
+              private processDataService: ProcessDataService,
+              private requestService: RequestService,
+              private notificationsService: NotificationsService,
+              private collectionService: CollectionDataService,
+              private translateService: TranslateService,
+              private httpClient: HttpClient,
+              private bitstreamService: BitstreamDataService
+  ) {
+  }
+
+  ngOnInit() {
+    this.contentSource$ = this.collectionService.findByHref(this.collection._links.self.href, false).pipe(
+      getAllSucceededRemoteDataPayload(),
+      switchMap((collection) => this.collectionService.getContentSource(collection.uuid, false)),
+      getAllSucceededRemoteDataPayload()
+    );
+  }
+
+  testConfiguration(contentSource) {
+    this.subs.push(this.scriptDataService.invoke('harvest', [
+      {name: '-g', value: null},
+      {name: '-a', value: contentSource.oaiSource},
+      {name: '-i', value: contentSource.oaiSetId},
+    ], []).pipe(
+      getFirstCompletedRemoteData(),
+      tap((rd) => {
+        if (rd.hasFailed) {
+          this.notificationsService.error(this.translateService.get('collection.source.controls.test.submit.error'));
+        }
+      }),
+      filter((rd) => rd.hasSucceeded && hasValue(rd.payload)),
+      switchMap((rd) => this.processDataService.findById(rd.payload.processId, false)),
+      getAllCompletedRemoteData(),
+      filter((rd) => !rd.isStale && (rd.hasSucceeded || rd.hasFailed)),
+      map((rd) => rd.payload),
+      hasValueOperator(),
+    ).subscribe((process: Process) => {
+        if (process.processStatus.toString() !== ProcessStatus[ProcessStatus.COMPLETED].toString() &&
+          process.processStatus.toString() !== ProcessStatus[ProcessStatus.FAILED].toString()) {
+          setTimeout(() => {
+            this.requestService.setStaleByHrefSubstring(process._links.self.href);
+          }, 5000);
+        }
+        if (process.processStatus.toString() === ProcessStatus[ProcessStatus.FAILED].toString()) {
+          this.notificationsService.error(this.translateService.get('collection.source.controls.test.failed'));
+        }
+        if (process.processStatus.toString() === ProcessStatus[ProcessStatus.COMPLETED].toString()) {
+          this.bitstreamService.findByHref(process._links.output.href, false).pipe(getFirstSucceededRemoteDataPayload()).subscribe((bitstream) => {
+            this.httpClient.get(bitstream._links.content.href, {responseType: 'text'}).subscribe((data: any) => {
+              const output = data.replaceAll(new RegExp('.*\\@(.*)', 'g'), '$1')
+                .replaceAll('The script has started', '')
+                .replaceAll('The script has completed', '');
+              this.notificationsService.success(this.translateService.get('collection.source.controls.test.completed'), output);
+            });
+          });
+        }
+      }
+    ));
+  }
+
+  importNow() {
+    this.subs.push(this.scriptDataService.invoke('harvest', [
+      {name: '-r', value: null},
+      {name: '-e', value: 'dspacedemo+admin@gmail.com'},
+      {name: '-c', value: this.collection.uuid},
+    ], [])
+      .pipe(
+        getFirstCompletedRemoteData(),
+        tap((rd) => {
+          if (rd.hasFailed) {
+            this.notificationsService.error(this.translateService.get('collection.source.controls.test.submit.error'));
+          }
+        }),
+        filter((rd) => rd.hasSucceeded && hasValue(rd.payload)),
+        switchMap((rd) => this.processDataService.findById(rd.payload.processId, false)),
+        getAllCompletedRemoteData(),
+        filter((rd) => !rd.isStale && (rd.hasSucceeded || rd.hasFailed)),
+        map((rd) => rd.payload),
+        hasValueOperator(),
+      ).subscribe((process) => {
+          if (process.processStatus.toString() !== ProcessStatus[ProcessStatus.COMPLETED].toString() &&
+            process.processStatus.toString() !== ProcessStatus[ProcessStatus.FAILED].toString()) {
+            setTimeout(() => {
+              this.requestService.setStaleByHrefSubstring(process._links.self.href);
+              this.requestService.setStaleByHrefSubstring(this.collection._links.self.href);
+            }, 5000);
+          }
+          if (process.processStatus.toString() === ProcessStatus[ProcessStatus.FAILED].toString()) {
+            this.notificationsService.error(this.translateService.get('collection.source.controls.import.failed'));
+          }
+          if (process.processStatus.toString() === ProcessStatus[ProcessStatus.COMPLETED].toString()) {
+            this.notificationsService.success(this.translateService.get('collection.source.controls.import.completed'));
+            setTimeout(() => {
+              this.requestService.setStaleByHrefSubstring(this.collection._links.self.href);
+            }, 5000);
+          }
+        }
+      ));
+  }
+
+  resetAndReimport() {
+    // TODO implement when a single option is present
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach((sub) => {
+      if (hasValue(sub)) {
+        sub.unsubscribe();
+      }
+    });
+  }
+}

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
@@ -1,57 +1,74 @@
 <div class="container-fluid">
-  <div class="d-inline-block float-right">
-    <button class=" btn btn-danger" *ngIf="!(isReinstatable() | async)"
-            [disabled]="!(hasChanges() | async)"
-            (click)="discard()"><i
-      class="fas fa-times"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.discard-button" | translate}}</span>
-    </button>
-    <button class="btn btn-warning" *ngIf="isReinstatable() | async"
-            (click)="reinstate()"><i
-      class="fas fa-undo-alt"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.reinstate-button" | translate}}</span>
-    </button>
-    <button class="btn btn-primary" [disabled]="!(hasChanges() | async) || !isValid() || (initialHarvestType === harvestTypeNone && contentSource.harvestType === initialHarvestType)"
-            (click)="onSubmit()"><i
-      class="fas fa-save"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.save-button" | translate}}</span>
-    </button>
-  </div>
-  <h4>{{ 'collection.edit.tabs.source.head' | translate }}</h4>
-  <div *ngIf="contentSource" class="form-check mb-4">
-    <input type="checkbox" class="form-check-input" id="externalSourceCheck" [checked]="(contentSource?.harvestType !== harvestTypeNone)" (change)="changeExternalSource()">
-    <label class="form-check-label" for="externalSourceCheck">{{ 'collection.edit.tabs.source.external' | translate }}</label>
-  </div>
-  <ds-loading *ngIf="!contentSource" [message]="'loading.content-source' | translate"></ds-loading>
-  <h4 *ngIf="contentSource && (contentSource?.harvestType !== harvestTypeNone)">{{ 'collection.edit.tabs.source.form.head' | translate }}</h4>
+    <div class="d-inline-block float-right">
+        <button class=" btn btn-danger" *ngIf="!(isReinstatable() | async)"
+                [disabled]="!(hasChanges() | async)"
+                (click)="discard()"><i
+                class="fas fa-times"></i>
+            <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.discard-button" | translate}}</span>
+        </button>
+        <button class="btn btn-warning" *ngIf="isReinstatable() | async"
+                (click)="reinstate()"><i
+                class="fas fa-undo-alt"></i>
+            <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.reinstate-button" | translate}}</span>
+        </button>
+        <button class="btn btn-primary"
+                [disabled]="!(hasChanges() | async) || !isValid() || (initialHarvestType === harvestTypeNone && contentSource.harvestType === initialHarvestType)"
+                (click)="onSubmit()"><i
+                class="fas fa-save"></i>
+            <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.save-button" | translate}}</span>
+        </button>
+    </div>
+    <h4>{{ 'collection.edit.tabs.source.head' | translate }}</h4>
+    <div *ngIf="contentSource" class="form-check mb-4">
+        <input type="checkbox" class="form-check-input" id="externalSourceCheck"
+               [checked]="(contentSource?.harvestType !== harvestTypeNone)" (change)="changeExternalSource()">
+        <label class="form-check-label"
+               for="externalSourceCheck">{{ 'collection.edit.tabs.source.external' | translate }}</label>
+    </div>
+    <ds-loading *ngIf="!contentSource" [message]="'loading.content-source' | translate"></ds-loading>
+    <h4 *ngIf="contentSource && (contentSource?.harvestType !== harvestTypeNone)">{{ 'collection.edit.tabs.source.form.head' | translate }}</h4>
 </div>
-<ds-form *ngIf="formGroup && contentSource && (contentSource?.harvestType !== harvestTypeNone)"
-         [formId]="'collection-source-form-id'"
-         [formGroup]="formGroup"
-         [formModel]="formModel"
-         [formLayout]="formLayout"
-         [displaySubmit]="false"
-         [displayCancel]="false"
-         (dfChange)="onChange($event)"
-         (submitForm)="onSubmit()"
-         (cancel)="onCancel()"></ds-form>
-<div class="container-fluid" *ngIf="(contentSource?.harvestType !== harvestTypeNone)">
-  <div class="d-inline-block float-right">
-    <button class=" btn btn-danger" *ngIf="!(isReinstatable() | async)"
-            [disabled]="!(hasChanges() | async)"
-            (click)="discard()"><i
-      class="fas fa-times"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.discard-button" | translate}}</span>
-    </button>
-    <button class="btn btn-warning" *ngIf="isReinstatable() | async"
-            (click)="reinstate()"><i
-      class="fas fa-undo-alt"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.reinstate-button" | translate}}</span>
-    </button>
-    <button class="btn btn-primary" [disabled]="!(hasChanges() | async) || !isValid() || (initialHarvestType === harvestTypeNone && contentSource.harvestType === initialHarvestType)"
-            (click)="onSubmit()"><i
-      class="fas fa-save"></i>
-      <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.save-button" | translate}}</span>
-    </button>
-  </div>
+<div class="row">
+    <ds-form *ngIf="formGroup && contentSource && (contentSource?.harvestType !== harvestTypeNone)"
+             [formId]="'collection-source-form-id'"
+             [formGroup]="formGroup"
+             [formModel]="formModel"
+             [formLayout]="formLayout"
+             [displaySubmit]="false"
+             [displayCancel]="false"
+             (dfChange)="onChange($event)"
+             (submitForm)="onSubmit()"
+             (cancel)="onCancel()"></ds-form>
 </div>
+<div class="container mt-2" *ngIf="(contentSource?.harvestType !== harvestTypeNone)">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-inline-block float-right ml-1">
+                <button class=" btn btn-danger" *ngIf="!(isReinstatable() | async)"
+                        [disabled]="!(hasChanges() | async)"
+                        (click)="discard()"><i
+                        class="fas fa-times"></i>
+                    <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.discard-button" | translate}}</span>
+                </button>
+                <button class="btn btn-warning" *ngIf="isReinstatable() | async"
+                        (click)="reinstate()"><i
+                        class="fas fa-undo-alt"></i>
+                    <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.reinstate-button" | translate}}</span>
+                </button>
+                <button class="btn btn-primary"
+                        [disabled]="!(hasChanges() | async) || !isValid() || (initialHarvestType === harvestTypeNone && contentSource.harvestType === initialHarvestType)"
+                        (click)="onSubmit()"><i
+                        class="fas fa-save"></i>
+                    <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.save-button" | translate}}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+<ds-collection-source-controls
+        [isEnabled]="!(hasChanges()|async)"
+        [shouldShow]="contentSource?.harvestType !== harvestTypeNone"
+        [collection]="(collectionRD$ |async)?.payload"
+>
+</ds-collection-source-controls>
+

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.ts
@@ -380,7 +380,7 @@ export class CollectionSourceComponent extends AbstractTrackableComponent implem
       switchMap((uuid) => this.collectionService.getHarvesterEndpoint(uuid)),
       take(1)
     ).subscribe((endpoint) => this.requestService.removeByHrefSubstring(endpoint));
-
+    this.requestService.setStaleByHrefSubstring(this.contentSource._links.self.href);
     // Update harvester
     this.collectionRD$.pipe(
       getFirstSucceededRemoteData(),

--- a/src/app/collection-page/edit-collection-page/edit-collection-page.module.ts
+++ b/src/app/collection-page/edit-collection-page/edit-collection-page.module.ts
@@ -9,6 +9,7 @@ import { CollectionCurateComponent } from './collection-curate/collection-curate
 import { CollectionSourceComponent } from './collection-source/collection-source.component';
 import { CollectionAuthorizationsComponent } from './collection-authorizations/collection-authorizations.component';
 import { CollectionFormModule } from '../collection-form/collection-form.module';
+import { CollectionSourceControlsComponent } from './collection-source/collection-source-controls/collection-source-controls.component';
 
 /**
  * Module that contains all components related to the Edit Collection page administrator functionality
@@ -26,6 +27,8 @@ import { CollectionFormModule } from '../collection-form/collection-form.module'
     CollectionRolesComponent,
     CollectionCurateComponent,
     CollectionSourceComponent,
+
+    CollectionSourceControlsComponent,
     CollectionAuthorizationsComponent
   ]
 })

--- a/src/app/core/data/collection-data.service.ts
+++ b/src/app/core/data/collection-data.service.ts
@@ -138,7 +138,7 @@ export class CollectionDataService extends ComColDataService<Collection> {
    * Get the collection's content harvester
    * @param collectionId
    */
-  getContentSource(collectionId: string): Observable<RemoteData<ContentSource>> {
+  getContentSource(collectionId: string, useCachedVersionIfAvailable = true): Observable<RemoteData<ContentSource>> {
     const href$ = this.getHarvesterEndpoint(collectionId).pipe(
       isNotEmptyOperator(),
       take(1)
@@ -146,7 +146,7 @@ export class CollectionDataService extends ComColDataService<Collection> {
 
     href$.subscribe((href: string) => {
       const request = new ContentSourceRequest(this.requestService.generateRequestId(), href);
-      this.requestService.send(request, true);
+      this.requestService.send(request, useCachedVersionIfAvailable);
     });
 
     return this.rdbService.buildSingle<ContentSource>(href$);

--- a/src/app/core/shared/content-source.model.ts
+++ b/src/app/core/shared/content-source.model.ts
@@ -70,6 +70,15 @@ export class ContentSource extends CacheableObject {
    */
   metadataConfigs: MetadataConfig[];
 
+  @autoserializeAs('harvest_status')
+  harvestStatus: string;
+
+  @autoserializeAs('harvest_start_time')
+  harvestStartTime: string;
+
+  @autoserializeAs('last_harvested')
+  lastHarvested: string;
+
   /**
    * The {@link HALLink}s for this ContentSource
    */

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -881,6 +881,22 @@
   "collection.select.table.title": "Title",
 
 
+  "collection.source.controls.head": "Harvest Controls",
+  "collection.source.controls.test.submit.error": "Something went wrong with initiating the testing of the settings",
+  "collection.source.controls.test.failed": "The script to test the settings has failed",
+  "collection.source.controls.test.completed": "The script to test the settings has successfully finished",
+  "collection.source.controls.test.submit": "Test configuration",
+  "collection.source.controls.import.submit.success": "The import has been successfully initiated",
+  "collection.source.controls.import.submit.error": "Something went wrong with initiating the import",
+  "collection.source.controls.import.submit": "Import now",
+  "collection.source.controls.import.failed": "An error occurred during the import",
+  "collection.source.controls.import.completed": "The import completed",
+  "collection.source.controls.reset.submit": "Reset and reimport",
+  "collection.source.controls.harvest.status": "Harvest status:",
+  "collection.source.controls.harvest.start": "Harvest start time:",
+  "collection.source.controls.harvest.last": "Last time harvested:",
+  "collection.source.controls.harvest.no-information": "N/A",
+
 
   "collection.source.update.notifications.error.content": "The provided settings have been tested and didn't work.",
 


### PR DESCRIPTION
## References
* Fixes #[761]
* Requires DSpace/DSpace#[7952]

## Description
This PR adds additional controls to the collection UI to harvest a collection.
These controls will allow a user to:
* verify the current configuration
* start an import with the present configuration
* reset and reimport a collection

## Instructions for Reviewers
To test the new functionality, a collection will need to set up with harvesting configuration.
The support for setting the configuration is already present.

To set up a collection for harvesting, go to an edit collection page and go to the "Content Source" tab.
Check the checkbox and fill in the form with a valid source to harvest items from. This can be any DSpace with OAI enabled.

After filling in the OAI information and saving it, verify that the harvest control buttons become available and test their functionality.

**Test configuration**

Click the "Test configuration" button. Verify that after the check, a notification is shown with the output for the test.

**Import now**

Click the the "Import now" button. This will start the import which can be a quite lengthy.
When the process is finished, a notification will be shown and the "Harvest start time" will be updated.

**Reset and reimport**

The "reset and reimport" button is not implemented yet since a command will still be added to the backend that will perform both a purge and a new import.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
