### PR TITLE
Upload files - Edit bitstream (improvements and bug fixes)

### DIFF
--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.html
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.html
@@ -1,9 +1,21 @@
 <div>
-  <ds-form *ngIf="formModel"
-           #formRef="formComponent"
-           [formId]="formId"
-           [formModel]="formModel"
-           [displaySubmit]="false"
-           [displayCancel]="false"
-           (dfChange)="onChange($event)"></ds-form>
+  <div class="modal-header">
+    <h4 class="modal-title">{{'submission.sections.upload.edit.title' | translate}}</h4>
+    <button type="button" class="close" (click)="onModalClose()" aria-label="Close" [disabled]="isSaving">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="modal-body">
+
+    <ds-form *ngIf="formModel"
+             #formRef="formComponent"
+             [formId]="formId"
+             [formModel]="formModel"
+             [displaySubmit]="!isSaving"
+             [displayCancel]="!isSaving"
+             (submitForm)="onSubmit()"
+             (cancel)="onModalClose()"
+             (dfChange)="onChange($event)"></ds-form>
+
+  </div>
 </div>

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, NO_ERRORS_SCHEMA } from '@angular/core';
-import { waitForAsync, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, inject, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
@@ -17,18 +17,18 @@ import { SubmissionService } from '../../../../submission.service';
 import { SubmissionSectionUploadFileEditComponent } from './section-upload-file-edit.component';
 import { POLICY_DEFAULT_WITH_LIST } from '../../section-upload.component';
 import {
-  mockGroup,
   mockSubmissionCollectionId,
   mockSubmissionId,
   mockUploadConfigResponse,
   mockUploadConfigResponseMetadata,
-  mockUploadFiles
+  mockUploadFiles,
+  mockFileFormData,
+  mockSubmissionObject,
 } from '../../../../../shared/mocks/submission.mock';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormComponent } from '../../../../../shared/form/form.component';
 import { FormService } from '../../../../../shared/form/form.service';
 import { getMockFormService } from '../../../../../shared/mocks/form-service.mock';
-import { Group } from '../../../../../core/eperson/models/group.model';
 import { createTestComponent } from '../../../../../shared/testing/utils.test';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { JsonPatchOperationsBuilder } from '../../../../../core/json-patch/builder/json-patch-operations-builder';
@@ -37,12 +37,17 @@ import { SubmissionJsonPatchOperationsService } from '../../../../../core/submis
 import { SectionUploadService } from '../../section-upload.service';
 import { getMockSectionUploadService } from '../../../../../shared/mocks/section-upload.service.mock';
 import { FormFieldMetadataValueObject } from '../../../../../shared/form/builder/models/form-field-metadata-value.model';
+import { JsonPatchOperationPathCombiner } from '../../../../../core/json-patch/builder/json-patch-operation-path-combiner';
+import { dateToISOFormat } from '../../../../../shared/date.util';
+import { of } from 'rxjs';
 
 const jsonPatchOpBuilder: any = jasmine.createSpyObj('jsonPatchOpBuilder', {
   add: jasmine.createSpy('add'),
   replace: jasmine.createSpy('replace'),
   remove: jasmine.createSpy('remove'),
 });
+
+const formMetadataMock = ['dc.title', 'dc.description'];
 
 fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
@@ -53,6 +58,8 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
   let formbuilderService: any;
   let operationsBuilder: any;
   let operationsService: any;
+  let formService: any;
+  let uploadService: any;
 
   const submissionJsonPatchOperationsServiceStub = new SubmissionJsonPatchOperationsServiceStub();
   const submissionId = mockSubmissionId;
@@ -64,6 +71,7 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
   const fileIndex = '0';
   const fileId = '123456-test-upload';
   const fileData: any = mockUploadFiles[0];
+  const pathCombiner = new JsonPatchOperationPathCombiner('sections', sectionId, 'files', fileIndex);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -137,6 +145,8 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
       formbuilderService = TestBed.inject(FormBuilderService);
       operationsBuilder = TestBed.inject(JsonPatchOperationsBuilder);
       operationsService = TestBed.inject(SubmissionJsonPatchOperationsService);
+      formService = TestBed.inject(FormService);
+      uploadService = TestBed.inject(SectionUploadService);
 
       comp.submissionId = submissionId;
       comp.collectionId = collectionId;
@@ -146,6 +156,7 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
       comp.fileIndex = fileIndex;
       comp.fileId = fileId;
       comp.configMetadataForm = configMetadataForm;
+      comp.formMetadata = formMetadataMock;
     });
 
     afterEach(() => {
@@ -220,6 +231,76 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
       field = [new FormFieldMetadataValueObject('test')];
       expect(compAsAny.retrieveValueFromField(field)).toBe('test');
     });
