### PR TITLE
[CST-5341] Link back to the item page in the now downloading page

### DIFF
--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.html
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.html
@@ -1,3 +1,8 @@
 <div class="container">
+  <div class="d-flex justify-content-between">
     <h3>{{'bitstream.download.page' | translate:{bitstream: (bitstream$ | async)?.name} }}</h3>
+    <button (click)="back()" class="btn btn-outline-secondary">
+      <i class="fas fa-arrow-left"></i> {{'bitstream.download.page.back' | translate}}
+    </button>
+  </div>
 </div>

--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.html
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.html
@@ -1,6 +1,6 @@
 <div class="container">
-  <div class="d-flex justify-content-between">
-    <h3>{{'bitstream.download.page' | translate:{bitstream: (bitstream$ | async)?.name} }}</h3>
+  <h3>{{'bitstream.download.page' | translate:{bitstream: (bitstream$ | async)?.name} }}</h3>
+  <div class="pt-3">
     <button (click)="back()" class="btn btn-outline-secondary">
       <i class="fas fa-arrow-left"></i> {{'bitstream.download.page.back' | translate}}
     </button>

--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
@@ -12,6 +12,7 @@ import { FileService } from '../../core/shared/file.service';
 import { HardRedirectService } from '../../core/services/hard-redirect.service';
 import { getForbiddenRoute } from '../../app-routing-paths';
 import { RemoteData } from '../../core/data/remote-data';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'ds-bitstream-download-page',
@@ -33,8 +34,13 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private auth: AuthService,
     private fileService: FileService,
     private hardRedirectService: HardRedirectService,
+    private location: Location,
   ) {
 
+  }
+
+  back(): void {
+    this.location.back();
   }
 
   ngOnInit(): void {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -551,6 +551,7 @@
 
   "bitstream.download.page": "Now downloading {{bitstream}}..." ,
 
+  "bitstream.download.page.back": "Back" ,
 
 
   "bitstream.edit.authorizations.link": "Edit bitstream's Policies",


### PR DESCRIPTION
## References
* Fixes #1477 

## Description
A "Back" button has been added to the download page

## Instructions for Reviewers
Open any item with an attached file, e.g. [this one](https://demo7.dspace.org/items/014153ff-a6c9-4f08-92f6-e7d638d54986), and download the file. The download page should have a "Back" button.

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
