### PR TITLE
Disallow Shibboleth users to change password

### DIFF
--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -13,6 +13,7 @@ export enum FeatureID {
   CanManageGroup = 'canManageGroup',
   IsCollectionAdmin = 'isCollectionAdmin',
   IsCommunityAdmin = 'isCommunityAdmin',
+  CanChangePassword = 'canChangePassword',
   CanDownload = 'canDownload',
   CanRequestACopy = 'canRequestACopy',
   CanManageVersions = 'canManageVersions',

--- a/src/app/profile-page/profile-page.component.html
+++ b/src/app/profile-page/profile-page.component.html
@@ -7,7 +7,7 @@
         <ds-profile-page-metadata-form [user]="user"></ds-profile-page-metadata-form>
       </div>
     </div>
-    <div *ngIf="canChangePassword$ | async" class="card mb-4">
+    <div *ngIf="canChangePassword$ | async" class="card mb-4 security-section">
       <div class="card-header">{{'profile.card.security' | translate}}</div>
       <div class="card-body">
         <ds-profile-page-security-form

--- a/src/app/profile-page/profile-page.component.html
+++ b/src/app/profile-page/profile-page.component.html
@@ -7,7 +7,7 @@
         <ds-profile-page-metadata-form [user]="user"></ds-profile-page-metadata-form>
       </div>
     </div>
-    <div class="card mb-4">
+    <div *ngIf="canChangePassword$ | async" class="card mb-4">
       <div class="card-header">{{'profile.card.security' | translate}}</div>
       <div class="card-body">
         <ds-profile-page-security-form

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ProfilePageComponent } from './profile-page.component';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { VarDirective } from '../shared/utils/var.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -13,10 +13,13 @@ import { NotificationsService } from '../shared/notifications/notifications.serv
 import { authReducer } from '../core/auth/auth.reducer';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
 import { createPaginatedList } from '../shared/testing/utils.test';
-import { of as observableOf } from 'rxjs';
+import { BehaviorSubject, of as observableOf } from 'rxjs';
 import { AuthService } from '../core/auth/auth.service';
 import { RestResponse } from '../core/cache/response.models';
 import { provideMockStore } from '@ngrx/store/testing';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { getTestScheduler } from 'jasmine-marbles';