+
+    it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
+      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
+      compAsAny.fileEditComp.formRef = {formGroup: null};
+      compAsAny.fileData = fileData;
+      compAsAny.pathCombiner = pathCombiner;
+      // const event = new Event('click', null);
+      // spyOn(comp, 'switchMode');
+      formService.validateAllFormFields.and.callFake(() => null);
+      formService.isValid.and.returnValue(of(true));
+      formService.getFormData.and.returnValue(of(mockFileFormData));
+
+      const response = [
+        Object.assign(mockSubmissionObject, {
+          sections: {
+            upload: {
+              files: mockUploadFiles
+            }
+          }
+        })
+      ];
+      operationsService.jsonPatchByResourceID.and.returnValue(of(response));
+
+      const accessConditionsToSave = [
+        { name: 'openaccess' },
+        { name: 'lease', endDate: dateToISOFormat('2019-01-16T00:00:00Z') },
+        { name: 'embargo', startDate: dateToISOFormat('2019-01-16T00:00:00Z') },
+      ];
+      comp.saveBitstreamData();
+      tick();
+
+      let path = 'metadata/dc.title';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath(path),
+        mockFileFormData.metadata['dc.title'],
+        true
+      );
+
+      path = 'metadata/dc.description';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath(path),
+        mockFileFormData.metadata['dc.description'],
+        true
+      );
+
+      path = 'accessConditions';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath(path),
+        accessConditionsToSave,
+        true
+      );
+
+      // expect(comp.switchMode).toHaveBeenCalled();
+      expect(uploadService.updateFileData).toHaveBeenCalledWith(submissionId, sectionId, mockUploadFiles[0].uuid, mockUploadFiles[0]);
+
+    }));
+
+    it('should not save Bitstream File data properly when form is not valid', fakeAsync(() => {
+      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
+      compAsAny.fileEditComp.formRef = {formGroup: null};
+      compAsAny.pathCombiner = pathCombiner;
+      // const event = new Event('click', null);
+      // spyOn(comp, 'switchMode');
+      formService.validateAllFormFields.and.callFake(() => null);
+      formService.isValid.and.returnValue(of(false));
+
+      // expect(comp.switchMode).not.toHaveBeenCalled();
+      expect(uploadService.updateFileData).not.toHaveBeenCalled();
+
+    }));
 
   });
 });

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -49,7 +49,7 @@ const jsonPatchOpBuilder: any = jasmine.createSpyObj('jsonPatchOpBuilder', {
 
 const formMetadataMock = ['dc.title', 'dc.description'];
 
-fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
+describe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
   let comp: SubmissionSectionUploadFileEditComponent;
   let compAsAny: any;
@@ -98,6 +98,7 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
         SubmissionSectionUploadFileEditComponent,
         NgbModal,
         NgbActiveModal,
+        FormComponent,
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents().then();
@@ -157,6 +158,8 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
       comp.fileId = fileId;
       comp.configMetadataForm = configMetadataForm;
       comp.formMetadata = formMetadataMock;
+
+      formService.isValid.and.returnValue(of(true));
     });
 
     afterEach(() => {
@@ -233,12 +236,9 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
     });
 
     it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
-      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
-      compAsAny.fileEditComp.formRef = {formGroup: null};
+      compAsAny.formRef = {formGroup: null};
       compAsAny.fileData = fileData;
       compAsAny.pathCombiner = pathCombiner;
-      // const event = new Event('click', null);
-      // spyOn(comp, 'switchMode');
       formService.validateAllFormFields.and.callFake(() => null);
       formService.isValid.and.returnValue(of(true));
       formService.getFormData.and.returnValue(of(mockFileFormData));
@@ -283,21 +283,18 @@ fdescribe('SubmissionSectionUploadFileEditComponent test suite', () => {
         true
       );
 
-      // expect(comp.switchMode).toHaveBeenCalled();
       expect(uploadService.updateFileData).toHaveBeenCalledWith(submissionId, sectionId, mockUploadFiles[0].uuid, mockUploadFiles[0]);
 
     }));
 
     it('should not save Bitstream File data properly when form is not valid', fakeAsync(() => {
-      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
-      compAsAny.fileEditComp.formRef = {formGroup: null};
+      compAsAny.formRef = {formGroup: null};
       compAsAny.pathCombiner = pathCombiner;
-      // const event = new Event('click', null);
-      // spyOn(comp, 'switchMode');
       formService.validateAllFormFields.and.callFake(() => null);
       formService.isValid.and.returnValue(of(false));
+      comp.saveBitstreamData();
+      tick();
 
-      // expect(comp.switchMode).not.toHaveBeenCalled();
       expect(uploadService.updateFileData).not.toHaveBeenCalled();
 
     }));

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -172,11 +172,6 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
 
   protected subscriptions: Subscription[] = [];
 
