### PR TITLE
[CST-5064] Show submitter in version history table

### DIFF
--- a/src/app/core/shared/version.model.ts
+++ b/src/app/core/shared/version.model.ts
@@ -48,6 +48,12 @@ export class Version extends DSpaceObject {
   summary: string;
 
   /**
+   * The name of the submitter of this version
+   */
+  @autoserialize
+  submitterName: string;
+
+  /**
    * The Date this version was created
    */
   @deserialize

--- a/src/app/shared/item/item-versions/item-versions.component.html
+++ b/src/app/shared/item/item-versions/item-versions.component.html
@@ -17,7 +17,7 @@
           <thead>
           <tr>
             <th scope="col">{{"item.version.history.table.version" | translate}}</th>
-            <th scope="col" *ngIf="(hasEpersons$ | async)">{{"item.version.history.table.editor" | translate}}</th>
+            <th scope="col" *ngIf="(showSubmitter() | async)">{{"item.version.history.table.editor" | translate}}</th>
             <th scope="col">{{"item.version.history.table.date" | translate}}</th>
             <th scope="col">{{"item.version.history.table.summary" | translate}}</th>
           </tr>
@@ -87,10 +87,8 @@
                 </ng-container>
               </ng-container>
             </td>
-            <td *ngIf="(hasEpersons$ | async)" class="version-row-element-editor">
-                <span *ngVar="(version?.eperson | async)?.payload as eperson">
-                  <a *ngIf="eperson" [href]="'mailto:' + eperson?.email">{{eperson?.name}}</a>
-                </span>
+            <td class="version-row-element-editor" *ngIf="(showSubmitter() | async)">
+              {{version?.submitterName}}
             </td>
             <td class="version-row-element-date">
               {{version?.created | date : 'yyyy-MM-dd HH:mm:ss'}}

--- a/src/app/shared/item/item-versions/item-versions.component.spec.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.spec.ts
@@ -26,7 +26,7 @@ import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem
 import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 
-fdescribe('ItemVersionsComponent', () => {
+describe('ItemVersionsComponent', () => {
   let component: ItemVersionsComponent;
   let fixture: ComponentFixture<ItemVersionsComponent>;
   let authenticationService: AuthService;
@@ -35,6 +35,7 @@ fdescribe('ItemVersionsComponent', () => {
   let workspaceItemDataService: WorkspaceitemDataService;
   let workflowItemDataService: WorkflowItemDataService;
   let versionService: VersionDataService;
+  let configurationService: ConfigurationDataService;
 
   const versionHistory = Object.assign(new VersionHistory(), {
     id: '1',
@@ -130,7 +131,7 @@ fdescribe('ItemVersionsComponent', () => {
         {provide: VersionDataService, useValue: versionServiceSpy},
         {provide: WorkspaceitemDataService, useValue: workspaceItemDataServiceSpy},
         {provide: WorkflowItemDataService, useValue: workflowItemDataServiceSpy},
-        {provide: ConfigurationDataService, useValue: configurationServiceSpy()},
+        {provide: ConfigurationDataService, useValue: configurationServiceSpy},
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -141,6 +142,7 @@ fdescribe('ItemVersionsComponent', () => {
     workspaceItemDataService = TestBed.inject(WorkspaceitemDataService);
     workflowItemDataService = TestBed.inject(WorkflowItemDataService);
     versionService = TestBed.inject(VersionDataService);
+    configurationService = TestBed.inject(ConfigurationDataService);
 
   }));
 

--- a/src/app/shared/item/item-versions/item-versions.component.spec.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.spec.ts
@@ -24,8 +24,9 @@ import { AuthorizationDataService } from '../../../core/data/feature-authorizati
 import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
 import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
+import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 
-describe('ItemVersionsComponent', () => {
+fdescribe('ItemVersionsComponent', () => {
   let component: ItemVersionsComponent;
   let fixture: ComponentFixture<ItemVersionsComponent>;
   let authenticationService: AuthService;
@@ -109,6 +110,10 @@ describe('ItemVersionsComponent', () => {
     findById: EMPTY,
   });
 
+  const configurationServiceSpy = jasmine.createSpyObj('configurationService', {
+    findByPropertyName: of(true),
+  });
+
   beforeEach(waitForAsync(() => {
 
     TestBed.configureTestingModule({
@@ -125,6 +130,7 @@ describe('ItemVersionsComponent', () => {
         {provide: VersionDataService, useValue: versionServiceSpy},
         {provide: WorkspaceitemDataService, useValue: workspaceItemDataServiceSpy},
         {provide: WorkflowItemDataService, useValue: workflowItemDataServiceSpy},
+        {provide: ConfigurationDataService, useValue: configurationServiceSpy()},
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/item/item-versions/item-versions.component.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.ts
@@ -5,7 +5,6 @@ import { RemoteData } from '../../../core/data/remote-data';
 import {
   BehaviorSubject,
   combineLatest,
-  combineLatest as observableCombineLatest,
   Observable,
   of,
   Subscription,
@@ -48,6 +47,7 @@ import { ItemVersionsSharedService } from './item-versions-shared.service';
 import { WorkspaceItem } from '../../../core/submission/models/workspaceitem.model';
 import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
 import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
+import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 
 @Component({
   selector: 'ds-item-versions',
@@ -180,6 +180,7 @@ export class ItemVersionsComponent implements OnInit {
               private authorizationService: AuthorizationDataService,
               private workspaceItemDataService: WorkspaceitemDataService,
               private workflowItemDataService: WorkflowItemDataService,
+              private configurationService: ConfigurationDataService,
   ) {
   }
 
@@ -376,6 +377,37 @@ export class ItemVersionsComponent implements OnInit {
   }
 
   /**
+   * Show submitter in version history table
+   */
+  showSubmitter() {
+
+    const includeSubmitter$ = this.configurationService.findByPropertyName('versioning.item.history.include.submitter').pipe(
+      getFirstSucceededRemoteDataPayload(),
+      map((configurationProperty) => configurationProperty.values[0]),
+      startWith(false),
+    );
+
+    const isAdmin$ = combineLatest([
+      this.authorizationService.isAuthorized(FeatureID.IsCollectionAdmin),
+      this.authorizationService.isAuthorized(FeatureID.IsCommunityAdmin),
+      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
+    ]).pipe(
+      map(([isCollectionAdmin, isCommunityAdmin, isSiteAdmin]) => {
+        return isCollectionAdmin || isCommunityAdmin || isSiteAdmin;
+      }),
+      take(1),
+      tap((res) => { console.log('isAdmin = ' + res); })
+    );
+
+    return combineLatest([includeSubmitter$, isAdmin$]).pipe(
+      map(([includeSubmitter, isAdmin]) => {
+        return includeSubmitter && isAdmin;
+      })
+    );
+
+  }
+
+  /**
    * Check if the current user can delete the version
    * @param version
    */
@@ -389,7 +421,7 @@ export class ItemVersionsComponent implements OnInit {
    */
   getAllVersions(versionHistory$: Observable<VersionHistory>): void {
     const currentPagination = this.paginationService.getCurrentPagination(this.options.id, this.options);
-    observableCombineLatest([versionHistory$, currentPagination]).pipe(
+    combineLatest([versionHistory$, currentPagination]).pipe(
       switchMap(([versionHistory, options]: [VersionHistory, PaginationComponentOptions]) => {
         return this.versionHistoryService.getVersions(versionHistory.id,
           new PaginatedSearchOptions({pagination: Object.assign({}, options, {currentPage: options.currentPage})}),
@@ -486,7 +518,7 @@ export class ItemVersionsComponent implements OnInit {
       );
       this.itemPageRoutes$ = this.versionsRD$.pipe(
         getAllSucceededRemoteDataPayload(),
-        switchMap((versions) => observableCombineLatest(...versions.page.map((version) => version.item.pipe(getAllSucceededRemoteDataPayload())))),
+        switchMap((versions) => combineLatest(versions.page.map((version) => version.item.pipe(getAllSucceededRemoteDataPayload())))),
         map((versions) => {
           const itemPageRoutes = {};
           versions.forEach((item) => itemPageRoutes[item.uuid] = getItemPageRoute(item));


### PR DESCRIPTION
## References
* Fixes #1385 

## Description
The content of _Editor_ column in version history table has been replaced with version's `submitterName`

## Instructions for Reviewers
The column previously showed item's `eperson`, which was missing; now it shows version's `submitterName`. The column is shown only if the user is an administrator (any of IsCollectionAdmin, IsCommunityAdmin, AdministratorOf) and `versioning.item.history.include.submitter` is true.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
