### PR TITLE
Fix menu icon i18n messages

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2430,7 +2430,7 @@
 
   "menu.section.icon.control_panel": "Control Panel menu section",
 
-  "menu.section.icon.curation_task": "Curation Task menu section",
+  "menu.section.icon.curation_tasks": "Curation Task menu section",
 
   "menu.section.icon.edit": "Edit menu section",
 
@@ -2449,6 +2449,8 @@
   "menu.section.icon.registries": "Registries menu section",
 
   "menu.section.icon.statistics_task": "Statistics Task menu section",
+
+  "menu.section.icon.workflow": "Administer workflow menu section",
 
   "menu.section.icon.unpin": "Unpin sidebar",
 


### PR DESCRIPTION
## Description
Fixes the tooltips you get when you hover over the icons for Curation Task and Administer Workflow in the sidebar:

![image](https://user-images.githubusercontent.com/1567693/141099714-8bc77235-b1f4-4da7-8cea-45cebbebc7e6.png)

![image](https://user-images.githubusercontent.com/1567693/141099790-247805e3-f4d9-41c0-8965-e557bc11eeab.png)



## Instructions for Reviewers
Verify that the messages are there now when you hover over those icons

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