-  private static retrieveValueFromField(field: any) {
-    const temp = Array.isArray(field) ? field[0] : field;
-    return (temp) ? temp.value : undefined;
-  }
-
   /**
    * Initialize form model values
    *
@@ -293,6 +288,11 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.unsubscribeAll();
+  }
+
+  protected retrieveValueFromField(field: any) {
+    const temp = Array.isArray(field) ? field[0] : field;
+    return (temp) ? temp.value : undefined;
   }
 
   /**
@@ -418,20 +418,20 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
 
             if (accessConditionOpt) {
               const currentAccessCondition = Object.assign({}, accessCondition);
-              currentAccessCondition.name = SubmissionSectionUploadFileEditComponent.retrieveValueFromField(accessCondition.name);
+              currentAccessCondition.name = this.retrieveValueFromField(accessCondition.name);
 
               /* When start and end date fields are deactivated, their values may be still present in formData,
               therefore it is necessary to delete them if they're not allowed by the current access condition option. */
               if (!accessConditionOpt.hasStartDate) {
                 delete currentAccessCondition.startDate;
               } else if (accessCondition.startDate) {
-                const startDate = SubmissionSectionUploadFileEditComponent.retrieveValueFromField(accessCondition.startDate);
+                const startDate = this.retrieveValueFromField(accessCondition.startDate);
                 currentAccessCondition.startDate = dateToISOFormat(startDate);
               }
               if (!accessConditionOpt.hasEndDate) {
                 delete currentAccessCondition.endDate;
               } else if (accessCondition.endDate) {
-                const endDate = SubmissionSectionUploadFileEditComponent.retrieveValueFromField(accessCondition.endDate);
+                const endDate = this.retrieveValueFromField(accessCondition.endDate);
                 currentAccessCondition.endDate = dateToISOFormat(endDate);
               }
               accessConditionsToSave.push(currentAccessCondition);

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 import {
@@ -61,6 +61,97 @@ import { Subscription } from 'rxjs';
 export class SubmissionSectionUploadFileEditComponent implements OnInit {
 
   /**
+   * The FormComponent reference
+   */
+  @ViewChild('formRef') public formRef: FormComponent;
+
+  /**
+   * The list of available access condition
+   * @type {Array}
+   */
+  public availableAccessConditionOptions: any[];
+
+  /**
+   * The submission id
+   * @type {string}
+   */
+  public collectionId: string;
+
+  /**
+   * Define if collection access conditions policy type :
+   * POLICY_DEFAULT_NO_LIST : is not possible to define additional access group/s for the single file
+   * POLICY_DEFAULT_WITH_LIST : is possible to define additional access group/s for the single file
+   * @type {number}
+   */
+  public collectionPolicyType: number;
+
+  /**
+   * The configuration for the bitstream's metadata form
+   * @type {SubmissionFormsModel}
+   */
+  public configMetadataForm: SubmissionFormsModel;
+
+  /**
+   * The bitstream's metadata data
+   * @type {WorkspaceitemSectionUploadFileObject}
+   */
+  public fileData: WorkspaceitemSectionUploadFileObject;
+
+  /**
+   * The bitstream id
+   * @type {string}
+   */
+  public fileId: string;
+
+  /**
+   * The bitstream array key
+   * @type {string}
+   */
+  public fileIndex: string;
+
+  /**
+   * The form id
+   * @type {string}
+   */
+  public formId: string;
+
+  /**
+   * The section id
+   * @type {string}
+   */
+  public sectionId: string;
+
+  /**
+   * The submission id
+   * @type {string}
+   */
+  public submissionId: string;
+
+  /**
+   * The list of all available metadata
+   */
+  formMetadata: string[] = [];
+
+  /**
+   * The form model
+   * @type {DynamicFormControlModel[]}
+   */
+  formModel: DynamicFormControlModel[];
+
+  /**
+   * When `true` form controls are deactivated
+   */
+  isSaving = false;
+
+  /**
+   * The [JsonPatchOperationPathCombiner] object
+   * @type {JsonPatchOperationPathCombiner}
+   */
+  protected pathCombiner: JsonPatchOperationPathCombiner;
+
+  protected subscriptions: Subscription[] = [];
+
+  /**
    * Initialize instance variables
    *
    * @param activeModal
@@ -83,94 +174,6 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
     private uploadService: SectionUploadService,
   ) {
   }
-
-  /**
-   * The list of available access condition
-   * @type {Array}
-   */
-  @Input() availableAccessConditionOptions: any[];
-
-  /**
-   * The submission id
-   * @type {string}
-   */
-  @Input() collectionId: string;
-
-  /**
-   * Define if collection access conditions policy type :
-   * POLICY_DEFAULT_NO_LIST : is not possible to define additional access group/s for the single file
-   * POLICY_DEFAULT_WITH_LIST : is possible to define additional access group/s for the single file
-   * @type {number}
-   */
-  @Input() collectionPolicyType: number;
-
-  /**
-   * The configuration for the bitstream's metadata form
-   * @type {SubmissionFormsModel}
-   */
-  @Input() configMetadataForm: SubmissionFormsModel;
-
-  /**
-   * The bitstream's metadata data
-   * @type {WorkspaceitemSectionUploadFileObject}
-   */
-  @Input() fileData: WorkspaceitemSectionUploadFileObject;
-
-  /**
-   * The bitstream id
-   * @type {string}
-   */
-  @Input() fileId: string;
-
-  /**
-   * The bitstream array key
-   * @type {string}
-   */
-  @Input() fileIndex: string;
-
-  /**
-   * The form id
-   * @type {string}
-   */
-  @Input() formId: string;
-
-  /**
-   * The section id
-   * @type {string}
-   */
-  @Input() sectionId: string;
-
-  /**
-   * The submission id
-   * @type {string}
-   */
-  @Input() submissionId: string;
-
-  /**
-   * The list of all available metadata
-   */
-  @Input() formMetadata: string[] = [];
-
-  /**
-   * The [JsonPatchOperationPathCombiner] object
-   * @type {JsonPatchOperationPathCombiner}
-   */
-  @Input() pathCombiner: JsonPatchOperationPathCombiner;
-
-  /**
-   * The FormComponent reference
-   */
-  @ViewChild('formRef') public formRef: FormComponent;
-
-  /**
-   * The form model
-   * @type {DynamicFormControlModel[]}
-   */
-  formModel: DynamicFormControlModel[];
-
-  isSaving = false;
-
-  protected subscriptions: Subscription[] = [];
 
   /**
    * Initialize form model values
@@ -379,7 +382,7 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
   /**
    * Save bitstream metadata
    */
-  protected saveBitstreamData() {
+  saveBitstreamData() {
     // validate form
     this.formService.validateAllFormFields(this.formRef.formGroup);
     const saveBitstreamDataSubscription = this.formService.isValid(this.formId).pipe(

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -243,12 +243,12 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
       const endDateControl: FormControl = control.parent.get('endDate') as FormControl;
 
       // Clear previous state
-      startDateControl.markAsUntouched();
-      endDateControl.markAsUntouched();
+      startDateControl?.markAsUntouched();
+      endDateControl?.markAsUntouched();
 
-      startDateControl.setValue(null);
+      startDateControl?.setValue(null);
       control.parent.markAsDirty();
-      endDateControl.setValue(null);
+      endDateControl?.setValue(null);
 
       if (showGroups) {
         if (accessCondition.hasStartDate) {

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -235,7 +235,7 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
   public setOptions(model: DynamicFormControlModel, control: FormControl) {
     let accessCondition: AccessConditionOption = null;
     this.availableAccessConditionOptions.filter((element) => element.name === control.value)
-      .forEach((element) => accessCondition = element);
+      .forEach((element) => accessCondition = element );
     if (isNotEmpty(accessCondition)) {
       const showGroups: boolean = accessCondition.hasStartDate === true || accessCondition.hasEndDate === true;
 
@@ -364,7 +364,9 @@ export class SubmissionSectionUploadFileEditComponent implements OnInit {
         const startDate = new DynamicDatePickerModel(startDateConfig, BITSTREAM_FORM_ACCESS_CONDITION_START_DATE_LAYOUT);
         const endDate = new DynamicDatePickerModel(endDateConfig, BITSTREAM_FORM_ACCESS_CONDITION_END_DATE_LAYOUT);
         const accessConditionGroupConfig = Object.assign({}, BITSTREAM_ACCESS_CONDITION_GROUP_CONFIG);
-        accessConditionGroupConfig.group = [type, startDate, endDate];
+        accessConditionGroupConfig.group = [type];
+        if (hasStart.length > 0) { accessConditionGroupConfig.group.push(startDate); }
+        if (hasEnd.length > 0) { accessConditionGroupConfig.group.push(endDate); }
         return [new DynamicFormGroupModel(accessConditionGroupConfig, BITSTREAM_ACCESS_CONDITION_GROUP_LAYOUT)];
       };
 

--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -9,14 +9,14 @@
         <h3>{{fileName}} <span class="text-muted">({{fileData?.sizeBytes | dsFileSize}})</span></h3>
       </div>
       <div class="float-right w-15" [class.sticky-buttons]="!readMode">
-        <ng-container *ngIf="readMode">
+        <ng-container>
           <ds-file-download-link [cssClasses]="'btn btn-link-focus'" [isBlank]="true" [bitstream]="getBitstream()" [enableRequestACopy]="false">
             <i class="fa fa-download fa-2x text-normal" aria-hidden="true"></i>
           </ds-file-download-link>
           <button class="btn btn-link-focus"
                   [attr.aria-label]="'submission.sections.upload.edit.title' | translate"
                   title="{{ 'submission.sections.upload.edit.title' | translate }}"
-                  (click)="$event.preventDefault();switchMode();">
+                  (click)="$event.preventDefault();editBitstreamData();">
             <i class="fa fa-edit fa-2x text-normal"></i>
           </button>
           <button class="btn btn-link-focus"
@@ -28,40 +28,9 @@
             <i *ngIf="!(processingDelete$ | async)" class="fa fa-trash fa-2x text-danger"></i>
           </button>
         </ng-container>
-        <ng-container *ngIf="!readMode">
-          <button class="btn btn-link-focus"
-                  [attr.aria-label]="'submission.sections.upload.save-metadata' | translate"
-                  title="{{ 'submission.sections.upload.save-metadata' | translate }}"
-                  (click)="saveBitstreamData($event);">
-            <i class="fa fa-save fa-2x text-success"></i>
-          </button>
-          <button class="btn btn-link-focus"
-                  [attr.aria-label]="'submission.sections.upload.undo' | translate"
-                  title="{{ 'submission.sections.upload.undo' | translate }}"
-                  (click)="$event.preventDefault();switchMode();"><i class="fa fa-ban fa-2x text-warning"></i></button>
-          <button class="btn btn-link-focus"
-                  [attr.aria-label]="'submission.sections.upload.delete.confirm.title' | translate"
-                  title="{{ 'submission.sections.upload.delete.confirm.title' | translate }}"
-                  [disabled]="(processingDelete$ | async)"
-                  (click)="$event.preventDefault();confirmDelete(content);">
-            <i *ngIf="(processingDelete$ | async)" class="fas fa-circle-notch fa-spin fa-2x text-danger"></i>
-            <i *ngIf="!(processingDelete$ | async)" class="fa fa-trash fa-2x text-danger"></i>
-          </button>
-        </ng-container>
       </div>
       <div class="clearfix"></div>
-      <ds-submission-section-upload-file-view *ngIf="readMode"
-                                              [fileData]="fileData"></ds-submission-section-upload-file-view>
-      <ds-submission-section-upload-file-edit *ngIf="!readMode"
-                                              [availableAccessConditionOptions]="availableAccessConditionOptions"
-                                              [collectionId]="collectionId"
-                                              [collectionPolicyType]="collectionPolicyType"
-                                              [configMetadataForm]="configMetadataForm"
-                                              [fileData]="fileData"
-                                              [fileId]="fileId"
-                                              [fileIndex]="fileIndex"
-                                              [formId]="formId"
-                                              [sectionId]="sectionId"></ds-submission-section-upload-file-edit>
+      <ds-submission-section-upload-file-view [fileData]="fileData"></ds-submission-section-upload-file-view>
     </div>
   </div>
 </ng-container>

--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -8,7 +8,7 @@
       <div class="float-left w-75">
         <h3>{{fileName}} <span class="text-muted">({{fileData?.sizeBytes | dsFileSize}})</span></h3>
       </div>
-      <div class="float-right w-15" [class.sticky-buttons]="!readMode">
+      <div class="float-right w-15">
         <ng-container>
           <ds-file-download-link [cssClasses]="'btn btn-link-focus'" [isBlank]="true" [bitstream]="getBitstream()" [enableRequestACopy]="false">
             <i class="fa fa-download fa-2x text-normal" aria-hidden="true"></i>

--- a/src/app/submission/sections/upload/file/section-upload-file.component.scss
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.scss
@@ -1,6 +1,0 @@
-.sticky-buttons {
-  position: sticky;
-  top: calc(var(--bs-dropdown-item-padding-x) * 3);
-  z-index: var(--ds-submission-footer-z-index);
-  background-color: rgba(255, 255, 255, .97);
-}

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -217,86 +217,20 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
         pathCombiner.subRootElement);
     });
 
-    /*it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
-      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
-      compAsAny.fileEditComp.formRef = {formGroup: null};
-      compAsAny.fileData = fileData;
-      compAsAny.pathCombiner = pathCombiner;
-      const event = new Event('click', null);
-      spyOn(comp, 'switchMode');
-      formService.validateAllFormFields.and.callFake(() => null);
-      formService.isValid.and.returnValue(observableOf(true));
-      formService.getFormData.and.returnValue(observableOf(mockFileFormData));
+    it('should open edit modal when edit button is clicked', () => {
+      spyOn(compAsAny, 'editBitstreamData').and.callThrough();
+      comp.fileData = fileData;
 
-      const response = [
-        Object.assign(mockSubmissionObject, {
-          sections: {
-            upload: {
-              files: mockUploadFiles
-            }
-          }
-        })
-      ];
-      operationsService.jsonPatchByResourceID.and.returnValue(observableOf(response));
+      fixture.detectChanges();
 
-      const accessConditionsToSave = [
-        { name: 'openaccess' },
-        { name: 'lease', endDate: dateToISOFormat('2019-01-16T00:00:00Z') },
-        { name: 'embargo', startDate: dateToISOFormat('2019-01-16T00:00:00Z') },
-      ];
-      comp.saveBitstreamData(event);
-      tick();
+      const modalBtn = fixture.debugElement.query(By.css('.fa-edit '));
 
-      let path = 'metadata/dc.title';
-      expect(operationsBuilder.add).toHaveBeenCalledWith(
-        pathCombiner.getPath(path),
-        mockFileFormData.metadata['dc.title'],
-        true
-      );
+      modalBtn.nativeElement.click();
+      fixture.detectChanges();
 
-      path = 'metadata/dc.description';
-      expect(operationsBuilder.add).toHaveBeenCalledWith(
-        pathCombiner.getPath(path),
-        mockFileFormData.metadata['dc.description'],
-        true
-      );
-
-      path = 'accessConditions';
-      expect(operationsBuilder.add).toHaveBeenCalledWith(
-        pathCombiner.getPath(path),
-        accessConditionsToSave,
-        true
-      );
-
-      expect(comp.switchMode).toHaveBeenCalled();
-      expect(uploadService.updateFileData).toHaveBeenCalledWith(submissionId, sectionId, mockUploadFiles[0].uuid, mockUploadFiles[0]);
-
-    }));*/
-
-    /*it('should not save Bitstream File data properly when form is not valid', fakeAsync(() => {
-      compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
-      compAsAny.fileEditComp.formRef = {formGroup: null};
-      compAsAny.pathCombiner = pathCombiner;
-      const event = new Event('click', null);
-      spyOn(comp, 'switchMode');
-      formService.validateAllFormFields.and.callFake(() => null);
-      formService.isValid.and.returnValue(observableOf(false));
-
-      expect(comp.switchMode).not.toHaveBeenCalled();
-      expect(uploadService.updateFileData).not.toHaveBeenCalled();
-
-    }));*/
-
-    it('should switch read mode', () => {
-      comp.readMode = false;
-
-      comp.switchMode();
-      expect(comp.readMode).toBeTruthy();
-
-      comp.switchMode();
-
-      expect(comp.readMode).toBeFalsy();
+      expect(compAsAny.editBitstreamData).toHaveBeenCalled();
     });
+
   });
 });
 

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -36,7 +36,6 @@ import { FormFieldMetadataValueObject } from '../../../../shared/form/builder/mo
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
 import { dateToISOFormat } from '../../../../shared/date.util';
-import { SubmissionFormModel } from '../../../../core/config/models/config-submission-form.model';
 
 const configMetadataFormMock = {
   rows: [{
@@ -49,7 +48,7 @@ const configMetadataFormMock = {
   }]
 };
 
-fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
+describe('SubmissionSectionUploadFileComponent test suite', () => {
 
   let comp: SubmissionSectionUploadFileComponent;
   let compAsAny: any;
@@ -130,8 +129,6 @@ fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
       testFixture = createTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
       testComp = testFixture.componentInstance;
 
-      // testComp.configMetadataForm = configMetadataFormMock;
-      // testFixture.detectChanges();
     });
 
     afterEach(() => {
@@ -139,7 +136,6 @@ fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
     });
 
     it('should create SubmissionSectionUploadFileComponent', inject([SubmissionSectionUploadFileComponent], (app: SubmissionSectionUploadFileComponent) => {
-      app.configMetadataForm = Object.assign(new SubmissionFormModel(), configMetadataFormMock);
       expect(app).toBeDefined();
     }));
   });
@@ -228,6 +224,7 @@ fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
     it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
       compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
       compAsAny.fileEditComp.formRef = {formGroup: null};
+      compAsAny.fileData = fileData;
       compAsAny.pathCombiner = pathCombiner;
       const event = new Event('click', null);
       spyOn(comp, 'switchMode');

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync } from
 import { BrowserModule, By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 
-import { of as observableOf } from 'rxjs';
+import { of, of as observableOf } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { FormService } from '../../../../shared/form/form.service';
@@ -36,8 +36,20 @@ import { FormFieldMetadataValueObject } from '../../../../shared/form/builder/mo
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
 import { dateToISOFormat } from '../../../../shared/date.util';
+import { SubmissionFormModel } from '../../../../core/config/models/config-submission-form.model';
 
-describe('SubmissionSectionUploadFileComponent test suite', () => {
+const configMetadataFormMock = {
+  rows: [{
+    fields: [{
+      selectableMetadata: [
+        {metadata: 'dc.title', label: null, closed: false},
+        {metadata: 'dc.description', label: null, closed: false}
+      ]
+    }]
+  }]
+};
+
+fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
 
   let comp: SubmissionSectionUploadFileComponent;
   let compAsAny: any;
@@ -117,6 +129,9 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
 
       testFixture = createTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
       testComp = testFixture.componentInstance;
+
+      // testComp.configMetadataForm = configMetadataFormMock;
+      // testFixture.detectChanges();
     });
 
     afterEach(() => {
@@ -124,9 +139,8 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
     });
 
     it('should create SubmissionSectionUploadFileComponent', inject([SubmissionSectionUploadFileComponent], (app: SubmissionSectionUploadFileComponent) => {
-
+      app.configMetadataForm = Object.assign(new SubmissionFormModel(), configMetadataFormMock);
       expect(app).toBeDefined();
-
     }));
   });
 
