### PR TITLE
Update legacy relative links to angular 11 format

### DIFF
--- a/src/app/shared/resource-policies/resource-policies.component.ts
+++ b/src/app/shared/resource-policies/resource-policies.component.ts
@@ -281,7 +281,7 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
    * Redirect to resource policy creation page
    */
   redirectToResourcePolicyCreatePage(): void {
-    this.router.navigate([`../create`], {
+    this.router.navigate([`./create`], {
       relativeTo: this.route,
       queryParams: {
         policyTargetId: this.resourceUUID,
@@ -296,7 +296,7 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
    * @param policy The resource policy
    */
   redirectToResourcePolicyEditPage(policy: ResourcePolicy): void {
-    this.router.navigate([`../edit`], {
+    this.router.navigate([`./edit`], {
       relativeTo: this.route,
       queryParams: {
         policyId: policy.id


### PR DESCRIPTION
## References
* Fixes #1456

## Description
The resource policy component used [legacy relative router paths](https://angular.io/api/router/ExtraOptions#relativeLinkResolution). However we disabled support for that in #1403 and #1452, so these paths needed to be updated to the new format

## Instructions for Reviewers
Follow the instructions in #1456, and verify that these buttons all work now

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
