### PR TITLE
Fixes to scope select in search

### DIFF
--- a/src/app/search-page/search.component.html
+++ b/src/app/search-page/search.component.html
@@ -52,7 +52,7 @@
                     [searchPlaceholder]="'search.search-form.placeholder' | translate">
     </ds-search-form>
     <div class="row mb-3 mb-md-1">
-        <div class="labels col-sm-9 offset-sm-3">
+        <div class="labels col-sm-9">
             <ds-search-labels *ngIf="searchEnabled" [inPlaceSearch]="inPlaceSearch"></ds-search-labels>
         </div>
     </div>

--- a/src/app/shared/search-form/search-form.component.scss
+++ b/src/app/shared/search-form/search-form.component.scss
@@ -5,5 +5,5 @@
 }
 
 .scope-button {
-  max-width: $search-form-scope-max-width;
+  max-width: var(--ds-search-form-scope-max-width);
 }

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -82,4 +82,6 @@
 
   --ds-slider-color: #{$green};
   --ds-slider-handle-width: 18px;
+
+  --ds-search-form-scope-max-width: 150px;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -3,5 +3,3 @@
 
 @import '_bootstrap_variables.scss';
 @import '../../node_modules/bootstrap/scss/variables.scss';
-
-$search-form-scope-max-width: 150px;


### PR DESCRIPTION
## References
- Fixes an issue introduced by https://github.com/DSpace/dspace-angular/pull/1348

## Description
Fixes the alignment of the search labels and moves a SCSS variable into a global CSS variable.

## Instructions for Reviewers
There's an issue with aligning the labels below the search form, as seen here: 
![image](https://user-images.githubusercontent.com/11385967/137932458-9bf32d88-031b-4ecc-9560-b353eae0f307.png)

This PR aligns the labels with the currently selected filters to the left.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
