### PR TITLE
84385: Tabbed search view breaks if switch away/back between tabs

### DIFF
--- a/src/app/search-page/configuration-search-page.component.spec.ts
+++ b/src/app/search-page/configuration-search-page.component.spec.ts
@@ -55,10 +55,4 @@ describe('ConfigurationSearchPageComponent', () => {
     expect(routeService.setParameter).toHaveBeenCalledWith('fixedFilterQuery', QUERY);
   });
 
-  it('should reset route parameters on destroy', () => {
-    fixture.destroy();
-
-    expect(routeService.setParameter).toHaveBeenCalledWith('configuration', undefined);
-    expect(routeService.setParameter).toHaveBeenCalledWith('fixedFilterQuery', undefined);
-  });
 });

--- a/src/app/search-page/configuration-search-page.component.ts
+++ b/src/app/search-page/configuration-search-page.component.ts
@@ -6,7 +6,6 @@ import {
   Component,
   Inject,
   Input,
-  OnDestroy,
   OnInit
 } from '@angular/core';
 import { pushInOut } from '../shared/animations/push';
@@ -34,7 +33,7 @@ import { Router } from '@angular/router';
   ]
 })
 
-export class ConfigurationSearchPageComponent extends SearchComponent implements OnInit, OnDestroy {
+export class ConfigurationSearchPageComponent extends SearchComponent implements OnInit {
   /**
    * The configuration to use for the search options
    * If empty, the configuration will be determined by the route parameter called 'configuration'
@@ -70,19 +69,6 @@ export class ConfigurationSearchPageComponent extends SearchComponent implements
     }
     if (hasValue(this.fixedFilterQuery)) {
       this.routeService.setParameter('fixedFilterQuery', this.fixedFilterQuery);
-    }
-  }
-
-  /**
-   * Reset the updated query/configuration set in ngOnInit()
-   */
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    if (hasValue(this.configuration)) {
-      this.routeService.setParameter('configuration', undefined);
-    }
-    if (hasValue(this.fixedFilterQuery)) {
-      this.routeService.setParameter('fixedFilterQuery', undefined);
     }
   }
 }


### PR DESCRIPTION
## References
* Reverses changes from #1022 but couldn't reproduce original bug

## Issue

On the tabbed search on the item page ([ex item](https://demo7.dspace.org/entities/orgunit/4b0bb46a-9086-4398-a6b4-09840404d8dc?spc.sf=score&spc.sd=DESC&tab=isOrgUnitOfPerson)) if you switch to another tab and then back to your original tab, the search is broken on the original tab. (The config queryParam gets set correctly, but the filter one does not)

This is because the [ngOnDestroy](https://github.com/DSpace/dspace-angular/pull/1022/files) of the 2nd tab is executed After the ngOnInit of the second time you render the first tab

It can be solved by removing the `ngOnDestroy`, and even in prod mode I could not recreate the original issue for which it was added in [this PR](https://github.com/DSpace/dspace-angular/pull/1022), so I assume this must have been fixed elsewhere/in another way, possibly [here](https://github.com/DSpace/dspace-angular/pull/1048).

## Instructions for Reviewers
- Go to item page with tabbed search ([ex](https://demo7.dspace.org/entities/orgunit/3cc4a1e7-01ce-4ebb-a056-50db1fe2126b))
- Switch to other tab, switch back
- The search in original tab is broken => Fixed with this change
- If you inspect the network tab you see that the configuration queryParam does update, but the filter doesn't. Also there seems to be an excessive amount of search/objects request being done, which should be addressed (see [this issue](https://github.com/DSpace/dspace-angular/issues/458))

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.h.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
