### PR TITLE
Fix so newly added value on resource policy result in ADD patch, not REPLACE

### DIFF
--- a/src/app/core/data/default-change-analyzer.service.ts
+++ b/src/app/core/data/default-change-analyzer.service.ts
@@ -3,7 +3,7 @@ import { compare } from 'fast-json-patch';
 import { Operation } from 'fast-json-patch';
 import { getClassForType } from '../cache/builders/build-decorators';
 import { TypedObject } from '../cache/object-cache.reducer';
-import { DSpaceSerializer } from '../dspace-rest/dspace.serializer';
+import { DSpaceNotNullSerializer } from '../dspace-rest/dspace-not-null.serializer';
 import { ChangeAnalyzer } from './change-analyzer';
 
 /**
@@ -22,8 +22,8 @@ export class DefaultChangeAnalyzer<T extends TypedObject> implements ChangeAnaly
    *    The second object to compare
    */
   diff(object1: T, object2: T): Operation[] {
-    const serializer1 = new DSpaceSerializer(getClassForType(object1.type));
-    const serializer2 = new DSpaceSerializer(getClassForType(object2.type));
+    const serializer1 = new DSpaceNotNullSerializer(getClassForType(object1.type));
+    const serializer2 = new DSpaceNotNullSerializer(getClassForType(object2.type));
     return compare(serializer1.serialize(object1), serializer2.serialize(object2));
   }
 }

--- a/src/app/core/dspace-rest/dspace-not-null.serializer.ts
+++ b/src/app/core/dspace-rest/dspace-not-null.serializer.ts
@@ -1,0 +1,76 @@
+import { Deserialize, Serialize } from 'cerialize';
+
+import { Serializer } from '../serializer';
+import { GenericConstructor } from '../shared/generic-constructor';
+
+/**
+ * This Serializer turns responses from DSpace's REST API
+ * to models and vice versa, but with all fields with null value removed for the Serialized objects
+ */
+export class DSpaceNotNullSerializer<T> implements Serializer<T> {
+
+  /**
+   * Create a new DSpaceNotNullSerializer instance
+   *
+   * @param modelType a class or interface to indicate
+   * the kind of model this serializer should work with
+   */
+  constructor(private modelType: GenericConstructor<T>) {
+  }
+
+  /**
+   * Convert a model in to the format expected by the backend, but with all fields with null value removed
+   *
+   * @param model The model to serialize
+   * @returns An object to send to the backend
+   */
+  serialize(model: T): any {
+    return getSerializedObjectWithoutNullFields(Serialize(model, this.modelType));
+  }
+
+  /**
+   * Convert an array of models in to the format expected by the backend, but with all fields with null value removed
+   *
+   * @param models The array of models to serialize
+   * @returns An object to send to the backend
+   */
+  serializeArray(models: T[]): any {
+    return getSerializedObjectWithoutNullFields(Serialize(models, this.modelType));
+  }
+
+  /**
+   * Convert a response from the backend in to a model.
+   *
+   * @param response An object returned by the backend
+   * @returns a model of type T
+   */
+  deserialize(response: any): T {
+    if (Array.isArray(response)) {
+      throw new Error('Expected a single model, use deserializeArray() instead');
+    }
+    return Deserialize(response, this.modelType) as T;
+  }
+
+  /**
+   * Convert a response from the backend in to an array of models
+   *
+   * @param response An object returned by the backend
+   * @returns an array of models of type T
+   */
+  deserializeArray(response: any): T[] {
+    if (!Array.isArray(response)) {
+      throw new Error('Expected an Array, use deserialize() instead');
+    }
+    return Deserialize(response, this.modelType) as T[];
+  }
+}
+
+function getSerializedObjectWithoutNullFields(serializedObjectBefore): any {
+  const copySerializedObject = {};
+  for (const [key, value] of Object.entries(serializedObjectBefore)) {
+    if (value !== null) {
+      copySerializedObject[key] = value;
+    }
+  }
+  return copySerializedObject;
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1532
* Related rest contract: https://github.com/DSpace/RestContract/blob/main/resourcepolicies.md

## Description
The creation of the these patches is done in `default-change-analyzer.service.ts` `#diff`

Serialisation of objects (the resource policy) before & after changes are done via library 'cerialize' => `DSpaceSerializer` => `node_modules/cerialize/src/serialize.ts` `#Serialize`

As well as creation of patch requests base on the difference op those via library 'fast-json-patch' => `node_modules/fast-json-patch/module/duplex.d.ts` `#compare`

=> But any field that has value null before and not after, should get ADD not REPLACE patch

=> Added in a serialiser which removes all fields whose value is null from the serialised object and used it for compare 

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* New `DSpaceNotNullSerializer` that removes fields with null value from return serialised object in `serialize` and `serializeArray`
* Utilised new serialiser in `DefaultChangeAnalyzer#diff`

Test cases:
Ex: https://demo7.dspace.org/bitstreams/123d98ae-b875-4775-8186-33b3c54a75bc/authorizations
- Adding a start date to an RP that didn’t have a start date before 
`{op: "add", path: "/startDate", value: "2022-08-11T02:00:00Z"}`
- Idem adding name
`{op: "add", path: "/name", value: "Test embargo"}`
- Combined changes on RP edit
`[{op: "replace", path: "/startDate", value: "2022-08-12T02:00:00Z"}, {op: "replace", path: "/name", value: "Test embargo name change"}, {op: "add", path: "/description", value: "Test description"}]`

- Adding end date
Sends `[{op: "replace", path: "/startDate", value: "2022-08-12T02:00:00Z"}, {op: "add", path: "/endDate", value: "2023-02-09T01:00:00Z"}]`
=> Requires this bug fix: https://github.com/DSpace/DSpace/pull/8180 to work

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