+import { By } from '@angular/platform-browser';
 
 describe('ProfilePageComponent', () => {
   let component: ProfilePageComponent;
@@ -28,10 +31,13 @@ describe('ProfilePageComponent', () => {
   let epersonService;
   let notificationsService;
 
+  let canChangePassword = new BehaviorSubject(true);
+
   function init() {
     user = Object.assign(new EPerson(), {
       id: 'userId',
-      groups: createSuccessfulRemoteDataObject$(createPaginatedList([]))
+      groups: createSuccessfulRemoteDataObject$(createPaginatedList([])),
+      _links: {self: {href: 'test.com/uuid/1234567654321'}}
     });
     initialState = {
       core: {
@@ -74,6 +80,7 @@ describe('ProfilePageComponent', () => {
         { provide: EPersonDataService, useValue: epersonService },
         { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthService, useValue: authService },
+        { provide: AuthorizationDataService, useValue: jasmine.createSpyObj('authorizationService', { isAuthorized: canChangePassword }) },
         provideMockStore({ initialState }),
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -183,7 +190,7 @@ describe('ProfilePageComponent', () => {
         component.setPasswordValue('testest');
         component.setInvalid(false);
 
-        operations = [{op: 'add', path: '/password', value: 'testest'}];
+        operations = [{ op: 'add', path: '/password', value: 'testest' }];
         result = component.updateSecurity();
       });
 
@@ -194,6 +201,37 @@ describe('ProfilePageComponent', () => {
       it('should return call epersonService.patch', () => {
         expect(epersonService.patch).toHaveBeenCalledWith(user, operations);
       });
+    });
+  });
+
+  describe('canChangePassword$', () => {
+    describe('when the user is allowed to change their password', () => {
+      beforeEach(() => {
+        canChangePassword.next(true);
+      });
+
+      it('should contain true', () => {
+        getTestScheduler().expectObservable(component.canChangePassword$).toBe('(a)', { a: true });
+      });
+
+      it('should show the security section on the page', () => {
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('.security-section'))).not.toBeNull();
+      });
+    });
+
+    describe('when the user is not allowed to change their password', () => {
+      beforeEach(() => {
+        canChangePassword.next(false);
+      });
+
+      it('should contain false', () => {
+        getTestScheduler().expectObservable(component.canChangePassword$).toBe('(a)', { a: false });
+      });
+
+      it('should not show the security section on the page', fakeAsync(() => {
+        expect(fixture.debugElement.query(By.css('.security-section'))).toBeNull();
+      }));
     });
   });
 });

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ProfilePageComponent } from './profile-page.component';
-import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { VarDirective } from '../shared/utils/var.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ProfilePageComponent } from './profile-page.component';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
 import { VarDirective } from '../shared/utils/var.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -31,7 +31,7 @@ describe('ProfilePageComponent', () => {
   let epersonService;
   let notificationsService;
 
-  let canChangePassword = new BehaviorSubject(true);
+  const canChangePassword = new BehaviorSubject(true);
 
   function init() {
     user = Object.assign(new EPerson(), {

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -204,7 +204,7 @@ describe('ProfilePageComponent', () => {
     });
   });
 
-  describe('canChangePassword$', () => {
+  fdescribe('canChangePassword$', () => {
     describe('when the user is allowed to change their password', () => {
       beforeEach(() => {
         canChangePassword.next(true);
@@ -229,9 +229,10 @@ describe('ProfilePageComponent', () => {
         getTestScheduler().expectObservable(component.canChangePassword$).toBe('(a)', { a: false });
       });
 
-      it('should not show the security section on the page', fakeAsync(() => {
+      it('should not show the security section on the page', () => {
+        fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('.security-section'))).toBeNull();
-      }));
+      });
     });
   });
 });

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -204,7 +204,7 @@ describe('ProfilePageComponent', () => {
     });
   });
 
-  fdescribe('canChangePassword$', () => {
+  describe('canChangePassword$', () => {
     describe('when the user is allowed to change their password', () => {
       beforeEach(() => {
         canChangePassword.next(true);

--- a/src/app/profile-page/profile-page.component.ts
+++ b/src/app/profile-page/profile-page.component.ts
@@ -18,6 +18,8 @@ import { hasValue, isNotEmpty } from '../shared/empty.util';
 import { followLink } from '../shared/utils/follow-link-config.model';
 import { AuthService } from '../core/auth/auth.service';
 import { Operation } from 'fast-json-patch';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../core/data/feature-authorization/feature-id';
 
 @Component({
   selector: 'ds-profile-page',
@@ -67,11 +69,13 @@ export class ProfilePageComponent implements OnInit {
    * The authenticated user
    */
   private currentUser: EPerson;
+  canChangePassword$: Observable<boolean>;
 
   constructor(private authService: AuthService,
               private notificationsService: NotificationsService,
               private translate: TranslateService,
-              private epersonService: EPersonDataService) {
+              private epersonService: EPersonDataService,
+              private authorizationService: AuthorizationDataService) {
   }
 
   ngOnInit(): void {
@@ -83,6 +87,7 @@ export class ProfilePageComponent implements OnInit {
       tap((user: EPerson) => this.currentUser = user)
     );
     this.groupsRD$ = this.user$.pipe(switchMap((user: EPerson) => user.groups));
+    this.canChangePassword$ = this.user$.pipe(switchMap((user:EPerson) => this.authorizationService.isAuthorized(FeatureID.CanChangePassword, user._links.self.href)));
   }
 
   /**

--- a/src/app/profile-page/profile-page.component.ts
+++ b/src/app/profile-page/profile-page.component.ts
@@ -87,7 +87,7 @@ export class ProfilePageComponent implements OnInit {
       tap((user: EPerson) => this.currentUser = user)
     );
     this.groupsRD$ = this.user$.pipe(switchMap((user: EPerson) => user.groups));
-    this.canChangePassword$ = this.user$.pipe(switchMap((user:EPerson) => this.authorizationService.isAuthorized(FeatureID.CanChangePassword, user._links.self.href)));
+    this.canChangePassword$ = this.user$.pipe(switchMap((user: EPerson) => this.authorizationService.isAuthorized(FeatureID.CanChangePassword, user._links.self.href)));
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes [#7959](https://github.com/DSpace/DSpace/issues/7959)
* Requires https://github.com/DSpace/DSpace/pull/8050

## Description
This PR fixes the Angular part of the issue where Shibboleth users were able to change their password using the DSpace UI.
It removes the `Security` form on the `Profile` page for users that are not allowed to change their password using the `canChangePassword` feature retrieved from the backend.

## Instructions for Reviewers
- Log in using the default DSpace login UI and visit the profile page at `/profile`. You should be able to change your password.
- Log in using Shibboleth (make sure Shibboleth is enabled for you backend server) and visit the profile page at `/profile`. You should not be able to change your password, and the `Security` part of the form should not be shown.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).

