### PR TITLE
[CST-5316] "Browsing by issue date" is stuck on loading

### DIFF
--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -18,6 +18,7 @@ import { PaginationService } from '../../core/pagination/pagination.service';
 import { map } from 'rxjs/operators';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
 import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
+import { isValidDate } from '../../shared/date.util';
 
 @Component({
   selector: 'ds-browse-by-date-page',
@@ -85,7 +86,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
         let lowerLimit = environment.browseBy.defaultLowerLimit;
         if (hasValue(firstItemRD.payload)) {
           const date = firstItemRD.payload.firstMetadataValue(metadataKeys);
-          if (isNotEmpty(new Date(date))) {
+          if (isNotEmpty(date) && isValidDate(date)) {
             const dateObj = new Date(date);
             // TODO: it appears that getFullYear (based on local time) is sometimes unreliable. Switching to UTC.
             lowerLimit = isNaN(dateObj.getUTCFullYear()) ? lowerLimit : dateObj.getUTCFullYear();

--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -88,7 +88,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
           if (hasValue(date)) {
             const dateObj = new Date(date);
             // TODO: it appears that getFullYear (based on local time) is sometimes unreliable. Switching to UTC.
-            lowerLimit = dateObj.getUTCFullYear();
+            lowerLimit = isNaN(dateObj.getUTCFullYear()) ? lowerLimit : dateObj.getUTCFullYear();
           }
         }
         const options = [];

--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -85,7 +85,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
         let lowerLimit = environment.browseBy.defaultLowerLimit;
         if (hasValue(firstItemRD.payload)) {
           const date = firstItemRD.payload.firstMetadataValue(metadataKeys);
-          if (hasValue(date)) {
+          if (isNotEmpty(new Date(date))) {
             const dateObj = new Date(date);
             // TODO: it appears that getFullYear (based on local time) is sometimes unreliable. Switching to UTC.
             lowerLimit = isNaN(dateObj.getUTCFullYear()) ? lowerLimit : dateObj.getUTCFullYear();

--- a/src/app/shared/date.util.ts
+++ b/src/app/shared/date.util.ts
@@ -113,3 +113,11 @@ export function dateToString(date: Date | NgbDateStruct): string {
   const dateStr = `${year}-${month}-${day}`;
   return moment.utc(dateStr, 'YYYYMMDD').format('YYYY-MM-DD');
 }
+
+/**
+ * Checks if the given string represents a valid date
+ * @param date the string to be checked
+ */
+export function isValidDate(date: string) {
+  return moment(date).isValid();
+}


### PR DESCRIPTION
## References
* Fixes #1523 

## Description
This component assigns to the variable `lowerLimit`a default value from the environment. Then it overwrites this value with the year from the metadata `dc.date.issue` of the first search result, if present.
If the metadata format is wrong, then the default value `lowerLimit` becomes undefined, and this causes loader to be shown indefinitely.

## Instructions for Reviewers
An additional check has been added to the metadata value. The correct behaviour can be tested by replacing the `dc.date.issue` of the first search result with a random non-numeric string.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
