### PR TITLE
Cleanup our LICENSE file so GitHub can detect our BSD license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-DSpace source code BSD License:
+BSD 3-Clause License
 
 Copyright (c) 2002-2021, LYRASIS.  All rights reserved.
 
@@ -13,13 +13,12 @@ notice, this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-- Neither the name DuraSpace nor the name of the DSpace Foundation
-nor the names of its contributors may be used to endorse or promote
-products derived from this software without specific prior written
-permission.
+- Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -30,10 +29,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-
-DSpace uses third-party libraries which may be distributed under
-different licenses to the above. Information about these licenses
-is detailed in the LICENSES_THIRD_PARTY file at the root of the source
-tree.  You must agree to the terms of these licenses, in addition to
-the above DSpace source code license, in order to use this software.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,28 @@
+Licenses of Third-Party Libraries
+=================================
+
+DSpace uses third-party libraries which may be distributed under
+different licenses than specified in our LICENSE file. Information
+about these licenses is detailed in the LICENSES_THIRD_PARTY file at
+the root of the source tree. You must agree to the terms of these
+licenses, in addition to the DSpace source code license, in order to
+use this software.
+
+Licensing Notices
+=================
+
+[July 2019] DuraSpace joined with LYRASIS (another 501(c)3 organization) in July 2019.
+LYRASIS holds the copyrights of DuraSpace.
+
+[July 2009] Fedora Commons joined with the DSpace Foundation and began operating under
+the new name DuraSpace in July 2009.  DuraSpace holds the copyrights of
+the DSpace Foundation, Inc.
+
+[July 2007] The DSpace Foundation, Inc. is a 501(c)3 corporation established in July 2007
+with a mission to promote and advance the dspace platform enabling management,
+access and preservation of digital works. The Foundation was able to transfer
+the legal copyright from Hewlett-Packard Company (HP) and Massachusetts
+Institute of Technology (MIT) to the  DSpace Foundation in October 2007. Many
+of the files in the source code may contain a copyright statement stating HP
+and MIT possess the copyright, in these instances please note that the copy
+right has transferred to the DSpace foundation, and subsequently to DuraSpace.

--- a/README.md
+++ b/README.md
@@ -449,4 +449,8 @@ DSpace uses GitHub to track issues:
 
 License
 -------
-This project's source code is made available under the DSpace BSD License: http://www.dspace.org/license
+DSpace source code is freely available under a standard [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause).
+The full license is available in the [LICENSE](LICENSE) file or online at http://www.dspace.org/license/
+
+DSpace uses third-party libraries which may be distributed under different licenses. Those licenses are listed
+in the [LICENSES_THIRD_PARTY](LICENSES_THIRD_PARTY) file.


### PR DESCRIPTION
Related to PR https://github.com/DSpace/DSpace/pull/8061

## Description
GitHub is able to detect the type of OSS license, provided that your `LICENSE` file doesn't contain a bunch of custom text.  See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license

This PR simply cleans up the formatting of our `LICENSE` file so that it matches a standard BSD 3-Clause License.  This includes:
* Minor formatting changes
* Replacing outdated text "Neither the name DuraSpace nor the name of the DSpace Foundation" with "Neither the name of the copyright holder" (which is the standard BSD language).
* Copy over `NOTICE` file from main "DSpace/DSpace" repository (this was accidentally missing)
* Moving our note about "third party licenses" to our `NOTICE` and `README` files.

This PR changes no code. Instead, I'm simply creating a PR to **document** the reason for this change. Therefore, I'll merge it immediately.