### PR TITLE
Remove second unnecessary "relativeLinkResolution: 'legacy'" setting after Angular 11 upgrade

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -203,7 +203,6 @@ import { GroupAdministratorGuard } from './core/data/feature-authorization/featu
       ]}
     ],{
     onSameUrlNavigation: 'reload',
-    relativeLinkResolution: 'legacy'
 })
   ],
   exports: [RouterModule],


### PR DESCRIPTION
## References
Minor cleanup to #1403 

## Description
In the feedback in #1403, we realized that the Angular 11 upgrade automatically added a `relativeLinkResolution: 'legacy'` setting to our `browser-app.module.ts`.  After we realized it was unnecessary, it was removed in https://github.com/DSpace/dspace-angular/commit/ad5a76aedc16abd59a201c17eac34da7845e13ea

However, just today, I stumbled on the fact that this same setting was added to our `app-routing.module.ts` in #1403.  

So, this PR simply removes that one line change.