### PR TITLE
Sync with DSpace/DSpace docker-compose setup

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -81,15 +81,22 @@ services:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
     # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
+    # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
+    # * Second, copy updated configs from mounted configsets to this core. If it already existed, this updates core
+    #   to the latest configs. If it's a newly created core, this is a no-op.
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       init-var-solr
       precreate-core authority /opt/solr/server/solr/configsets/dspace/authority
+      cp -r -u /opt/solr/server/solr/configsets/dspace/authority/* authority
       precreate-core oai /opt/solr/server/solr/configsets/dspace/oai
+      cp -r -u /opt/solr/server/solr/configsets/dspace/oai/* oai
       precreate-core search /opt/solr/server/solr/configsets/dspace/search
+      cp -r -u /opt/solr/server/solr/configsets/dspace/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
+      cp -r -u /opt/solr/server/solr/configsets/dspace/statistics/* statistics
       exec solr -f
 volumes:
   assetstore:


### PR DESCRIPTION
## Description
Small update to `docker-compose-rest.yml` to "sync" it up with the `docker-compose.yml` in the DSpace/DSpace repo: https://github.com/DSpace/DSpace/blob/main/docker-compose.yml

These files should be kept in sync at all times (to avoid oddities in CI or similar), and it looks like I forgot to copy over the changes that I applied in https://github.com/DSpace/DSpace/pull/7999

Assuming this passes in GitHub CI, I'm going to merge immediately just to resync these files.