### PR TITLE
Fix user profile page

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -163,6 +163,7 @@ import { RootDataService } from './data/root-data.service';
 import { Root } from './data/root.model';
 import { SearchConfig } from './shared/search/search-filters/search-config.model';
 import { SequenceService } from './shared/sequence.service';
+import { GroupDataService } from './eperson/group-data.service';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
@@ -285,6 +286,7 @@ const PROVIDERS = [
   VocabularyService,
   VocabularyTreeviewService,
   SequenceService,
+  GroupDataService
 ];
 
 /**

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -40,9 +40,7 @@ const editGroupSelector = createSelector(groupRegistryStateSelector, (groupRegis
 /**
  * Provides methods to retrieve eperson group resources from the REST API & Group related CRUD actions.
  */
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 @dataService(GROUP)
 export class GroupDataService extends DataService<Group> {
   protected linkPath = 'groups';


### PR DESCRIPTION
## References
* Fixes #1494

## Description
The reason for this issue is that the `@dataService` annotation for the GroupDataservice isn't registered yet when the LinkService tries to resolve the group link on the eperson module. To solve it, I removed the `providedIn: 'root'` from GroupDataservice and provided it manually in CoreModule, which ensures that it is loaded in time.

## Instructions for Reviewers
Verify that the profile page works as it should

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
