### PR TITLE
Disable CLI analytics by default

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -238,5 +238,8 @@
       }
     }
   },
-  "defaultProject": "dspace-angular"
+  "defaultProject": "dspace-angular",
+  "cli": {
+    "analytics": false
+  }
 }


### PR DESCRIPTION
## Description
After moving to a new laptop and installing Angular CLI globally (`npm install -g @angular/cli`), all of my `ng` commands now prompt me to enable or disable analytics for `dspace-angular`.  The prompt looks like...

```
Would you like to share anonymous usage data about this project with the Angular Team at
Google under Google’s Privacy Policy at https://policies.google.com/privacy? For more
details and how to change this setting, see http://angular.io/analytics. (y/N)
```

Either answer updates our `angular.json`, which obviously gets annoying...as that change could be accidentally committed back in any future PR.

I suspect this is updated behavior in a more recent version of Angular CLI (as I didn't notice this until I moved to a new laptop).  However, the only way to seemingly disable this behavior is to specify a value for `analytics` in our `angular.json`, so I've chosen to disable it (set it to false)

No other code changes.  This PR just ensures that no one else will be annoyed by this consistent prompt every time `ng` runs on `dspace-angular`. 
