### PR TITLE
Docker-Compose Environment variables must be strings or numbers, not booleans

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,11 +16,11 @@ services:
   dspace-angular:
     container_name: dspace-angular
     environment:
-      DSPACE_UI_SSL: false
+      DSPACE_UI_SSL: 'false'
       DSPACE_UI_HOST: dspace-angular
       DSPACE_UI_PORT: '4000'
       DSPACE_UI_NAMESPACE: /
-      DSPACE_REST_SSL: false
+      DSPACE_REST_SSL: 'false'
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server


### PR DESCRIPTION
## Description
Very small fix to our `docker-compose`.  In recent versions of Docker, env variables cannot have boolean values.  This error occurs on `main`:
```
ERROR: The Compose file 'docker/docker-compose.yml' is invalid because:
services.dspace-angular.environment.DSPACE_UI_SSL contains false, which is an invalid type, it should be a string, number, or a null
```

This tiny PR fixes the issue by ensuring booleans are strings.
