### PR TITLE
Add a config:dev:check:rest option for checking dev environment settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "config:test:watch": "nodemon --config mock-nodemon.json",
     "config:dev:watch": "nodemon",
     "config:check:rest": "yarn run config:prod && ts-node --project ./tsconfig.ts-node.json scripts/test-rest.ts",
+    "config:dev:check:rest": "yarn run config:dev && ts-node --project ./tsconfig.ts-node.json scripts/test-rest.ts",
     "prestart:dev": "yarn run config:dev",
     "prebuild": "yarn run config:dev",
     "pretest": "yarn run config:test",


### PR DESCRIPTION
## References
* Fixes #1409

## Description
Adds a new `yarn config:dev:check:rest` command, which is the equivalent of `yarn config:check:rest`, but for *development* environments (as the latter command only works for production).

## Instructions for Reviewers
Test the new script in a development environment, with an `environment.dev.ts`