### PR TITLE
Fix minor modal UX issues

### DIFF
--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -3,7 +3,7 @@
            class="form-control"
            (click)="$event.stopPropagation();"
            placeholder="{{'dso-selector.placeholder' | translate: { type: typesString } }}"
-           [formControl]="input" dsAutoFocus (keyup.enter)="selectSingleResult()">
+           [formControl]="input" ngbAutofocus (keyup.enter)="selectSingleResult()">
 </div>
 <div class="dropdown-divider"></div>
 <div class="scrollable-menu list-group">

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -59,3 +59,18 @@ ds-admin-sidebar {
     display: none;
   }
 }
+
+ngb-modal-backdrop {
+  // ng-bootsrap animates opacity, causing the fully opaque background to flash briefly before the transition starts
+  // animating background-color between transparent & a RGBA color instead looks smoother
+  &.fade {
+    opacity: 1 !important;
+    background-color: transparent;
+    transition: background-color 0.15s linear;
+
+    &.show {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+  }
+}
+


### PR DESCRIPTION
## Description

Fixed two minor annoyances with Bootstrap modals

## Instructions for Reviewers

List of changes in this PR:

1. Made the modal backdrop color transition smoother
   * Replicating: open a "new/edit DSO" modal on https://demo7.dspace.org/home
     the animation starts out with a fully dark background instead of transparent
   * Seems like this is an issue with `opacity` transitions; animating the background between fully transparent and an equivalent RGBA color solves it
2. Fixed scrolling background when opening a modal
   * Replicating: open a modal on https://demo7.dspace.org/search?spc.page=1&query=&spc.sf=score&spc.sd=DESC&spc.rpp=40
   * This is a side effect of the `focus` method ~ `dsAutoFocus` in `ds-dso-selector`, solved by using  `ngbAutofocus` instead
   * An alternative solution could be to [call focus with `{ preventScroll: true }`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters)

### Testing

Confirm that the issues listed above can't be replicated anymore

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.