### PR TITLE
Add GitHub action to build Docker images and push to DockerHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       # https://github.com/actions/setup-node
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -82,7 +82,7 @@ jobs:
       # Upload coverage reports to Codecov (for Node v12 only)
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         if: matrix.node-version == '12.x'
 
       # Using docker-compose start backend using CI configuration

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,14 +8,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
-      # Define tags to use for Docker images based on Git tags/branches
-      # For a new branch commit, tag Docker image with that branch name
-      # Except for 'main' branch, where we use the literal 'dspace-7_x' tag (see below).
-      # For a new tag, tag Docker image with that same tag
+      # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+      # For a new commit on default branch (main), use the literal tag 'dspace-7_x' on Docker image.
+      # For a new commit on other branches, use the branch name as the tag for Docker image.
+      # For a new tag, copy that tag name as the tag for Docker image.
       IMAGE_TAGS: |
-        type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
-        type=raw,value=dspace-7_x,enable=${{ github.ref == 'refs/heads/main' }}
+        type=raw,value=dspace-7_x,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
         type=ref,event=tag
+      # Define default tag "flavor" for docker/metadata-action per
+      # https://github.com/docker/metadata-action#flavor-input
+      # We turn off 'latest' tag by default.
+      TAGS_FLAVOR: |
+        latest=false
 
     steps:
       # https://github.com/actions/checkout
@@ -45,6 +50,7 @@ jobs:
         with:
           images: dspace/dspace-angular
           tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
 
       # https://github.com/docker/build-push-action
       - name: Build and push 'dspace-angular' image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+# DSpace Docker image build for hub.docker.com
+name: Docker images
+
+# Run this Build for all pushes / PRs to current branch
+on: [push, pull_request]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      # Define tags to use for Docker images based on Git tags/branches
+      # For a new branch commit, tag Docker image with that branch name
+      # Except for 'main' branch, where we use the literal 'dspace-7_x' tag (see below).
+      # For a new tag, tag Docker image with that same tag
+      IMAGE_TAGS: |
+        type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
+        type=raw,value=dspace-7_x,enable=${{ github.ref == 'refs/heads/main' }}
+        type=ref,event=tag
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      ###############################################
+      # Build/Push the 'dspace/dspace-angular' image
+      ###############################################
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-angular' image
+        id: meta_build
+        uses: docker/metadata-action@v3
+        with:
+          images: dspace/dspace-angular
+          tags: ${{ env.IMAGE_TAGS }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push 'dspace-angular' image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace-angular
-# See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
+# See https://github.com/DSpace/dspace-angular/tree/main/docker for usage details
 
-FROM node:12-alpine
+FROM node:14-alpine
 WORKDIR /app
 ADD . /app/
 EXPOSE 4000

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,20 @@
 :warning: **NOT PRODUCTION READY**  The below Docker Compose resources are not guaranteed "production ready" at this time. They have been built for development/testing only. Therefore, DSpace Docker images may not be fully secured or up-to-date. While you are welcome to base your own images on these DSpace images/resources, these should not be used "as is" in any production scenario.
 ***
 
+## 'Dockerfile' in root directory 
+This Dockerfile is used to build a *development* DSpace 7 Angular UI image, published as 'dspace/dspace-angular'
+
+```
+docker build -t dspace/dspace-angular:dspace-7_x .
+```
+
+This image is built *automatically* after each commit is made to the `main` branch.
+
+Admins to our DockerHub repo can manually publish with the following command.
+```
+docker push dspace/dspace-angular:dspace-7_x
+```
+
 ## docker directory
 - docker-compose.yml
   - Starts DSpace Angular with Docker Compose from the current branch.  This file assumes that a DSpace 7 REST instance will also be started in Docker.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       DSPACE_NAMESPACE: /
       DSPACE_PORT: '4000'
       DSPACE_SSL: "false"
-    image: dspace/dspace-angular:latest
+    image: dspace/dspace-angular:dspace-7_x
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## Related work
Corresponding Docker Action for DSpace/DSpace in https://github.com/DSpace/DSpace/pull/8058

## Description
This PR adds a new `docker.yml` GitHub action, which is configured to automatically build DSpace Docker images and push to DockerHub.

This includes the following setup:
* New `docker.yml` action runs for all pushes, releases and PRs.  However, PRs _only_ build the Docker images (to verify no new build errors occur). PRs do NOT push updated Docker images to DockerHub
* When a new commit occurs on `main`, images will all be built and tagged in DockerHub with `dspace-7_x`
    * When a new commit occurs on a different branch, images will be built and tagged with that branch name.
* When a new tag is created in GitHub, images will all be built and tagged in DockerHub with same tag as the DSpace release.