@@ -135,6 +149,7 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       fixture = TestBed.createComponent(SubmissionSectionUploadFileComponent);
       comp = fixture.componentInstance;
       compAsAny = comp;
+      compAsAny.configMetadataForm = configMetadataFormMock;
       submissionServiceStub = TestBed.inject(SubmissionService as any);
       uploadService = TestBed.inject(SectionUploadService);
       formService = TestBed.inject(FormService);
@@ -314,7 +329,7 @@ class TestComponent {
   availableAccessConditionOptions;
   collectionId = mockSubmissionCollectionId;
   collectionPolicyType;
-  configMetadataForm$;
+  configMetadataForm$ = of(configMetadataFormMock);
   fileIndexes = [];
   fileList = [];
   fileNames = [];

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -48,7 +48,7 @@ const configMetadataFormMock = {
   }]
 };
 
-describe('SubmissionSectionUploadFileComponent test suite', () => {
+fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
 
   let comp: SubmissionSectionUploadFileComponent;
   let compAsAny: any;
@@ -221,7 +221,7 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
         pathCombiner.subRootElement);
     });
 
-    it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
+    /*it('should save Bitstream File data properly when form is valid', fakeAsync(() => {
       compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
       compAsAny.fileEditComp.formRef = {formGroup: null};
       compAsAny.fileData = fileData;
@@ -275,9 +275,9 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       expect(comp.switchMode).toHaveBeenCalled();
       expect(uploadService.updateFileData).toHaveBeenCalledWith(submissionId, sectionId, mockUploadFiles[0].uuid, mockUploadFiles[0]);
 
-    }));
+    }));*/
 
