### PR TITLE
Admin is unable to reset other users' password

### DIFF
--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -36,9 +36,13 @@
   </button>
 </ds-form>
 
+<ds-loading [showMessage]="false" *ngIf="!formGroup"></ds-loading>
+
 <div *ngIf="epersonService.getActiveEPerson() | async">
   <h5>{{messagePrefix + '.groupsEPersonIsMemberOf' | translate}}</h5>
 
+  <ds-loading [showMessage]="false" *ngIf="!(groups | async)"></ds-loading>
+  
   <ds-pagination
     *ngIf="(groups | async)?.payload?.totalElements > 0"
     [paginationOptions]="config"

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -19,7 +19,7 @@
             class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{messagePrefix + '.return' | translate}}</button>
   </div>
   <div between class="btn-group">
-    <button class="btn btn-primary" [disabled]="!(canReset$ | async)">
+    <button class="btn btn-primary" [disabled]="!(canReset$ | async)" (click)="resetPassword()">
       <i class="fa fa-key"></i> {{'admin.access-control.epeople.actions.reset' | translate}}
     </button>
   </div>
@@ -42,7 +42,7 @@
   <h5>{{messagePrefix + '.groupsEPersonIsMemberOf' | translate}}</h5>
 
   <ds-loading [showMessage]="false" *ngIf="!(groups | async)"></ds-loading>
-  
+
   <ds-pagination
     *ngIf="(groups | async)?.payload?.totalElements > 0"
     [paginationOptions]="config"

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -2,7 +2,7 @@ import { Observable, of as observableOf } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
@@ -14,6 +14,7 @@ import { EPerson } from '../../../core/eperson/models/eperson.model';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { EPeopleRegistryComponent } from '../epeople-registry.component';
 import { EPersonFormComponent } from './eperson-form.component';
 import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
@@ -28,10 +29,8 @@ import { createPaginatedList } from '../../../shared/testing/utils.test';
 import { RequestService } from '../../../core/data/request.service';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../../shared/testing/pagination-service.stub';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ValidateEmailNotTaken } from './validators/email-taken.validator';
 import { EpersonRegistrationService } from '../../../core/data/eperson-registration.service';
-
 
 describe('EPersonFormComponent', () => {
   let component: EPersonFormComponent;
@@ -201,7 +200,9 @@ describe('EPersonFormComponent', () => {
         { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: PaginationService, useValue: paginationService },
-        { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) }
+        { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring'])},
+        { provide: EpersonRegistrationService, useValue: epersonRegistrationService },
+        EPeopleRegistryComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -520,7 +521,6 @@ describe('EPersonFormComponent', () => {
       expect(component.epersonService.deleteEPerson).toHaveBeenCalledWith(eperson);
     });
   });
-
 
   describe('Reset Password', () => {
     let ePersonId;

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -28,8 +28,9 @@ import { createPaginatedList } from '../../../shared/testing/utils.test';
 import { RequestService } from '../../../core/data/request.service';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../../shared/testing/pagination-service.stub';
-import { FormArray, FormControl, FormGroup,Validators, NG_VALIDATORS, NG_ASYNC_VALIDATORS } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ValidateEmailNotTaken } from './validators/email-taken.validator';
+import { EpersonRegistrationService } from '../../../core/data/eperson-registration.service';
 
 
 describe('EPersonFormComponent', () => {
@@ -42,6 +43,7 @@ describe('EPersonFormComponent', () => {
   let authService: AuthServiceStub;
   let authorizationService: AuthorizationDataService;
   let groupsDataService: GroupDataService;
+  let epersonRegistrationService: EpersonRegistrationService;
 
   let paginationService;
 
@@ -204,6 +206,10 @@ describe('EPersonFormComponent', () => {
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   }));
+
+  epersonRegistrationService = jasmine.createSpyObj('epersonRegistrationService', {
+    registerEmail: createSuccessfulRemoteDataObject$(null)
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EPersonFormComponent);
@@ -512,6 +518,26 @@ describe('EPersonFormComponent', () => {
       deleteButton.triggerEventHandler('click', null);
       fixture.detectChanges();
       expect(component.epersonService.deleteEPerson).toHaveBeenCalledWith(eperson);
+    });
+  });
+
+
+  describe('Reset Password', () => {
+    let ePersonId;
+    let ePersonEmail;
+
+    beforeEach(() => {
+      ePersonId = 'testEPersonId';
+      ePersonEmail = 'person.email@4science.it';
+      component.epersonInitial = Object.assign(new EPerson(), {
+        id: ePersonId,
+        email: ePersonEmail
+      });
+      component.resetPassword();
+    });
+
+    it('should call epersonRegistrationService.registerEmail', () => {
+      expect(epersonRegistrationService.registerEmail).toHaveBeenCalledWith(ePersonEmail);
     });
   });
 });

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -315,11 +315,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       this.canDelete$ = activeEPerson$.pipe(
         switchMap((eperson) => this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(eperson) ? eperson.self : undefined))
       );
-      this.canReset$ = activeEPerson$.pipe(
-        switchMap((eperson) => {
-          return observableOf(true);
-        })
-      );
+      this.canReset$ = observableOf(true);
     });
   }
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -121,7 +121,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    * Observable whether or not the admin is allowed to reset the EPerson's password
    * TODO: Initialize the observable once the REST API supports this (currently hardcoded to return false)
    */
-  canReset$: Observable<boolean> = observableOf(false);
+  canReset$: Observable<boolean>;
 
   /**
    * Observable whether or not the admin is allowed to delete the EPerson
@@ -309,6 +309,11 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       );
       this.canDelete$ = activeEPerson$.pipe(
         switchMap((eperson) => this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(eperson) ? eperson.self : undefined))
+      );
+      this.canReset$ = activeEPerson$.pipe(
+        switchMap((eperson) => {
+          return observableOf(true);
+        })
       );
     });
   }


### PR DESCRIPTION
## References

* Fixes #1349 

## Description
Admin can now reset other users' password

## Instructions for Reviewers

Reset password button, that was disabled by default, is now enabled.
Reset password functionality has been implemented.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
