### PR TITLE
Pad date range sliders to fix search facet animation issues

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.scss
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.scss
@@ -28,4 +28,13 @@
   .noUi-connect {
       background: var(--ds-slider-color);
   }
+
+  .noUi-target {
+    padding: 0 calc((var(--ds-slider-handle-width) / 2) - 1.5px);
+    margin: 0 1px;
+  }
+  .noUi-connect {
+    margin: 0 calc(-1 * (var(--ds-slider-handle-width) / 2));
+    width: calc(100% + var(--ds-slider-handle-width));
+  }
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Originally noticed when working on #1138

## Description

Currently, date range sliders in search facets cover the full width of the facet, which causes the handles to jut out a little bit to the left/right.
This works fine, but causes those handles to get pushed behind the facet's padding during the collapse/expand animation.

This PR fixes this by padding the sliders so that the ends of handles at the min/max positions are flush with the slider itself

https://user-images.githubusercontent.com/31547038/159553028-db9f5275-b4fe-4d0f-94b3-67d3643ad28b.mov

## Instructions for Reviewers

Confirm that
* the slider handles are no longer cut in half during the animation when positioned at the ends of the slider
* the date range sliders still work as they did

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.