### PR TITLE
Support external links in menus

### DIFF
--- a/src/app/shared/menu/menu-item-type.model.ts
+++ b/src/app/shared/menu/menu-item-type.model.ts
@@ -2,5 +2,5 @@
  * List of possible MenuItemTypes
  */
 export enum MenuItemType {
-  TEXT, LINK, ALTMETRIC, SEARCH, ONCLICK
+  TEXT, LINK, ALTMETRIC, SEARCH, ONCLICK, EXTERNAL
 }

--- a/src/app/shared/menu/menu-item/external-link-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/external-link-menu-item.component.html
@@ -1,0 +1,7 @@
+<a class="nav-item nav-link"
+   [ngClass]="{'disabled': !hasLink }"
+   [attr.aria-disabled]="!hasLink"
+   [href]="href"
+   [title]="item.text | translate"
+   (click)="$event.stopPropagation()"
+>{{item.text | translate}}</a>

--- a/src/app/shared/menu/menu-item/external-link-menu-item.component.spec.ts
+++ b/src/app/shared/menu/menu-item/external-link-menu-item.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { ExternalLinkMenuItemComponent } from './external-link-menu-item.component';
+
+describe('ExternalLinkMenuItemComponent', () => {
+  let component: ExternalLinkMenuItemComponent;
+  let fixture: ComponentFixture<ExternalLinkMenuItemComponent>;
+  let debugElement: DebugElement;
+  let text;
+  let link;
+
+  function init() {
+    text = 'HELLO';
+    link = 'https://google.com/';
+  }
+
+  beforeEach(waitForAsync(() => {
+    init();
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [ExternalLinkMenuItemComponent],
+      providers: [
+        { provide: 'itemModelProvider', useValue: { text: text, href: link } },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExternalLinkMenuItemComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the correct text', () => {
+    const textContent = debugElement.query(By.css('a')).nativeElement.textContent;
+    expect(textContent).toEqual(text);
+  });
+
+  it('should have the right href attribute', () => {
+    const links = fixture.debugElement.queryAll(By.css('a'));
+    expect(links.length).toBe(1);
+    expect(links[0].nativeElement.href).toBe(link);
+  });
+});

--- a/src/app/shared/menu/menu-item/external-link-menu-item.component.ts
+++ b/src/app/shared/menu/menu-item/external-link-menu-item.component.ts
@@ -1,0 +1,36 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { rendersMenuItemForType } from '../menu-item.decorator';
+import { isNotEmpty } from '../../empty.util';
+import { ExternalLinkMenuItemModel } from './models/external-link.model';
+import { MenuItemType } from '../menu-item-type.model';
+
+/**
+ * Component that renders a menu section of type EXTERNAL
+ */
+@Component({
+  selector: 'ds-external-link-menu-item',
+  templateUrl: './external-link-menu-item.component.html'
+})
+@rendersMenuItemForType(MenuItemType.EXTERNAL)
+export class ExternalLinkMenuItemComponent implements OnInit {
+  item: ExternalLinkMenuItemModel;
+
+  hasLink: boolean;
+
+  constructor(
+    @Inject('itemModelProvider') item: ExternalLinkMenuItemModel
+  ) {
+    this.item = item;
+  }
+
+  ngOnInit() {
+    this.hasLink = isNotEmpty(this.item.href);
+  }
+
+  get href() {
+    if (this.hasLink) {
+      return this.item.href;
+    }
+    return undefined;
+  }
+}

--- a/src/app/shared/menu/menu-item/link-menu-item.component.spec.ts
+++ b/src/app/shared/menu/menu-item/link-menu-item.component.spec.ts
@@ -19,7 +19,7 @@ describe('LinkMenuItemComponent', () => {
 
   function init() {
     text = 'HELLO';
-    link = 'http://google.com';
+    link = '/world/hello';
     queryParams = {params: true};
   }
 

--- a/src/app/shared/menu/menu-item/models/external-link.model.ts
+++ b/src/app/shared/menu/menu-item/models/external-link.model.ts
@@ -1,0 +1,11 @@
+import { MenuItemModel } from './menu-item.model';
+import { MenuItemType } from '../../menu-item-type.model';
+
+/**
+ * Model representing a Link Menu Section for an external link
+ */
+export class ExternalLinkMenuItemModel implements MenuItemModel {
+  type = MenuItemType.EXTERNAL;
+  text: string;
+  href: string;
+}

--- a/src/app/shared/menu/menu.module.ts
+++ b/src/app/shared/menu/menu.module.ts
@@ -7,13 +7,15 @@ import { LinkMenuItemComponent } from './menu-item/link-menu-item.component';
 import { TextMenuItemComponent } from './menu-item/text-menu-item.component';
 import { OnClickMenuItemComponent } from './menu-item/onclick-menu-item.component';
 import { CommonModule } from '@angular/common';
+import { ExternalLinkMenuItemComponent } from './menu-item/external-link-menu-item.component';
 
 const COMPONENTS = [
   MenuSectionComponent,
   MenuComponent,
   LinkMenuItemComponent,
   TextMenuItemComponent,
-  OnClickMenuItemComponent
+  OnClickMenuItemComponent,
+  ExternalLinkMenuItemComponent,
 ];
 
 const MODULES = [

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -172,6 +172,7 @@ import { BitstreamRequestACopyPageComponent } from './bitstream-request-a-copy-p
 import { DsSelectComponent } from './ds-select/ds-select.component';
 import { LogInOidcComponent } from './log-in/methods/oidc/log-in-oidc.component';
 import { ThemedItemListPreviewComponent } from './object-list/my-dspace-result-list-element/item-list-preview/themed-item-list-preview.component';
+import { ExternalLinkMenuItemComponent } from './menu/menu-item/external-link-menu-item.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -397,6 +398,7 @@ const ENTRY_COMPONENTS = [
   OnClickMenuItemComponent,
   TextMenuItemComponent,
   ScopeSelectorModalComponent,
+  ExternalLinkMenuItemComponent,
 ];
 
 const SHARED_ITEM_PAGE_COMPONENTS = [


### PR DESCRIPTION
## Description

Because `LinkMenuItemComponent` uses the Angular router, it can't readily support links to pages _outside_ of Angular, i.e.

* Links to external pages
* Links to internal static assets (e.g. a PDF file)

This PR introduces `ExternalLinkMenuItemComponent` for those use cases.

## Instructions for Reviewers

#### List of changes in this PR

* Add `ExternalLinkMenuItemComponent` & `ExternalLinkItemModel`
* New `MenuItemType` value: `EXTERNAL`

#### Reviewing

Start up a local instance at [pr_external-links-in-menus_testing](https://github.com/ybnd/dspace-angular/tree/pr_external-links-in-menus_testing)

The header should include 
* A new "Banner Image" link, which should link to the banner image via a relative URL
* A new "GitHub" dropdown, with links to the REST & DSpace repos

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.