### PR TITLE
Tell Cypress to retry twice if an e2e test failure occurs

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,6 @@
   "screenshotsFolder": "cypress/screenshots",
   "pluginsFile": "cypress/plugins/index.ts",
   "fixturesFolder": "cypress/fixtures",
-  "baseUrl": "http://localhost:4000"
+  "baseUrl": "http://localhost:4000",
+  "retries": 2
 }


### PR DESCRIPTION
## Description
This PR is an attempt to try to "stabilize" a few e2e tests which are semi-flakey right now.  The flakey tests seem to all relate to **searching**. If the test search doesn't respond in 4 seconds, the test times out.  It seems like the test backend (which is being searched against) might be responding slowly at times (or maybe getting bogged down temporarily?).  

In any case, it only seems to happen randomly so far, and in the same e2e test run, usually some of the search tests *succeed* even while one fails.  This implies to me that we are hitting some sort of temporary slowness in the search response.

So, for now, I'm just adding a configuration for Cypress to tell it to retry twice if a test fails. This means it'll run a maximum of 3 times before an error occurs.

I will see how this PR behaves in our CI environment to see if it at least makes e2e tests less likely to randomly/temporarily fail.
