### PR TITLE
linkType search-results bug fix

### DIFF
--- a/src/app/shared/search/search-results/search-results.component.html
+++ b/src/app/shared/search/search-results/search-results.component.html
@@ -7,6 +7,7 @@
             [hideGear]="true"
             [selectable]="selectable"
             [selectionConfig]="selectionConfig"
+            [linkType]="linkType"
             [context]="context"
             [hidePaginationDetail]="hidePaginationDetail"
             (deselectObject)="deselectObject.emit($event)"


### PR DESCRIPTION
## Description
This PR fixes a bug with linkType not being passed on to the list elements within search-results. This affects the results in lookup windows for example, where the linkType should be ExternalLink, but isn't.

Fixes https://github.com/DSpace/DSpace/issues/8002

## Instructions for Reviewers
Code changes:
* Passing over linkType from search-results component to viewable-collection

How to test:
* Visit submission for a publication
* Click the lookup icon (magnifying glass) for the Authors input
* Click on one of the author links in the lookup window
* Before the bug fix, this would cause the user to move away from submission to the item page. After the bug fix, the linkType is properly passed on to the list elements, causing the link to navigate to the item page in a new tab instead.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