-    it('should not save Bitstream File data properly when form is not valid', fakeAsync(() => {
+    /*it('should not save Bitstream File data properly when form is not valid', fakeAsync(() => {
       compAsAny.fileEditComp = TestBed.inject(SubmissionSectionUploadFileEditComponent);
       compAsAny.fileEditComp.formRef = {formGroup: null};
       compAsAny.pathCombiner = pathCombiner;
@@ -289,18 +289,7 @@ describe('SubmissionSectionUploadFileComponent test suite', () => {
       expect(comp.switchMode).not.toHaveBeenCalled();
       expect(uploadService.updateFileData).not.toHaveBeenCalled();
 
-    }));
-
-    it('should retrieve Value From Field properly', () => {
-      let field;
-      expect(compAsAny.retrieveValueFromField(field)).toBeUndefined();
-
-      field = new FormFieldMetadataValueObject('test');
-      expect(compAsAny.retrieveValueFromField(field)).toBe('test');
-
-      field = [new FormFieldMetadataValueObject('test')];
-      expect(compAsAny.retrieveValueFromField(field)).toBe('test');
-    });
+    }));*/
 
     it('should switch read mode', () => {
       comp.readMode = false;

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 
@@ -17,10 +17,8 @@ import { SubmissionJsonPatchOperationsService } from '../../../../core/submissio
 import { SubmissionSectionUploadFileComponent } from './section-upload-file.component';
 import { SubmissionServiceStub } from '../../../../shared/testing/submission-service.stub';
 import {
-  mockFileFormData,
   mockSubmissionCollectionId,
   mockSubmissionId,
-  mockSubmissionObject,
   mockUploadConfigResponse,
   mockUploadFiles
 } from '../../../../shared/mocks/submission.mock';
@@ -32,10 +30,8 @@ import { FileSizePipe } from '../../../../shared/utils/file-size-pipe';
 import { POLICY_DEFAULT_WITH_LIST } from '../section-upload.component';
 import { JsonPatchOperationPathCombiner } from '../../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { getMockSectionUploadService } from '../../../../shared/mocks/section-upload.service.mock';
-import { FormFieldMetadataValueObject } from '../../../../shared/form/builder/models/form-field-metadata-value.model';
 import { SubmissionSectionUploadFileEditComponent } from './edit/section-upload-file-edit.component';
 import { FormBuilderService } from '../../../../shared/form/builder/form-builder.service';
-import { dateToISOFormat } from '../../../../shared/date.util';
 
 const configMetadataFormMock = {
   rows: [{

--- a/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.spec.ts
@@ -44,7 +44,7 @@ const configMetadataFormMock = {
   }]
 };
 
-fdescribe('SubmissionSectionUploadFileComponent test suite', () => {
+describe('SubmissionSectionUploadFileComponent test suite', () => {
 
   let comp: SubmissionSectionUploadFileComponent;
   let compAsAny: any;

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -247,10 +247,6 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
     activeModal.componentInstance.pathCombiner = this.pathCombiner;
     activeModal.componentInstance.submissionId = this.submissionId;
 
-    /*activeModal.componentInstance.saveBitstreamDataEvent.subscribe((res) => {
-      console.log(JSON.stringify(res));
-    });*/
-
   }
 
   ngOnDestroy(): void {

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -217,14 +217,6 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
     });
   }
 
-  /**
-   * Switch from edit form to metadata view
-   */
-  public switchMode() {
-    this.readMode = !this.readMode;
-    this.cdr.detectChanges();
-  }
-
   editBitstreamData() {
 
     const options: NgbModalOptions = {

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -262,17 +262,24 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit {
               .forEach((element) => accessConditionOpt = element);
 
             if (accessConditionOpt) {
-                accessConditionOpt = Object.assign({}, accessCondition);
-                accessConditionOpt.name = this.retrieveValueFromField(accessCondition.name);
-                if (accessCondition.startDate) {
-                  const startDate = this.retrieveValueFromField(accessCondition.startDate);
-                  accessConditionOpt.startDate = dateToISOFormat(startDate);
-                }
-                if (accessCondition.endDate) {
-                  const endDate = this.retrieveValueFromField(accessCondition.endDate);
-                  accessConditionOpt.endDate = dateToISOFormat(endDate);
-                }
-                accessConditionsToSave.push(accessConditionOpt);
+              const currentAccessCondition = Object.assign({}, accessCondition);
+              currentAccessCondition.name = this.retrieveValueFromField(accessCondition.name);
+
+              /* When start and end date fields are deactivated, their values may be still present in formData,
+              therefore it is necessary to delete them if they're not allowed by the current access condition option. */
+              if (!accessConditionOpt.hasStartDate) {
+                delete currentAccessCondition.startDate;
+              } else if (accessCondition.startDate) {
+                const startDate = this.retrieveValueFromField(accessCondition.startDate);
+                currentAccessCondition.startDate = dateToISOFormat(startDate);
+              }
+              if (!accessConditionOpt.hasEndDate) {
+                delete currentAccessCondition.endDate;
+              } else if (accessCondition.endDate) {
+                const endDate = this.retrieveValueFromField(accessCondition.endDate);
+                currentAccessCondition.endDate = dateToISOFormat(endDate);
+              }
+              accessConditionsToSave.push(currentAccessCondition);
             }
           });
 


### PR DESCRIPTION
## References
* Fixes #1337 
* Fixes #1359 
* Fixes #1399 
* Fixes #1415 
* Fixes DSpace/DSpace#7977 (this was actually a **dspace-angular** issue)

## Description
The **Edit bitstream** form has been moved in a modal. Several bugs in the form, mostly related to the **Access condition type**, have been fixed.


## Instructions for Reviewers

List of changes in this PR:

1. The **Edit bitstream** form (`section-upload-file-edit.component`) is now displayed inside a modal. Saving process is managed within the modal component.
2. When  **Access condition type** is changed the PATCH does not fail anymore.
  * Bug reason: when the previous access condition type had a start date or an end date and the new condition type did not have it the previously saved date was still included in the patch, although the corresponding form field was deactivated
3. **Grant access from/until** fields are now correctly deactivated
  * Bug reason: if no access condition type had a start date or an end date the corresponding field was not deactivated for all the access condition types
  * With this fix, when no access condition requires start date or end date the corresponding field is not present at all
4. The description can now be deleted 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
