### PR TITLE
Fix forced re-init due to out-of-scope fields

### DIFF
--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -357,7 +357,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
       describe('in workspace scope', () => {
         beforeEach(() => {
           // @ts-ignore
-          comp.workspaceItem = { type: WorkspaceItem.type };
+          comp.submissionObject = { type: WorkspaceItem.type };
         });
 
         it('should return true for unscoped fields', () => {
@@ -376,7 +376,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
       describe('in workflow scope', () => {
         beforeEach(() => {
           // @ts-ignore
-          comp.workspaceItem = { type: WorkflowItem.type };
+          comp.submissionObject = { type: WorkflowItem.type };
         });
 
         it('should return true when field is unscoped', () => {

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -364,11 +364,11 @@ describe('SubmissionSectionFormComponent test suite', () => {
           expect((comp as any).inCurrentSubmissionScope('dc.title')).toBe(true);
         });
 
-        it('should return true for fields scoped to workflow', () => {
+        it('should return true for fields scoped to workspace', () => {
           expect((comp as any).inCurrentSubmissionScope('scoped.workspace')).toBe(true);
         });
 
-        it('should return false for fields scoped to workspace', () => {
+        it('should return false for fields scoped to workflow', () => {
           expect((comp as any).inCurrentSubmissionScope('scoped.workflow')).toBe(false);
         });
       });

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -34,6 +34,8 @@ import { followLink } from '../../../shared/utils/follow-link-config.model';
 import { environment } from '../../../../environments/environment';
 import { ConfigObject } from '../../../core/config/models/config.model';
 import { RemoteData } from '../../../core/data/remote-data';
+import { SubmissionScopeType } from '../../../core/submission/submission-scope-type';
+import { WorkflowItem } from '../../../core/submission/models/workflowitem.model';
 
 /**
  * This component represents a section that contains a Form.
@@ -223,7 +225,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
 
     const sectionDataToCheck = {};
     Object.keys(sectionData).forEach((key) => {
-      if (this.sectionMetadata && this.sectionMetadata.includes(key)) {
+      if (this.sectionMetadata && this.sectionMetadata.includes(key) && this.inCurrentSubmissionScope(key)) {
         sectionDataToCheck[key] = sectionData[key];
       }
     });
@@ -244,6 +246,28 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         });
       });
     return isNotEmpty(diffResult);
+  }
+
+  /**
+   * Whether a specific field is editable in the current scope. Unscoped fields always return true.
+   * @private
+   */
+  private inCurrentSubmissionScope(field: string): boolean {
+    const scope = this.formConfig?.rows.find(row => {
+      return row.fields?.[0]?.selectableMetadata?.[0]?.metadata === field;
+    }).fields?.[0]?.scope;
+
+    switch (scope) {
+      case SubmissionScopeType.WorkspaceItem: {
+        return this.workspaceItem.type === WorkspaceItem.type;
+      }
+      case SubmissionScopeType.WorkflowItem: {
+        return this.workspaceItem.type === WorkflowItem.type;
+      }
+      default: {
+        return true;
+      }
+    }
   }
 
   /**

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -36,6 +36,7 @@ import { ConfigObject } from '../../../core/config/models/config.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { SubmissionScopeType } from '../../../core/submission/submission-scope-type';
 import { WorkflowItem } from '../../../core/submission/models/workflowitem.model';
+import { SubmissionObject } from '../../../core/submission/models/submission-object.model';
 
 /**
  * This component represents a section that contains a Form.
@@ -114,7 +115,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
    */
   protected subs: Subscription[] = [];
 
-  protected workspaceItem: WorkspaceItem;
+  protected submissionObject: SubmissionObject;
   /**
    * The FormComponent reference
    */
@@ -175,10 +176,10 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
             getRemoteDataPayload())
         ])),
       take(1))
-      .subscribe(([sectionData, workspaceItem]: [WorkspaceitemSectionFormObject, WorkspaceItem]) => {
+      .subscribe(([sectionData, submissionObject]: [WorkspaceitemSectionFormObject, SubmissionObject]) => {
         if (isUndefined(this.formModel)) {
           // this.sectionData.errorsToShow = [];
-          this.workspaceItem = workspaceItem;
+          this.submissionObject = submissionObject;
           // Is the first loading so init form
           this.initForm(sectionData);
           this.sectionData.data = sectionData;
@@ -259,10 +260,10 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
 
     switch (scope) {
       case SubmissionScopeType.WorkspaceItem: {
-        return this.workspaceItem.type === WorkspaceItem.type;
+        return this.submissionObject.type === WorkspaceItem.type;
       }
       case SubmissionScopeType.WorkflowItem: {
-        return this.workspaceItem.type === WorkflowItem.type;
+        return this.submissionObject.type === WorkflowItem.type;
       }
       default: {
         return true;


### PR DESCRIPTION
## References

* #1427
* #1507

## Description

Porting the two PRs mentioned above to repositories with custom submission forms that include  `<visibility>` tags reveals a bug: 

* When a form contains a **pre-filled out-of-scope field** (e.g. a field with `<visibility>workflow</visibility>` while in the workspace), it will always be included in the `diffResult` [here](https://github.com/DSpace/dspace-angular/blob/fb2d22d7a25761580e3fc9aba5f7cfd04a3c7ee5/src/app/submission/sections/form/section-form.component.ts#L242) because it's excluded from `this.formData`
* This causes `hasMetadataEnrichment` to return true, which forces the form component to re-initialize when it doesn't have to

This PR addresses this bug by adding a scope check.

### List of changes

* New method: `inCurrentSubmissionScope`, used to filter which keys to include in `sectionDataToCheck` in   `hasMetadataEnrichment`
* Refactored `SubmissionSectionFormComponent.workspaceItem` to cover both `WorkspaceItem` and `WorkflowItem` since it can be either. For clarity.

## Reviewing

1. Start up a local REST instance **at [w2p-87242_Test](https://github.com/atmire/DSpace/commits/w2p-87242_Test)**

   This branch includes a `dc.description.provenance` field with `<visibility>workflow</visibility>` on `traditionalpageone`

   Start up a local Angular instance **at main**

2. Set up a Collection with a template Item with metadata

   `dc.description.provenance="test"`

3. Start a new submission in this Collection and fill out at one required field, leaving the rest unfilled

4. Click "Deposit"

   * You should see the required fields' errors for a moment before they disappear again.

     This is the form re-initializing.

5. Check out this PR's branch and click "Deposit" again

   * The re-initialization shouldn't happen anymore

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [[TSLint](https://palantir.github.io/tslint/)](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [[TypeDoc](https://typedoc.org/)](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [[Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide)](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [[DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE)](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [[Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.