### PR TITLE
Always enable deposit button

### DIFF
--- a/src/app/core/json-patch/json-patch-operations.service.ts
+++ b/src/app/core/json-patch/json-patch-operations.service.ts
@@ -40,15 +40,13 @@ export abstract class JsonPatchOperationsService<ResponseDefinitionDomain, Patch
    *    The resource type value
    * @param resourceId
    *    The resource id value
-   * @param allowEmptyRequest
-   *    Allow an empty list of operations in the request's body
    * @return Observable<ResponseDefinitionDomain>
    *    observable of response
    */
-  protected submitJsonPatchOperations(hrefObs: Observable<string>, resourceType: string, resourceId?: string, allowEmptyRequest = false): Observable<ResponseDefinitionDomain> {
+  protected submitJsonPatchOperations(hrefObs: Observable<string>, resourceType: string, resourceId?: string): Observable<ResponseDefinitionDomain> {
     const requestId = this.requestService.generateRequestId();
     let startTransactionTime = null;
-    const [patchRequest$, emptyRequest$] = partition((request: PatchRequestDefinition) => allowEmptyRequest || isNotEmpty(request.body))(hrefObs.pipe(
+    const [patchRequest$, emptyRequest$] = partition((request: PatchRequestDefinition) => isNotEmpty(request.body))(hrefObs.pipe(
       mergeMap((endpointURL: string) => {
         return this.store.select(jsonPatchOperationsByResourceType(resourceType)).pipe(
           take(1),
@@ -81,11 +79,11 @@ export abstract class JsonPatchOperationsService<ResponseDefinitionDomain, Patch
 
     return observableMerge(
       emptyRequest$.pipe(
-        filter((request: PatchRequestDefinition) => !allowEmptyRequest && isEmpty(request.body)),
+        filter((request: PatchRequestDefinition) => isEmpty(request.body)),
         tap(() => startTransactionTime = null),
         map(() => null)),
       patchRequest$.pipe(
-        filter((request: PatchRequestDefinition) => allowEmptyRequest || isNotEmpty(request.body)),
+        filter((request: PatchRequestDefinition) => isNotEmpty(request.body)),
         tap(() => this.store.dispatch(new StartTransactionPatchOperationsAction(resourceType, resourceId, startTransactionTime))),
         tap((request: PatchRequestDefinition) => this.requestService.send(request)),
         mergeMap(() => {
@@ -143,18 +141,16 @@ export abstract class JsonPatchOperationsService<ResponseDefinitionDomain, Patch
    *    The scope id
    * @param resourceType
    *    The resource type value
-   * @param allowEmptyRequest
-   *    Allow an empty list of operations in the request's body
    * @return Observable<ResponseDefinitionDomain>
    *    observable of response
    */
-  public jsonPatchByResourceType(linkPath: string, scopeId: string, resourceType: string, allowEmptyRequest = false): Observable<ResponseDefinitionDomain> {
+  public jsonPatchByResourceType(linkPath: string, scopeId: string, resourceType: string): Observable<ResponseDefinitionDomain> {
     const href$ = this.halService.getEndpoint(linkPath).pipe(
       filter((href: string) => isNotEmpty(href)),
       distinctUntilChanged(),
       map((endpointURL: string) => this.getEndpointByIDHref(endpointURL, scopeId)));
 
-    return this.submitJsonPatchOperations(href$, resourceType, undefined, allowEmptyRequest);
+    return this.submitJsonPatchOperations(href$, resourceType);
   }
 
   /**

--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -41,7 +41,6 @@
       <button *ngIf="(showDepositAndDiscard | async)"
               type="button"
               class="btn btn-success"
-              [disabled]="(submissionIsInvalid | async) || (processingSaveStatus | async) || (processingDepositStatus | async)"
               (click)="deposit($event)">
         <span><i class="fas fa-plus"></i> {{'submission.general.deposit' | translate}}</span>
       </button>

--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -41,6 +41,7 @@
       <button *ngIf="(showDepositAndDiscard | async)"
               type="button"
               class="btn btn-success"
+              [disabled]="(processingSaveStatus | async) || (processingDepositStatus | async)"
               (click)="deposit($event)">
         <span><i class="fas fa-plus"></i> {{'submission.general.deposit' | translate}}</span>
       </button>

--- a/src/app/submission/form/footer/submission-form-footer.component.spec.ts
+++ b/src/app/submission/form/footer/submission-form-footer.component.spec.ts
@@ -201,6 +201,15 @@ describe('SubmissionFormFooterComponent Component', () => {
       });
     });
 
+    it('should not have deposit button disabled when submission is not valid', () => {
+      comp.showDepositAndDiscard = observableOf(true);
+      compAsAny.submissionIsInvalid = observableOf(true);
+      fixture.detectChanges();
+      const depositBtn: any = fixture.debugElement.query(By.css('.btn-success'));
+
+      expect(depositBtn.nativeElement.disabled).toBeFalsy();
+    });
+
     it('should not have deposit button disabled when submission is valid', () => {
       comp.showDepositAndDiscard = observableOf(true);
       compAsAny.submissionIsInvalid = observableOf(false);

--- a/src/app/submission/form/footer/submission-form-footer.component.spec.ts
+++ b/src/app/submission/form/footer/submission-form-footer.component.spec.ts
@@ -201,15 +201,6 @@ describe('SubmissionFormFooterComponent Component', () => {
       });
     });
 
-    it('should have deposit button disabled when submission is not valid', () => {
-      comp.showDepositAndDiscard = observableOf(true);
-      compAsAny.submissionIsInvalid = observableOf(true);
-      fixture.detectChanges();
-      const depositBtn: any = fixture.debugElement.query(By.css('.btn-success'));
-
-      expect(depositBtn.nativeElement.disabled).toBeTruthy();
-    });
-
     it('should not have deposit button disabled when submission is valid', () => {
       comp.showDepositAndDiscard = observableOf(true);
       compAsAny.submissionIsInvalid = observableOf(false);

--- a/src/app/submission/objects/submission-objects.effects.spec.ts
+++ b/src/app/submission/objects/submission-objects.effects.spec.ts
@@ -879,59 +879,6 @@ describe('SubmissionObjectEffects test suite', () => {
       expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
     });
 
-    it('should not allow to deposit when there are errors', () => {
-      store.nextState({
-        submission: {
-          objects: submissionState
-        }
-      } as any);
-
-      actions = hot('--a-', {
-        a: {
-          type: SubmissionObjectActionTypes.SAVE_AND_DEPOSIT_SUBMISSION,
-          payload: {
-            submissionId: submissionId
-          }
-        }
-      });
-
-      const response = [Object.assign({}, mockSubmissionRestResponse[0], {
-        sections: mockSectionsData,
-        errors: mockSectionsErrors
-      })];
-
-      submissionJsonPatchOperationsServiceStub.jsonPatchByResourceType.and.returnValue(observableOf(response));
-
-      const errorsList = parseSectionErrors(mockSectionsErrors);
-      const expected = cold('--b-', {
-        b: [
-          new UpdateSectionDataAction(
-            submissionId,
-            'traditionalpageone',
-            mockSectionsData.traditionalpageone as any,
-            errorsList.traditionalpageone || [],
-            errorsList.traditionalpageone || []
-          ),
-          new UpdateSectionDataAction(
-            submissionId,
-            'license',
-            mockSectionsData.license as any,
-            errorsList.license || [],
-            errorsList.license || []
-          ),
-          new UpdateSectionDataAction(
-            submissionId,
-            'upload',
-            mockSectionsData.upload as any,
-            errorsList.upload || [],
-            errorsList.upload || []
-          )
-        ]
-      });
-
-      expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
-    });
-
     it('should catch errors and return a SAVE_SUBMISSION_FORM_ERROR', () => {
       actions = hot('--a-', {
         a: {

--- a/src/app/submission/objects/submission-objects.effects.spec.ts
+++ b/src/app/submission/objects/submission-objects.effects.spec.ts
@@ -54,6 +54,8 @@ import { Item } from '../../core/shared/item.model';
 import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
 import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
+import { SubmissionObjectDataService } from '../../core/submission/submission-object-data.service';
+import { mockSubmissionObjectDataService } from '../../shared/testing/submission-oject-data-service.mock';
 
 describe('SubmissionObjectEffects test suite', () => {
   let submissionObjectEffects: SubmissionObjectEffects;
@@ -63,6 +65,7 @@ describe('SubmissionObjectEffects test suite', () => {
   let notificationsServiceStub;
   let submissionServiceStub;
   let submissionJsonPatchOperationsServiceStub;
+  let submissionObjectDataServiceStub;
   const collectionId: string = mockSubmissionCollectionId;
   const submissionId: string = mockSubmissionId;
   const submissionDefinitionResponse: any = mockSubmissionDefinitionResponse;
@@ -75,6 +78,9 @@ describe('SubmissionObjectEffects test suite', () => {
     notificationsServiceStub = new NotificationsServiceStub();
     submissionServiceStub =  new SubmissionServiceStub();
     submissionJsonPatchOperationsServiceStub = new SubmissionJsonPatchOperationsServiceStub();
+    submissionObjectDataServiceStub = mockSubmissionObjectDataService;
+
+    submissionServiceStub.hasUnsavedModification.and.returnValue(observableOf(true));
 
     TestBed.configureTestingModule({
       imports: [
@@ -99,6 +105,7 @@ describe('SubmissionObjectEffects test suite', () => {
         { provide: WorkflowItemDataService, useValue: {} },
         { provide: WorkflowItemDataService, useValue: {} },
         { provide: HALEndpointService, useValue: {} },
+        { provide: SubmissionObjectDataService, useValue: submissionObjectDataServiceStub },
       ],
     });
 

--- a/src/app/submission/objects/submission-objects.effects.spec.ts
+++ b/src/app/submission/objects/submission-objects.effects.spec.ts
@@ -879,6 +879,36 @@ describe('SubmissionObjectEffects test suite', () => {
       expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
     });
 
+    it('should return a SAVE_SUBMISSION_FORM_SUCCESS action when there are errors', () => {
+      store.nextState({
+        submission: {
+          objects: submissionState
+        }
+      } as any);
+
+      actions = hot('--a-', {
+        a: {
+          type: SubmissionObjectActionTypes.SAVE_AND_DEPOSIT_SUBMISSION,
+          payload: {
+            submissionId: submissionId
+          }
+        }
+      });
+
+      const response = [Object.assign({}, mockSubmissionRestResponse[0], {
+        sections: mockSectionsData,
+        errors: mockSectionsErrors
+      })];
+
+      submissionJsonPatchOperationsServiceStub.jsonPatchByResourceType.and.returnValue(observableOf(response));
+
+      const expected = cold('--b-', {
+        b: new SaveSubmissionFormSuccessAction(submissionId, response as any[])
+      });
+
+      expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
+    });
+
     it('should catch errors and return a SAVE_SUBMISSION_FORM_ERROR', () => {
       actions = hot('--a-', {
         a: {

--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -196,13 +196,21 @@ export class SubmissionObjectEffects {
    */
   @Effect() saveAndDeposit$ = this.actions$.pipe(
     ofType(SubmissionObjectActionTypes.SAVE_AND_DEPOSIT_SUBMISSION),
-    withLatestFrom(this.store$),
-    switchMap(([action, currentState]: [SaveAndDepositSubmissionAction, any]) => {
-      return this.operationsService.jsonPatchByResourceType(
-        this.submissionService.getSubmissionObjectLinkName(),
-        action.payload.submissionId,
-        'sections',
-        true).pipe(
+    withLatestFrom(this.submissionService.hasUnsavedModification()),
+    switchMap(([action, hasUnsavedModification]: [SaveAndDepositSubmissionAction, boolean]) => {
+      let response$: Observable<SubmissionObject[]>;
+      if (hasUnsavedModification) {
+        response$ = this.operationsService.jsonPatchByResourceType(
+          this.submissionService.getSubmissionObjectLinkName(),
+          action.payload.submissionId,
+          'sections') as Observable<SubmissionObject[]>;
+      } else {
+        response$ = this.submissionObjectService.findById(action.payload.submissionId).pipe(
+          getFirstSucceededRemoteDataPayload(),
+          map((submissionObject: SubmissionObject) => [submissionObject])
+        );
+      }
+      return response$.pipe(
         map((response: SubmissionObject[]) => {
           if (this.canDeposit(response)) {
             return new DepositSubmissionAction(action.payload.submissionId);

--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -201,7 +201,8 @@ export class SubmissionObjectEffects {
       return this.operationsService.jsonPatchByResourceType(
         this.submissionService.getSubmissionObjectLinkName(),
         action.payload.submissionId,
-        'sections').pipe(
+        'sections',
+        true).pipe(
         map((response: SubmissionObject[]) => {
           if (this.canDeposit(response)) {
             return new DepositSubmissionAction(action.payload.submissionId);

--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -206,9 +206,7 @@ export class SubmissionObjectEffects {
           if (this.canDeposit(response)) {
             return new DepositSubmissionAction(action.payload.submissionId);
           } else {
-            this.notificationsService.warning(null, this.translate.get('submission.sections.general.sections_not_valid'));
-            return this.parseSaveResponse((currentState.submission as SubmissionState).objects[action.payload.submissionId],
-              response, action.payload.submissionId, currentState.forms);
+            return new SaveSubmissionFormSuccessAction(action.payload.submissionId, response);
           }
         }),
         catchError(() => observableOf(new SaveSubmissionFormErrorAction(action.payload.submissionId))));


### PR DESCRIPTION
## References
This PR fixes #1358

## Description
Currently, during submission, the "Deposit" button is disabled until all requirements for the deposit has been fulfilled.
As a fix for #1358, this PR would change it so the "Deposit" button is always enabled, but fix it to where it gives the same input as a save would, if it doesn't meet the requirements.

## Instructions for Reviewers
Changes made:
- Removed "disabled" input for the deposit button when requirements aren't met (but keep it disabled when a save/deposit is being processed)
- Modified the saved-and-deposit effect to fire a `SaveSubmissionFormSuccessAction` when the requirements aren't met. This will trigger the processing of the json patch response into error fields being displayed and the progress bar finishing.
- The deposit didn't allow for an empty json patch to be sent, which caused the deposit button to produce an error when pressed without making any changes to the submission. This issue originates from the json-patch service, so I added an optional parameter called "allowEmptyRequest" (defaults to false), which, when true, allows for an empty array of operations to be sent with the patch request. Providing true for this parameter in the save-and-deposit effect fixes being able to deposit without any changes and result in the normal error fields and notifications (similar to a save).

How to test:
- Start a new submission
- The deposit button should be enabled from the start
- Pressing it should highlight the required fields that haven't been filled in and display two notifications: a warning that there's missing fields and a success for saving. Note that the button should be disabled while the save is being processed.
- Make any change and press deposit again
- It should have the same effect as before
- Pressing save should have the same effect
- Fill in all the required fields and press deposit again
- It should save and successfully deposit the submission

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs for any bug fixes, improvements or new features. A few reminders about what constitutes good tests:
    * Include tests for different user types (if behavior differs), including: (1) Anonymous user, (2) Logged in user (non-admin), and (3) Administrator.
    * Include tests for error scenarios, e.g. when errors/warnings should appear (or buttons should be disabled).
    * For bug fixes, include a test that reproduces the bug and proves it is fixed. For clarity, it may be useful to provide the test in a separate commit from the bug fix.
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/master/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.