### PR TITLE
Changed the public/private terminology

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -491,9 +491,9 @@
 
   "admin.search.item.edit": "Edit",
 
-  "admin.search.item.make-private": "Make Private",
+  "admin.search.item.make-private": "Make non-discoverable",
 
-  "admin.search.item.make-public": "Make Public",
+  "admin.search.item.make-public": "Make discoverable",
 
   "admin.search.item.move": "Move",
 
@@ -1623,7 +1623,7 @@
 
 
 
-  "item.alerts.private": "This item is private",
+  "item.alerts.private": "This item is non-discoverable",
 
   "item.alerts.withdrawn": "This item has been withdrawn",
 
@@ -1635,7 +1635,7 @@
 
 
 
-  "item.badge.private": "Private",
+  "item.badge.private": "Non-discoverable",
 
   "item.badge.withdrawn": "Withdrawn",
 
@@ -1874,29 +1874,29 @@
 
   "item.edit.private.cancel": "Cancel",
 
-  "item.edit.private.confirm": "Make it Private",
+  "item.edit.private.confirm": "Make it non-discoverable",
 
-  "item.edit.private.description": "Are you sure this item should be made private in the archive?",
+  "item.edit.private.description": "Are you sure this item should be made non-discoverable in the archive?",
 
-  "item.edit.private.error": "An error occurred while making the item private",
+  "item.edit.private.error": "An error occurred while making the item non-discoverable",
 
-  "item.edit.private.header": "Make item private: {{ id }}",
+  "item.edit.private.header": "Make item non-discoverable: {{ id }}",
 
-  "item.edit.private.success": "The item is now private",
+  "item.edit.private.success": "The item is now non-discoverable",
 
 
 
   "item.edit.public.cancel": "Cancel",
 
-  "item.edit.public.confirm": "Make it Public",
+  "item.edit.public.confirm": "Make it discoverable",
 
-  "item.edit.public.description": "Are you sure this item should be made public in the archive?",
+  "item.edit.public.description": "Are you sure this item should be made discoverable in the archive?",
 
-  "item.edit.public.error": "An error occurred while making the item public",
+  "item.edit.public.error": "An error occurred while making the item discoverable",
 
-  "item.edit.public.header": "Make item public: {{ id }}",
+  "item.edit.public.header": "Make item discoverable: {{ id }}",
 
-  "item.edit.public.success": "The item is now public",
+  "item.edit.public.success": "The item is now discoverable",
 
 
 
@@ -1980,13 +1980,13 @@
 
   "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
 
-  "item.edit.tabs.status.buttons.private.button": "Make it private...",
+  "item.edit.tabs.status.buttons.private.button": "Make it non-discoverable...",
 
-  "item.edit.tabs.status.buttons.private.label": "Make item private",
+  "item.edit.tabs.status.buttons.private.label": "Make item non-discoverable",
 
-  "item.edit.tabs.status.buttons.public.button": "Make it public...",
+  "item.edit.tabs.status.buttons.public.button": "Make it discoverable...",
 
-  "item.edit.tabs.status.buttons.public.label": "Make item public",
+  "item.edit.tabs.status.buttons.public.label": "Make item discoverable",
 
   "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
 
@@ -3201,7 +3201,7 @@
 
   "search.filters.applied.f.dateSubmitted": "Date submitted",
 
-  "search.filters.applied.f.discoverable": "Private",
+  "search.filters.applied.f.discoverable": "Non-discoverable",
 
   "search.filters.applied.f.entityType": "Item Type",
 
@@ -3279,7 +3279,7 @@
 
   "search.filters.filter.dateSubmitted.label": "Search date submitted",
 
-  "search.filters.filter.discoverable.head": "Private",
+  "search.filters.filter.discoverable.head": "Non-discoverable",
 
   "search.filters.filter.withdrawn.head": "Withdrawn",
 


### PR DESCRIPTION
## References
* Fixes #1510

## Description
This changes the terminology around public and private items. Items are now either "discoverable" or "non-discoverable"

## Instructions for Reviewers

List of changes in this PR:
* The word private / public is no longer used anywhere in pages to describe an item's state
* The same terminology now gets used througout DSpace for describing an item's state

* Log in as an administrator
* Go to the edit item page -> status tab
* The button should now display "Make it non-discoverable", instead of "Make it private"
* Go to the administrative Search, the filter for searching should now state "non-discoverable" instead of "private". The red "Private" label above these items, should now also be changed in the same manner.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.