### PR TITLE
Fixes to allow UI to be deployed on a subpath (e.g. `nameSpace: /dspace`)

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -187,7 +187,7 @@ describe('App component', () => {
       link.setAttribute('rel', 'stylesheet');
       link.setAttribute('type', 'text/css');
       link.setAttribute('class', 'theme-css');
-      link.setAttribute('href', '/custom-theme.css');
+      link.setAttribute('href', 'custom-theme.css');
 
       expect(headSpy.appendChild).toHaveBeenCalledWith(link);
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -269,7 +269,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
     link.setAttribute('class', 'theme-css');
-    link.setAttribute('href', `/${encodeURIComponent(themeName)}-theme.css`);
+    link.setAttribute('href', `${encodeURIComponent(themeName)}-theme.css`);
     // wait for the new css to download before removing the old one to prevent a
     // flash of unstyled content
     link.onload = () => {

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -68,7 +68,7 @@ export class MiradorViewerComponent implements OnInit {
     const manifestApiEndpoint = encodeURIComponent(environment.rest.baseUrl + '/iiif/'
       + this.object.id + '/manifest');
     // The Express path to Mirador viewer.
-    let viewerPath = '/iiif/mirador/index.html?manifest=' + manifestApiEndpoint;
+    let viewerPath = environment.ui.nameSpace + '/iiif/mirador/index.html?manifest=' + manifestApiEndpoint;
     if (this.searchable) {
       // Tell the viewer add search to menu.
       viewerPath += '&searchable=' + this.searchable;

--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -6,7 +6,9 @@ $sidebar-items-width: 250px !default;
 $total-sidebar-width: $collapsed-sidebar-width + $sidebar-items-width !default;
 
 /* Fonts */
-$fa-font-path: "/assets/fonts" !default;
+// Starting this url with a caret (^) allows it to be a relative path based on UI's deployment path
+// See https://github.com/angular/angular-cli/issues/12797#issuecomment-598534241
+$fa-font-path: "^assets/fonts" !default;
 /* Images */
 $image-path: "../assets/images" !default;
 

--- a/src/themes/dspace/app/home-page/home-news/home-news.component.scss
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.scss
@@ -6,7 +6,9 @@
     color: white;
     background-color: var(--bs-info);
     position: relative;
-    background-image: url('/assets/dspace/images/banner.jpg');
+    // Starting this url with a caret (^) allows it to be a relative path based on UI's deployment path
+    // See https://github.com/angular/angular-cli/issues/12797#issuecomment-598534241
+    background-image: url('^assets/dspace/images/banner.jpg');
     background-size: cover;
 
     .container {


### PR DESCRIPTION
## Description

This PR was inspired by a question on dspace-tech about running the UI on a subpath (i.e. http://localhost:4000/dspace/): https://groups.google.com/g/dspace-tech/c/YD5x0IGSuGc/m/D6GQcQUkBgAJ

When trying to answer that question, I discovered this isn't really possible because our base theme, and some images/fonts all assume you will run the UI on the root path (i.e. http://localhost:4000/)

This PR fixes those issues by ensuring all such paths are **relative** to the UI's deployment path.

## Instructions for Reviewers

Should be tested in two ways (I've tested both and they work for me);
1. Install this PR and run the UI on the root path (default) of http://localhost:4000/   Ensure theme loads, and all fonts/images.
2. Then, change the UI to run on a subpath (e.g. "/dspace"). This involves 3 changes at this time:
    * Change your `config.*.yml` to have `nameSpace: /dspace` in the `ui` section.
    * Modify the `index.html` to have `<base href="/dspace/">` here https://github.com/DSpace/dspace-angular/blob/main/src/index.html#L6
    * Modify the `index.csr.html` to have `<base href="/dspace/">` here https://github.com/DSpace/dspace-angular/blob/main/src/index.csr.html#L6
    * Redeploy/restart UI. Ensure everything loads properly when accessing the UI at http://localhost:4000/dspace/
