### PR TITLE
[CST-4918] Process status remains Running in detail page

### DIFF
--- a/src/app/process-page/process-page.resolver.ts
+++ b/src/app/process-page/process-page.resolver.ts
@@ -23,7 +23,7 @@ export class ProcessPageResolver implements Resolve<RemoteData<Process>> {
    * or an error if something went wrong
    */
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<RemoteData<Process>> {
-    return this.processService.findById(route.params.id, true, false, followLink('script')).pipe(
+    return this.processService.findById(route.params.id, false, true, followLink('script')).pipe(
       getFirstCompletedRemoteData(),
     );
   }


### PR DESCRIPTION
## References
* Fixes #1405 

## Description

Process status remained "running" because process page resolver (`src/app/process-page/process-page.resolver.ts`) retrieved the process from cache.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
