### PR TITLE
#1294 [Submission] - Fix for required dropdown initial select click not working

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -40,7 +40,7 @@
 
       <button class="dropdown-item disabled" *ngIf="optionsList && optionsList.length == 0">{{'form.no-results' | translate}}</button>
       <button class="dropdown-item collection-item text-truncate" *ngFor="let listEntry of optionsList"
-              (click)="onSelect(listEntry); sdRef.close()"
+              (click)="onSelect(listEntry); sdRef.close()" (mousedown)="onSelect(listEntry); sdRef.close()"
               title="{{ listEntry.display }}" role="option"
               [attr.id]="listEntry.display == (currentValue|async) ? ('combobox_' + id + '_selected') : null">
         {{inputFormatter(listEntry)}}


### PR DESCRIPTION
## References
* Fixes #1294

## Description
When you have a dropdown in submission form that is required, the first time you select an option in the dropdown, it doesn't select the option you clicked and shows the error message stating the required message. The method (`onSelect`) that is on the dropdown options buttons on the click event is not triggered. This is probably because the view changes between the mousedown and mouseup event, showing the error message instead.
Source: https://blog.davidjs.com/2019/04/angular-click-not-fired-and-how-to-fix-it/

## Instructions for Reviewers
- Add a required dropdown in the submission (`{dspaceDir}/config/submission-forms.xml` in backend)
- The first time you select an option => Nothing is selected and the required error message is shown
- Second time you select an option, the click event works

Expected: select option should work immediately, bypassing the required error message showing.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
