### PR TITLE
[Issue 1525] Unwrap environment during conversion to YAML

### DIFF
--- a/scripts/env-to-yaml.ts
+++ b/scripts/env-to-yaml.ts
@@ -24,7 +24,7 @@ if (!fs.existsSync(envFullPath)) {
 }
 
 try {
-  const env = require(envFullPath);
+  const env = require(envFullPath).environment;
 
   const config = yaml.dump(env);
   if (args[1]) {


### PR DESCRIPTION
## References

* Fixes #1525 

## Description
N/A

## Instructions for Reviewers
```
yarn env:yaml src/environments/environment.production.ts
```

should output without top level environment

```
production: true
universal:
  preboot: false
  async: true
  time: false
rest:
  ssl: false
  host: localhost
  port: 8080
  nameSpace: /dspace-local
```

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
