### PR TITLE
Update Docker to use latest Solr 8

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -64,7 +64,7 @@ services:
   dspacesolr:
     container_name: dspacesolr
     # Uses official Solr image at https://hub.docker.com/_/solr/
-    image: solr:8.8
+    image: solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
     - dspace

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -62,7 +62,7 @@ services:
   dspacesolr:
     container_name: dspacesolr
     # Uses official Solr image at https://hub.docker.com/_/solr/
-    image: solr:8.8
+    image: solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
     - dspace


### PR DESCRIPTION
## Description
Update our docker-compose configs for 'rest' and 'ci' to use Solr 8.11.  Porting of Solr changes applied to backend in https://github.com/DSpace/DSpace/pull/8069

## Instructions for Reviewers
I've tested this locally and found now issues. These are all relatively minor updates...so assuming CI passes, I'll move forward with merging.
