### PR TITLE
Scripts & Processes without parameters fix

### DIFF
--- a/src/app/process-page/form/process-form.component.spec.ts
+++ b/src/app/process-page/form/process-form.component.spec.ts
@@ -87,4 +87,15 @@ describe('ProcessFormComponent', () => {
     component.submitForm({ controls: {} } as any);
     expect(scriptService.invoke).toHaveBeenCalled();
   });
+
+  describe('when undefined parameters are provided', () => {
+    beforeEach(() => {
+      component.parameters = undefined;
+    });
+
+    it('should invoke the script with an empty array of parameters', () => {
+      component.submitForm({ controls: {} } as any);
+      expect(scriptService.invoke).toHaveBeenCalledWith(script.id, [], jasmine.anything());
+    });
+  });
 });

--- a/src/app/process-page/form/process-form.component.ts
+++ b/src/app/process-page/form/process-form.component.ts
@@ -12,6 +12,7 @@ import { Router } from '@angular/router';
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { RemoteData } from '../../core/data/remote-data';
 import { getProcessListRoute } from '../process-page-routing.paths';
+import { isEmpty } from '../../shared/empty.util';
 
 /**
  * Component to create a new script
@@ -35,7 +36,7 @@ export class ProcessFormComponent implements OnInit {
   /**
    * The parameter values to use to start the process
    */
-  @Input() public parameters: ProcessParameter[];
+  @Input() public parameters: ProcessParameter[] = [];
 
   /**
    * Optional files that are used as parameter values
@@ -69,6 +70,9 @@ export class ProcessFormComponent implements OnInit {
    * @param form
    */
   submitForm(form: NgForm) {
+    if (isEmpty(this.parameters)) {
+      this.parameters = [];
+    }
     if (!this.validateForm(form) || this.isRequiredMissing()) {
       return;
     }


### PR DESCRIPTION
## References
This PR fixes #1445

## Description
This PR fixes an error occurring when trying to run a script through Scripts & Processes without any arguments/parameters, even if that script allows it.

## Instructions for Reviewers
Changes made:
- Before submitting, it checks if the parameters are empty (meaning undefined, null or empty array) and replace it with an empty array to ensure no "undefined" errors occur after
- Added a test case covering this

How to test:
- Log in as a site administrator
- Go to the /processes page
- Create a new process and select a script that allows empty parameters (e.g. index-discovery)
- Save
- This should now work as expected and create a process for the script

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
