### PR TITLE
German language syntax fix, add trailing quote

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -2182,7 +2182,7 @@
   "item.edit.bitstreams.headers.name": "Name",
   
   // "item.edit.bitstreams.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
-  "item.edit.bitstreams.notifications.discarded.content": "Ihre Änderungen wurden verworfen. Um Ihre Änderungen wiederherzustellen, klicken Sie auf die Schaltfläche 'Rückgängig',
+  "item.edit.bitstreams.notifications.discarded.content": "Ihre Änderungen wurden verworfen. Um Ihre Änderungen wiederherzustellen, klicken Sie auf die Schaltfläche 'Rückgängig'",
   
   // "item.edit.bitstreams.notifications.discarded.title": "Changes discarded",
   "item.edit.bitstreams.notifications.discarded.title": "Änderungen verworfen",


### PR DESCRIPTION
Fixes #1453 

## Description
The `de.json5` German language pack was missing a closing quote on one line, which caused it to not work.  See #1453.
