### PR TITLE
French translation reviewed and updated

### DIFF
--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -1,32 +1,37 @@
 {
 
   // "401.help": "You're not authorized to access this page. You can use the button below to get back to the home page.",
-  "401.help": "Vous n'êtes pas autorisé à accéder à cette page. Vous pouvez utiliser le bouton ci-dessous pour revenir sur la page d'accueil.",
+  "401.help": "Vous n'êtes pas autorisé à accéder à cette page. Vous pouvez utiliser le bouton ci-dessous pour revenir à la page d'accueil.",
 
   // "401.link.home-page": "Take me to the home page",
-  "401.link.home-page": "Retour sur la page d'accueil",
+  "401.link.home-page": "Retour à la page d'accueil",
 
   // "401.unauthorized": "unauthorized",
   "401.unauthorized": "Accès non autorisé",
 
-
-
   // "403.help": "You don't have permission to access this page. You can use the button below to get back to the home page.",
-  "403.help": "Vous n'avez pas les permissions requises pour accéder à cette page. Vous pouvez utiliser le bouton ci-dessous pour revenir sur la page d'accueil.",
+  "403.help": "Vous n'avez pas les permissions requises pour accéder à cette page. Vous pouvez utiliser le bouton ci-dessous pour revenir à la page d'accueil.",
 
   // "403.link.home-page": "Take me to the home page",
-  "403.link.home-page": "Retour sur la page d'accueil",
+  "403.link.home-page": "Retour à la page d'accueil",
 
   // "403.forbidden": "forbidden",
   "403.forbidden": "Accès interdit",
 
+  // "500.page-internal-server-error": "Service Unavailable",
+  "500.page-internal-server-error": "Service indisponible",
 
+  // "500.help": "The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.",
+  "500.help": "Le serveur n'est temporairement pas en mesure de répondre à votre demande en raison d'un arrêt dû à une opération de maintenance ou à des problèmes de capacité. Veuillez réessayer plus tard.",
+
+  // "500.link.home-page": "Take me to the home page",
+  "500.link.home-page": "Aller à la page d'accueil",
 
   // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
-  "404.help": "La page que vous recherchez n'a pas pu être localisée. Cette page pourrait avoir été déplacée ou supprimée. Vous pouvez utiliser le bouton ci-dessous pour revenir sur la page d'accueil.",
+  "404.help": "La page que vous recherchez n'a pas pu être localisée. Cette page pourrait avoir été déplacée ou supprimée. Vous pouvez utiliser le bouton ci-dessous pour revenir à la page d'accueil.",
 
   // "404.link.home-page": "Take me to the home page",
-  "404.link.home-page": "Retour sur la page d'accueil",
+  "404.link.home-page": "Retour à la page d'accueil",
 
   // "404.page-not-found": "page not found",
   "404.page-not-found": "Page introuvable",
@@ -53,10 +58,10 @@
   "admin.registries.bitstream-formats.create.failure.head": "Erreur",
 
   // "admin.registries.bitstream-formats.create.head": "Create Bitstream format",
-  "admin.registries.bitstream-formats.create.head": "Ajouter un format Bistream",
+  "admin.registries.bitstream-formats.create.head": "Créer un format Bistream",
 
   // "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
-  "admin.registries.bitstream-formats.create.new": "Ajouter un format Bitstream",
+  "admin.registries.bitstream-formats.create.new": "Ajouter un nouveau format Bitstream",
 
   // "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
   "admin.registries.bitstream-formats.create.success.content": "Le nouveau format Bitstream a été ajouté avec succès.",
@@ -104,10 +109,10 @@
   "admin.registries.bitstream-formats.edit.failure.head": "Échec",
 
   // "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
-  "admin.registries.bitstream-formats.edit.head": "Format Bitstream: {{ format }}",
+  "admin.registries.bitstream-formats.edit.head": "Format Bitstream : {{ format }}",
 
   // "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are hidden from the user, and used for administrative purposes.",
-  "admin.registries.bitstream-formats.edit.internal.hint": "Les formats identifiés en tant que formats internes sont cachés pour l'utilisateur et utilisés uniquement à des fins administratives.",
+  "admin.registries.bitstream-formats.edit.internal.hint": "Les formats identifiés en tant que formats internes sont cachés à l'utilisateur et utilisés uniquement à des fins administratives.",
 
   // "admin.registries.bitstream-formats.edit.internal.label": "Internal",
   "admin.registries.bitstream-formats.edit.internal.label": "Interne",
@@ -119,7 +124,7 @@
   "admin.registries.bitstream-formats.edit.mimetype.label": "Type MIME",
 
   // "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
-  "admin.registries.bitstream-formats.edit.shortDescription.hint": "Nom unique pour ce format (p. ex. Microsoft Word XP or Microsoft Word 2000)",
+  "admin.registries.bitstream-formats.edit.shortDescription.hint": "Nom unique pour ce format (ex. Microsoft Word XP ou Microsoft Word 2000)",
 
   // "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
   "admin.registries.bitstream-formats.edit.shortDescription.label": "Nom",
@@ -131,10 +136,10 @@
   "admin.registries.bitstream-formats.edit.success.head": "Succès",
 
   // "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
-  "admin.registries.bitstream-formats.edit.supportLevel.hint": "Le niveau de support auquel votre institution souscrit pour ce format.",
+  "admin.registries.bitstream-formats.edit.supportLevel.hint": "Le niveau de soutien auquel votre institution souscrit pour ce format.",
 
   // "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
-  "admin.registries.bitstream-formats.edit.supportLevel.label": "Niveau de support",
+  "admin.registries.bitstream-formats.edit.supportLevel.label": "Niveau de soutien",
 
   // "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
   "admin.registries.bitstream-formats.head": "Registre des formats Bitstream",
@@ -157,7 +162,7 @@
   // "admin.registries.bitstream-formats.table.name": "Name",
   "admin.registries.bitstream-formats.table.name": "Nom",
 
-  // "admin.registries.bitstream-formats.table.return": "Return",
+  // "admin.registries.bitstream-formats.table.return": "Back",
   "admin.registries.bitstream-formats.table.return": "Retour",
 
   // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
@@ -170,12 +175,10 @@
   "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Inconnu",
 
   // "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
-  "admin.registries.bitstream-formats.table.supportLevel.head": "Niveau de support",
+  "admin.registries.bitstream-formats.table.supportLevel.head": "Niveau de soutien",
 
-  // "admin.registries.bitstream-formats.title": "DSpace Angular :: Bitstream Format Registry",
-  "admin.registries.bitstream-formats.title": "DSpace Angular :: Registre des formats Bitstream",
-
-
+  // "admin.registries.bitstream-formats.title": "Bitstream Format Registry",
+  "admin.registries.bitstream-formats.title": "Registre des formats Bitstream",
 
   // "admin.registries.metadata.breadcrumbs": "Metadata registry",
   "admin.registries.metadata.breadcrumbs": "Registre de métadonnées",
@@ -213,10 +216,8 @@
   // "admin.registries.metadata.schemas.table.namespace": "Namespace",
   "admin.registries.metadata.schemas.table.namespace": "Espace de nommage",
 
-  // "admin.registries.metadata.title": "DSpace Angular :: Metadata Registry",
-  "admin.registries.metadata.title": "DSpace Angular :: Registre de métadonnées",
-
-
+  // "admin.registries.metadata.title": "Metadata Registry",
+  "admin.registries.metadata.title": "Registre de métadonnées",
 
   // "admin.registries.schema.breadcrumbs": "Metadata schema",
   "admin.registries.schema.breadcrumbs": "Schéma de métadonnées",
@@ -243,7 +244,7 @@
   "admin.registries.schema.form.create": "Ajouter un champ de métadonnées",
 
   // "admin.registries.schema.form.edit": "Edit metadata field",
-  "admin.registries.schema.form.edit": "Éditer champ de métadonnées",
+  "admin.registries.schema.form.edit": "Éditer un champ de métadonnées",
 
   // "admin.registries.schema.form.element": "Element",
   "admin.registries.schema.form.element": "Élément",
@@ -287,16 +288,14 @@
   // "admin.registries.schema.notification.success": "Success",
   "admin.registries.schema.notification.success": "Succès",
 
-  // "admin.registries.schema.return": "Return",
+  // "admin.registries.schema.return": "Back",
   "admin.registries.schema.return": "Retour",
 
-  // "admin.registries.schema.title": "DSpace Angular :: Metadata Schema Registry",
-  "admin.registries.schema.title": "DSpace Angular :: Registre des schémas de métadonnées",
-
-
+  // "admin.registries.schema.title": "Metadata Schema Registry",
+  "admin.registries.schema.title": "Registre des schémas de métadonnées",
 
   // "admin.access-control.epeople.actions.delete": "Delete EPerson",
-  "admin.access-control.epeople.actions.delete": "Supprimer EPerson",
+  "admin.access-control.epeople.actions.delete": "Supprimer un(e) EPerson",
 
   // "admin.access-control.epeople.actions.impersonate": "Impersonate EPerson",
   "admin.access-control.epeople.actions.impersonate": "Se connecter en tant que cet(te) EPerson",
@@ -307,8 +306,11 @@
   // "admin.access-control.epeople.actions.stop-impersonating": "Stop impersonating EPerson",
   "admin.access-control.epeople.actions.stop-impersonating": "Retour à votre propre EPerson ",
 
-  // "admin.access-control.epeople.title": "DSpace Angular :: EPeople",
-  "admin.access-control.epeople.title": "DSpace Angular :: EPeople",
+  // "admin.access-control.epeople.breadcrumbs": "EPeople",
+  "admin.access-control.epeople.breadcrumbs": "EPeople",
+
+  // "admin.access-control.epeople.title": "EPeople",
+  "admin.access-control.epeople.title": "EPeople",
 
   // "admin.access-control.epeople.head": "EPeople",
   "admin.access-control.epeople.head": "EPeople",
@@ -323,13 +325,16 @@
   "admin.access-control.epeople.search.scope.metadata": "Métadonnées",
 
   // "admin.access-control.epeople.search.scope.email": "E-mail (exact)",
-  "admin.access-control.epeople.search.scope.email": "E-mail (exact)",
+  "admin.access-control.epeople.search.scope.email": "Adresse électronique (exacte)",
 
   // "admin.access-control.epeople.search.button": "Search",
   "admin.access-control.epeople.search.button": "Rechercher",
 
+  // "admin.access-control.epeople.search.placeholder": "Search people...",
+  "admin.access-control.epeople.search.placeholder": "Rechercher des personnes...",
+
   // "admin.access-control.epeople.button.add": "Add EPerson",
-  "admin.access-control.epeople.button.add": "Ajouter EPerson",
+  "admin.access-control.epeople.button.add": "Ajouter un(e) EPerson",
 
   // "admin.access-control.epeople.table.id": "ID",
   "admin.access-control.epeople.table.id": "ID",
@@ -338,7 +343,7 @@
   "admin.access-control.epeople.table.name": "Nom",
 
   // "admin.access-control.epeople.table.email": "E-mail (exact)",
-  "admin.access-control.epeople.table.email": "E-mail (exact)",
+  "admin.access-control.epeople.table.email": "Adresse électronique (exacte)",
 
   // "admin.access-control.epeople.table.edit": "Edit",
   "admin.access-control.epeople.table.edit": "Éditer",
@@ -346,17 +351,20 @@
   // "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",
   "admin.access-control.epeople.table.edit.buttons.edit": "Éditer \"{{name}}\"",
 
+  // "admin.access-control.epeople.table.edit.buttons.edit-disabled": "You are not authorized to edit this group",
+  "admin.access-control.epeople.table.edit.buttons.edit-disabled": "Vous n'êtes pas autorisé à modifier ce groupe",
+
   // "admin.access-control.epeople.table.edit.buttons.remove": "Delete \"{{name}}\"",
   "admin.access-control.epeople.table.edit.buttons.remove": "Supprimer \"{{name}}\"",
 
   // "admin.access-control.epeople.no-items": "No EPeople to show.",
-  "admin.access-control.epeople.no-items": "Aucune EPerson ne correspond à votre recherche",
+  "admin.access-control.epeople.no-items": "Aucun(e) EPerson ne correspond à votre recherche",
 
   // "admin.access-control.epeople.form.create": "Create EPerson",
-  "admin.access-control.epeople.form.create": "Créer EPerson",
+  "admin.access-control.epeople.form.create": "Créer un(e) EPerson",
 
   // "admin.access-control.epeople.form.edit": "Edit EPerson",
-  "admin.access-control.epeople.form.edit": "Éditer EPerson",
+  "admin.access-control.epeople.form.edit": "Éditer un(e) EPerson",
 
   // "admin.access-control.epeople.form.firstName": "First name",
   "admin.access-control.epeople.form.firstName": "Prénom",
@@ -365,10 +373,10 @@
   "admin.access-control.epeople.form.lastName": "Nom de famille",
 
   // "admin.access-control.epeople.form.email": "E-mail",
-  "admin.access-control.epeople.form.email": "E-mail",
+  "admin.access-control.epeople.form.email": "Adresse électronique",
 
   // "admin.access-control.epeople.form.emailHint": "Must be valid e-mail address",
-  "admin.access-control.epeople.form.emailHint": "Il doit s'agir d'une adresse mail valide",
+  "admin.access-control.epeople.form.emailHint": "Il doit s'agir d'une adresse électronique valide",
 
   // "admin.access-control.epeople.form.canLogIn": "Can log in",
   "admin.access-control.epeople.form.canLogIn": "Peut se connecter",
@@ -376,26 +384,29 @@
   // "admin.access-control.epeople.form.requireCertificate": "Requires certificate",
   "admin.access-control.epeople.form.requireCertificate": "Doit avoir recours à un certificat",
 
+  // "admin.access-control.epeople.form.return": "Back",
+  "admin.access-control.epeople.form.return": "Retour",
+
   // "admin.access-control.epeople.form.notification.created.success": "Successfully created EPerson \"{{name}}\"",
-  "admin.access-control.epeople.form.notification.created.success": "EPerson \"{{name}}\" créée avec succès",
+  "admin.access-control.epeople.form.notification.created.success": "EPerson \"{{name}}\" créé(e) avec succès",
 
   // "admin.access-control.epeople.form.notification.created.failure": "Failed to create EPerson \"{{name}}\"",
   "admin.access-control.epeople.form.notification.created.failure": "Erreur lors de la création de l'EPerson \"{{name}}\"",
 
   // "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Failed to create EPerson \"{{name}}\", email \"{{email}}\" already in use.",
-  "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Erreur lors de la création de l'EPerson \"{{name}}\", l'adresse mail \"{{email}}\" est déjà utilisée.",
+  "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Erreur lors de la création de l'EPerson \"{{name}}\", l'adresse électronique \"{{email}}\" est déjà utilisée.",
 
   // "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Failed to edit EPerson \"{{name}}\", email \"{{email}}\" already in use.",
-  "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Erreur lors de la modification de l'EPerson \"{{name}}\", l'adresse mail \"{{email}}\" est déjà utilisée.",
+  "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Erreur lors de la modification de l'EPerson \"{{name}}\", l'adresse électronique \"{{email}}\" est déjà utilisée.",
 
   // "admin.access-control.epeople.form.notification.edited.success": "Successfully edited EPerson \"{{name}}\"",
-  "admin.access-control.epeople.form.notification.edited.success": "EPerson \"{{name}}\" modifiée avec succès",
+  "admin.access-control.epeople.form.notification.edited.success": "EPerson \"{{name}}\" modifié(e) avec succès",
 
   // "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",
   "admin.access-control.epeople.form.notification.edited.failure": "Erreur lors de la modification de l'EPerson \"{{name}}\"",
 
   // "admin.access-control.epeople.form.notification.deleted.success": "Successfully deleted EPerson \"{{name}}\"",
-  "admin.access-control.epeople.form.notification.deleted.success": "EPerson \"{{name}}\" supprimée avec succès",
+  "admin.access-control.epeople.form.notification.deleted.success": "EPerson \"{{name}}\" supprimé(e) avec succès",
 
   // "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
   "admin.access-control.epeople.form.notification.deleted.failure": "Erreur lors de la suppression de l'EPerson \"{{name}}\"",
@@ -409,37 +420,47 @@
   // "admin.access-control.epeople.form.table.name": "Name",
   "admin.access-control.epeople.form.table.name": "Nom",
 
+  // "admin.access-control.epeople.form.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.epeople.form.table.collectionOrCommunity": "Collection/Communauté",
+
   // "admin.access-control.epeople.form.memberOfNoGroups": "This EPerson is not a member of any groups",
   "admin.access-control.epeople.form.memberOfNoGroups": "Cette EPerson n'est membre d'aucun groupe",
 
   // "admin.access-control.epeople.form.goToGroups": "Add to groups",
-  "admin.access-control.epeople.form.goToGroups": "Ajouter groupe(s)",
+  "admin.access-control.epeople.form.goToGroups": "Ajouter au(x) groupe(s)",
 
   // "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
   "admin.access-control.epeople.notification.deleted.failure": "Erreur lors de la suppression de l'EPerson \"{{name}}\"",
 
   // "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
-  "admin.access-control.epeople.notification.deleted.success": "EPerson \"{{name}}\" supprimée avec succès",
+  "admin.access-control.epeople.notification.deleted.success": "EPerson \"{{name}}\" supprimé(e) avec succès",
 
+  // "admin.access-control.groups.title": "Groups",
+  "admin.access-control.groups.title": "Groupes",
 
+  // "admin.access-control.groups.breadcrumbs": "Groups",
+  "admin.access-control.groups.breadcrumbs": "Groupes",
 
-  // "admin.access-control.groups.title": "DSpace Angular :: Groups",
-  "admin.access-control.groups.title": "DSpace Angular :: Groupes",
+  // "admin.access-control.groups.singleGroup.breadcrumbs": "Edit Group",
+  "admin.access-control.groups.singleGroup.breadcrumbs": "Éditer un groupe",
 
-  // "admin.access-control.groups.title.singleGroup": "DSpace Angular :: Edit Group",
-  "admin.access-control.groups.title.singleGroup": "DSpace Angular :: Éditer Groupe",
+  // "admin.access-control.groups.title.singleGroup": "Edit Group",
+  "admin.access-control.groups.title.singleGroup": "Éditer groupe",
 
-  // "admin.access-control.groups.title.addGroup": "DSpace Angular :: New Group",
-  "admin.access-control.groups.title.addGroup": "DSpace Angular :: Nouveau Groupe",
+  // "admin.access-control.groups.title.addGroup": "New Group",
+  "admin.access-control.groups.title.addGroup": "Nouveau groupe",
+
+  // "admin.access-control.groups.addGroup.breadcrumbs": "New Group",
+  "admin.access-control.groups.addGroup.breadcrumbs": "Nouveau groupe",
 
   // "admin.access-control.groups.head": "Groups",
   "admin.access-control.groups.head": "Groupes",
 
   // "admin.access-control.groups.button.add": "Add group",
-  "admin.access-control.groups.button.add": "Ajouter groupe",
+  "admin.access-control.groups.button.add": "Ajouter un groupe",
 
   // "admin.access-control.groups.search.head": "Search groups",
-  "admin.access-control.groups.search.head": "Recherche",
+  "admin.access-control.groups.search.head": "Rechercher des groupes",
 
   // "admin.access-control.groups.button.see-all": "Browse all",
   "admin.access-control.groups.button.see-all": "Voir tout",
@@ -447,11 +468,17 @@
   // "admin.access-control.groups.search.button": "Search",
   "admin.access-control.groups.search.button": "Rechercher",
 
+  // "admin.access-control.groups.search.placeholder": "Search groups...",
+  "admin.access-control.groups.search.placeholder": "Rechercher des groupes...",
+
   // "admin.access-control.groups.table.id": "ID",
   "admin.access-control.groups.table.id": "ID",
 
   // "admin.access-control.groups.table.name": "Name",
   "admin.access-control.groups.table.name": "Nom",
+
+  // "admin.access-control.groups.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.groups.table.collectionOrCommunity": "Collection/Community",
 
   // "admin.access-control.groups.table.members": "Members",
   "admin.access-control.groups.table.members": "Membres",
@@ -477,22 +504,23 @@
   // "admin.access-control.groups.notification.deleted.failure.content": "Cause: \"{{cause}}\"",
   "admin.access-control.groups.notification.deleted.failure.content": "Cause : \"{{cause}}\"",
 
-
-
   // "admin.access-control.groups.form.alert.permanent": "This group is permanent, so it can't be edited or deleted. You can still add and remove group members using this page.",
-  "admin.access-control.groups.form.alert.permanent": "Ce groupe est permanent et ne peut, par conséquent, être édité ou supprimé.  Ici, vous pouvez cependant ajouter ou retirer des membres au groupe.",
+  "admin.access-control.groups.form.alert.permanent": "Ce groupe est permanent et ne peut être édité ni supprimé. Vous pouvez toutefois ajouter ou retirer ici des membres au groupe.",
 
   // "admin.access-control.groups.form.alert.workflowGroup": "This group can’t be modified or deleted because it corresponds to a role in the submission and workflow process in the \"{{name}}\" {{comcol}}. You can delete it from the <a href='{{comcolEditRolesRoute}}'>\"assign roles\"</a> tab on the edit {{comcol}} page. You can still add and remove group members using this page.",
-  "admin.access-control.groups.form.alert.workflowGroup": "Ce groupe ne peut être modifié ou supprimé car il correspond à un rôle dans le processus de dépôt et/ou de validation dans \"{{name}}\" {{comcol}}. Vous pouvez le supprimer depuis l'onglet <a href='{{comcolEditRolesRoute}}'>\"Attribuer des rôles\"</a> de la page d'édition {{comcol}}. Ici, vous pouvez cependant ajouter ou retirer des membres au groupe.",
+  "admin.access-control.groups.form.alert.workflowGroup": "Ce groupe ne peut être modifié ou supprimé car il correspond à un rôle dans le processus de dépôt et/ou de validation dans la {{comcol}} \"{{name}}\". Vous pouvez le supprimer depuis l'onglet <a href='{{comcolEditRolesRoute}}'>\"Attribuer des rôles\"</a> de la page d'édition {{comcol}}. Vous pouvez toutefois ajouter ou retirer ici des membres au groupe.",
 
   // "admin.access-control.groups.form.head.create": "Create group",
-  "admin.access-control.groups.form.head.create": "Créer groupe",
+  "admin.access-control.groups.form.head.create": "Créer un groupe",
 
   // "admin.access-control.groups.form.head.edit": "Edit group",
-  "admin.access-control.groups.form.head.edit": "Éditer groupe",
+  "admin.access-control.groups.form.head.edit": "Éditer le groupe",
 
   // "admin.access-control.groups.form.groupName": "Group name",
   "admin.access-control.groups.form.groupName": "Nom du groupe",
+
+  // "admin.access-control.groups.form.groupCommunity": "Community or Collection",
+  "admin.access-control.groups.form.groupCommunity": "Communauté ou collection",
 
   // "admin.access-control.groups.form.groupDescription": "Description",
   "admin.access-control.groups.form.groupDescription": "Description",
@@ -516,13 +544,13 @@
   "admin.access-control.groups.form.notification.edited.success": "Groupe \"{{name}}\" édité avec succès",
 
   // "admin.access-control.groups.form.actions.delete": "Delete Group",
-  "admin.access-control.groups.form.actions.delete": "Supprimer groupe",
+  "admin.access-control.groups.form.actions.delete": "Supprimer le groupe",
 
   // "admin.access-control.groups.form.delete-group.modal.header": "Delete Group \"{{ dsoName }}\"",
-  "admin.access-control.groups.form.delete-group.modal.header": "Supprimer groupe \"{{ dsoName }}\"",
+  "admin.access-control.groups.form.delete-group.modal.header": "Supprimer le groupe \"{{ dsoName }}\"",
 
   // "admin.access-control.groups.form.delete-group.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\"",
-  "admin.access-control.groups.form.delete-group.modal.info": "Êtes-vous certain de vouloir supprimer le groupe \"{{ dsoName }}\"",
+  "admin.access-control.groups.form.delete-group.modal.info": "Êtes-vous certain(e) de vouloir supprimer le groupe \"{{ dsoName }}\"",
 
   // "admin.access-control.groups.form.delete-group.modal.cancel": "Cancel",
   "admin.access-control.groups.form.delete-group.modal.cancel": "Annuler",
@@ -555,7 +583,7 @@
   "admin.access-control.groups.form.members-list.search.scope.metadata": "Métadonnées",
 
   // "admin.access-control.groups.form.members-list.search.scope.email": "E-mail (exact)",
-  "admin.access-control.groups.form.members-list.search.scope.email": "E-mail (exact)",
+  "admin.access-control.groups.form.members-list.search.scope.email": "Adresse électronique (exacte)",
 
   // "admin.access-control.groups.form.members-list.search.button": "Search",
   "admin.access-control.groups.form.members-list.search.button": "Rechercher",
@@ -566,11 +594,20 @@
   // "admin.access-control.groups.form.members-list.table.name": "Name",
   "admin.access-control.groups.form.members-list.table.name": "Nom",
 
+  // "admin.access-control.groups.form.members-list.table.identity": "Identity",
+  "admin.access-control.groups.form.members-list.table.identity": "Identité",
+
+  // "admin.access-control.groups.form.members-list.table.email": "Email",
+  "admin.access-control.groups.form.members-list.table.email": "Adresse électronique",
+
+  // "admin.access-control.groups.form.members-list.table.netid": "NetID",
+  "admin.access-control.groups.form.members-list.table.netid": "Identifiant Réseau",
+
   // "admin.access-control.groups.form.members-list.table.edit": "Remove / Add",
   "admin.access-control.groups.form.members-list.table.edit": "Supprimer / Ajouter",
 
   // "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Remove member with name \"{{name}}\"",
-  "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Supprimer \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Supprimer le membre \"{{name}}\"",
 
   // "admin.access-control.groups.form.members-list.notification.success.addMember": "Successfully added member: \"{{name}}\"",
   "admin.access-control.groups.form.members-list.notification.success.addMember": "Membre \"{{name}}\" ajouté avec succès",
@@ -585,7 +622,7 @@
   "admin.access-control.groups.form.members-list.notification.failure.deleteMember": "Erreur lors de la suppression de \"{{name}}\"",
 
   // "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
-  "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Ajouter \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Ajouter le membre \"{{name}}\"",
 
   // "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
   "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "Pas de groupe actif, veuillez d'abord entrer un nom.",
@@ -594,7 +631,7 @@
   "admin.access-control.groups.form.members-list.no-members-yet": "Ce groupe ne contient pas encore de membres, vous pouvez en rechercher et les ajouter.",
 
   // "admin.access-control.groups.form.members-list.no-items": "No EPeople found in that search",
-  "admin.access-control.groups.form.members-list.no-items": "Aucune EPerson ne correspond à cette recherche",
+  "admin.access-control.groups.form.members-list.no-items": "Aucun(e) EPerson ne correspond à cette recherche",
 
   // "admin.access-control.groups.form.subgroups-list.notification.failure": "Something went wrong: \"{{cause}}\"",
   "admin.access-control.groups.form.subgroups-list.notification.failure": "Une erreur s'est produite : \"{{cause}}\"",
@@ -619,6 +656,9 @@
 
   // "admin.access-control.groups.form.subgroups-list.table.name": "Name",
   "admin.access-control.groups.form.subgroups-list.table.name": "Nom",
+
+  // "admin.access-control.groups.form.subgroups-list.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.groups.form.subgroups-list.table.collectionOrCommunity": "Collection/Communauté",
 
   // "admin.access-control.groups.form.subgroups-list.table.edit": "Remove / Add",
   "admin.access-control.groups.form.subgroups-list.table.edit": "Supprimer / Ajouter",
@@ -648,7 +688,7 @@
   "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "Pas de groupe actif, veuillez d'abord entrer un nom.",
 
   // "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "This is the current group, can't be added.",
-  "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "Il s'agit du groupe actuel, impossible de l'ajouter comme sous-groupe.",
+  "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "Il s'agit du groupe actuel, impossible de l'ajouter.",
 
   // "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
   "admin.access-control.groups.form.subgroups-list.no-items": "Aucun groupe ne correspond à ce nom ou cet identifiant UUID",
@@ -656,10 +696,8 @@
   // "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet.",
   "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "Pas encore de sous-groupes liés à ce groupe.",
 
-  // "admin.access-control.groups.form.return": "Return to groups",
-  "admin.access-control.groups.form.return": "Retour aux groupes",
-
-
+  // "admin.access-control.groups.form.return": "Back",
+  "admin.access-control.groups.form.return": "Retour",
 
   // "admin.search.breadcrumbs": "Administrative Search",
   "admin.search.breadcrumbs": "Recherche Administrateur",
@@ -697,12 +735,11 @@
   // "administrativeView.search.results.head": "Administrative Search",
   "administrativeView.search.results.head": "Recherche Administrateur",
 
-
   // "admin.workflow.breadcrumbs": "Administer Workflow",
-  "admin.workflow.breadcrumbs": "Workflow Administrateur",
+  "admin.workflow.breadcrumbs": "Gestion du Workflow",
 
   // "admin.workflow.title": "Administer Workflow",
-  "admin.workflow.title": "Workflow Adminisrateur",
+  "admin.workflow.title": "Gestion du Workflow",
 
   // "admin.workflow.item.workflow": "Workflow",
   "admin.workflow.item.workflow": "Workflow",
@@ -723,7 +760,7 @@
   "admin.metadata-import.page.header": "Importer Métadonnées",
 
   // "admin.metadata-import.page.help": "You can drop or browse CSV files that contain batch metadata operations on files here",
-  "admin.metadata-import.page.help": "Ici, vous pouvez glisser-déposer ou rechercher des fichiers CSV qui contiennent des opérations sur métadonnées",
+  "admin.metadata-import.page.help": "Vous pouvez glisser-déposer ou rechercher ici des fichiers CSV qui contiennent des opérations en lot sur les métadonnées",
 
   // "admin.metadata-import.page.dropMsg": "Drop a metadata CSV to import",
   "admin.metadata-import.page.dropMsg": "Déposer un fichier CSV à importer",
@@ -731,7 +768,7 @@
   // "admin.metadata-import.page.dropMsgReplace": "Drop to replace the metadata CSV to import",
   "admin.metadata-import.page.dropMsgReplace": "Déposer un nouveau fichier CSV pour remplacer le fichier à importer",
 
-  // "admin.metadata-import.page.button.return": "Return",
+  // "admin.metadata-import.page.button.return": "Back",
   "admin.metadata-import.page.button.return": "Retour",
 
   // "admin.metadata-import.page.button.proceed": "Proceed",
@@ -740,39 +777,53 @@
   // "admin.metadata-import.page.error.addFile": "Select file first!",
   "admin.metadata-import.page.error.addFile": "Veuillez d'abord sélectionner un fichier",
 
-
-
   // "auth.errors.invalid-user": "Invalid email address or password.",
-  "auth.errors.invalid-user": "Adresse e-mail ou mot de passe non valide.",
+  "auth.errors.invalid-user": "Adresse électronique ou mot de passe non valide.",
 
   // "auth.messages.expired": "Your session has expired. Please log in again.",
   "auth.messages.expired": "Votre session a expiré. Veuillez vous reconnecter.",
 
+  // "auth.messages.token-refresh-failed": "Refreshing your session token failed. Please log in again.",
+  "auth.messages.token-refresh-failed": "Le rafraîchissement de votre jeton de session a échoué. Veuillez vous reconnecter.",
 
+  // "bitstream.download.page": "Now downloading {{bitstream}}..." ,
+  "bitstream.download.page": "Téléchargement de {{bitstream}} en cours...",
+
+  // "bitstream.download.page.back": "Back" ,
+  "bitstream.download.page.back": "Retour",
+
+  // "bitstream.edit.authorizations.link": "Edit bitstream's Policies",
+  "bitstream.edit.authorizations.link": "Éditer les politiques de Bitstream",
+
+  // "bitstream.edit.authorizations.title": "Edit bitstream's Policies",
+  "bitstream.edit.authorizations.title": "Éditer les politiques de Bitstream",
+
+  // "bitstream.edit.return": "Back",
+  "bitstream.edit.return": "Retour",
 
   // "bitstream.edit.bitstream": "Bitstream: ",
-  "bitstream.edit.bitstream": "Bitstream: ",
+  "bitstream.edit.bitstream": "Bitstream : ",
 
   // "bitstream.edit.form.description.hint": "Optionally, provide a brief description of the file, for example \"<i>Main article</i>\" or \"<i>Experiment data readings</i>\".",
-  "bitstream.edit.form.description.hint": "Il vous est possible d'entrer une description facultative pour le fichier, par exemple \"<i>Article principal</i>\" ou \"<i>Données sous-jacentes</i>\".",
+  "bitstream.edit.form.description.hint": "Il vous est possible d'entrer une description facultative pour le fichier, par exemple \"<i>Article principal</i>\" ou \"<i>Données expérimentales</i>\".",
 
   // "bitstream.edit.form.description.label": "Description",
   "bitstream.edit.form.description.label": "Description",
 
   // "bitstream.edit.form.embargo.hint": "The first day from which access is allowed. <b>This date cannot be modified on this form.</b> To set an embargo date for a bitstream, go to the <i>Item Status</i> tab, click <i>Authorizations...</i>, create or edit the bitstream's <i>READ</i> policy, and set the <i>Start Date</i> as desired.",
-  "bitstream.edit.form.embargo.hint": "Le premier jour à partir duquel l'accès est autorisé. <b>Cette date ne peut être modifiée depuis ce formulaire.</b> Pour définir une date d'embargo sur un fichier, aller dans l'onglet <i>Statut Item</i>, cliquer sur <i>Autorisations...</i>, créer ou éditer les politiques <i>READ</i> du fichier et configurer la <i>Date de début</i> souhaitée.",
+  "bitstream.edit.form.embargo.hint": "Le premier jour à partir duquel l'accès est autorisé. <b>Cette date ne peut être modifiée depuis ce formulaire.</b> Pour définir une date d'embargo sur un Bitstream, aller dans l'onglet <i>Statut de l'Item</i>, cliquer sur <i>Autorisations...</i>, créer ou éditer les politiques <i>READ</i> du fichier et configurer la <i>date de début</i> souhaitée.",
 
   // "bitstream.edit.form.embargo.label": "Embargo until specific date",
   "bitstream.edit.form.embargo.label": "Embargo jusqu'à une date spécifique",
 
   // "bitstream.edit.form.fileName.hint": "Change the filename for the bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.",
-  "bitstream.edit.form.fileName.hint": "Changer le nom du fichier. Ceci modifiera l'URL affichée pour le fichier mais les anciens liens continuerons de fonctionner tant que le numéro de séquence n'est pas modifié.",
+  "bitstream.edit.form.fileName.hint": "Changer le nom du Bitstream. Ceci modifiera l'URL affichée pour le Bitstream mais les anciens liens continueront de fonctionner tant que le numéro de séquence n'est pas modifié.",
 
   // "bitstream.edit.form.fileName.label": "Filename",
   "bitstream.edit.form.fileName.label": "Nom du fichier",
 
   // "bitstream.edit.form.newFormat.label": "Describe new format",
-  "bitstream.edit.form.newFormat.label": "Décrire nouveau format",
+  "bitstream.edit.form.newFormat.label": "Décrire un nouveau format",
 
   // "bitstream.edit.form.newFormat.hint": "The application you used to create the file, and the version number (for example, \"<i>ACMESoft SuperApp version 1.5</i>\").",
   "bitstream.edit.form.newFormat.hint": "L'application utilisée pour créer le fichier et le numéro de version (par exemple, \"<i>ACMESoft SuperApp version 1.5</i>\").",
@@ -781,7 +832,7 @@
   "bitstream.edit.form.primaryBitstream.label": "Bitstream principal",
 
   // "bitstream.edit.form.selectedFormat.hint": "If the format is not in the above list, <b>select \"format not in list\" above</b> and describe it under \"Describe new format\".",
-  "bitstream.edit.form.selectedFormat.hint": "Si le format souhaité ne se trouve pas dans la liste ci-dessus, <b>sélectionner \"Format non disponible dans la liste\" ci-dessus</b> et le décrire via \"Décrire nouveau format\".",
+  "bitstream.edit.form.selectedFormat.hint": "Si le format souhaité ne se trouve pas dans la liste ci-dessus, <b>sélectionner \"Format non disponible dans la liste\" ci-dessus</b> et le décrire via \"Décrire un nouveau format\".",
 
   // "bitstream.edit.form.selectedFormat.label": "Selected Format",
   "bitstream.edit.form.selectedFormat.label": "Format sélectionné",
@@ -790,18 +841,97 @@
   "bitstream.edit.form.selectedFormat.unknown": "Format non disponible dans la liste",
 
   // "bitstream.edit.notifications.error.format.title": "An error occurred saving the bitstream's format",
-  "bitstream.edit.notifications.error.format.title": "Une erreur s'est produite lors de la sauvegarde du format bitstream",
+  "bitstream.edit.notifications.error.format.title": "Une erreur s'est produite lors de la sauvegarde du format du Bitstream",
+
+  // "bitstream.edit.form.iiifLabel.label": "IIIF Label",
+  "bitstream.edit.form.iiifLabel.label": "Étiquette IIIF",
+
+  // "bitstream.edit.form.iiifLabel.hint": "Canvas label for this image. If not provided default label will be used.",
+  "bitstream.edit.form.iiifLabel.hint": "Libellé du canevas pour cette image. Si elle n'est pas fournie, l'étiquette par défaut sera utilisée.",
+
+  // "bitstream.edit.form.iiifToc.label": "IIIF Table of Contents",
+  "bitstream.edit.form.iiifToc.label": "Table des matières de l'IIIF",
+
+  // "bitstream.edit.form.iiifToc.hint": "Adding text here makes this the start of a new table of contents range.",
+  "bitstream.edit.form.iiifToc.hint": "L'ajout de texte ici fait de cet endroit le début d'une nouvelle plage de table des matières.",
+
+  // "bitstream.edit.form.iiifWidth.label": "IIIF Canvas Width",
+  "bitstream.edit.form.iiifWidth.label": "Largeur du canevas IIIF",
+
+  // "bitstream.edit.form.iiifWidth.hint": "The canvas width should usually match the image width.",
+  "bitstream.edit.form.iiifWidth.hint": "La largeur du canevas doit généralement correspondre à celle de l'image",
+
+  // "bitstream.edit.form.iiifHeight.label": "IIIF Canvas Height",
+  "bitstream.edit.form.iiifHeight.label": "Hauteur du canevas IIIF",
+
+  // "bitstream.edit.form.iiifHeight.hint": "The canvas height should usually match the image height.",
+  "bitstream.edit.form.iiifHeight.hint": "La hauteur du canevas doit généralement correspondre à celle de l'image.",
 
   // "bitstream.edit.notifications.saved.content": "Your changes to this bitstream were saved.",
-  "bitstream.edit.notifications.saved.content": "Vos changements ont bien été sauvegardés.",
+  "bitstream.edit.notifications.saved.content": "Vos modifications à ce Bitstream ont bien été sauvegardées.",
 
   // "bitstream.edit.notifications.saved.title": "Bitstream saved",
   "bitstream.edit.notifications.saved.title": "Bitstream sauvegardé",
 
   // "bitstream.edit.title": "Edit bitstream",
-  "bitstream.edit.title": "Éditer Bitstream",
+  "bitstream.edit.title": "Éditer un Bitstream",
 
+  // "bitstream-request-a-copy.alert.canDownload1": "You already have access to this file. If you want to download the file, click ",
+  "bitstream-request-a-copy.alert.canDownload1": "Vous avez déjà accès à ce fichier. Si vous voulez télécharger le fichier, cliquer sur ",
 
+  // "bitstream-request-a-copy.alert.canDownload2": "here",
+  "bitstream-request-a-copy.alert.canDownload2": "ici",
+
+  // "bitstream-request-a-copy.header": "Request a copy of the file",
+  "bitstream-request-a-copy.header": "Demander une copie du fichier",
+
+  // "bitstream-request-a-copy.intro": "Enter the following information to request a copy for the following item: ",
+  "bitstream-request-a-copy.intro": "Entrer les informations suivantes pour demander une copie de l'élément suivant : ",
+
+  // "bitstream-request-a-copy.intro.bitstream.one": "Requesting the following file: ",
+  "bitstream-request-a-copy.intro.bitstream.one": "Demander les fichiers suivants : ",
+  
+  // "bitstream-request-a-copy.intro.bitstream.all": "Requesting all files. ",
+  "bitstream-request-a-copy.intro.bitstream.all": "Demander tous les fichiers",
+
+  // "bitstream-request-a-copy.name.label": "Name *",
+  "bitstream-request-a-copy.name.label": "Nom *",
+
+  // "bitstream-request-a-copy.name.error": "The name is required",
+  "bitstream-request-a-copy.name.error": "Le nom est obligatoire",
+
+  // "bitstream-request-a-copy.email.label": "Your e-mail address *",
+  "bitstream-request-a-copy.email.label": "Votre adresse électronique *",
+
+  // "bitstream-request-a-copy.email.hint": "This email address is used for sending the file.",
+  "bitstream-request-a-copy.email.hint": "Cette adresse électronique est utilisée pour l'envoi du fichier.",
+
+  // "bitstream-request-a-copy.email.error": "Please enter a valid email address.",
+  "bitstream-request-a-copy.email.error": "Veuillez saisir une adresse électronique valide.",
+
+  // "bitstream-request-a-copy.allfiles.label": "Files",
+  "bitstream-request-a-copy.allfiles.label": "Fichiers",
+
+  // "bitstream-request-a-copy.files-all-false.label": "Only the requested file",
+  "bitstream-request-a-copy.files-all-false.label": "Seulement le fichier demandé",
+
+  // "bitstream-request-a-copy.files-all-true.label": "All files (of this item) in restricted access",
+  "bitstream-request-a-copy.files-all-true.label": "Tous les fichiers (de cet Item) en accès restreint",
+
+  // "bitstream-request-a-copy.message.label": "Message",
+  "bitstream-request-a-copy.message.label": "Message",
+
+  // "bitstream-request-a-copy.return": "Back",
+  "bitstream-request-a-copy.return": "Retour",
+
+  // "bitstream-request-a-copy.submit": "Request copy",
+  "bitstream-request-a-copy.submit": "Demander une copie",
+
+  // "bitstream-request-a-copy.submit.success": "The item request was submitted successfully.",
+  "bitstream-request-a-copy.submit.success": "La demande d'Item a été soumise avec succès.",
+
+  // "bitstream-request-a-copy.submit.error": "Something went wrong with submitting the item request.",
+  "bitstream-request-a-copy.submit.error": "Un problème est survenu lors de la soumission de la demande d'Item",
 
   // "browse.comcol.by.author": "By Author",
   "browse.comcol.by.author": "Auteur",
@@ -845,11 +975,20 @@
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "Parcourir par Titre",
 
+  // "browse.next.button": "Next",
+  "browse.next.button": "Suivant(e)",
+
+  // "browse.previous.button": "Previous",
+  "browse.previous.button": "Précédent(e)",
+
   // "browse.startsWith.choose_start": "(Choose start)",
-  "browse.startsWith.choose_start": "(Choisir point de départ)",
+  "browse.startsWith.choose_start": "(Choisir le début)",
 
   // "browse.startsWith.choose_year": "(Choose year)",
   "browse.startsWith.choose_year": "(Choisir l'année)",
+
+  // "browse.startsWith.choose_year.label": "Choose the issue year",
+  "browse.startsWith.choose_year.label": "Choisir l'année de publication",
 
   // "browse.startsWith.jump": "Jump to a point in the index:",
   "browse.startsWith.jump": "Aller directement à une entrée de l'index :",
@@ -884,6 +1023,9 @@
   // "browse.startsWith.months.none": "(Choose month)",
   "browse.startsWith.months.none": "(Choisir le mois)",
 
+  // "browse.startsWith.months.none.label": "Choose the issue month",
+  "browse.startsWith.months.none.label": "Choisir le mois de publication",
+
   // "browse.startsWith.months.november": "November",
   "browse.startsWith.months.november": "Novembre",
 
@@ -893,35 +1035,35 @@
   // "browse.startsWith.months.september": "September",
   "browse.startsWith.months.september": "Septembre",
 
-  // "browse.startsWith.submit": "Go",
+  // "browse.startsWith.submit": "Browse",
   "browse.startsWith.submit": "Valider",
 
-  // "browse.startsWith.type_date": "Or type in a date (year-month):",
-  "browse.startsWith.type_date": "Ou saisir une date (année-mois) :",
+  // "browse.startsWith.type_date": "Or type in a date (year-month) and click 'Browse'",
+  "browse.startsWith.type_date": "Ou saisir une date (année-mois) puis cliquer sur « Parcourir par »",
 
-  // "browse.startsWith.type_text": "Or enter first few letters:",
-  "browse.startsWith.type_text": "Ou saisir les premières lettres :",
+  // "browse.startsWith.type_date.label": "Or type in a date (year-month) and click on the Browse button",
+  "browse.startsWith.type_date.label": "Ou saisir une date (année-mois) puis cliquer sur le bouton « Parcourir »",
+
+  // "browse.startsWith.type_text": "Type the first few letters and click on the Browse button",
+  "browse.startsWith.type_text": "Ou saisir les premières lettres puis cliquer sur le bouton « Parcourir »",
 
   // "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
-  "browse.title": "Parcourir {{ collection }} par {{ field }} {{ value }}",
-
+  "browse.title": "Parcourir la collection {{ collection }} par {{ field }} {{ value }}",
 
   // "chips.remove": "Remove chip",
   "chips.remove": "Supprimer fragment",
 
-
-
   // "collection.create.head": "Create a Collection",
-  "collection.create.head": "Créer une Collection",
+  "collection.create.head": "Créer une collection",
 
   // "collection.create.notifications.success": "Successfully created the Collection",
-  "collection.create.notifications.success": "Collection créée avec succès",
+  "collection.create.notifications.success": "collection créée avec succès",
 
   // "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
-  "collection.create.sub-head": "Créer une Collection au sein de la Communauté {{ parent }}",
+  "collection.create.sub-head": "Créer une collection au sein de la communauté {{ parent }}",
 
   // "collection.curate.header": "Curate Collection: {{collection}}",
-  "collection.curate.header": "Gestion contenu Collection: {{collection}}",
+  "collection.curate.header": "Gestion du contenu de la collection : {{collection}}",
 
   // "collection.delete.cancel": "Cancel",
   "collection.delete.cancel": "Annuler",
@@ -929,34 +1071,35 @@
   // "collection.delete.confirm": "Confirm",
   "collection.delete.confirm": "Valider",
 
+  // "collection.delete.processing": "Deleting",
+  "collection.delete.processing": "Suppression de",
+
   // "collection.delete.head": "Delete Collection",
-  "collection.delete.head": "Supprimer Collection",
+  "collection.delete.head": "Supprimer collection",
 
   // "collection.delete.notification.fail": "Collection could not be deleted",
-  "collection.delete.notification.fail": "La Collection n'a pas pu être supprimée",
+  "collection.delete.notification.fail": "La collection n'a pas pu être supprimée",
 
   // "collection.delete.notification.success": "Successfully deleted collection",
   "collection.delete.notification.success": "Collection supprimée avec succès",
 
   // "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
-  "collection.delete.text": "Êtes-vous certain de vouloir supprimer la Collection « {{ dso }} »",
-
-
+  "collection.delete.text": "Êtes-vous certain(e) de vouloir supprimer la collection « {{ dso }} »",
 
   // "collection.edit.delete": "Delete this collection",
-  "collection.edit.delete": "Supprimer cette Collection",
+  "collection.edit.delete": "Supprimer cette collection",
 
   // "collection.edit.head": "Edit Collection",
-  "collection.edit.head": "Éditer Collection",
+  "collection.edit.head": "Éditer une collection",
 
   // "collection.edit.breadcrumbs": "Edit Collection",
-  "collection.edit.breadcrumbs": "Éditer Collection",
+  "collection.edit.breadcrumbs": "Éditer une collection",
 
   // "collection.edit.tabs.mapper.head": "Item Mapper",
-  "collection.edit.tabs.mapper.head": "Item Mapper",
+  "collection.edit.tabs.mapper.head": "Association d'Items",
 
   // "collection.edit.tabs.item-mapper.title": "Collection Edit - Item Mapper",
-  "collection.edit.tabs.item-mapper.title": "Collection Edit - Item Mapper",
+  "collection.edit.tabs.item-mapper.title": "Édition de collection - Association d'Items",
 
   // "collection.edit.item-mapper.cancel": "Cancel",
   "collection.edit.item-mapper.cancel": "Annuler",
@@ -968,13 +1111,13 @@
   "collection.edit.item-mapper.confirm": "Associer les Items sélectionnés",
 
   // "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
-  "collection.edit.item-mapper.description": "L'Item Mapper permet aux administrateurs de Collection d'associer des Items provenant d'autres Collections dans cette Collection. Vous pouvez rechercher des Items d'autres Collections et les associer, ou consulter la liste des Items actuellement associés.",
+  "collection.edit.item-mapper.description": "L'outil d'association d'Items permet aux administrateurs de collections d'associer des Items provenant d'autres collections à cette collection. Vous pouvez rechercher des Items d'autres collections et les associer, ou encore consulter la liste des Items actuellement associés.",
 
   // "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
-  "collection.edit.item-mapper.head": "Item Mapper - Associer des Items provenant d'autres Collections",
+  "collection.edit.item-mapper.head": "Association d'Items - Associer des Items provenant d'autres collections",
 
   // "collection.edit.item-mapper.no-search": "Please enter a query to search",
-  "collection.edit.item-mapper.no-search": "Veuillez entrer un élément à rechercher",
+  "collection.edit.item-mapper.no-search": "Veuillez entrer une requête de recherche",
 
   // "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
   "collection.edit.item-mapper.notifications.map.error.content": "Des erreurs se sont produites lors de l'association de {{amount}} Item(s).",
@@ -992,85 +1135,88 @@
   "collection.edit.item-mapper.notifications.unmap.error.content": "Des erreurs se sont produites lors de la suppression de l'association de {{amount}} Item(s).",
 
   // "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
-  "collection.edit.item-mapper.notifications.unmap.error.head": "Erreurs de suppression d'association",
+  "collection.edit.item-mapper.notifications.unmap.error.head": "Erreurs de suppression d'association(s)",
 
   // "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
   "collection.edit.item-mapper.notifications.unmap.success.content": "{{amount}} association(s) supprimée(s) avec succès.",
 
   // "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
-  "collection.edit.item-mapper.notifications.unmap.success.head": "Suppression d'association terminée",
+  "collection.edit.item-mapper.notifications.unmap.success.head": "Suppression d'association(s) terminée",
 
   // "collection.edit.item-mapper.remove": "Remove selected item mappings",
-  "collection.edit.item-mapper.remove": "Supprimer les associations sélectionnées",
+  "collection.edit.item-mapper.remove": "Supprimer les associations des Items sélectionnées",
+
+  // "collection.edit.item-mapper.search-form.placeholder": "Search items...",
+  "collection.edit.item-mapper.search-form.placeholder": "Rechercher des Items... ",
 
   // "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
   "collection.edit.item-mapper.tabs.browse": "Parcourir les Items associés",
 
   // "collection.edit.item-mapper.tabs.map": "Map new items",
-  "collection.edit.item-mapper.tabs.map": "Associer nouveaux Items",
+  "collection.edit.item-mapper.tabs.map": "Associer de nouveaux Items",
 
+  // "collection.edit.logo.delete.title": "Delete logo",
+  "collection.edit.logo.delete.title": "Supprimer le logo",
 
+  // "collection.edit.logo.delete-undo.title": "Undo delete",
+  "collection.edit.logo.delete-undo.title": "Annuler la suppression",
 
   // "collection.edit.logo.label": "Collection logo",
-  "collection.edit.logo.label": "Logo de la Collection",
+  "collection.edit.logo.label": "Logo de la collection",
 
   // "collection.edit.logo.notifications.add.error": "Uploading Collection logo failed. Please verify the content before retrying.",
-  "collection.edit.logo.notifications.add.error": "Erreur lors du chargement du logo de la Collection. Veuillez vérifier le contenu et réessayer.",
+  "collection.edit.logo.notifications.add.error": "Erreur lors du chargement du logo de la collection. Veuillez vérifier le contenu et réessayer.",
 
   // "collection.edit.logo.notifications.add.success": "Upload Collection logo successful.",
-  "collection.edit.logo.notifications.add.success": "Logo de la Collection chargé avec succès.",
+  "collection.edit.logo.notifications.add.success": "Logo de la collection chargé avec succès.",
 
   // "collection.edit.logo.notifications.delete.success.title": "Logo deleted",
   "collection.edit.logo.notifications.delete.success.title": "Logo supprimé",
 
   // "collection.edit.logo.notifications.delete.success.content": "Successfully deleted the collection's logo",
-  "collection.edit.logo.notifications.delete.success.content": "Logo de la Collection supprimé avec succès",
+  "collection.edit.logo.notifications.delete.success.content": "Logo de la collection supprimé avec succès",
 
   // "collection.edit.logo.notifications.delete.error.title": "Error deleting logo",
-  "collection.edit.logo.notifications.delete.error.title": "Erreur lors de la suppression du logo de la Collection.",
+  "collection.edit.logo.notifications.delete.error.title": "Erreur lors de la suppression du logo de la collection.",
 
   // "collection.edit.logo.upload": "Drop a Collection Logo to upload",
-  "collection.edit.logo.upload": "Glisser-Déposer un logo à charger pour la Collection",
-
-
+  "collection.edit.logo.upload": "Glisser-Déposer un logo à charger pour la collection",
 
   // "collection.edit.notifications.success": "Successfully edited the Collection",
   "collection.edit.notifications.success": "Collection mise à jour avec succès",
 
-  // "collection.edit.return": "Return",
+  // "collection.edit.return": "Back",
   "collection.edit.return": "Retour",
-
-
 
   // "collection.edit.tabs.curate.head": "Curate",
   "collection.edit.tabs.curate.head": "Gestion du contenu",
 
   // "collection.edit.tabs.curate.title": "Collection Edit - Curate",
-  "collection.edit.tabs.curate.title": "Édition Collection - Gestion du contenu",
+  "collection.edit.tabs.curate.title": "Édition de collection - Gestion du contenu",
 
   // "collection.edit.tabs.authorizations.head": "Authorizations",
   "collection.edit.tabs.authorizations.head": "Autorisations",
 
   // "collection.edit.tabs.authorizations.title": "Collection Edit - Authorizations",
-  "collection.edit.tabs.authorizations.title": "Édition Collection - Autorisations",
+  "collection.edit.tabs.authorizations.title": "Édition de collection - Autorisations",
 
   // "collection.edit.tabs.metadata.head": "Edit Metadata",
-  "collection.edit.tabs.metadata.head": "Éditer Métadonnées",
+  "collection.edit.tabs.metadata.head": "Éditer les Métadonnées",
 
   // "collection.edit.tabs.metadata.title": "Collection Edit - Metadata",
-  "collection.edit.tabs.metadata.title": "Édition Collection - Métadonnées",
+  "collection.edit.tabs.metadata.title": "Édition de collection - Métadonnées",
 
   // "collection.edit.tabs.roles.head": "Assign Roles",
   "collection.edit.tabs.roles.head": "Attribuer des rôles",
 
   // "collection.edit.tabs.roles.title": "Collection Edit - Roles",
-  "collection.edit.tabs.roles.title": "Édition Collection - Rôles",
+  "collection.edit.tabs.roles.title": "Édition de collection - Rôles",
 
   // "collection.edit.tabs.source.external": "This collection harvests its content from an external source",
-  "collection.edit.tabs.source.external": "Cette Collection moissonne son contenu depuis une source externe",
+  "collection.edit.tabs.source.external": "Cette collection moissonne son contenu depuis une source externe",
 
   // "collection.edit.tabs.source.form.errors.oaiSource.required": "You must provide a set id of the target collection.",
-  "collection.edit.tabs.source.form.errors.oaiSource.required": "Vous devez fournir l'ID du set OAI correspondant à la Collection cible.",
+  "collection.edit.tabs.source.form.errors.oaiSource.required": "Vous devez fournir l'ID de l'ensemble (set) OAI correspondant à la collection cible.",
 
   // "collection.edit.tabs.source.form.harvestType": "Content being harvested",
   "collection.edit.tabs.source.form.harvestType": "Contenu en cours de moissonnage",
@@ -1082,16 +1228,16 @@
   "collection.edit.tabs.source.form.metadataConfigId": "Format de métadonnées",
 
   // "collection.edit.tabs.source.form.oaiSetId": "OAI specific set id",
-  "collection.edit.tabs.source.form.oaiSetId": "ID spécifique du set OAI",
+  "collection.edit.tabs.source.form.oaiSetId": "ID spécifique de l'ensemble (set) OAI",
 
   // "collection.edit.tabs.source.form.oaiSource": "OAI Provider",
   "collection.edit.tabs.source.form.oaiSource": "Fournisseur OAI",
 
   // "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_BITSTREAMS": "Harvest metadata and bitstreams (requires ORE support)",
-  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_BITSTREAMS": "Moissonner métadonnées et bitstreams (le protocol ORE doit être supporté)",
+  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_BITSTREAMS": "Moissonner métadonnées et Bitstreams (le protocole ORE doit être supporté)",
 
   // "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_REF": "Harvest metadata and references to bitstreams (requires ORE support)",
-  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_REF": "Moissonner métadonnées et bitstreams (le protocol ORE doit être supporté)",
+  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_REF": "Moissonner métadonnées et références aux Bitstreams (le protocole ORE doit être supporté)",
 
   // "collection.edit.tabs.source.form.options.harvestType.METADATA_ONLY": "Harvest metadata only",
   "collection.edit.tabs.source.form.options.harvestType.METADATA_ONLY": "Moissonner métadonnées uniquement",
@@ -1100,7 +1246,7 @@
   "collection.edit.tabs.source.head": "Source de contenu",
 
   // "collection.edit.tabs.source.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
-  "collection.edit.tabs.source.notifications.discarded.content": "Vos changements ont été annulés. Pour restaurer vos changements, veuillez cliquer sur le bouton 'Annuler'",
+  "collection.edit.tabs.source.notifications.discarded.content": "Vos changements ont été annulés. Pour restaurer vos changements, veuillez cliquer sur le bouton « Annuler »",
 
   // "collection.edit.tabs.source.notifications.discarded.title": "Changed discarded",
   "collection.edit.tabs.source.notifications.discarded.title": "Changements annulés",
@@ -1112,21 +1258,19 @@
   "collection.edit.tabs.source.notifications.invalid.title": "Metadonnée invalide",
 
   // "collection.edit.tabs.source.notifications.saved.content": "Your changes to this collection's content source were saved.",
-  "collection.edit.tabs.source.notifications.saved.content": "Les changements relatifs à la source de contenu de cette Collection ont bien été sauvegardés.",
+  "collection.edit.tabs.source.notifications.saved.content": "Les changements relatifs à la source de contenu de cette collection ont bien été sauvegardés.",
 
   // "collection.edit.tabs.source.notifications.saved.title": "Content Source saved",
   "collection.edit.tabs.source.notifications.saved.title": "Source de contenu sauvegardée",
 
   // "collection.edit.tabs.source.title": "Collection Edit - Content Source",
-  "collection.edit.tabs.source.title": "Édition Collection - Source de contenu",
-
-
+  "collection.edit.tabs.source.title": "Édition de collection - Source de contenu",
 
   // "collection.edit.template.add-button": "Add",
   "collection.edit.template.add-button": "Ajouter",
 
   // "collection.edit.template.breadcrumbs": "Item template",
-  "collection.edit.template.breadcrumbs": "Template Item",
+  "collection.edit.template.breadcrumbs": "Modèle d'Item",
 
   // "collection.edit.template.cancel": "Cancel",
   "collection.edit.template.cancel": "Annuler",
@@ -1137,22 +1281,26 @@
   // "collection.edit.template.edit-button": "Edit",
   "collection.edit.template.edit-button": "Éditer",
 
+  // "collection.edit.template.error": "An error occurred retrieving the template item",
+  "collection.edit.template.error": "Une erreur s'est produite lors de la récupération du modèle d'Item",
+
   // "collection.edit.template.head": "Edit Template Item for Collection \"{{ collection }}\"",
-  "collection.edit.template.head": "Éditer le Template Item (modèle de document) pour la Collection \"{{ collection }}\"",
+  "collection.edit.template.head": "Éditer le modèle d'Item pour la collection \"{{ collection }}\"",
 
   // "collection.edit.template.label": "Template item",
-  "collection.edit.template.label": "Template Item",
+  "collection.edit.template.label": "Modèle modèle d'Item",
+
+  // "collection.edit.template.loading": "Loading template item...",
+  "collection.edit.template.loading": "Chargement du modèle d'Item...",
 
   // "collection.edit.template.notifications.delete.error": "Failed to delete the item template",
-  "collection.edit.template.notifications.delete.error": "Erreur lors de la suprresion du Template Item",
+  "collection.edit.template.notifications.delete.error": "Erreur lors de la suprresion du modèle d'Item",
 
   // "collection.edit.template.notifications.delete.success": "Successfully deleted the item template",
-  "collection.edit.template.notifications.delete.success": "Item Template supprimé avec succès",
+  "collection.edit.template.notifications.delete.success": "Modèle d'Item supprimé avec succès",
 
   // "collection.edit.template.title": "Edit Template Item",
-  "collection.edit.template.title": "Éditer Template Item",
-
-
+  "collection.edit.template.title": "Éditer le modèle d'Item",
 
   // "collection.form.abstract": "Short Description",
   "collection.form.abstract": "Description succincte",
@@ -1161,7 +1309,7 @@
   "collection.form.description": "Texte d'introduction (HTML)",
 
   // "collection.form.errors.title.required": "Please enter a collection name",
-  "collection.form.errors.title.required": "Veuillez entrer un nom de Collection",
+  "collection.form.errors.title.required": "Veuillez saisir un nom de collection",
 
   // "collection.form.license": "License",
   "collection.form.license": "Licence",
@@ -1178,11 +1326,11 @@
   // "collection.form.title": "Name",
   "collection.form.title": "Nom",
 
-
+  // "collection.form.entityType": "Entity Type",
+  "collection.form.entityType": "Type d'entité",
 
   // "collection.listelement.badge": "Collection",
   "collection.listelement.badge": "Collection",
-
 
   // "collection.page.browse.recent.head": "Recent Submissions",
   "collection.page.browse.recent.head": "Dépôts récents",
@@ -1191,10 +1339,10 @@
   "collection.page.browse.recent.empty": "Aucun dépôt disponible",
 
   // "collection.page.edit": "Edit this collection",
-  "collection.page.edit": "Éditer cette Collection",
+  "collection.page.edit": "Éditer cette collection",
 
   // "collection.page.handle": "Permanent URI for this collection",
-  "collection.page.handle": "URI permanent de cette Collection",
+  "collection.page.handle": "URI permanent de cette collection",
 
   // "collection.page.license": "License",
   "collection.page.license": "Licence",
@@ -1202,48 +1350,113 @@
   // "collection.page.news": "News",
   "collection.page.news": "Nouvelles",
 
-
-
   // "collection.select.confirm": "Confirm selected",
-  "collection.select.confirm": "Confirmer sélection",
+  "collection.select.confirm": "Confirmer la sélection",
 
   // "collection.select.empty": "No collections to show",
-  "collection.select.empty": "Aucune Collection disponible",
+  "collection.select.empty": "Aucune collection disponible",
 
   // "collection.select.table.title": "Title",
   "collection.select.table.title": "Titre",
 
+  // "collection.source.controls.head": "Harvest Controls",
+  "collection.source.controls.head": "Paramétrage du moissonnage",
+  
+  // "collection.source.controls.test.submit.error": "Something went wrong with initiating the testing of the settings",
+  "collection.source.controls.test.submit.error": "Un problème est survenu lors du lancement du test des paramètres.",
+  
+  // "collection.source.controls.test.failed": "The script to test the settings has failed",
+  "collection.source.controls.test.failed": "Le script pour tester les paramètres a échoué",
+  
+  // "collection.source.controls.test.completed": "The script to test the settings has successfully finished",
+  "collection.source.controls.test.completed": "Le script pour tester les paramètres s'est terminé avec succès",
+  
+  // "collection.source.controls.test.submit": "Test configuration",
+  "collection.source.controls.test.submit": "Test de configuration",
+  
+  // "collection.source.controls.test.running": "Testing configuration...",
+  "collection.source.controls.test.running": "Test de la configuration lancé...",
+  
+  // "collection.source.controls.import.submit.success": "The import has been successfully initiated",
+  "collection.source.controls.import.submit.success": "L'importation a été lancée avec succès",
+  
+  // "collection.source.controls.import.submit.error": "Something went wrong with initiating the import",
+  "collection.source.controls.import.submit.error": "Un problème est survenu lors du lancement de l'importation",
 
+  // "collection.source.controls.import.submit": "Import now",
+  "collection.source.controls.import.submit": "Lancer l'importation",
+  
+  // "collection.source.controls.import.running": "Importing...",
+  "collection.source.controls.import.running": "Importation lancée...",
+  
+  // "collection.source.controls.import.failed": "An error occurred during the import",
+  "collection.source.controls.import.failed": "Un problème est survenu lors de l'importation",
+  
+  // "collection.source.controls.import.completed": "The import completed",
+  "collection.source.controls.import.completed": "Importation complétée",
+  
+  // "collection.source.controls.reset.submit.success": "The reset and reimport has been successfully initiated",
+  "collection.source.controls.reset.submit.success": "La réinitialisation et la réimportation ont été lancées avec succès.",
+  
+  // "collection.source.controls.reset.submit.error": "Something went wrong with initiating the reset and reimport",
+  "collection.source.controls.reset.submit.error": "Un problème est survenu lors du lancement de la réinitialisation et de la réimportation. ",
+  
+  // "collection.source.controls.reset.failed": "An error occurred during the reset and reimport",
+  "collection.source.controls.reset.failed": "Une erreur s'est produite pendant la réinitialisation et la réimportation.",
+  
+  // "collection.source.controls.reset.completed": "The reset and reimport completed",
+  "collection.source.controls.reset.completed": "La réinitialisation et la réimportation sont terminées",
+  
+  // "collection.source.controls.reset.submit": "Reset and reimport",
+  "collection.source.controls.reset.submit": "Réinitialisation et réimportation",
+  
+  // "collection.source.controls.reset.running": "Resetting and reimporting...",
+  "collection.source.controls.reset.running": "Réinitialisation et réimportation...",
+  
+  // "collection.source.controls.harvest.status": "Harvest status:",
+  "collection.source.controls.harvest.status": "État du moissonnage",
+  
+  // "collection.source.controls.harvest.start": "Harvest start time:",
+  "collection.source.controls.harvest.start": "Heure de début du moissonnage :",
+  
+  // "collection.source.controls.harvest.last": "Last time harvested:",
+  "collection.source.controls.harvest.last": "Dernier moissonnage en date du :",
+  
+  // "collection.source.controls.harvest.message": "Harvest info:",
+  "collection.source.controls.harvest.message": "Détails du moissonnage :",
+  
+  // "collection.source.controls.harvest.no-information": "N/A",
+  "collection.source.controls.harvest.no-information": "Non disponible",
 
   // "collection.source.update.notifications.error.content": "The provided settings have been tested and didn't work.",
-  "collection.source.update.notifications.error.content": "Les paramètres fournis sont invalides. La connection n'a pas pu être établie.",
+  "collection.source.update.notifications.error.content": "Les paramètres fournis ont été testés et n'ont pas fonctionné correctement.",
 
   // "collection.source.update.notifications.error.title": "Server Error",
-  "collection.source.update.notifications.error.title": "Erreur serveur",
+  "collection.source.update.notifications.error.title": "Erreur du serveur",
 
+  // "communityList.breadcrumbs": "Community List",
+  "communityList.breadcrumbs": "Liste des communautés",
 
-  // "communityList.tabTitle": "DSpace - Community List",
-  "communityList.tabTitle": "DSpace - Liste des Communautés",
+  // "communityList.tabTitle": "Community List",
+  "communityList.tabTitle": "Liste des communautés",
 
   // "communityList.title": "List of Communities",
-  "communityList.title": "Liste des Communautés",
+  "communityList.title": "Liste des communautés",
 
   // "communityList.showMore": "Show More",
-  "communityList.showMore": "Voir plus",
-
-
+  "communityList.showMore": "Afficher davantage",
 
   // "community.create.head": "Create a Community",
-  "community.create.head": "Créer une Communauté",
+  "community.create.head": "Créer une communauté",
 
   // "community.create.notifications.success": "Successfully created the Community",
   "community.create.notifications.success": "Communauté créée avec succès",
 
   // "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
-  "community.create.sub-head": "Créer une Sous-Communauté pour la Communauté {{ parent }}",
+  "community.create.sub-head": "Créer une sous-communauté pour la communauté {{ parent }}",
 
   // "community.curate.header": "Curate Community: {{community}}",
-  "community.curate.header": "Gestion contenu Communauté : {{community}}",
+  "community.curate.header": "Gestion du contenu de la communauté : {{community}}",
 
   // "community.delete.cancel": "Cancel",
   "community.delete.cancel": "Annuler",
@@ -1251,50 +1464,56 @@
   // "community.delete.confirm": "Confirm",
   "community.delete.confirm": "Confirmer",
 
+  // "community.delete.processing": "Deleting...",
+  "community.delete.processing": "Suppression...",
+
   // "community.delete.head": "Delete Community",
-  "community.delete.head": "Supprimer Communauté",
+  "community.delete.head": "Supprimer une communauté",
 
   // "community.delete.notification.fail": "Community could not be deleted",
-  "community.delete.notification.fail": "La Communauté n'a pas pu être supprimée",
+  "community.delete.notification.fail": "La communauté n'a pas pu être supprimée",
 
   // "community.delete.notification.success": "Successfully deleted community",
-  "community.delete.notification.success": "La Communauté a été supprimée avec succès",
+  "community.delete.notification.success": "La communauté a été supprimée avec succès",
 
   // "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
-  "community.delete.text": "Êtes-vous sûr(e) de vouloir supprimer la Communauté « {{ dso }} »",
+  "community.delete.text": "Êtes-vous certain(e) de vouloir supprimer la communauté « {{ dso }} »",
 
   // "community.edit.delete": "Delete this community",
-  "community.edit.delete": "Supprimer cette Communauté",
+  "community.edit.delete": "Supprimer cette communauté",
 
   // "community.edit.head": "Edit Community",
-  "community.edit.head": "Éditer Communauté",
+  "community.edit.head": "Éditer une communauté",
 
   // "community.edit.breadcrumbs": "Edit Community",
-  "community.edit.breadcrumbs": "Éditer Communauté",
+  "community.edit.breadcrumbs": "Éditer une communauté",
 
+  // "community.edit.logo.delete.title": "Delete logo",
+  "community.edit.logo.delete.title": "Supprimer le logo",
+
+  // "community.edit.logo.delete-undo.title": "Undo delete",
+  "community.edit.logo.delete-undo.title": "Annuler la suppression",
 
   // "community.edit.logo.label": "Community logo",
-  "community.edit.logo.label": "Logo de la Communauté",
+  "community.edit.logo.label": "Logo de la communauté",
 
   // "community.edit.logo.notifications.add.error": "Uploading Community logo failed. Please verify the content before retrying.",
-  "community.edit.logo.notifications.add.error": "Erreur lors du chargement du logo de la Communauté. Veuillez vérifier le contenu et réessayer.",
+  "community.edit.logo.notifications.add.error": "Erreur lors du chargement du logo de la communauté. Veuillez vérifier le contenu et réessayer.",
 
   // "community.edit.logo.notifications.add.success": "Upload Community logo successful.",
-  "community.edit.logo.notifications.add.success": "Logo de la Communauté chargé avec succès.",
+  "community.edit.logo.notifications.add.success": "Logo de la communauté chargé avec succès.",
 
   // "community.edit.logo.notifications.delete.success.title": "Logo deleted",
   "community.edit.logo.notifications.delete.success.title": "Logo supprimé",
 
   // "community.edit.logo.notifications.delete.success.content": "Successfully deleted the community's logo",
-  "community.edit.logo.notifications.delete.success.content": "Logo de la Communauté supprimé avec succès",
+  "community.edit.logo.notifications.delete.success.content": "Logo de la communauté supprimé avec succès",
 
   // "community.edit.logo.notifications.delete.error.title": "Error deleting logo",
-  "community.edit.logo.notifications.delete.error.title": "Erreur lors de la suppression du logo de la Communauté.",
+  "community.edit.logo.notifications.delete.error.title": "Erreur lors de la suppression du logo de la communauté.",
 
   // "community.edit.logo.upload": "Drop a Community Logo to upload",
-  "community.edit.logo.upload": "Glisser-Déposer un logo à charger pour la Communauté",
-
-
+  "community.edit.logo.upload": "Glisser-Déposer un logo à charger pour la communauté",
 
   // "community.edit.notifications.success": "Successfully edited the Community",
   "community.edit.notifications.success": "Communauté mise à jour avec succès",
@@ -1303,43 +1522,37 @@
   "community.edit.notifications.unauthorized": "Vous n'avez pas les autorisations requises pour réaliser ce changement",
 
   // "community.edit.notifications.error": "An error occured while editing the Community",
-  "community.edit.notifications.error": "Une erreur s'est produite lors de l'édition de la Communauté",
+  "community.edit.notifications.error": "Une erreur s'est produite lors de l'édition de la communauté",
 
-  // "community.edit.return": "Return",
+  // "community.edit.return": "Back",
   "community.edit.return": "Retour",
-
-
 
   // "community.edit.tabs.curate.head": "Curate",
   "community.edit.tabs.curate.head": "Gestion du contenu",
 
   // "community.edit.tabs.curate.title": "Community Edit - Curate",
-  "community.edit.tabs.curate.title": "Édition Communauté - Gestion du contenu",
+  "community.edit.tabs.curate.title": "Édition de communauté - Gestion du contenu",
 
   // "community.edit.tabs.metadata.head": "Edit Metadata",
   "community.edit.tabs.metadata.head": "Éditer Métadonnées",
 
   // "community.edit.tabs.metadata.title": "Community Edit - Metadata",
-  "community.edit.tabs.metadata.title": "Édition Communauté - Métadonnées",
+  "community.edit.tabs.metadata.title": "Édition de communauté - Métadonnées",
 
   // "community.edit.tabs.roles.head": "Assign Roles",
   "community.edit.tabs.roles.head": "Attribuer des rôles",
 
   // "community.edit.tabs.roles.title": "Community Edit - Roles",
-  "community.edit.tabs.roles.title": "Édition Communauté - Rôles",
+  "community.edit.tabs.roles.title": "Édition de communauté - Rôles",
 
   // "community.edit.tabs.authorizations.head": "Authorizations",
   "community.edit.tabs.authorizations.head": "Autorisations",
 
   // "community.edit.tabs.authorizations.title": "Community Edit - Authorizations",
-  "community.edit.tabs.authorizations.title": "Édition Communauté - Autorisations",
-
-
+  "community.edit.tabs.authorizations.title": "Édition de communauté - Autorisations",
 
   // "community.listelement.badge": "Community",
   "community.listelement.badge": "Communauté",
-
-
 
   // "comcol-role.edit.no-group": "None",
   "comcol-role.edit.no-group": "Aucun",
@@ -1353,47 +1566,41 @@
   // "comcol-role.edit.delete": "Delete",
   "comcol-role.edit.delete": "Supprimer",
 
-
   // "comcol-role.edit.community-admin.name": "Administrators",
   "comcol-role.edit.community-admin.name": "Administrateurs",
 
   // "comcol-role.edit.collection-admin.name": "Administrators",
   "comcol-role.edit.collection-admin.name": "Administrateurs",
 
-
   // "comcol-role.edit.community-admin.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
-  "comcol-role.edit.community-admin.description": "Les administrateurs de Communauté peuvent créer des Sous-Communautés ou Collections et gérer ou assigner la gestion de ces Sous-Communautés ou Collections. De plus, ils peuvent déterminer qui peut déposer des Items dans toutes les Collections de la Communauté, éditer les métadonnées (après dépôt) et ajouter (mapper) les Items existants dans d'autres Collections (en fonction des autorisations appropriées).",
+  "comcol-role.edit.community-admin.description": "Les administrateurs de communauté peuvent créer des sous-communautés ou collections et gérer ou assigner la gestion de ces sous-communautés ou collections. De plus, ils peuvent déterminer qui peut déposer des Items dans toutes les collections de la communauté, éditer les métadonnées (après dépôt) et ajouter (associer) les Items existants dans d'autres collections (en fonction des autorisations appropriées).",
 
   // "comcol-role.edit.collection-admin.description": "Collection administrators decide who can submit items to the collection, edit item metadata (after submission), and add (map) existing items from other collections to this collection (subject to authorization for that collection).",
-  "comcol-role.edit.collection-admin.description": "Les administrateurs de Collection peuvent déterminer qui peut déposer des Items dans la Collection, éditer les métadonnées (après dépôt) et ajouter (mapper) les Items existants dans d'autres collections (en fonction des autorisations appropriées).",
-
+  "comcol-role.edit.collection-admin.description": "Les administrateurs de collection peuvent déterminer qui peut déposer des Items dans la collection, éditer les métadonnées (après dépôt) et ajouter (associer) les Items existants dans d'autres collections (en fonction des autorisations appropriées).",
 
   // "comcol-role.edit.submitters.name": "Submitters",
   "comcol-role.edit.submitters.name": "Déposants",
 
   // "comcol-role.edit.submitters.description": "The E-People and Groups that have permission to submit new items to this collection.",
-  "comcol-role.edit.submitters.description": "Utilisateurs E-People et Groupes qui ont la permission de dépôt dans cette Collection.",
-
+  "comcol-role.edit.submitters.description": "Utilisateurs EPeople et groupes qui ont la permission de déposer de nouveaux Items dans cette collection.",
 
   // "comcol-role.edit.item_read.name": "Default item read access",
-  "comcol-role.edit.item_read.name": "Accès en lecture (Item) par défaut",
+  "comcol-role.edit.item_read.name": "Accès à l'Item par défaut en lecture",
 
   // "comcol-role.edit.item_read.description": "E-People and Groups that can read new items submitted to this collection. Changes to this role are not retroactive. Existing items in the system will still be viewable by those who had read access at the time of their addition.",
-  "comcol-role.edit.item_read.description": "Utilisateurs E-People et Groupes qui peuvent voir les nouveaux Items déposés dans cette Collection. Les changements appliqués à ce rôle ne sont pas rétroactifs. Les Items existants dans le système resteront visibles par les utilisateurs/groupes qui disposaient des droits de lecture avant l'application du changement.",
+  "comcol-role.edit.item_read.description": "Utilisateurs E-People et groupes qui peuvent voir les nouveaux Items déposés dans cette collection. Les changements appliqués à ce rôle ne sont pas rétroactifs. Les Items existants dans le système resteront visibles par les utilisateurs/groupes qui disposaient des droits de lecture avant l'application du changement.",
 
   // "comcol-role.edit.item_read.anonymous-group": "Default read for incoming items is currently set to Anonymous.",
-  "comcol-role.edit.item_read.anonymous-group": "Les droits de lecture par défaut sur les nouveaux Items sont actuellement octroyés au groupe Anonymous (correspondant aux utilisateurs non connectés).",
-
+  "comcol-role.edit.item_read.anonymous-group": "Les droits de lecture par défaut sur les nouveaux Items sont actuellement octroyés au groupe Anonymous.",
 
   // "comcol-role.edit.bitstream_read.name": "Default bitstream read access",
-  "comcol-role.edit.bitstream_read.name": "Droits de lecture Bitstream par défaut",
+  "comcol-role.edit.bitstream_read.name": "Droits de lecture par défaut des Bitstreams",
 
   // "comcol-role.edit.bitstream_read.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
-  "comcol-role.edit.bitstream_read.description": "Les administrateurs de Communauté peuvent créer des Sous-Communautés ou Collections et gérer ou assigner la gestion de ces Sous-Communautés ou Collections. De plus, ils peuvent déterminer qui peut déposer des Items dans toutes les Collections de la Communauté, éditer les métadonnées (après dépôt) et ajouter (mapper) les Items existants dans d'autres Collections (en fonction des autorisations appropriées).",
+  "comcol-role.edit.bitstream_read.description": "Les administrateurs de communauté peuvent créer des sous-communautés ou collections et gérer ou assigner la gestion de ces sous-communautés ou collections. De plus, ils peuvent déterminer qui peut déposer des Items dans toutes les collections de la communauté, éditer les métadonnées (après dépôt) et ajouter (associer) les Items existants dans d'autres collections (en fonction des autorisations appropriées).",
 
   // "comcol-role.edit.bitstream_read.anonymous-group": "Default read for incoming bitstreams is currently set to Anonymous.",
-  "comcol-role.edit.bitstream_read.anonymous-group": "Les droits de lecture par défaut sur les nouveaux Bitstreams sont actuellement octroyés au groupe Anonymous (correspondant aux utilisateurs non connectés).",
-
+  "comcol-role.edit.bitstream_read.anonymous-group": "Les droits de lecture par défaut sur les nouveaux Bitstreams sont actuellement octroyés au groupe Anonymous.",
 
   // "comcol-role.edit.editor.name": "Editors",
   "comcol-role.edit.editor.name": "Éditeurs",
@@ -1408,10 +1615,10 @@
   "comcol-role.edit.finaleditor.description": "Les éditeurs finaux peuvent modifier les métadonnées des dépôts mais ne sont pas en mesure de les rejeter.",
 
   // "comcol-role.edit.reviewer.name": "Reviewers",
-  "comcol-role.edit.reviewer.name": "Approbateur",
+  "comcol-role.edit.reviewer.name": "Évaluateurs",
 
   // "comcol-role.edit.reviewer.description": "Reviewers are able to accept or reject incoming submissions. However, they are not able to edit the submission's metadata.",
-  "comcol-role.edit.reviewer.description": "Les approbateurs peuvent accepter ou refuser les dépôts mais ne sont pas en mesure de modifier les métadonnées de ces dépôts.",
+  "comcol-role.edit.reviewer.description": "Les évaluateurs peuvent accepter ou refuser les dépôts mais ne sont pas en mesure de modifier les métadonnées de ces dépôts.",
 
   // "community.form.abstract": "Short Description",
   "community.form.abstract": "Description succincte",
@@ -1420,7 +1627,7 @@
   "community.form.description": "Texte d'introduction (HTML)",
 
   // "community.form.errors.title.required": "Please enter a community name",
-  "community.form.errors.title.required": "Veuillez entrer un nom de Communauté",
+  "community.form.errors.title.required": "Veuillez entrer un nom de communauté",
 
   // "community.form.rights": "Copyright text (HTML)",
   "community.form.rights": "Texte de copyright (HTML)",
@@ -1432,10 +1639,10 @@
   "community.form.title": "Nom",
 
   // "community.page.edit": "Edit this community",
-  "community.page.edit": "Éditer cette Communauté",
+  "community.page.edit": "Éditer cette communauté",
 
   // "community.page.handle": "Permanent URI for this community",
-  "community.page.handle": "URI permanent de cette Communauté",
+  "community.page.handle": "URI permanent de cette communauté",
 
   // "community.page.license": "License",
   "community.page.license": "Licence",
@@ -1444,15 +1651,13 @@
   "community.page.news": "Nouvelles",
 
   // "community.all-lists.head": "Subcommunities and Collections",
-  "community.all-lists.head": "Sous-Communautés et Collections",
+  "community.all-lists.head": "Sous-communautés et collections",
 
   // "community.sub-collection-list.head": "Collections of this Community",
-  "community.sub-collection-list.head": "Collections au sein de cette Communauté",
+  "community.sub-collection-list.head": "collections au sein de cette communauté",
 
   // "community.sub-community-list.head": "Communities of this Community",
-  "community.sub-community-list.head": "Sous-Communautés au sein de cette Communauté",
-
-
+  "community.sub-community-list.head": "Sous-communautés au sein de cette communauté",
 
   // "cookies.consent.accept-all": "Accept all",
   "cookies.consent.accept-all": "Accepter tout",
@@ -1464,7 +1669,7 @@
   "cookies.consent.app.opt-out.description": "Cette application est chargée par défaut (mais vous pouvez choisir de la désactiver)",
 
   // "cookies.consent.app.opt-out.title": "(opt-out)",
-  "cookies.consent.app.opt-out.title": "(opt-out)",
+  "cookies.consent.app.opt-out.title": "(désactivation)",
 
   // "cookies.consent.app.purpose": "purpose",
   "cookies.consent.app.purpose": "usage",
@@ -1485,13 +1690,13 @@
   "cookies.consent.decline": "Refuser",
 
   // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: <strong>Authentication, Preferences, Acknowledgement and Statistics</strong>. <br/> To learn more, please read our {privacyPolicy}.",
-  "cookies.consent.content-notice.description": "Vos données personnelles sont récupérées et utilisées dans les contextes suivants : <strong>Authentification, Préférences, Consentement et Statistiques</strong>. <br/> Pour plus d'informations, veuillez vous référer à la {privacyPolicy}.",
+  "cookies.consent.content-notice.description": "Vos données personnelles sont récupérées et utilisées dans les contextes suivants : <strong>authentification, préférences, consentement et statistiques</strong>. <br/> Pour plus d'informations, veuillez vous référer à la {privacyPolicy}.",
 
   // "cookies.consent.content-notice.learnMore": "Customize",
   "cookies.consent.content-notice.learnMore": "Personnaliser",
 
   // "cookies.consent.content-modal.description": "Here you can see and customize the information that we collect about you.",
-  "cookies.consent.content-modal.description": "Vous pouvez ici voir et personnaliser les informations privées que nous collectons à votre sujet.",
+  "cookies.consent.content-modal.description": "Vous pouvez voir et personnaliser ici les données que nous recueillons à votre sujet.",
 
   // "cookies.consent.content-modal.privacy-policy.name": "privacy policy",
   "cookies.consent.content-modal.privacy-policy.name": "politique de protection de la vie privée",
@@ -1500,14 +1705,13 @@
   "cookies.consent.content-modal.privacy-policy.text": "Pour plus d'informations, veuillez lire notre {privacyPolicy}.",
 
   // "cookies.consent.content-modal.title": "Information that we collect",
-  "cookies.consent.content-modal.title": "Informations collectées",
-
+  "cookies.consent.content-modal.title": "Données collectées",
 
   // "cookies.consent.app.title.authentication": "Authentication",
   "cookies.consent.app.title.authentication": "Authentification",
 
   // "cookies.consent.app.description.authentication": "Required for signing you in",
-  "cookies.consent.app.description.authentication": "Requis pour permettre votre connection",
+  "cookies.consent.app.description.authentication": "Requis pour permettre votre connexion",
 
   // "cookies.consent.app.title.preferences": "Preferences",
   "cookies.consent.app.title.preferences": "Préférences",
@@ -1533,7 +1737,6 @@
   // "cookies.consent.purpose.statistical": "Statistical",
   "cookies.consent.purpose.statistical": "Statistique",
 
-
   // "curation-task.task.checklinks.label":  "Check Links in Metadata",
   "curation-task.task.checklinks.label":  "Vérification des liens dans les métadonnées",
 
@@ -1552,8 +1755,6 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Virus Scan",
 
-
-
   // "curation.form.task-select.label": "Task:",
   "curation.form.task-select.label": "Tâche :",
 
@@ -1564,7 +1765,7 @@
   "curation.form.submit.success.head": "La tâche de conservation a été lancée avec succès",
 
   // "curation.form.submit.success.content": "You will be redirected to the corresponding process page.",
-  "curation.form.submit.success.content": "Vous allez être redirigé vers la page de Processus correspondante.",
+  "curation.form.submit.success.content": "Vous allez être redirigé vers la page de processus correspondante.",
 
   // "curation.form.submit.error.head": "Running the curation task failed",
   "curation.form.submit.error.head": "L'exécution de la tâche de conservation a échoué",
@@ -1576,24 +1777,43 @@
   "curation.form.handle.label": "Handle :",
 
   // "curation.form.handle.hint": "Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)",
-  "curation.form.handle.hint": "Aide : Entrer [votre-préfixe-handle]/0 afin de lancer une tâche de conservation sur l'entièreté du site (ceci peut ne pas être supporté pour toutes les tâches)",
+  "curation.form.handle.hint": "Aide : Saisir [votre-préfixe-handle]/0 afin de lancer une tâche de conservation sur l'entièreté du site (ceci peut ne pas être supporté pour toutes les tâches)",
 
+  // "deny-request-copy.email.message": "Dear {{ recipientName }},\nIn response to your request I regret to inform you that it's not possible to send you a copy of the file(s) you have requested, concerning the document: \"{{ itemUrl }}\" ({{ itemName }}), of which I am an author.\n\nBest regards,\n{{ authorName }} <{{ authorEmail }}>",
+  "deny-request-copy.email.message": "Cher {{ recipientName }},\NEn réponse à votre demande, j'ai le regret de vous informer qu'il n'est pas possible de vous envoyer une copie du ou des fichiers que vous avez demandés, concernant le document : \"{{ itemUrl }}\" ({{ itemName }}), dont je suis l'auteur(e).\n\nCordialement,\n{{ authorName }} <{{ auteurEmail }}>",
 
+  // "deny-request-copy.email.subject": "Request copy of document",
+  "deny-request-copy.email.subject": "Demander une copie du document",
+
+  // "deny-request-copy.error": "An error occurred",
+  "deny-request-copy.error": "Une erreur s'est produite",
+
+  // "deny-request-copy.header": "Deny document copy request",
+  "deny-request-copy.header": "Refuser la demande de copie de document",
+
+  // "deny-request-copy.intro": "This message will be sent to the applicant of the request",
+  "deny-request-copy.intro": "Ce message sera envoyé au demandeur de la demande.",
+
+  // "deny-request-copy.success": "Successfully denied item request",
+  "deny-request-copy.success": "Demande de document refusée avec succès",
+
+  // "dso.name.untitled": "Untitled",
+  "dso.name.untitled": "Sans titre",
 
   // "dso-selector.create.collection.head": "New collection",
-  "dso-selector.create.collection.head": "Nouvelle Collection",
+  "dso-selector.create.collection.head": "Nouvelle collection",
 
   // "dso-selector.create.collection.sub-level": "Create a new collection in",
-  "dso-selector.create.collection.sub-level": "Créer une nouvelle Collection dans",
+  "dso-selector.create.collection.sub-level": "Créer une nouvelle collection dans",
 
   // "dso-selector.create.community.head": "New community",
-  "dso-selector.create.community.head": "Nouvelle Communauté",
+  "dso-selector.create.community.head": "Nouvelle communauté",
 
   // "dso-selector.create.community.sub-level": "Create a new community in",
-  "dso-selector.create.community.sub-level": "Créer une nouvelle Communauté dans",
+  "dso-selector.create.community.sub-level": "Créer une nouvelle communauté dans",
 
   // "dso-selector.create.community.top-level": "Create a new top-level community",
-  "dso-selector.create.community.top-level": "Créer une nouvelle Communauté de 1er niveau",
+  "dso-selector.create.community.top-level": "Créer une nouvelle communauté de 1er niveau",
 
   // "dso-selector.create.item.head": "New item",
   "dso-selector.create.item.head": "Nouvel Item",
@@ -1605,13 +1825,16 @@
   "dso-selector.create.submission.head": "Nouveau dépôt",
 
   // "dso-selector.edit.collection.head": "Edit collection",
-  "dso-selector.edit.collection.head": "Éditer Collection",
+  "dso-selector.edit.collection.head": "Éditer une collection",
 
   // "dso-selector.edit.community.head": "Edit community",
-  "dso-selector.edit.community.head": "Éditer Communauté",
+  "dso-selector.edit.community.head": "Éditer une communauté",
 
   // "dso-selector.edit.item.head": "Edit item",
-  "dso-selector.edit.item.head": "Éditer Item",
+  "dso-selector.edit.item.head": "Éditer un Item",
+
+  // "dso-selector.error.title": "An error occurred searching for a {{ type }}",
+  "dso-selector.error.title": "Une erreur est survenue lors de la recherche d'un(e) {{ type }}}.",
 
   // "dso-selector.export-metadata.dspaceobject.head": "Export metadata from",
   "dso-selector.export-metadata.dspaceobject.head": "Exporter les métadonnées de",
@@ -1626,21 +1849,19 @@
   "dso-selector.select.collection.head": "Sélectionner une collection",
 
   // "dso-selector.set-scope.community.head": "Select a search scope",
-  "dso-selector.set-scope.community.head": "Sélectionnez un champ de recherche",
+  "dso-selector.set-scope.community.head": "Sélectionner un champ de recherche",
 
   // "dso-selector.set-scope.community.button": "Search all of DSpace",
   "dso-selector.set-scope.community.button": "Chercher dans toutes les collections",
 
   // "dso-selector.set-scope.community.input-header": "Search for a community or collection",
   "dso-selector.set-scope.community.input-header": "Chercher une communauté ou une collection",
-  
-    
 
   // "confirmation-modal.export-metadata.header": "Export metadata for {{ dsoName }}",
-  "confirmation-modal.export-metadata.header": "Exporter métadonnées de {{ dsoName }}",
+  "confirmation-modal.export-metadata.header": "Exporter les métadonnées de {{ dsoName }}",
 
   // "confirmation-modal.export-metadata.info": "Are you sure you want to export metadata for {{ dsoName }}",
-  "confirmation-modal.export-metadata.info": "Êtes-vous certain de vouloir exporter les métadonnées de {{ dsoName }}",
+  "confirmation-modal.export-metadata.info": "Êtes-vous certain(e) de vouloir exporter les métadonnées de {{ dsoName }}",
 
   // "confirmation-modal.export-metadata.cancel": "Cancel",
   "confirmation-modal.export-metadata.cancel": "Annuler",
@@ -1649,10 +1870,10 @@
   "confirmation-modal.export-metadata.confirm": "Exporter",
 
   // "confirmation-modal.delete-eperson.header": "Delete EPerson \"{{ dsoName }}\"",
-  "confirmation-modal.delete-eperson.header": "Supprimer EPerson \"{{ dsoName }}\"",
+  "confirmation-modal.delete-eperson.header": "Supprimer l'EPerson \"{{ dsoName }}\"",
 
   // "confirmation-modal.delete-eperson.info": "Are you sure you want to delete EPerson \"{{ dsoName }}\"",
-  "confirmation-modal.delete-eperson.info": "Êtes-vous certain de vouloir supprimer l'EPerson \"{{ dsoName }}\"",
+  "confirmation-modal.delete-eperson.info": "Êtes-vous certain(e) de vouloir supprimer l'EPerson \"{{ dsoName }}\"",
 
   // "confirmation-modal.delete-eperson.cancel": "Cancel",
   "confirmation-modal.delete-eperson.cancel": "Annuler",
@@ -1667,13 +1888,13 @@
   "error.browse-by": "Erreur lors de la récupération des Items",
 
   // "error.collection": "Error fetching collection",
-  "error.collection": "Erreur lors de la récupération de la Collection",
+  "error.collection": "Erreur lors de la récupération de la collection",
 
   // "error.collections": "Error fetching collections",
-  "error.collections": "Erreur lors de la récupération des Collections",
+  "error.collections": "Erreur lors de la récupération des collections",
 
   // "error.community": "Error fetching community",
-  "error.community": "Erreur lors de la récupération de la Communauté",
+  "error.community": "Erreur lors de la récupération de la communauté",
 
   // "error.identifier": "No item found for the identifier",
   "error.identifier": "Aucun Item correspondant à cet identifiant",
@@ -1688,7 +1909,7 @@
   "error.items": "Erreur lors de la récupération des Items",
 
   // "error.objects": "Error fetching objects",
-  "error.objects": "Erreur lors de la récupération des Objets",
+  "error.objects": "Erreur lors de la récupération des objets",
 
   // "error.recent-submissions": "Error fetching recent submissions",
   "error.recent-submissions": "Erreur lors de la récupération des dépôts récents",
@@ -1696,82 +1917,98 @@
   // "error.search-results": "Error fetching search results",
   "error.search-results": "Erreur lors de la récupération des résultats de recherche",
 
+  // "error.invalid-search-query": "Search query is not valid. Please check <a href=\"https://solr.apache.org/guide/query-syntax-and-parsing.html\" target=\"_blank\">Solr query syntax</a> best practices for further information about this error.",
+  "error.invalid-search-query": "La requête de recherche n'est pas valide. Veuillez consulter les meilleures pratiques de la syntaxe des <a href=\"https://solr.apache.org/guide/query-syntax-and-parsing.html\" target=\"_blank\">requêtes Solr</a> pour plus d'informations sur cette erreur.",
+
   // "error.sub-collections": "Error fetching sub-collections",
-  "error.sub-collections": "Erreur lors de la récupération des Sous-Collections",
+  "error.sub-collections": "Erreur lors de la récupération des sous-collections",
 
   // "error.sub-communities": "Error fetching sub-communities",
-  "error.sub-communities": "Erreur lors de la récupération des Sous-Communautés",
+  "error.sub-communities": "Erreur lors de la récupération des sous-communautés",
 
   // "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
-  "error.submission.sections.init-form-error": "Une erreur s'est produite dans la section d'initialisation, veuillez vérifier la configuration de votre formulaire de dépôt. Plus de détails disponibles ci-dessous : <br> <br>",
+  "error.submission.sections.init-form-error": "Une erreur s'est produite dans la section d'initialisation, veuillez vérifier la configuration de votre formulaire de dépôt. Plus de détails sont disponibles ci-dessous : <br> <br>",
 
   // "error.top-level-communities": "Error fetching top-level communities",
-  "error.top-level-communities": "Erreur lors de la récupération des Communautés de 1er niveau",
+  "error.top-level-communities": "Erreur lors de la récupération des communautés de 1er niveau",
 
   // "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
   "error.validation.license.notgranted": "Vous devez accepter cette licence pour terminer votre dépôt. Si vous êtes dans l'incapacité d'accepter cette licence actuellement, vous pouvez sauvegarder votre dépôt et y revenir ultérieurement ou le supprimer.",
 
   // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
-  "error.validation.pattern": "Cette entrée est invalide en vertu du pattern : {{ pattern }}.",
+  "error.validation.pattern": "Cette entrée est invalide en vertu du modèle actuel : {{ pattern }}.",
 
   // "error.validation.filerequired": "The file upload is mandatory",
   "error.validation.filerequired": "Le téléchargement de fichier est obligatoire",
 
+  // "error.validation.required": "This field is required",
+  "error.validation.required": "Ce champ est obligatoire",
+
+  // "error.validation.NotValidEmail": "This E-mail is not a valid email",
+  "error.validation.NotValidEmail": "Cette adresse électronique n'est pas une adresse valide",
+
+  // "error.validation.emailTaken": "This E-mail is already taken",
+  "error.validation.emailTaken": "Cette adresse électronique est déjà attribuée",
+
+  // "error.validation.groupExists": "This group already exists",
+  "error.validation.groupExists": "Ce groupe existe déjà",
+
   // "file-section.error.header": "Error obtaining files for this item",
   "file-section.error.header": "Erreur lors de la récupération des fichiers liés à cet Item",
-
 
   // "footer.copyright": "copyright © 2002-{{ year }}",
   "footer.copyright": "copyright © 2002-{{ year }}",
 
   // "footer.link.dspace": "DSpace software",
-  "footer.link.dspace": "DSpace software",
+  "footer.link.dspace": "Logiciel DSpace",
 
   // "footer.link.lyrasis": "LYRASIS",
   "footer.link.lyrasis": "LYRASIS",
 
   // "footer.link.cookies": "Cookie settings",
-  "footer.link.cookies": "Paramètre des cookies",
+  "footer.link.cookies": "Paramètres des témoins de connexion",
 
   // "footer.link.privacy-policy": "Privacy policy",
   "footer.link.privacy-policy": "Politique de protection de la vie privée",
 
   // "footer.link.end-user-agreement":"End User Agreement",
-  "footer.link.end-user-agreement":"Licence de l'Utilisateur Final",
+  "footer.link.end-user-agreement":"Licence de l'utilisateur final",
 
+  // "footer.link.feedback":"Send Feedback",
+  "footer.link.feedback": "Envoyer un commentaire",
 
   // "forgot-email.form.header": "Forgot Password",
   "forgot-email.form.header": "Mot de passe oublié",
 
   // "forgot-email.form.info": "Enter Register an account to subscribe to collections for email updates, and submit new items to DSpace.",
-  "forgot-email.form.info": "Créer un compte pour vous abonner à des collections afin de recevoir des mises à jour via mail ainsi que pour déposer de nouveaux Items dans DSpace.",
+  "forgot-email.form.info": "Créer un compte pour vous abonner à des collections afin de recevoir des mises à jour via courrier électronique ainsi que pour déposer de nouveaux Items dans DSpace.",
 
   // "forgot-email.form.email": "Email Address *",
-  "forgot-email.form.email": "Adresse e-mail *",
+  "forgot-email.form.email": "Adresse électronique *",
 
   // "forgot-email.form.email.error.required": "Please fill in an email address",
-  "forgot-email.form.email.error.required": "Veuillez remplir une adresse e-mail",
+  "forgot-email.form.email.error.required": "Veuillez saisir une adresse électronique",
 
   // "forgot-email.form.email.error.pattern": "Please fill in a valid email address",
-  "forgot-email.form.email.error.pattern": "Veuillez remplir une adresse e-mail valide",
+  "forgot-email.form.email.error.pattern": "Veuillez saisir une adresse électronique valide",
 
   // "forgot-email.form.email.hint": "This address will be verified and used as your login name.",
-  "forgot-email.form.email.hint": "Cette adresse sera vérifiée et utilisée en tant qu'identifiant de connection.",
+  "forgot-email.form.email.hint": "Cette adresse sera vérifiée et utilisée en tant qu'identifiant de connexion.",
 
-  // "forgot-email.form.submit": "Submit",
-  "forgot-email.form.submit": "Envoyer",
+  // "forgot-email.form.submit": "Save",
+  "forgot-email.form.submit": "Sauvegarder",
 
   // "forgot-email.form.success.head": "Verification email sent",
-  "forgot-email.form.success.head": "E-mail de vérification envoyé",
+  "forgot-email.form.success.head": "Courrier électronique de vérification envoyé",
 
   // "forgot-email.form.success.content": "An email has been sent to {{ email }} containing a special URL and further instructions.",
-  "forgot-email.form.success.content": "Un mail a été envoyé à {{ email }} avec une URL d'activation et de plus amples instructions.",
+  "forgot-email.form.success.content": "Un courrier électronique a été envoyé à {{ email }} avec une URL d'activation et de plus amples instructions.",
 
   // "forgot-email.form.error.head": "Error when trying to register email",
-  "forgot-email.form.error.head": "Erreur lors de l'enregistrement de l'adresse e-mail",
+  "forgot-email.form.error.head": "Erreur lors de l'enregistrement de l'adresse électronique",
 
   // "forgot-email.form.error.content": "An error occured when registering the following email address: {{ email }}",
-  "forgot-email.form.error.content": "Une erreur s'est produite au niveau de l'adresse e-mail suivante : {{ email }}",
+  "forgot-email.form.error.content": "Une erreur s'est produite au niveau de l'adresse électronique suivante : {{ email }}",
 
   // "forgot-password.title": "Forgot Password",
   "forgot-password.title": "Mot de passe oublié",
@@ -1780,7 +2017,7 @@
   "forgot-password.form.head": "Mot de passe oublié",
 
   // "forgot-password.form.info": "Enter a new password in the box below, and confirm it by typing it again into the second box. It should be at least six characters long.",
-  "forgot-password.form.info": "Entrer un nouveau mot de passe dans le zone ci-dessous et confirmer en l'entrant à nouveau dans la seconde zone. Le mot de passe doit au moins faire 6 caractères.",
+  "forgot-password.form.info": "Entrer un nouveau mot de passe dans la case ci-dessous et le confirmer en l'entrant à nouveau dans la seconde case. Le mot de passe doit comporter au moins six caractères.",
 
   // "forgot-password.form.card.security": "Security",
   "forgot-password.form.card.security": "Sécurité",
@@ -1789,7 +2026,7 @@
   "forgot-password.form.identification.header": "Identification",
 
   // "forgot-password.form.identification.email": "Email address: ",
-  "forgot-password.form.identification.email": "Adresse e-mail : ",
+  "forgot-password.form.identification.email": "Adresse électronique : ",
 
   // "forgot-password.form.label.password": "Password",
   "forgot-password.form.label.password": "Mot de passe",
@@ -1798,16 +2035,16 @@
   "forgot-password.form.label.passwordrepeat": "Entrer à nouveau pour confirmer",
 
   // "forgot-password.form.error.empty-password": "Please enter a password in the box below.",
-  "forgot-password.form.error.empty-password": "Veuillez entrer un mot de passe dans la zone ci-dessous.",
+  "forgot-password.form.error.empty-password": "Veuillez entrer un mot de passe dans la case ci-dessous.",
 
   // "forgot-password.form.error.matching-passwords": "The passwords do not match.",
   "forgot-password.form.error.matching-passwords": "Les mots de passe ne correspondent pas.",
 
   // "forgot-password.form.error.password-length": "The password should be at least 6 characters long.",
-  "forgot-password.form.error.password-length": "La longueur minimale du mot de passe est de 6 caractères.",
+  "forgot-password.form.error.password-length": "Le mot de passe doit comporter au moins six caractères.",
 
   // "forgot-password.form.notification.error.title": "Error when trying to submit new password",
-  "forgot-password.form.notification.error.title": "Erreur lors de l'enregistrement du mot de passe",
+  "forgot-password.form.notification.error.title": "Erreur lors de la soumission du nouveau mot de passe",
 
   // "forgot-password.form.notification.success.content": "The password reset was successful. You have been logged in as the created user.",
   "forgot-password.form.notification.success.content": "La réinitialisation du mot de passe a été effectuée avec succès. Vous êtes connecté avec le compte de l'utilisateur ainsi créé.",
@@ -1818,9 +2055,7 @@
   // "forgot-password.form.submit": "Submit password",
   "forgot-password.form.submit": "Confirmer mot de passe",
 
-
-
-  // "form.add": "Add",
+  // "form.add": "Add more",
   "form.add": "Ajouter",
 
   // "form.add-help": "Click here to add the current entry and to add another one",
@@ -1834,6 +2069,12 @@
 
   // "form.clear-help": "Click here to remove the selected value",
   "form.clear-help": "Cliquer ici pour supprimer la valeur sélectionnée",
+
+  // "form.discard": "Discard",
+  "form.discard": "Rejeter",
+
+  // "form.drag": "Drag",
+  "form.drag": "Glisser",
 
   // "form.edit": "Edit",
   "form.edit": "Éditer",
@@ -1857,7 +2098,7 @@
   "form.group-expand-help": "Cliquer ici pour développer et ajouter davantage d'éléments",
 
   // "form.last-name": "Last name",
-  "form.last-name": "Nom",
+  "form.last-name": "Nom de famille",
 
   // "form.loading": "Loading...",
   "form.loading": "En cours de chargement...",
@@ -1869,7 +2110,7 @@
   "form.lookup-help": "Cliquer ici pour rechercher une relation existante",
 
   // "form.no-results": "No results found",
-  "form.no-results": "Aucun résultat disponible",
+  "form.no-results": "Aucun résultat trouvé",
 
   // "form.no-value": "No value entered",
   "form.no-value": "Aucune valeur entrée",
@@ -1884,7 +2125,7 @@
   "form.save": "Sauvegarder",
 
   // "form.save-help": "Save changes",
-  "form.save-help": "Sauvegarder changements",
+  "form.save-help": "Sauvegarder les modifications",
 
   // "form.search": "Search",
   "form.search": "Rechercher",
@@ -1892,10 +2133,74 @@
   // "form.search-help": "Click here to look for an existing correspondence",
   "form.search-help": "Cliquer ici pour rechercher une correspondance existante",
 
-  // "form.submit": "Submit",
-  "form.submit": "Déposer",
+  // "form.submit": "Save",
+  "form.submit": "Sauvegarder",
 
+  // "form.repeatable.sort.tip": "Drop the item in the new position",
+  "form.repeatable.sort.tip": "Déposer l'objet dans la nouvelle position",
 
+  // "grant-deny-request-copy.deny": "Don't send copy",
+  "grant-deny-request-copy.deny": "Ne pas envoyer de copie ",
+
+  // "grant-deny-request-copy.email.back": "Back",
+  "grant-deny-request-copy.email.back": "Retour",
+
+  // "grant-deny-request-copy.email.message": "Message",
+  "grant-deny-request-copy.email.message": "Message",
+
+  // "grant-deny-request-copy.email.message.empty": "Please enter a message",
+  "grant-deny-request-copy.email.message.empty": "Veuillez entrer un message",
+
+  // "grant-deny-request-copy.email.permissions.info": "You may use this occasion to reconsider the access restrictions on the document, to avoid having to respond to these requests. If you’d like to ask the repository administrators to remove these restrictions, please check the box below.",
+  "grant-deny-request-copy.email.permissions.info": "Vous pouvez profiter de cette occasion pour réévaluer les restrictions d'accès au document, afin d'éviter d'avoir à répondre à ces demandes. Si vous souhaitez demander aux administrateurs du dépôt de supprimer ces restrictions, veuillez cocher la case ci-dessous.",
+
+  // "grant-deny-request-copy.email.permissions.label": "Change to open access",
+  "grant-deny-request-copy.email.permissions.label": "Passer en libre accès",
+
+  // "grant-deny-request-copy.email.send": "Send",
+  "grant-deny-request-copy.email.send": "Envoyer",
+
+  // "grant-deny-request-copy.email.subject": "Subject",
+  "grant-deny-request-copy.email.subject": "Sujet",
+
+  // "grant-deny-request-copy.email.subject.empty": "Please enter a subject",
+  "grant-deny-request-copy.email.subject.empty": "Veuillez entrer un sujet",
+
+  // "grant-deny-request-copy.grant": "Send copy",
+  "grant-deny-request-copy.grant": "Envoyer une copie",
+
+  // "grant-deny-request-copy.header": "Document copy request",
+  "grant-deny-request-copy.header": "Demande de copie de document",
+
+  // "grant-deny-request-copy.home-page": "Take me to the home page",
+  "grant-deny-request-copy.home-page": "Aller à la page d'accueil",
+
+  // "grant-deny-request-copy.intro1": "If you are one of the authors of the document <a href='{{ url }}'>{{ name }}</a>, then please use one of the options below to respond to the user's request.",
+  "grant-deny-request-copy.intro1": "Si vous êtes l'un des auteurs du document <a href='{{ url }}'>{{ name }}</a>, veuillez utiliser l'une des options ci-dessous pour répondre à la demande de l'utilisateur.",
+
+  // "grant-deny-request-copy.intro2": "After choosing an option, you will be presented with a suggested email reply which you may edit.",
+  "grant-deny-request-copy.intro2": "Après avoir choisi une option, une proposition de message de réponse par courrier électronique vous sera présentée, que vous pourrez modifier.",
+
+  // "grant-deny-request-copy.processed": "This request has already been processed. You can use the button below to get back to the home page.",
+  "grant-deny-request-copy.processed": "Cette demande a déjà été traitée. Vous pouvez utiliser le bouton ci-dessous pour revenir à la page d'accueil.",
+
+  // "grant-request-copy.email.message": "Dear {{ recipientName }},\nIn response to your request I have the pleasure to send you in attachment a copy of the file(s) concerning the document: \"{{ itemUrl }}\" ({{ itemName }}), of which I am an author.\n\nBest regards,\n{{ authorName }} <{{ authorEmail }}>",
+  "grant-request-copy.email.message": "Cher {{ recipientName }},\nEn réponse à votre demande, j'ai le plaisir de vous envoyer en pièce jointe une copie du ou des fichiers constituant le document : \"{{ itemUrl }}\" ({{ itemName }}), dont je suis l'auteur.\n\nCordialement,\n{{ authorName }} <{{ authorEmail }}>",
+
+  // "grant-request-copy.email.subject": "Request copy of document",
+  "grant-request-copy.email.subject": "Demander une copie du document",
+
+  // "grant-request-copy.error": "An error occurred",
+  "grant-request-copy.error": "Une erreur est survenue",
+
+  // "grant-request-copy.header": "Grant document copy request",
+  "grant-request-copy.header": "Approuver la demande de copie du document",
+
+  // "grant-request-copy.intro": "This message will be sent to the applicant of the request. The requested document(s) will be attached.",
+  "grant-request-copy.intro": "Ce message sera envoyé à l'instigateur de la demande. Le ou les documents demandés seront joints.",
+
+  // "grant-request-copy.success": "Successfully granted item request",
+  "grant-request-copy.success": "Demande de copie de document acceptée avec succès",
 
   // "home.description": "",
   "home.description": "",
@@ -1903,28 +2208,29 @@
   // "home.breadcrumbs": "Home",
   "home.breadcrumbs": "Accueil",
 
-  // "home.title": "DSpace Angular :: Home",
-  "home.title": "DSpace Angular :: Home",
+  // "home.search-form.placeholder": "Search the repository ...",
+  "home.search-form.placeholder": "Rechercher dans le dépôt...",
+
+  // "home.title": "Home",
+  "home.title": "Accueil",
 
   // "home.top-level-communities.head": "Communities in DSpace",
-  "home.top-level-communities.head": "Communautés DSpace",
+  "home.top-level-communities.head": "Communautés dans DSpace",
 
   // "home.top-level-communities.help": "Select a community to browse its collections.",
-  "home.top-level-communities.help": "Sélectionner une Communauté pour parcourir les Collections sous-jacentes.",
-
-
+  "home.top-level-communities.help": "Sélectionner une communauté pour parcourir les collections sous-jacentes.",
 
   // "info.end-user-agreement.accept": "I have read and I agree to the End User Agreement",
-  "info.end-user-agreement.accept": "J'ai lu et j'accepte la Licence de l'Utilisateur Final",
+  "info.end-user-agreement.accept": "J'ai lu et j'accepte la licence de l'utilisateur final",
 
   // "info.end-user-agreement.accept.error": "An error occurred accepting the End User Agreement",
-  "info.end-user-agreement.accept.error": "Une erreur s'est produite lors de l'acceptation de la Licence de l'Utilisateur Final",
+  "info.end-user-agreement.accept.error": "Une erreur s'est produite lors de l'acceptation de la licence de l'utilisateur final",
 
   // "info.end-user-agreement.accept.success": "Successfully updated the End User Agreement",
-  "info.end-user-agreement.accept.success": "Licence de l'Utilisateur Final mise à jour avec succès",
+  "info.end-user-agreement.accept.success": "Licence de l'utilisateur final mise à jour avec succès",
 
   // "info.end-user-agreement.breadcrumbs": "End User Agreement",
-  "info.end-user-agreement.breadcrumbs": "Licence de l'Utilisateur Final",
+  "info.end-user-agreement.breadcrumbs": "Licence de l'utilisateur final",
 
   // "info.end-user-agreement.buttons.cancel": "Cancel",
   "info.end-user-agreement.buttons.cancel": "Annuler",
@@ -1933,10 +2239,10 @@
   "info.end-user-agreement.buttons.save": "Sauvegarder",
 
   // "info.end-user-agreement.head": "End User Agreement",
-  "info.end-user-agreement.head": "Licence de l'Utilisateur Final",
+  "info.end-user-agreement.head": "Licence de l'utilisateur final",
 
   // "info.end-user-agreement.title": "End User Agreement",
-  "info.end-user-agreement.title": "Licence de l'Utilisateur Final",
+  "info.end-user-agreement.title": "Licence de l'utilisateur final",
 
   // "info.privacy.breadcrumbs": "Privacy Statement",
   "info.privacy.breadcrumbs": "Déclaration de confidentialité",
@@ -1947,7 +2253,44 @@
   // "info.privacy.title": "Privacy Statement",
   "info.privacy.title": "Déclaration de confidentialité",
 
+  // "info.feedback.breadcrumbs": "Feedback",
+  "info.feedback.breadcrumbs": "Votre avis",
 
+  // "info.feedback.head": "Feedback",
+  "info.feedback.head": "Votre avis",
+
+  // "info.feedback.title": "Feedback",
+  "info.feedback.title": "Votre avis",
+
+  // "info.feedback.info": "Thanks for sharing your feedback about the DSpace system. Your comments are appreciated!",
+  "info.feedback.info": "Merci de nous faire part de votre avis sur le système DSpace. Vos commentaires sont appréciés !",
+
+  // "info.feedback.email_help": "This address will be used to follow up on your feedback.",
+  "info.feedback.email_help": "Cette adresse sera utilisée pour donner suite à vos commentaires.",
+
+  // "info.feedback.send": "Send Feedback",
+  "info.feedback.send": "Envoyer un commentaire",
+
+  // "info.feedback.comments": "Comments",
+  "info.feedback.comments": "Commentaires",
+
+  // "info.feedback.email-label": "Your Email",
+  "info.feedback.email-label": "Votre adresse électronique",
+
+  // "info.feedback.create.success": "Feedback Sent Successfully!",
+  "info.feedback.create.success": "Commentaires envoyés avec succès !",
+
+  // "info.feedback.error.email.required": "A valid email address is required",
+  "info.feedback.error.email.required": "Une adresse électronique valide est requise",
+
+  // "info.feedback.error.message.required": "A comment is required",
+  "info.feedback.error.message.required": "Un contenu est requis",
+
+  // "info.feedback.page-label": "Page",
+ "info.feedback.page-label": "Page",
+ 
+  // "info.feedback.page_help": "The page related to your feedback",
+  "info.feedback.page_help": "La page relative à vos commentaires",
 
   // "item.alerts.private": "This item is private",
   "item.alerts.private": "Cet Item est privé",
@@ -1956,12 +2299,10 @@
   "item.alerts.withdrawn": "Cet Item a été retiré",
 
   // "item.edit.authorizations.heading": "With this editor you can view and alter the policies of an item, plus alter policies of individual item components: bundles and bitstreams. Briefly, an item is a container of bundles, and bundles are containers of bitstreams. Containers usually have ADD/REMOVE/READ/WRITE policies, while bitstreams only have READ/WRITE policies.",
-  "item.edit.authorizations.heading": "Depuis cette page, il vous est possible de visualiser et modifier les autorisations d'un Item et de ses composants Bundles et Bitstreams. Un Item peut inclure un ou plusieurs Bundle(s) et chaque Bundle peut inclure un ou plusieurs Bitstream(s). Les Items et Bundles ont habituellement des autorisations de type ADD/REMOVE/READ/WRITE alors que les Bitstreams ont uniquement des autorisations READ/WRITE.",
+  "item.edit.authorizations.heading": "Avec cet éditeur, il vous est possible de visualiser et modifier les autorisations d'un Item de même que de modifier les autorisations de ses composants Bundles et Bitstream. En bref, Un Item peut inclure un ou plusieurs Bundle(s) et chaque Bundle peut inclure un ou plusieurs Bitstream(s). Les Items et Bundles ont habituellement des autorisations de type ADD/REMOVE/READ/WRITE alors que les Bitstreams ont uniquement des autorisations READ/WRITE.",
 
   // "item.edit.authorizations.title": "Edit item's Policies",
   "item.edit.authorizations.title": "Éditer les autorisations de l'Item",
-
-
 
   // "item.badge.private": "Private",
   "item.badge.private": "Privé",
@@ -1976,19 +2317,19 @@
   "item.bitstreams.upload.bundle.placeholder": "Selectionner un Bundle",
 
   // "item.bitstreams.upload.bundle.new": "Create bundle",
-  "item.bitstreams.upload.bundle.new": "Créer Bundle",
+  "item.bitstreams.upload.bundle.new": "Créer un Bundle",
 
   // "item.bitstreams.upload.bundles.empty": "This item doesn\'t contain any bundles to upload a bitstream to.",
-  "item.bitstreams.upload.bundles.empty": "Il n'existe pas, au niveau de cet Item, de Bundle dans lequel un Bitstream pourrait être ajouté.",
+  "item.bitstreams.upload.bundles.empty": "Il n'existe pas, au niveau de cet Item, de Bundle dans lequel un Bitstream pourrait être téléchargé.",
 
   // "item.bitstreams.upload.cancel": "Cancel",
   "item.bitstreams.upload.cancel": "Annuler",
 
   // "item.bitstreams.upload.drop-message": "Drop a file to upload",
-  "item.bitstreams.upload.drop-message": "Déposer un fichier pour l'ajouter",
+  "item.bitstreams.upload.drop-message": "Déposer un fichier pour le télécharger",
 
   // "item.bitstreams.upload.item": "Item: ",
-  "item.bitstreams.upload.item": "Item: ",
+  "item.bitstreams.upload.item": "Item : ",
 
   // "item.bitstreams.upload.notifications.bundle.created.content": "Successfully created new bundle.",
   "item.bitstreams.upload.notifications.bundle.created.content": "Bundle créé avec succès.",
@@ -1997,27 +2338,25 @@
   "item.bitstreams.upload.notifications.bundle.created.title": "Bundle créé",
 
   // "item.bitstreams.upload.notifications.upload.failed": "Upload failed. Please verify the content before retrying.",
-  "item.bitstreams.upload.notifications.upload.failed": "Echec du téléchargement. Veuillez vérifier le contenu avant de réessayer.",
+  "item.bitstreams.upload.notifications.upload.failed": "Échec du téléchargement. Veuillez vérifier le contenu avant de réessayer.",
 
   // "item.bitstreams.upload.title": "Upload bitstream",
-  "item.bitstreams.upload.title": "Ajouter Bitstream",
-
-
+  "item.bitstreams.upload.title": "Télécharger un Bitstream",
 
   // "item.edit.bitstreams.bundle.edit.buttons.upload": "Upload",
-  "item.edit.bitstreams.bundle.edit.buttons.upload": "Ajouter",
+  "item.edit.bitstreams.bundle.edit.buttons.upload": "Télécharger",
 
   // "item.edit.bitstreams.bundle.displaying": "Currently displaying {{ amount }} bitstreams of {{ total }}.",
   "item.edit.bitstreams.bundle.displaying": "{{ amount }} Bitstreams actuellement visible(s) sur un total de {{ total }}.",
 
   // "item.edit.bitstreams.bundle.load.all": "Load all ({{ total }})",
-  "item.edit.bitstreams.bundle.load.all": "Charger tout ({{ total }})",
+  "item.edit.bitstreams.bundle.load.all": "Charger tous les ({{ total }})",
 
   // "item.edit.bitstreams.bundle.load.more": "Load more",
-  "item.edit.bitstreams.bundle.load.more": "Charger plus",
+  "item.edit.bitstreams.bundle.load.more": "Charger davantage",
 
   // "item.edit.bitstreams.bundle.name": "BUNDLE: {{ name }}",
-  "item.edit.bitstreams.bundle.name": "BUNDLE: {{ name }}",
+  "item.edit.bitstreams.bundle.name": "BUNDLE : {{ name }}",
 
   // "item.edit.bitstreams.discard-button": "Discard",
   "item.edit.bitstreams.discard-button": "Annuler",
@@ -2026,7 +2365,7 @@
   "item.edit.bitstreams.edit.buttons.download": "Télécharger",
 
   // "item.edit.bitstreams.edit.buttons.drag": "Drag",
-  "item.edit.bitstreams.edit.buttons.drag": "Glisser-Déposer",
+  "item.edit.bitstreams.edit.buttons.drag": "Glisser-déposer",
 
   // "item.edit.bitstreams.edit.buttons.edit": "Edit",
   "item.edit.bitstreams.edit.buttons.edit": "Éditer",
@@ -2035,10 +2374,10 @@
   "item.edit.bitstreams.edit.buttons.remove": "Supprimer",
 
   // "item.edit.bitstreams.edit.buttons.undo": "Undo changes",
-  "item.edit.bitstreams.edit.buttons.undo": "Annuler changements",
+  "item.edit.bitstreams.edit.buttons.undo": "Annuler les modifications",
 
   // "item.edit.bitstreams.empty": "This item doesn't contain any bitstreams. Click the upload button to create one.",
-  "item.edit.bitstreams.empty": "Aucun Bitstream n'est associé à cet Item. Utiliser le bouton d'ajout pour en créer un.",
+  "item.edit.bitstreams.empty": "Aucun Bitstream n'est associé à cet Item. Cliquer sur le bouton de téléchargement pour en créer un.",
 
   // "item.edit.bitstreams.headers.actions": "Actions",
   "item.edit.bitstreams.headers.actions": "Actions",
@@ -2056,22 +2395,22 @@
   "item.edit.bitstreams.headers.name": "Nom",
 
   // "item.edit.bitstreams.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
-  "item.edit.bitstreams.notifications.discarded.content": "Vos changements ont été annulés. Pour rétablir vos changements, cliquer sur le bouton 'Rétablir'",
+  "item.edit.bitstreams.notifications.discarded.content": "Vos modifications ont été annulés. Pour rétablir vos modifications, cliquer sur le bouton « Rétablir »",
 
   // "item.edit.bitstreams.notifications.discarded.title": "Changes discarded",
-  "item.edit.bitstreams.notifications.discarded.title": "Changements annulés",
+  "item.edit.bitstreams.notifications.discarded.title": "Modifications annulées",
 
   // "item.edit.bitstreams.notifications.move.failed.title": "Error moving bitstreams",
   "item.edit.bitstreams.notifications.move.failed.title": "Erreur lors du déplacement des Bitstreams",
 
   // "item.edit.bitstreams.notifications.move.saved.content": "Your move changes to this item's bitstreams and bundles have been saved.",
-  "item.edit.bitstreams.notifications.move.saved.content": "Les déplacements Bundles/Bitstreams de cet Item ont été sauvegardés avec succès.",
+  "item.edit.bitstreams.notifications.move.saved.content": "Vos déplacements Bundles/Bitstreams de cet Item ont été sauvegardés avec succès.",
 
   // "item.edit.bitstreams.notifications.move.saved.title": "Move changes saved",
   "item.edit.bitstreams.notifications.move.saved.title": "Déplacements sauvegardés",
 
   // "item.edit.bitstreams.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
-  "item.edit.bitstreams.notifications.outdated.content": "L'Item sur lequel vous êtes en train de travailler a été édité par un autre utilisateur. Vos changements en cours sont ignorés pour éviter des conflits",
+  "item.edit.bitstreams.notifications.outdated.content": "L'Item sur lequel vous êtes en train de travailler a été édité par un autre utilisateur. Vos modifications en cours sont ignorés pour éviter des conflits",
 
   // "item.edit.bitstreams.notifications.outdated.title": "Changes outdated",
   "item.edit.bitstreams.notifications.outdated.title": "Changements obsolètes",
@@ -2092,9 +2431,7 @@
   "item.edit.bitstreams.save-button": "Sauvegarder",
 
   // "item.edit.bitstreams.upload-button": "Upload",
-  "item.edit.bitstreams.upload-button": "Ajouter",
-
-
+  "item.edit.bitstreams.upload-button": "Télécharger",
 
   // "item.edit.delete.cancel": "Cancel",
   "item.edit.delete.cancel": "Annuler",
@@ -2103,88 +2440,91 @@
   "item.edit.delete.confirm": "Supprimer",
 
   // "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
-  "item.edit.delete.description": "Êtes-vous certain de vouloir complètement supprimer cet Item ? Attention, il n'y aura pas de retour en arrière possible.",
+  "item.edit.delete.description": "Êtes-vous certain(e) de vouloir complètement supprimer cet Item ? Attention, il n'y aura pas de retour en arrière possible.",
 
   // "item.edit.delete.error": "An error occurred while deleting the item",
   "item.edit.delete.error": "Une erreur s'est produite lors de la suppression de l'Item",
 
   // "item.edit.delete.header": "Delete item: {{ id }}",
-  "item.edit.delete.header": "Supprimer Item : {{ id }}",
+  "item.edit.delete.header": "Supprimer l'Item : {{ id }}",
 
   // "item.edit.delete.success": "The item has been deleted",
   "item.edit.delete.success": "L'Item a été supprimé",
 
   // "item.edit.head": "Edit Item",
-  "item.edit.head": "Éditer Item",
+  "item.edit.head": "Éditer l'Item",
 
   // "item.edit.breadcrumbs": "Edit Item",
-  "item.edit.breadcrumbs": "Éditer Item",
+  "item.edit.breadcrumbs": "Éditer l'Item",
 
+  // "item.edit.tabs.disabled.tooltip": "You're not authorized to access this tab",
+  "item.edit.tabs.disabled.tooltip": "Vous n'êtes pas autorisé à accéder à cet onglet",
 
   // "item.edit.tabs.mapper.head": "Collection Mapper",
-  "item.edit.tabs.mapper.head": "Collection Mapper",
+  "item.edit.tabs.mapper.head": "Association de collection",
 
   // "item.edit.tabs.item-mapper.title": "Item Edit - Collection Mapper",
-  "item.edit.tabs.item-mapper.title": "Édition Item - Collection Mapper",
+  "item.edit.tabs.item-mapper.title": "Édition d'Item - Association de collection",
 
   // "item.edit.item-mapper.buttons.add": "Map item to selected collections",
-  "item.edit.item-mapper.buttons.add": "Associer Item aux Collections sélectionnées",
+  "item.edit.item-mapper.buttons.add": "Associer l'Item aux collections sélectionnées",
 
   // "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
-  "item.edit.item-mapper.buttons.remove": "Supprimer l'association d'Item pour les Collections sélectionnées",
+  "item.edit.item-mapper.buttons.remove": "Supprimer l'association de l'Item aux collections sélectionnées",
 
   // "item.edit.item-mapper.cancel": "Cancel",
   "item.edit.item-mapper.cancel": "Annuler",
 
   // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
-  "item.edit.item-mapper.description": "L'Item Mapper permet aux administrateurs de Collection d'associer des Items avec d'autres Collections. Vous pouvez rechercher des Collections et les associer ou parcourir la liste des Collections auxquelles l'Item est actuellement associé.",
+  "item.edit.item-mapper.description": "L'outil d'association d'Items permet aux administrateurs d'associer cet Item à d'autres collections. Vous pouvez rechercher des collections et les associer, ou encore consulter la liste des collections pour lesquelles l'Item est présentement associé.",
 
   // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
-  "item.edit.item-mapper.head": "Item Mapper - Associer Item avec Collections",
+  "item.edit.item-mapper.head": "Association d'Items - Associer l'Item aux collections",
 
   // "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
   "item.edit.item-mapper.item": "Item : « <b>{{name}}</b> »",
 
   // "item.edit.item-mapper.no-search": "Please enter a query to search",
-  "item.edit.item-mapper.no-search": "Veuillez entrer un élément à rechercher",
+  "item.edit.item-mapper.no-search": "Veuillez entrer une requête de recherche",
 
   // "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.add.error.content": "Des erreurs se sont produites à l'association de l'Item avec {{amount}} Collections.",
+  "item.edit.item-mapper.notifications.add.error.content": "Des erreurs se sont produites dans l'association de l'Item avec {{amount}} collections.",
 
   // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
   "item.edit.item-mapper.notifications.add.error.head": "Erreurs d'association",
 
   // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.add.success.content": "Item associé avec succès avec {{amount}} Collections.",
+  "item.edit.item-mapper.notifications.add.success.content": "Item associé avec succès à {{amount}} collections.",
 
   // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
   "item.edit.item-mapper.notifications.add.success.head": "Association terminée",
 
   // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.remove.error.content": "Des erreurs se sont produites à la suppression de l'association de {{amount}} Collections.",
+  "item.edit.item-mapper.notifications.remove.error.content": "Des erreurs se sont produites à la suppression de l'association de {{amount}} collections.",
 
   // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
   "item.edit.item-mapper.notifications.remove.error.head": "Erreurs à la suppression d'association",
 
   // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.remove.success.content": "Association de l'item avec {{amount}} Collections supprimée avec succès.",
+  "item.edit.item-mapper.notifications.remove.success.content": "Association de l'Item à {{amount}} collections supprimée avec succès.",
 
   // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
   "item.edit.item-mapper.notifications.remove.success.head": "Suppression d'association terminée",
 
+  // "item.edit.item-mapper.search-form.placeholder": "Search collections...",
+  "item.edit.item-mapper.search-form.placeholder": "Rechercher des collections...",
+
   // "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
-  "item.edit.item-mapper.tabs.browse": "Parcourir Collections associées",
+  "item.edit.item-mapper.tabs.browse": "Parcourir les collections associées",
 
   // "item.edit.item-mapper.tabs.map": "Map new collections",
-  "item.edit.item-mapper.tabs.map": "Associer nouvelles Collections",
-
-
+  "item.edit.item-mapper.tabs.map": "Associer à de nouvelles collections",
 
   // "item.edit.metadata.add-button": "Add",
   "item.edit.metadata.add-button": "Ajouter",
 
   // "item.edit.metadata.discard-button": "Discard",
-  "item.edit.metadata.discard-button": "Annuler",
+  "item.edit.metadata.discard-button": "Rejeter",
 
   // "item.edit.metadata.edit.buttons.edit": "Edit",
   "item.edit.metadata.edit.buttons.edit": "Éditer",
@@ -2193,13 +2533,13 @@
   "item.edit.metadata.edit.buttons.remove": "Supprimer",
 
   // "item.edit.metadata.edit.buttons.undo": "Undo changes",
-  "item.edit.metadata.edit.buttons.undo": "Annuler changements",
+  "item.edit.metadata.edit.buttons.undo": "Annuler les modifications",
 
   // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
-  "item.edit.metadata.edit.buttons.unedit": "Stopper l'édition",
+  "item.edit.metadata.edit.buttons.unedit": "Arrêter l'édition",
 
   // "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
-  "item.edit.metadata.empty": "Aucune métadonnée n'est associée à cet Item. Cliquer 'Ajouter' pour commencer à ajouter une métadonnée.",
+  "item.edit.metadata.empty": "Aucune métadonnée n'est associée à cet Item. Cliquer sur « Ajouter » pour commencer à ajouter une métadonnée.",
 
   // "item.edit.metadata.headers.edit": "Edit",
   "item.edit.metadata.headers.edit": "Éditer",
@@ -2217,28 +2557,28 @@
   "item.edit.metadata.metadatafield.invalid": "Veuillez choisir un champ de métadonnée valide",
 
   // "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
-  "item.edit.metadata.notifications.discarded.content": "Vos changements ont été annulés. Pour rétablir vos changements, cliquer sur le bouton 'Rétablir'",
+  "item.edit.metadata.notifications.discarded.content": "Vos modifications ont été annulées. Pour rétablir vos modifications, cliquer sur le bouton « Rétablir »",
 
   // "item.edit.metadata.notifications.discarded.title": "Changed discarded",
-  "item.edit.metadata.notifications.discarded.title": "Changements annulés",
+  "item.edit.metadata.notifications.discarded.title": "Modifications annulées",
 
   // "item.edit.metadata.notifications.error.title": "An error occurred",
   "item.edit.metadata.notifications.error.title": "Une erreur s'est produite",
 
   // "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
-  "item.edit.metadata.notifications.invalid.content": "Vos changements n'ont pas été sauvegardés. Veuillez vérifier que tous les champs sont valides avant de sauvegarder.",
+  "item.edit.metadata.notifications.invalid.content": "Vos modifications n'ont pas été sauvegardées. Veuillez vérifier que tous les champs soient valides avant de sauvegarder.",
 
   // "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
   "item.edit.metadata.notifications.invalid.title": "Métadonnée invalide",
 
   // "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
-  "item.edit.metadata.notifications.outdated.content": "L'Item sur lequel vous êtes en train de travailler a été édité par un autre utilisateur. Vos changements en cours sont ignorés pour éviter des conflits",
+  "item.edit.metadata.notifications.outdated.content": "L'Item sur lequel vous êtes en train de travailler a été édité par un autre utilisateur. Vos modifications en cours sont ignorées pour éviter des conflits",
 
   // "item.edit.metadata.notifications.outdated.title": "Changed outdated",
-  "item.edit.metadata.notifications.outdated.title": "Changements obsolètes",
+  "item.edit.metadata.notifications.outdated.title": "Modifications obsolètes",
 
   // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
-  "item.edit.metadata.notifications.saved.content": "Vos modifications de métadonnées n'ont pas été sauvegardées.",
+  "item.edit.metadata.notifications.saved.content": "Vos modifications aux métadonnées de cet Item ont été sauvegardées.",
 
   // "item.edit.metadata.notifications.saved.title": "Metadata saved",
   "item.edit.metadata.notifications.saved.title": "Métadonnée sauvegardée",
@@ -2249,8 +2589,6 @@
   // "item.edit.metadata.save-button": "Save",
   "item.edit.metadata.save-button": "Sauvegarder",
 
-
-
   // "item.edit.modify.overview.field": "Field",
   "item.edit.modify.overview.field": "Champ",
 
@@ -2260,82 +2598,80 @@
   // "item.edit.modify.overview.value": "Value",
   "item.edit.modify.overview.value": "Valeur",
 
-
-
-  // "item.edit.move.cancel": "Cancel",
+  // "item.edit.move.cancel": "Back",
   "item.edit.move.cancel": "Annuler",
 
+  // "item.edit.move.save-button": "Save",
+  "item.edit.move.save-button": "Sauvegarder",
+
+  // "item.edit.move.discard-button": "Discard",
+  "item.edit.move.discard-button": "Rejeter",
+
   // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
-  "item.edit.move.description": "Sélectionner la Collection dans laquelle vous souhaitez transférer l'Item. Pour limiter la liste de Collections affichées, vous pouvez utiliser le champ de recherche.",
+  "item.edit.move.description": "Sélectionner la collection dans laquelle vous souhaitez déplacer l'Item. Pour limiter la liste de collections affichées, vous pouvez saisir une requête de recherche dans la case.",
 
   // "item.edit.move.error": "An error occurred when attempting to move the item",
-  "item.edit.move.error": "Une erreur s'est produite lors du transfert de l'Item",
+  "item.edit.move.error": "Une erreur s'est produite lors du déplacement de l'Item",
 
   // "item.edit.move.head": "Move item: {{id}}",
-  "item.edit.move.head": "Transférer item : {{id}}",
+  "item.edit.move.head": "Déplacer l'Item : {{id}}",
 
   // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
-  "item.edit.move.inheritpolicies.checkbox": "Récupérer règles",
+  "item.edit.move.inheritpolicies.checkbox": "Hériter des politiques",
 
   // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
-  "item.edit.move.inheritpolicies.description": "Récupérer les règles par défaut de la Collection de destination",
+  "item.edit.move.inheritpolicies.description": "Hériter des politiques par défaut de la collection de destination",
 
   // "item.edit.move.move": "Move",
-  "item.edit.move.move": "Transférer",
+  "item.edit.move.move": "Déplacer",
 
   // "item.edit.move.processing": "Moving...",
-  "item.edit.move.processing": "En cours de transfert...",
+  "item.edit.move.processing": "En cours de déplacement...",
 
   // "item.edit.move.search.placeholder": "Enter a search query to look for collections",
-  "item.edit.move.search.placeholder": "Rechercher Collection",
+  "item.edit.move.search.placeholder": "Saisir une requête pour rechercher des collections",
 
   // "item.edit.move.success": "The item has been moved successfully",
-  "item.edit.move.success": "L'Item a été transféré avec succès",
+  "item.edit.move.success": "L'Item a été déplacé avec succès",
 
   // "item.edit.move.title": "Move item",
-  "item.edit.move.title": "Transférer item",
-
-
+  "item.edit.move.title": "Déplacer l'Item",
 
   // "item.edit.private.cancel": "Cancel",
   "item.edit.private.cancel": "Annuler",
 
   // "item.edit.private.confirm": "Make it Private",
-  "item.edit.private.confirm": "Définir comme Privé",
+  "item.edit.private.confirm": "Définir comme privé",
 
   // "item.edit.private.description": "Are you sure this item should be made private in the archive?",
-  "item.edit.private.description": "Êtes-vous certain de vouloir définir cet Item comme Privé ?",
+  "item.edit.private.description": "Êtes-vous certain(e) de vouloir définir cet Item comme privé ?",
 
   // "item.edit.private.error": "An error occurred while making the item private",
-  "item.edit.private.error": "Une erreur s'est produite lors de la définition de l'Item en tant qu'Item Privé",
+  "item.edit.private.error": "Une erreur s'est produite lors de la privatisation de l'Item",
 
   // "item.edit.private.header": "Make item private: {{ id }}",
-  "item.edit.private.header": "Définir Item comme Privé : {{ id }}",
+  "item.edit.private.header": "Définir l'Item {{ id }} comme privé",
 
   // "item.edit.private.success": "The item is now private",
-  "item.edit.private.success": "L'Item est désormais Privé",
-
-
+  "item.edit.private.success": "L'Item est désormais privé",
 
   // "item.edit.public.cancel": "Cancel",
   "item.edit.public.cancel": "Annuler",
 
   // "item.edit.public.confirm": "Make it Public",
-  "item.edit.public.confirm": "Définir comme Public",
+  "item.edit.public.confirm": "Définir comme public",
 
   // "item.edit.public.description": "Are you sure this item should be made public in the archive?",
-  "item.edit.public.description": "Êtes-vous certain de vouloir définir cet Item comme Public ?",
+  "item.edit.public.description": "Êtes-vous certain(e) de vouloir définir cet Item comme public ?",
 
   // "item.edit.public.error": "An error occurred while making the item public",
-  "item.edit.public.error": "Une erreur s'est produite lors e la définition de l'Item en tant qu'Item Public",
+  "item.edit.public.error": "Une erreur s'est produite lors de la définition de l'Item en tant qu'Item public",
 
   // "item.edit.public.header": "Make item public: {{ id }}",
-  "item.edit.public.header": "Définir Item comme Public : {{ id }}",
+  "item.edit.public.header": "Définir l'Item {{ id }} comme public",
 
   // "item.edit.public.success": "The item is now public",
-  "item.edit.public.success": "L'Item est désormais Public",
-
-
+  "item.edit.public.success": "L'Item est désormais public",
 
   // "item.edit.reinstate.cancel": "Cancel",
   "item.edit.reinstate.cancel": "Annuler",
@@ -2344,18 +2680,16 @@
   "item.edit.reinstate.confirm": "Réintégrer",
 
   // "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
-  "item.edit.reinstate.description": "Êtes-vous certain de vouloir réintégrer cet Item ?",
+  "item.edit.reinstate.description": "Êtes-vous certain(e) de vouloir réintégrer cet Item ?",
 
   // "item.edit.reinstate.error": "An error occurred while reinstating the item",
   "item.edit.reinstate.error": "Une erreur s'est produite lors de la réintégration de l'Item",
 
   // "item.edit.reinstate.header": "Reinstate item: {{ id }}",
-  "item.edit.reinstate.header": "Réintégrer Item : {{ id }}",
+  "item.edit.reinstate.header": "Réintégrer l'Item : {{ id }}",
 
   // "item.edit.reinstate.success": "The item was reinstated successfully",
   "item.edit.reinstate.success": "L'Item a été réintégré avec succès",
-
-
 
   // "item.edit.relationships.discard-button": "Discard",
   "item.edit.relationships.discard-button": "Annuler",
@@ -2367,16 +2701,16 @@
   "item.edit.relationships.edit.buttons.remove": "Supprimer",
 
   // "item.edit.relationships.edit.buttons.undo": "Undo changes",
-  "item.edit.relationships.edit.buttons.undo": "Annuler changements",
+  "item.edit.relationships.edit.buttons.undo": "Annuler les modifications",
 
   // "item.edit.relationships.no-relationships": "No relationships",
   "item.edit.relationships.no-relationships": "Aucune relation",
 
   // "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
-  "item.edit.relationships.notifications.discarded.content": "Vos changements ont été annulés. Pour rétablir vos changements, cliquer sur le bouton 'Rétablir'",
+  "item.edit.relationships.notifications.discarded.content": "Vos modifications ont été annulées. Pour rétablir vos modifications, cliquer sur le bouton « Rétablir »",
 
   // "item.edit.relationships.notifications.discarded.title": "Changes discarded",
-  "item.edit.relationships.notifications.discarded.title": "Changements annulés",
+  "item.edit.relationships.notifications.discarded.title": "Modifications annulées",
 
   // "item.edit.relationships.notifications.failed.title": "Error editing relationships",
   "item.edit.relationships.notifications.failed.title": "Erreur lors de l'édition des relations",
@@ -2385,10 +2719,10 @@
   "item.edit.relationships.notifications.outdated.content": "L'Item sur lequel vous êtes en train de travailler a été édité par un autre utilisateur. Vos changements en cours sont ignorés pour éviter des conflits.",
 
   // "item.edit.relationships.notifications.outdated.title": "Changes outdated",
-  "item.edit.relationships.notifications.outdated.title": "Changements obsolètes",
+  "item.edit.relationships.notifications.outdated.title": "Modifications obsolètes",
 
   // "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
-  "item.edit.relationships.notifications.saved.content": "Vos changements aux Relations de l'Item ont été sauvegardés.",
+  "item.edit.relationships.notifications.saved.content": "Vos modifications aux relations de l'Item ont été sauvegardées.",
 
   // "item.edit.relationships.notifications.saved.title": "Relationships saved",
   "item.edit.relationships.notifications.saved.title": "Relations sauvegardées",
@@ -2400,39 +2734,40 @@
   "item.edit.relationships.save-button": "Sauvegarder",
 
   // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
-  "item.edit.relationships.no-entity-type": "Ajouter la métadonnée 'dspace.entity.type' pour activer les relations pour cet Item",
+  "item.edit.relationships.no-entity-type": "Ajouter la métadonnée « dspace.entity.type » pour permettre d'établir des relations pour cet Item",
 
-
+  // "item.edit.return": "Back",
+  "item.edit.return": "Retour",
 
   // "item.edit.tabs.bitstreams.head": "Bitstreams",
   "item.edit.tabs.bitstreams.head": "Bitstreams",
 
   // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
-  "item.edit.tabs.bitstreams.title": "Édition Item - Bitstreams",
+  "item.edit.tabs.bitstreams.title": "Édition d'Item - Bitstreams",
 
   // "item.edit.tabs.curate.head": "Curate",
   "item.edit.tabs.curate.head": "Gestion de contenu",
 
   // "item.edit.tabs.curate.title": "Item Edit - Curate",
-  "item.edit.tabs.curate.title": "Édition Item - Gestion de contenu",
+  "item.edit.tabs.curate.title": "Édition d'Item - Gestion de contenu",
 
   // "item.edit.tabs.metadata.head": "Metadata",
   "item.edit.tabs.metadata.head": "Métadonnées",
 
   // "item.edit.tabs.metadata.title": "Item Edit -  Metadata",
-  "item.edit.tabs.metadata.title": "Édition Item - Métadonnées",
+  "item.edit.tabs.metadata.title": "Édition d'Item - Métadonnées",
 
   // "item.edit.tabs.relationships.head": "Relationships",
-  "item.edit.tabs.relationships.head": "Relations de l'Item",
+  "item.edit.tabs.relationships.head": "Relations",
 
   // "item.edit.tabs.relationships.title": "Item Edit - Relationships",
-  "item.edit.tabs.relationships.title": "Édition Item - Relations",
+  "item.edit.tabs.relationships.title": "Édition d'Item - Relations",
 
   // "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
-  "item.edit.tabs.status.buttons.authorizations.button": "Accès...",
+  "item.edit.tabs.status.buttons.authorizations.button": "Autorisations d'accès...",
 
   // "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
-  "item.edit.tabs.status.buttons.authorizations.label": "Éditer les règles d'accès de l'Item",
+  "item.edit.tabs.status.buttons.authorizations.label": "Éditer les autorisations d'accès de l'Item",
 
   // "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
   "item.edit.tabs.status.buttons.delete.button": "Supprimer définitivement",
@@ -2444,40 +2779,43 @@
   "item.edit.tabs.status.buttons.mappedCollections.button": "Collections associées",
 
   // "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
-  "item.edit.tabs.status.buttons.mappedCollections.label": "Gérer les Collections associées",
+  "item.edit.tabs.status.buttons.mappedCollections.label": "Gérer les collections associées",
 
   // "item.edit.tabs.status.buttons.move.button": "Move...",
-  "item.edit.tabs.status.buttons.move.button": "Transférer...",
+  "item.edit.tabs.status.buttons.move.button": "Déplacer...",
 
   // "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
-  "item.edit.tabs.status.buttons.move.label": "Transférer l'Item dans une autre Collection",
+  "item.edit.tabs.status.buttons.move.label": "Déplacer l'Item dans une autre collection",
 
   // "item.edit.tabs.status.buttons.private.button": "Make it private...",
   "item.edit.tabs.status.buttons.private.button": "Définir comme privé...",
 
   // "item.edit.tabs.status.buttons.private.label": "Make item private",
-  "item.edit.tabs.status.buttons.private.label": "Définir l'Item en tant qu'Item Privé",
+  "item.edit.tabs.status.buttons.private.label": "Définir l'Item en tant que document privé",
 
   // "item.edit.tabs.status.buttons.public.button": "Make it public...",
   "item.edit.tabs.status.buttons.public.button": "Définir comme public...",
 
   // "item.edit.tabs.status.buttons.public.label": "Make item public",
-  "item.edit.tabs.status.buttons.public.label": "Définir l'Item en tant qu'Item public",
+  "item.edit.tabs.status.buttons.public.label": "Définir l'Item en tant que document public",
 
   // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
   "item.edit.tabs.status.buttons.reinstate.button": "Réintégrer...",
 
   // "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
-  "item.edit.tabs.status.buttons.reinstate.label": "Réintégrer l'Item",
+  "item.edit.tabs.status.buttons.reinstate.label": "Réintégrer l'Item dans le dépôt",
+
+  // "item.edit.tabs.status.buttons.unauthorized": "You're not authorized to perform this action",
+  "item.edit.tabs.status.buttons.unauthorized": "Vous n'êtes pas autorisé à effectuer cette action",
 
   // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw...",
   "item.edit.tabs.status.buttons.withdraw.button": "Retirer...",
 
   // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
-  "item.edit.tabs.status.buttons.withdraw.label": "Retirer l'Item",
+  "item.edit.tabs.status.buttons.withdraw.label": "Retirer l'Item du dépôt",
 
   // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
-  "item.edit.tabs.status.description": "Bienvenue sur la page de gestion de l'Item. D'ici, vous pouvez retirer, réintégrer, transférer ou supprimer l'Item. Dans les autres onglets, vous pouvez également mettre à jour, ajouter ou supprimer des métadonnées et/ou bitstreams.",
+  "item.edit.tabs.status.description": "Bienvenue sur la page de gestion de l'Item. D'ici, vous pouvez retirer, réintégrer, déplacer ou supprimer l'Item. Dans les autres onglets, vous pouvez également mettre à jour, ajouter ou supprimer des métadonnées et/ou Bitstreams.",
 
   // "item.edit.tabs.status.head": "Status",
   "item.edit.tabs.status.head": "Statut",
@@ -2495,24 +2833,22 @@
   "item.edit.tabs.status.labels.lastModified": "Date de dernière modification",
 
   // "item.edit.tabs.status.title": "Item Edit -  Status",
-  "item.edit.tabs.status.title": "Édition Item - Statut",
+  "item.edit.tabs.status.title": "Édition d'Item - Statut",
 
   // "item.edit.tabs.versionhistory.head": "Version History",
   "item.edit.tabs.versionhistory.head": "Historique des versions",
 
   // "item.edit.tabs.versionhistory.title": "Item Edit - Version History",
-  "item.edit.tabs.versionhistory.title": "Édition Item - Historique des versions",
+  "item.edit.tabs.versionhistory.title": "Édition d'Item - Historique des versions",
 
   // "item.edit.tabs.versionhistory.under-construction": "Editing or adding new versions is not yet possible in this user interface.",
   "item.edit.tabs.versionhistory.under-construction": "L'ajout ou l'édition de versions n'est pas encore possible depuis cette interface utilisateur.",
 
   // "item.edit.tabs.view.head": "View Item",
-  "item.edit.tabs.view.head": "Voir Item",
+  "item.edit.tabs.view.head": "Voir l'Item",
 
   // "item.edit.tabs.view.title": "Item Edit -  View",
-  "item.edit.tabs.view.title": "Édition Item - View",
-
-
+  "item.edit.tabs.view.title": "Édition d'Item - Afficher",
 
   // "item.edit.withdraw.cancel": "Cancel",
   "item.edit.withdraw.cancel": "Annuler",
@@ -2527,21 +2863,16 @@
   "item.edit.withdraw.error": "Une erreur s'est produite lors du retrait de l'Item",
 
   // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
-  "item.edit.withdraw.header": "Retrait item : {{ id }}",
+  "item.edit.withdraw.header": "Retrait de l'Item : {{ id }}",
 
   // "item.edit.withdraw.success": "The item was withdrawn successfully",
   "item.edit.withdraw.success": "L'Item a été retiré avec succès",
-
-
 
   // "item.listelement.badge": "Item",
   "item.listelement.badge": "Item",
 
   // "item.page.description": "Description",
   "item.page.description": "Description",
-
-  // "item.page.edit": "Edit this item",
-  "item.page.edit": "Éditer cet Item",
 
   // "item.page.journal-issn": "Journal ISSN",
   "item.page.journal-issn": "ISSN de la revue",
@@ -2553,18 +2884,16 @@
   "item.page.publisher": "Éditeur",
 
   // "item.page.titleprefix": "Item: ",
-  "item.page.titleprefix": "Item: ",
+  "item.page.titleprefix": "Item : ",
 
   // "item.page.volume-title": "Volume Title",
   "item.page.volume-title": "Titre du volume",
 
   // "item.search.results.head": "Item Search Results",
-  "item.search.results.head": "Résultats de la recherche",
+  "item.search.results.head": "Résultats de la recherche d'Items",
 
-  // "item.search.title": "DSpace Angular :: Item Search",
-  "item.search.title": "DSpace Angular :: Item Search",
-
-
+  // "item.search.title": "Item Search",
+  "item.search.title": "Recherche d'Items",
 
   // "item.page.abstract": "Abstract",
   "item.page.abstract": "Résumé",
@@ -2578,11 +2907,17 @@
   // "item.page.collections": "Collections",
   "item.page.collections": "Collections",
 
+  // "item.page.collections.loading": "Loading...",
+  "item.page.collections.loading": "Chargement...",
+
+  // "item.page.collections.load-more": "Load more",
+  "item.page.collections.load-more": "Charger davantage",
+
   // "item.page.date": "Date",
   "item.page.date": "Date",
 
   // "item.page.edit": "Edit this item",
-  "item.page.edit": "Éditer cet item",
+  "item.page.edit": "Éditer cet Item",
 
   // "item.page.files": "Files",
   "item.page.files": "Fichiers",
@@ -2609,7 +2944,7 @@
   "item.page.link.full": "Notice complète",
 
   // "item.page.link.simple": "Simple item page",
-  "item.page.link.simple": "Notice simple",
+  "item.page.link.simple": "Notice brève",
 
   // "item.page.person.search.title": "Articles by this author",
   "item.page.person.search.title": "Articles de cet auteur",
@@ -2644,11 +2979,20 @@
   // "item.page.bitstreams.collapse": "Collapse",
   "item.page.bitstreams.collapse": "Réduire",
 
-  // "item.page.filesection.original.bundle" : "Original bundle",
-  "item.page.filesection.original.bundle" : "Bundle Original",
+  // "item.page.filesection.original.bundle": "Original bundle",
+  "item.page.filesection.original.bundle": "Bundle original",
 
-  // "item.page.filesection.license.bundle" : "License bundle",
-  "item.page.filesection.license.bundle" : "Bundle Licence",
+ // "item.page.filesection.license.bundle": "License bundle",
+  "item.page.filesection.license.bundle": "Bundle de license",
+
+  // "item.page.return": "Back",
+  "item.page.return": "Retour",
+
+  // "item.page.version.create": "Create new version",
+  "item.page.version.create": "Créer une nouvelle version",
+
+  // "item.page.version.hasDraft": "A new version cannot be created because there is an inprogress submission in the version history",
+  "item.page.version.hasDraft": "Une nouvelle version ne peut être créée car il y a une soumission en cours dans l'historique des versions",
 
   // "item.preview.dc.identifier.uri": "Identifier:",
   "item.preview.dc.identifier.uri": "Identifiant :",
@@ -2678,14 +3022,31 @@
   "item.preview.person.familyName": "Nom de famille :",
 
   // "item.preview.person.givenName": "Name:",
-  "item.preview.person.givenName": "Prénom:",
+  "item.preview.person.givenName": "Prénom :",
 
   // "item.preview.person.identifier.orcid": "ORCID:",
-  "item.preview.person.identifier.orcid": "ORCID:",
+  "item.preview.person.identifier.orcid": "ORCID :",
 
+  // "item.preview.project.funder.name": "Funder:",
+  "item.preview.project.funder.name": "Bailleur de fonds",
+
+  // "item.preview.project.funder.identifier": "Funder Identifier:",
+  "item.preview.project.funder.identifier": "Identifiant du bailleur de fonds",
+
+  // "item.preview.oaire.awardNumber": "Funding ID:",
+  "item.preview.oaire.awardNumber": "Identifiant du bailleur de fonds :",
+
+  // "item.preview.dc.title.alternative": "Acronym:",
+  "item.preview.dc.title.alternative": "Acronyme :",
+
+  // "item.preview.dc.coverage.spatial": "Jurisdiction:",
+  "item.preview.dc.coverage.spatial": "Juridiction :",
+
+  // "item.preview.oaire.fundingStream": "Funding Stream:",
+  "item.preview.oaire.fundingStream": "Volet de financement :",
 
   // "item.select.confirm": "Confirm selected",
-  "item.select.confirm": "Confirmer sélection",
+  "item.select.confirm": "Confirmer la sélection",
 
   // "item.select.empty": "No items to show",
   "item.select.empty": "Aucun Item à afficher",
@@ -2699,18 +3060,20 @@
   // "item.select.table.title": "Title",
   "item.select.table.title": "Titre",
 
-
   // "item.version.history.empty": "There are no other versions for this item yet.",
   "item.version.history.empty": "Il n'y a pas encore d'autres versions de cet Item.",
 
   // "item.version.history.head": "Version History",
   "item.version.history.head": "Historique des versions",
 
-  // "item.version.history.return": "Return",
+  // "item.version.history.return": "Back",
   "item.version.history.return": "Retour",
 
   // "item.version.history.selected": "Selected version",
   "item.version.history.selected": "Version sélectionnée",
+
+  // "item.version.history.selected.alert": "You are currently viewing version {{version}} of the item.",
+  "item.version.history.selected.alert": "Vous consultez actuellement la version {{version}} de l'Item.",
 
   // "item.version.history.table.version": "Version",
   "item.version.history.table.version": "Version",
@@ -2727,12 +3090,104 @@
   // "item.version.history.table.summary": "Summary",
   "item.version.history.table.summary": "Résumé",
 
+  // "item.version.history.table.workspaceItem": "Workspace item",
+  "item.version.history.table.workspaceItem": "Item de l'espace de travail",
 
+  // "item.version.history.table.workflowItem": "Workflow item",
+  "item.version.history.table.workflowItem": "Item du Workflow",
+
+  // "item.version.history.table.actions": "Action",
+  "item.version.history.table.actions": "Action",
+
+  // "item.version.history.table.action.editWorkspaceItem": "Edit workspace item",
+  "item.version.history.table.action.editWorkspaceItem": "Éditer l'Item de l'espace de travail",
+
+  // "item.version.history.table.action.editSummary": "Edit summary",
+  "item.version.history.table.action.editSummary": "Éditer le sommaire",
+
+  // "item.version.history.table.action.saveSummary": "Save summary edits",
+  "item.version.history.table.action.saveSummary": "Sauvegarder les modifications au sommaire",
+
+  // "item.version.history.table.action.discardSummary": "Discard summary edits",
+  "item.version.history.table.action.discardSummary": "Annuler les modifications au sommaire",
+
+  // "item.version.history.table.action.newVersion": "Create new version from this one",
+  "item.version.history.table.action.newVersion": "Créer une nouvelle version à partir de celui-ci",
+
+  // "item.version.history.table.action.deleteVersion": "Delete version",
+  "item.version.history.table.action.deleteVersion": "Supprimer la version",
+
+  // "item.version.history.table.action.hasDraft": "A new version cannot be created because there is an inprogress submission in the version history",
+  "item.version.history.table.action.hasDraft": "Une nouvelle version ne peut pas être créée parce qu'il y a une soumission en cours dans l'historique des versions.",
 
   // "item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
   "item.version.notice": "Ceci n'est pas la version la plus récente de cet Item. La dernière version est accessible <a href='{{destination}}'>ici</a>.",
 
+  // "item.version.create.modal.header": "New version",
+  "item.version.create.modal.header": "Nouvelle version",
 
+  // "item.version.create.modal.text": "Create a new version for this item",
+  "item.version.create.modal.text": "Créer une nouvelle version pour cet Item",
+
+  // "item.version.create.modal.text.startingFrom": "starting from version {{version}}",
+  "item.version.create.modal.text.startingFrom": "à partir de la version {{version}}",
+
+  // "item.version.create.modal.button.confirm": "Create",
+  "item.version.create.modal.button.confirm": "Créer",
+
+  // "item.version.create.modal.button.confirm.tooltip": "Create new version",
+  "item.version.create.modal.button.confirm.tooltip": "Créer une nouvelle version",
+
+  // "item.version.create.modal.button.cancel": "Cancel",
+  "item.version.create.modal.button.cancel": "Annuler",
+
+  // "item.version.create.modal.button.cancel.tooltip": "Do not create new version",
+  "item.version.create.modal.button.cancel.tooltip": "Ne pas créer de nouvelle version",
+
+  // "item.version.create.modal.form.summary.label": "Summary",
+  "item.version.create.modal.form.summary.label": "Sommaire",
+
+  // "item.version.create.modal.form.summary.placeholder": "Insert the summary for the new version",
+  "item.version.create.modal.form.summary.placeholder": "Insérer le sommaire de la nouvelle version",
+
+  // "item.version.create.notification.success": "New version has been created with version number {{version}}",
+  "item.version.create.notification.success": "Une nouvelle version a été créée avec le numéro de version {{version}}.",
+
+  // "item.version.create.notification.failure": "New version has not been created",
+  "item.version.create.notification.failure": "La nouvelle version n'a pas été créée",
+  
+  // "item.version.create.notification.inProgress": "A new version cannot be created because there is an inprogress submission in the version history",
+  "item.version.create.notification.inProgress": "Une nouvelle version ne peut pas être créée parce qu'il y a une soumission en cours dans l'historique des versions.",
+
+  // "item.version.delete.modal.header": "Delete version",
+  "item.version.delete.modal.header": "Supprimer la version",
+
+  // "item.version.delete.modal.text": "Do you want to delete version {{version}}?",
+  "item.version.delete.modal.text": "Voulez-vous supprimer la version {{version}} ?",
+
+  // "item.version.delete.modal.button.confirm": "Delete",
+  "item.version.delete.modal.button.confirm": "Supprimer",
+
+  // "item.version.delete.modal.button.confirm.tooltip": "Delete this version",
+  "item.version.delete.modal.button.confirm.tooltip": "Supprimer cette version",
+
+  // "item.version.delete.modal.button.cancel": "Cancel",
+  "item.version.delete.modal.button.cancel": "Annuler",
+
+  // "item.version.delete.modal.button.cancel.tooltip": "Do not delete this version",
+  "item.version.delete.modal.button.cancel.tooltip": "Ne pas supprimer cette version",
+
+  // "item.version.delete.notification.success": "Version number {{version}} has been deleted",
+  "item.version.delete.notification.success": "Le numéro de version {{version}} a été supprimé.",
+
+  // "item.version.delete.notification.failure": "Version number {{version}} has not been deleted",
+  "item.version.delete.notification.failure": "Le numéro de version {{version}} n'a pas été supprimé.",
+
+  // "item.version.edit.notification.success": "The summary of version number {{version}} has been changed",
+  "item.version.edit.notification.success": "Le sommaire du numéro de version {{version}} a été modifié",
+
+  // "item.version.edit.notification.failure": "The summary of version number {{version}} has not been changed",
+  "item.version.edit.notification.failure": "Le sommaire du numéro de version {{version}} n'a pas été modifié.",
 
   // "journal.listelement.badge": "Journal",
   "journal.listelement.badge": "Revue",
@@ -2756,12 +3211,10 @@
   "journal.page.titleprefix": "Revue : ",
 
   // "journal.search.results.head": "Journal Search Results",
-  "journal.search.results.head": "Résultats de recherche Revue",
+  "journal.search.results.head": "Résultats de recherche de revues",
 
-  // "journal.search.title": "DSpace Angular :: Journal Search",
-  "journal.search.title": "DSpace Angular :: Recherche Revue",
-
-
+  // "journal.search.title": "Journal Search",
+  "journal.search.title": "Rechercher des revues",
 
   // "journalissue.listelement.badge": "Journal Issue",
   "journalissue.listelement.badge": "Numéro de revue",
@@ -2790,8 +3243,6 @@
   // "journalissue.page.titleprefix": "Journal Issue: ",
   "journalissue.page.titleprefix": "Numéro de revue : ",
 
-
-
   // "journalvolume.listelement.badge": "Journal Volume",
   "journalvolume.listelement.badge": "Volume de la revue",
 
@@ -2799,7 +3250,7 @@
   "journalvolume.page.description": "Description",
 
   // "journalvolume.page.edit": "Edit this item",
-  "journalvolume.page.edit": "Éditer cet item",
+  "journalvolume.page.edit": "Éditer cet Item",
 
   // "journalvolume.page.issuedate": "Issue Date",
   "journalvolume.page.issuedate": "Date de publication",
@@ -2810,7 +3261,38 @@
   // "journalvolume.page.volume": "Volume",
   "journalvolume.page.volume": "Volume",
 
+  // "iiifsearchable.listelement.badge": "Document Media",
+  "iiifsearchable.listelement.badge": "Media du document",
 
+  // "iiifsearchable.page.titleprefix": "Document: ",
+  "iiifsearchable.page.titleprefix": "Document : ",
+
+  // "iiifsearchable.page.doi": "Permanent Link: ",
+  "iiifsearchable.page.doi": "Lien permanent",
+
+  // "iiifsearchable.page.issue": "Issue: ",
+  "iiifsearchable.page.issue": "Numéro",
+
+  // "iiifsearchable.page.description": "Description: ",
+  "iiifsearchable.page.description": "Description : ",
+
+  // "iiifviewer.fullscreen.notice": "Use full screen for better viewing.",
+  "iiifviewer.fullscreen.notice": "Utiliser le plein écran pour une meilleure visualisation.",
+
+  // "iiif.listelement.badge": "Image Media",
+  "iiif.listelement.badge": "Média de l'image",
+
+  // "iiif.page.titleprefix": "Image: ",
+  "iiif.page.titleprefix": "Image : ",
+
+  // "iiif.page.doi": "Permanent Link: ",
+  "iiif.page.doi": "Lien permanent",
+
+  // "iiif.page.issue": "Issue: ",
+  "iiif.page.issue": "Numéro : ",
+
+  // "iiif.page.description": "Description: ",
+  "iiif.page.description": "Description :",
 
   // "loading.bitstream": "Loading bitstream...",
   "loading.bitstream": "Bitstream en cours de chargement...",
@@ -2858,30 +3340,31 @@
   "loading.search-results": "Résultats de recherche en cours de chargement...",
 
   // "loading.sub-collections": "Loading sub-collections...",
-  "loading.sub-collections": "Sous-Collections en cours de chargement...",
+  "loading.sub-collections": "Sous-collections en cours de chargement...",
 
   // "loading.sub-communities": "Loading sub-communities...",
-  "loading.sub-communities": "Sous-Communautés en cours de chargement...",
+  "loading.sub-communities": "Sous-communautés en cours de chargement...",
 
   // "loading.top-level-communities": "Loading top-level communities...",
   "loading.top-level-communities": "Communautés de 1er niveau en cours de chargement...",
 
-
-
   // "login.form.email": "Email address",
-  "login.form.email": "Adresse e-mail",
+  "login.form.email": "Adresse électronique",
 
   // "login.form.forgot-password": "Have you forgotten your password?",
   "login.form.forgot-password": "Mot de passe oublié ?",
 
   // "login.form.header": "Please log in to DSpace",
-  "login.form.header": "Se connecter sur DSpace",
+  "login.form.header": "Se connecter à DSpace",
 
   // "login.form.new-user": "New user? Click here to register.",
-  "login.form.new-user": "Pas encore de compte ? Cliquez ici pour vous enregistrer.",
+  "login.form.new-user": "Pas encore de compte ? Cliquer ici pour vous enregistrer.",
 
   // "login.form.or-divider": "or",
   "login.form.or-divider": "ou",
+
+  // "login.form.oidc": "Log in with OIDC",
+  "login.form.oidc": "Connexion par OpenID",
 
   // "login.form.password": "Password",
   "login.form.password": "Mot de passe",
@@ -2893,12 +3376,10 @@
   "login.form.submit": "Se connecter",
 
   // "login.title": "Login",
-  "login.title": "Connection",
+  "login.title": "Connexion",
 
   // "login.breadcrumbs": "Login",
-  "login.breadcrumbs": "Connection",
-
-
+  "login.breadcrumbs": "Connexion",
 
   // "logout.form.header": "Log out from DSpace",
   "logout.form.header": "Se déconnecter de DSpace",
@@ -2907,17 +3388,16 @@
   "logout.form.submit": "Se déconnecter",
 
   // "logout.title": "Logout",
-  "logout.title": "Déconnection",
+  "logout.title": "Déconnexion",
 
-
-
-  // "menu.header.admin": "Admin",
-  "menu.header.admin": "Admin",
+  // "menu.header.admin": "Management",
+  "menu.header.admin": "Administration",
 
   // "menu.header.image.logo": "Repository logo",
   "menu.header.image.logo": "Logo du site",
 
-
+  // "menu.header.admin.description": "Management menu",
+  "menu.header.admin.description": "Menu d'administration",
 
   // "menu.section.access_control": "Access Control",
   "menu.section.access_control": "Contrôle d'accès",
@@ -2926,20 +3406,16 @@
   "menu.section.access_control_authorizations": "Autorisations",
 
   // "menu.section.access_control_groups": "Groups",
-  "menu.section.access_control_groups": "Groupes d'utilisateurs",
+  "menu.section.access_control_groups": "Groupes",
 
   // "menu.section.access_control_people": "People",
   "menu.section.access_control_people": "Utilisateurs",
 
-
-
   // "menu.section.admin_search": "Admin Search",
   "menu.section.admin_search": "Recherche Administrateur",
 
-
-
   // "menu.section.browse_community": "This Community",
-  "menu.section.browse_community": "Cette Communauté",
+  "menu.section.browse_community": "Cette communauté",
 
   // "menu.section.browse_community_by_author": "By Author",
   "menu.section.browse_community_by_author": "Auteur",
@@ -2966,17 +3442,13 @@
   "menu.section.browse_global_by_title": "Titre",
 
   // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
-  "menu.section.browse_global_communities_and_collections": "Communautés & Collections",
-
-
+  "menu.section.browse_global_communities_and_collections": "Communautés et collections",
 
   // "menu.section.control_panel": "Control Panel",
   "menu.section.control_panel": "Panneau de configuration",
 
   // "menu.section.curation_task": "Curation Task",
-  "menu.section.curation_task": "Tâches de Curation",
-
-
+  "menu.section.curation_task": "Tâches de curation",
 
   // "menu.section.edit": "Edit",
   "menu.section.edit": "Éditer",
@@ -2989,8 +3461,6 @@
 
   // "menu.section.edit_item": "Item",
   "menu.section.edit_item": "Item",
-
-
 
   // "menu.section.export": "Export",
   "menu.section.export": "Exporter",
@@ -3007,8 +3477,6 @@
   // "menu.section.export_metadata": "Metadata",
   "menu.section.export_metadata": "Métadonnées",
 
-
-
   // "menu.section.icon.access_control": "Access Control menu section",
   "menu.section.icon.access_control": "Section du menu relative au contrôle d'accès",
 
@@ -3018,51 +3486,50 @@
   // "menu.section.icon.control_panel": "Control Panel menu section",
   "menu.section.icon.control_panel": "Section du menu relative au panneau de configuration",
 
-  // "menu.section.icon.curation_task": "Curation Task menu section",
-  "menu.section.icon.curation_task": "Section du menu relative aux tâches de Curation",
+  // "menu.section.icon.curation_tasks": "Curation Task menu section",
+  "menu.section.icon.curation_tasks": "Section du menu relative aux tâches de curation",
 
   // "menu.section.icon.edit": "Edit menu section",
   "menu.section.icon.edit": "Section du menu relative à l'édition",
 
   // "menu.section.icon.export": "Export menu section",
-  "menu.section.icon.export": "Section du menu relative à l'export",
+  "menu.section.icon.export": "Section du menu relative à l'exportation",
 
   // "menu.section.icon.find": "Find menu section",
   "menu.section.icon.find": "Section du menu relative à la recherche",
 
   // "menu.section.icon.import": "Import menu section",
-  "menu.section.icon.import": "Section du menu relative à l'import",
+  "menu.section.icon.import": "Section du menu relative à l'importation",
 
   // "menu.section.icon.new": "New menu section",
   "menu.section.icon.new": "Section du menu relative à l'ajout d'éléments",
 
   // "menu.section.icon.pin": "Pin sidebar",
-  "menu.section.icon.pin": "Epingler menu latéral",
+  "menu.section.icon.pin": "Épingler le menu latéral",
 
   // "menu.section.icon.processes": "Processes menu section",
-  "menu.section.icon.processes": "Section du menu relatif aux Processus",
+  "menu.section.icon.processes": "Section du menu relatif aux processus",
 
   // "menu.section.icon.registries": "Registries menu section",
-  "menu.section.icon.registries": "Section du menu relative aux Registres",
+  "menu.section.icon.registries": "Section du menu relative aux registres",
 
   // "menu.section.icon.statistics_task": "Statistics Task menu section",
-  "menu.section.icon.statistics_task": "Section du menu relative aux tâches Statistiques",
+  "menu.section.icon.statistics_task": "Section du menu relative aux tâches statistiques",
+
+  // "menu.section.icon.workflow": "Administer workflow menu section",
+  "menu.section.icon.workflow": "Section du menu relative à l'administration du Workflow",
 
   // "menu.section.icon.unpin": "Unpin sidebar",
-  "menu.section.icon.unpin": "Libérer menu latéral",
-
-
+  "menu.section.icon.unpin": "Libérer le menu latéral",
 
   // "menu.section.import": "Import",
   "menu.section.import": "Importer",
 
   // "menu.section.import_batch": "Batch Import (ZIP)",
-  "menu.section.import_batch": "Import par lot (ZIP)",
+  "menu.section.import_batch": "Importation par lots (ZIP)",
 
   // "menu.section.import_metadata": "Metadata",
-  "menu.section.import_metadata": "Import de métadonnées",
-
-
+  "menu.section.import_metadata": "Métadonnées",
 
   // "menu.section.new": "New",
   "menu.section.new": "Créer",
@@ -3077,25 +3544,19 @@
   "menu.section.new_item": "Item",
 
   // "menu.section.new_item_version": "Item Version",
-  "menu.section.new_item_version": "Version",
+  "menu.section.new_item_version": "Version de l'Item",
 
   // "menu.section.new_process": "Process",
   "menu.section.new_process": "Processus",
 
-
-
   // "menu.section.pin": "Pin sidebar",
-  "menu.section.pin": "Epingler menu latéral",
+  "menu.section.pin": "Épingler le menu latéral",
 
   // "menu.section.unpin": "Unpin sidebar",
-  "menu.section.unpin": "Libérer menu latéral",
-
-
+  "menu.section.unpin": "Libérer le menu latéral",
 
   // "menu.section.processes": "Processes",
   "menu.section.processes": "Processus",
-
-
 
   // "menu.section.registries": "Registries",
   "menu.section.registries": "Registres",
@@ -3106,15 +3567,11 @@
   // "menu.section.registries_metadata": "Metadata",
   "menu.section.registries_metadata": "Métadonnées",
 
-
-
   // "menu.section.statistics": "Statistics",
   "menu.section.statistics": "Statistiques",
 
   // "menu.section.statistics_task": "Statistics Task",
   "menu.section.statistics_task": "Tâche statistiques",
-
-
 
   // "menu.section.toggle.access_control": "Toggle Access Control section",
   "menu.section.toggle.access_control": "Ouvrir/Fermer section Contrôle d'accès",
@@ -3146,10 +3603,11 @@
   // "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
   "menu.section.toggle.statistics_task": "Ouvrir/Fermer section Tâche statistiques",
 
-
   // "menu.section.workflow": "Administer Workflow",
   "menu.section.workflow": "Workflow Administrateur",
 
+  // "mydspace.breadcrumbs": "MyDSpace",
+  "mydspace.breadcrumbs": "Mon compte DSpace",
 
   // "mydspace.description": "",
   "mydspace.description": "",
@@ -3215,7 +3673,7 @@
   "mydspace.results.no-authors": "Aucun auteur",
 
   // "mydspace.results.no-collections": "No Collections",
-  "mydspace.results.no-collections": "Aucune Collection",
+  "mydspace.results.no-collections": "Aucune collection",
 
   // "mydspace.results.no-date": "No Date",
   "mydspace.results.no-date": "Aucune date",
@@ -3232,8 +3690,11 @@
   // "mydspace.results.no-uri": "No Uri",
   "mydspace.results.no-uri": "Aucune URL",
 
-  // "mydspace.show.workflow": "All tasks",
-  "mydspace.show.workflow": "Tâches de validation",
+  // "mydspace.search-form.placeholder": "Search in mydspace...",
+  "mydspace.search-form.placeholder": "Rechercher dans mon compte DSpace...",
+
+  // "mydspace.show.workflow": "Workflow tasks",
+  "mydspace.show.workflow": "Tâches du Workflow",
 
   // "mydspace.show.workspace": "Your Submissions",
   "mydspace.show.workspace": "Vos dépôts",
@@ -3251,36 +3712,34 @@
   "mydspace.status.workflow": "Workflow",
 
   // "mydspace.status.workspace": "Workspace",
-  "mydspace.status.workspace": "Workspace",
+  "mydspace.status.workspace": "Espace de travail",
 
   // "mydspace.title": "MyDSpace",
-  "mydspace.title": "MyDSpace",
+  "mydspace.title": "Mon compte DSpace",
 
   // "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
-  "mydspace.upload.upload-failed": "Erreur à la création du Workspace. Veuillez vérifier le contenu téléchargé avant de réessayer.",
+  "mydspace.upload.upload-failed": "Erreur à la création de l'espace de travail. Veuillez vérifier le contenu téléchargé avant de réessayer.",
 
   // "mydspace.upload.upload-failed-manyentries": "Unprocessable file. Detected too many entries but allowed only one for file.",
-  "mydspace.upload.upload-failed-manyentries": "Erreur lors du traitement du fichier. Maximum une entrée fichier autorisée.",
+  "mydspace.upload.upload-failed-manyentries": "Erreur lors du traitement du fichier. Maximum une entrée de fichier autorisée.",
 
   // "mydspace.upload.upload-failed-moreonefile": "Unprocessable request. Only one file is allowed.",
   "mydspace.upload.upload-failed-moreonefile": "Erreur lors du traitement de la requête. Un seul fichier est autorisé.",
 
   // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
-  "mydspace.upload.upload-multiple-successful": "{{qty}} nouveaux Items créés dans le Workspace.",
+  "mydspace.upload.upload-multiple-successful": "{{qty}} nouveaux Items créés dans l'espace de travail.",
 
   // "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
-  "mydspace.upload.upload-successful": "Nouvel item créé dans le Workspace. Cliquer {{here}} pour l'éditer.",
+  "mydspace.upload.upload-successful": "Nouvel item créé dans l'espace de travail. Cliquer {{here}} pour l'éditer.",
 
   // "mydspace.view-btn": "View",
   "mydspace.view-btn": "Afficher",
-
-
 
   // "nav.browse.header": "All of DSpace",
   "nav.browse.header": "Tout Dspace",
 
   // "nav.community-browse.header": "By Community",
-  "nav.community-browse.header": "Par Communauté",
+  "nav.community-browse.header": "Par communauté",
 
   // "nav.language": "Language switch",
   "nav.language": "Sélecteur de langue",
@@ -3288,11 +3747,14 @@
   // "nav.login": "Log In",
   "nav.login": "Se connecter",
 
-  // "nav.logout": "Log Out",
+  // "nav.logout": "User profile menu and Log Out",
   "nav.logout": "Se déconnecter",
 
+  // "nav.main.description": "Main navigation bar",
+  "nav.main.description": "Barre de navigation principale",
+
   // "nav.mydspace": "MyDSpace",
-  "nav.mydspace": "MyDSpace",
+  "nav.mydspace": "Mon compte DSpace",
 
   // "nav.profile": "Profile",
   "nav.profile": "Profil",
@@ -3306,10 +3768,17 @@
   // "nav.stop-impersonating": "Stop impersonating EPerson",
   "nav.stop-impersonating": "Retour à votre propre EPerson",
 
+  // "nav.toggle": "Toggle navigation",
+  "nav.toggle": "Basculer la navigation",
+  
+  // "nav.user.description": "User profile bar",
+  "nav.user.description": "Barre de profil utilisateur",
 
+  // "none.listelement.badge": "Item",
+  "none.listelement.badge": "Item",
 
   // "orgunit.listelement.badge": "Organizational Unit",
-  "orgunit.listelement.badge": "Structure Organisationnelle",
+  "orgunit.listelement.badge": "Structure organisationnelle",
 
   // "orgunit.page.city": "City",
   "orgunit.page.city": "Ville",
@@ -3324,7 +3793,7 @@
   "orgunit.page.description": "Description",
 
   // "orgunit.page.edit": "Edit this item",
-  "orgunit.page.edit": "Éditer cet item",
+  "orgunit.page.edit": "Éditer cet Item",
 
   // "orgunit.page.id": "ID",
   "orgunit.page.id": "ID",
@@ -3332,7 +3801,8 @@
   // "orgunit.page.titleprefix": "Organizational Unit: ",
   "orgunit.page.titleprefix": "Structure Organisationnelle : ",
 
-
+  // "pagination.options.description": "Pagination options",
+  "pagination.options.description": "Options de pagination",
 
   // "pagination.results-per-page": "Results Per Page",
   "pagination.results-per-page": "Résultats par page",
@@ -3346,8 +3816,6 @@
   // "pagination.sort-direction": "Sort Options",
   "pagination.sort-direction": "Options de tri",
 
-
-
   // "person.listelement.badge": "Person",
   "person.listelement.badge": "Personne",
 
@@ -3358,10 +3826,10 @@
   "person.page.birthdate": "Date de naissance",
 
   // "person.page.edit": "Edit this item",
-  "person.page.edit": "Éditer cet item",
+  "person.page.edit": "Éditer cet enregistrement",
 
   // "person.page.email": "Email Address",
-  "person.page.email": "Adresse mail",
+  "person.page.email": "Adresse électronique",
 
   // "person.page.firstname": "First Name",
   "person.page.firstname": "Prénom",
@@ -3379,18 +3847,16 @@
   "person.page.orcid": "ORCID",
 
   // "person.page.staffid": "Staff ID",
-  "person.page.staffid": "Staff ID",
+  "person.page.staffid": "Matricule",
 
   // "person.page.titleprefix": "Person: ",
   "person.page.titleprefix": "Personne : ",
 
   // "person.search.results.head": "Person Search Results",
-  "person.search.results.head": "Résultats de recherche Personne",
+  "person.search.results.head": "Résultats de recherche de personnes",
 
-  // "person.search.title": "DSpace Angular :: Person Search",
-  "person.search.title": "DSpace Angular :: Recherche Personne",
-
-
+  // "person.search.title": "Person Search",
+  "person.search.title": "Recherche de personnes",
 
   // "process.new.select-parameters": "Parameters",
   "process.new.select-parameters": "Paramètres",
@@ -3398,7 +3864,7 @@
   // "process.new.cancel": "Cancel",
   "process.new.cancel": "Annuler",
 
-  // "process.new.submit": "Submit",
+  // "process.new.submit": "Save",
   "process.new.submit": "Confirmer",
 
   // "process.new.select-script": "Script",
@@ -3441,30 +3907,28 @@
   "process.new.notification.error.content": "Une erreur s'est produite lors de la création du processus",
 
   // "process.new.header": "Create a new process",
-  "process.new.header": "Créer nouveau processus",
+  "process.new.header": "Créer un nouveau processus",
 
   // "process.new.title": "Create a new process",
-  "process.new.title": "Créer nouveau processus",
+  "process.new.title": "Créer un nouveau processus",
 
   // "process.new.breadcrumbs": "Create a new process",
-  "process.new.breadcrumbs": "Créer nouveau processus",
+  "process.new.breadcrumbs": "Créer un nouveau processus",
 
+  // "process.detail.arguments": "Arguments",
+  "process.detail.arguments": "Arguments",
 
-
-  // "process.detail.arguments" : "Arguments",
-  "process.detail.arguments" : "Arguments",
-
-  // "process.detail.arguments.empty" : "This process doesn't contain any arguments",
-  "process.detail.arguments.empty" : "Aucun argument défini pour ce processus",
-
-  // "process.detail.back" : "Back",
-  "process.detail.back" : "Retour",
-
-  // "process.detail.output" : "Process Output",
-  "process.detail.output" : "Rapport du processus",
-
+  // "process.detail.arguments.empty": "This process doesn't contain any arguments",
+  "process.detail.arguments.empty": "Ce processus ne contient pas d'arguments",
+  
+  // "process.detail.back": "Back",
+  "process.detail.back": "Retour",
+  
+  // "process.detail.output": "Process Output",
+  "process.detail.output": "Sortie du processus",
+  
   // "process.detail.logs.button": "Retrieve process output",
-  "process.detail.logs.button": "Récupérer le rapport du processus",
+  "process.detail.logs.button": "Récupérer la sortie du processus",
 
   // "process.detail.logs.loading": "Retrieving",
   "process.detail.logs.loading": "En cours de récupération",
@@ -3472,50 +3936,48 @@
   // "process.detail.logs.none": "This process has no output",
   "process.detail.logs.none": "Aucun rapport pour ce processus",
 
-  // "process.detail.output-files" : "Output Files",
-  "process.detail.output-files" : "Fichiers de rapport",
+  // "process.detail.output-files": "Output Files",
+  "process.detail.output-files": "Fichiers de sortie",
+  
+  // "process.detail.output-files.empty": "This process doesn't contain any output files",
+  "process.detail.output-files.empty": "Ce processus ne contient pas de fichiers de sortie",
+  
+  // "process.detail.script": "Script",
+  "process.detail.script": "Script",
+  
+  // "process.detail.title": "Process: {{ id }} - {{ name }}",
+  "process.detail.title": "Processus : {{ id }} - {{ name }}",
+  
+  // "process.detail.start-time": "Start time",
+  "process.detail.start-time": "Début",
+  
+  // "process.detail.end-time": "Finish time",
+  "process.detail.end-time": "Fin",
+  
+  // "process.detail.status": "Status",
+  "process.detail.status": "Statut",
+  
+  // "process.detail.create": "Create similar process",
+  "process.detail.create": "Créer un processus similaire",
 
-  // "process.detail.output-files.empty" : "This process doesn't contain any output files",
-  "process.detail.output-files.empty" : "Aucun fichier de rapport pour ce processus",
+  // "process.overview.table.finish": "Finish time (UTC)",
+  "process.overview.table.finish": "Heure de fin (TUC)",
+  
+  // "process.overview.table.id": "Process ID",
+  "process.overview.table.id": "ID du processus",
+  
+  // "process.overview.table.name": "Name",
+  "process.overview.table.name": "Nom",
 
-  // "process.detail.script" : "Script",
-  "process.detail.script" : "Script",
-
-  // "process.detail.title" : "Process: {{ id }} - {{ name }}",
-  "process.detail.title" : "Processus : {{ id }} - {{ name }}",
-
-  // "process.detail.start-time" : "Start time",
-  "process.detail.start-time" : "Heure de début",
-
-  // "process.detail.end-time" : "Finish time",
-  "process.detail.end-time" : "Heure de fin",
-
-  // "process.detail.status" : "Status",
-  "process.detail.status" : "Statut",
-
-  // "process.detail.create" : "Create similar process",
-  "process.detail.create" : "Créer processus similaire",
-
-
-
-  // "process.overview.table.finish" : "Finish time",
-  "process.overview.table.finish" : "Heure de fin",
-
-  // "process.overview.table.id" : "Process ID",
-  "process.overview.table.id" : "ID Processus",
-
-  // "process.overview.table.name" : "Name",
-  "process.overview.table.name" : "Nom",
-
-  // "process.overview.table.start" : "Start time",
-  "process.overview.table.start" : "Heure de début",
-
-  // "process.overview.table.status" : "Status",
-  "process.overview.table.status" : "Statut",
-
-  // "process.overview.table.user" : "User",
-  "process.overview.table.user" : "Utilisateur",
-
+  // "process.overview.table.start": "Start time (UTC)",
+  "process.overview.table.start": "Heure de début (TUC)",
+  
+  // "process.overview.table.status": "Status",
+  "process.overview.table.status": "Statut",
+  
+  // "process.overview.table.user": "User",
+  "process.overview.table.user": "Utilisateur",
+  
   // "process.overview.title": "Processes Overview",
   "process.overview.title": "Sommaire des processus",
 
@@ -3524,7 +3986,6 @@
 
   // "process.overview.new": "New",
   "process.overview.new": "Nouveau",
-
 
   // "profile.breadcrumbs": "Update Profile",
   "profile.breadcrumbs": "Mise à jour profil",
@@ -3535,14 +3996,14 @@
   // "profile.card.security": "Security",
   "profile.card.security": "Sécurité",
 
-  // "profile.form.submit": "Update Profile",
+  // "profile.form.submit": "Save",
   "profile.form.submit": "Confirmer",
 
   // "profile.groups.head": "Authorization groups you belong to",
-  "profile.groups.head": "Groupes auxquelles vous appartenez",
+  "profile.groups.head": "Groupes auxquels vous appartenez",
 
   // "profile.head": "Update Profile",
-  "profile.head": "Mise à jour profil",
+  "profile.head": "Mise à jour du profil",
 
   // "profile.metadata.form.error.firstname.required": "First Name is required",
   "profile.metadata.form.error.firstname.required": "Le prénom est obligatoire",
@@ -3551,7 +4012,7 @@
   "profile.metadata.form.error.lastname.required": "Le nom de famille est obligatoire",
 
   // "profile.metadata.form.label.email": "Email Address",
-  "profile.metadata.form.label.email": "Adresse E-mail",
+  "profile.metadata.form.label.email": "Adresse électronique",
 
   // "profile.metadata.form.label.firstname": "First Name",
   "profile.metadata.form.label.firstname": "Prénom",
@@ -3566,13 +4027,13 @@
   "profile.metadata.form.label.phone": "Numéro de téléphone",
 
   // "profile.metadata.form.notifications.success.content": "Your changes to the profile were saved.",
-  "profile.metadata.form.notifications.success.content": "Les adaptations du profil ont été sauvegardées avec succès.",
+  "profile.metadata.form.notifications.success.content": "Les modifications du profil ont été sauvegardées avec succès.",
 
   // "profile.metadata.form.notifications.success.title": "Profile saved",
   "profile.metadata.form.notifications.success.title": "Profil sauvegardé",
 
   // "profile.notifications.warning.no-changes.content": "No changes were made to the Profile.",
-  "profile.notifications.warning.no-changes.content": "Aucun changement n'a été réalisé au niveau de ce profil.",
+  "profile.notifications.warning.no-changes.content": "Aucun changement n'a été fait au niveau de ce profil.",
 
   // "profile.notifications.warning.no-changes.title": "No changes",
   "profile.notifications.warning.no-changes.title": "Aucun changement",
@@ -3581,10 +4042,10 @@
   "profile.security.form.error.matching-passwords": "Les mots de passe ne correspondent pas.",
 
   // "profile.security.form.error.password-length": "The password should be at least 6 characters long.",
-  "profile.security.form.error.password-length": "Le mot de passe doit au moins faire 6 caractères..",
+  "profile.security.form.error.password-length": "Le mot de passe doit comporter au moins six caractères.",
 
   // "profile.security.form.info": "Optionally, you can enter a new password in the box below, and confirm it by typing it again into the second box. It should be at least six characters long.",
-  "profile.security.form.info": "Un mot de passe facultatif peut être en dans les zone ci-dessous. Il doit faire au moins 6 caractères.",
+  "profile.security.form.info": "Optionnellement, un nouveau mot de passe peut être entré dans la case ci-dessous. Le doit comporter au moins six caractères.",
 
   // "profile.security.form.label.password": "Password",
   "profile.security.form.label.password": "Mot de passe",
@@ -3599,18 +4060,16 @@
   "profile.security.form.notifications.success.title": "Mot de passe sauvegardé",
 
   // "profile.security.form.notifications.error.title": "Error changing passwords",
-  "profile.security.form.notifications.error.title": "Erreur modification mot de passe",
+  "profile.security.form.notifications.error.title": "Erreur de modification mot de passe",
 
   // "profile.security.form.notifications.error.not-long-enough": "The password has to be at least 6 characters long.",
-  "profile.security.form.notifications.error.not-long-enough": "Le mot de passe doit faire au moins 6 caractères.",
+  "profile.security.form.notifications.error.not-long-enough": "Le mot de passe doit comporter au moins six caractères.",
 
   // "profile.security.form.notifications.error.not-same": "The provided passwords are not the same.",
   "profile.security.form.notifications.error.not-same": "Les mots de passe ne correspondent pas.",
 
   // "profile.title": "Update Profile",
-  "profile.title": "Mise à jour profil",
-
-
+  "profile.title": "Mise à jour du profil",
 
   // "project.listelement.badge": "Research Project",
   "project.listelement.badge": "Projet de recherche",
@@ -3643,9 +4102,7 @@
   "project.page.titleprefix": "Projet de recherche : ",
 
   // "project.search.results.head": "Project Search Results",
-  "project.search.results.head": "Résultats de recherche Projet",
-
-
+  "project.search.results.head": "Résultats de recherche de projets",
 
   // "publication.listelement.badge": "Publication",
   "publication.listelement.badge": "Publication",
@@ -3672,38 +4129,46 @@
   "publication.page.volume-title": "Titre du volume",
 
   // "publication.search.results.head": "Publication Search Results",
-  "publication.search.results.head": "Résultats de recherche Publication",
+  "publication.search.results.head": "Résultats de recherche de publications",
 
-  // "publication.search.title": "DSpace Angular :: Publication Search",
-  "publication.search.title": "DSpace Angular :: Recherche Publication",
+  // "publication.search.title": "Publication Search",
+  "publication.search.title": "Recherche de publications",
 
+  // "media-viewer.next": "Next",
+  "media-viewer.next": "Suivant",
+
+  // "media-viewer.previous": "Previous",
+  "media-viewer.previous": "Précédent",
+
+  // "media-viewer.playlist": "Playlist",
+  "media-viewer.playlist": "Liste de lecture",
 
   // "register-email.title": "New user registration",
-  "register-email.title": "Inscription nouvel utilisateur",
+  "register-email.title": "Inscription d'un nouvel utilisateur",
 
   // "register-page.create-profile.header": "Create Profile",
-  "register-page.create-profile.header": "Créer Profil",
+  "register-page.create-profile.header": "Créer un profil",
 
   // "register-page.create-profile.identification.header": "Identify",
   "register-page.create-profile.identification.header": "Identification",
 
   // "register-page.create-profile.identification.email": "Email Address",
-  "register-page.create-profile.identification.email": "Adresse e-mail",
+  "register-page.create-profile.identification.email": "Adresse électronique",
 
   // "register-page.create-profile.identification.first-name": "First Name *",
   "register-page.create-profile.identification.first-name": "Prénom *",
-
+  
   // "register-page.create-profile.identification.first-name.error": "Please fill in a First Name",
-  "register-page.create-profile.identification.first-name.error": "Veuillez remplir le prénom",
+  "register-page.create-profile.identification.first-name.error": "Veuillez saisir un prénom",
 
   // "register-page.create-profile.identification.last-name": "Last Name *",
   "register-page.create-profile.identification.last-name": "Nom de famille *",
 
   // "register-page.create-profile.identification.last-name.error": "Please fill in a Last Name",
-  "register-page.create-profile.identification.last-name.error": "Veuillez remplir le nom de famille",
+  "register-page.create-profile.identification.last-name.error": "Veuillez saisir un nom de famille",
 
   // "register-page.create-profile.identification.contact": "Contact Telephone",
-  "register-page.create-profile.identification.contact": "N° Téléphone",
+  "register-page.create-profile.identification.contact": "Téléphone",
 
   // "register-page.create-profile.identification.language": "Language",
   "register-page.create-profile.identification.language": "Langue",
@@ -3712,7 +4177,7 @@
   "register-page.create-profile.security.header": "Sécurité",
 
   // "register-page.create-profile.security.info": "Please enter a password in the box below, and confirm it by typing it again into the second box. It should be at least six characters long.",
-  "register-page.create-profile.security.info": "Veuillez entrer un mot de passe dans la zone ci-dessous et confirmer en l'entrant à nouveau dans la seconde zone. Le mot de passe doit au moins faire 6 caractères.",
+  "register-page.create-profile.security.info": "Veuillez entrer un mot de passe dans la case ci-dessous et confirmer en l'entrant à nouveau dans la seconde case. Le mot de passe doit comporter au moins six caractères.",
 
   // "register-page.create-profile.security.label.password": "Password *",
   "register-page.create-profile.security.label.password": "Mot de passe *",
@@ -3727,7 +4192,7 @@
   "register-page.create-profile.security.error.matching-passwords": "Les mots de passe ne correspondent pas.",
 
   // "register-page.create-profile.security.error.password-length": "The password should be at least 6 characters long.",
-  "register-page.create-profile.security.error.password-length": "Le mot de passe doit au moins faire 6 caractères.",
+  "register-page.create-profile.security.error.password-length": "Le mot de passe doit comporter au moins six caractères.",
 
   // "register-page.create-profile.submit": "Complete Registration",
   "register-page.create-profile.submit": "Confirmer l'inscription",
@@ -3736,7 +4201,7 @@
   "register-page.create-profile.submit.error.content": "Une erreur s'est produite lors de la création de l'utilisateur.",
 
   // "register-page.create-profile.submit.error.head": "Registration failed",
-  "register-page.create-profile.submit.error.head": "Echec lors de l'inscription",
+  "register-page.create-profile.submit.error.head": "Échec lors de l'inscription",
 
   // "register-page.create-profile.submit.success.content": "The registration was successful. You have been logged in as the created user.",
   "register-page.create-profile.submit.success.content": "L'utilisateur a été créé avec succès. Vous êtes connecté avec le compte de l'utilisateur ainsi créé.",
@@ -3744,41 +4209,38 @@
   // "register-page.create-profile.submit.success.head": "Registration completed",
   "register-page.create-profile.submit.success.head": "Inscription terminée",
 
-
   // "register-page.registration.header": "New user registration",
-  "register-page.registration.header": "Inscription nouvel utilisateur",
+  "register-page.registration.header": "Inscription d'un nouvel utilisateur",
 
   // "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to DSpace.",
-  "register-page.registration.info": "Créer un compte pour pouvoir vous abonner aux collections et recevoir les nouveautés via mail ainsi que déposer de nouveaux Items dans DSpace.",
+  "register-page.registration.info": "Créer un compte pour pouvoir vous abonner aux collections et recevoir les nouveautés via courrier électronique ainsi que déposer de nouveaux Items dans DSpace.",
 
   // "register-page.registration.email": "Email Address *",
-  "register-page.registration.email": "Adresse e-mail *",
+  "register-page.registration.email": "Adresse électronique *",
 
   // "register-page.registration.email.error.required": "Please fill in an email address",
-  "register-page.registration.email.error.required": "Veuillez remplir une adresse e-mail",
+  "register-page.registration.email.error.required": "Veuillez saisir une adresse électronique",
 
   // "register-page.registration.email.error.pattern": "Please fill in a valid email address",
-  "register-page.registration.email.error.pattern": "Veuillez remplir une adresse e-mail valide",
+  "register-page.registration.email.error.pattern": "Veuillez saisir une adresse électronique valide",
 
   // "register-page.registration.email.hint": "This address will be verified and used as your login name.",
-  "register-page.registration.email.hint": "Cette adresse va être vérifiée et utilisée en tant qu'identifiant de connection.",
+  "register-page.registration.email.hint": "Cette adresse sera vérifiée et utilisée en tant qu'identifiant de connection.",
 
   // "register-page.registration.submit": "Register",
-  "register-page.registration.submit": "Enregistrer",
+  "register-page.registration.submit": "S'enregistrer",
 
   // "register-page.registration.success.head": "Verification email sent",
-  "register-page.registration.success.head": "Mail de vérification",
+  "register-page.registration.success.head": "Courrier électronique de vérification",
 
   // "register-page.registration.success.content": "An email has been sent to {{ email }} containing a special URL and further instructions.",
-  "register-page.registration.success.content": "Un mail de vérification a été envoyé à l'adresse et contient une URL de validation ainsi que de plus amples instructions.",
+  "register-page.registration.success.content": "Un courrier électronique de vérification a été envoyé à l'adresse et contient une URL de validation ainsi que de plus amples instructions.",
 
   // "register-page.registration.error.head": "Error when trying to register email",
   "register-page.registration.error.head": "Erreur lors de l'inscription",
 
   // "register-page.registration.error.content": "An error occured when registering the following email address: {{ email }}",
-  "register-page.registration.error.content": "Une erreur s'est produite lors de l'inscription de l'adresse e-mail : {{ email }}",
-
-
+  "register-page.registration.error.content": "Une erreur s'est produite lors de l'inscription de l'adresse électronique : {{ email }}",
 
   // "relationships.add.error.relationship-type.content": "No suitable match could be found for relationship type {{ type }} between the two items",
   "relationships.add.error.relationship-type.content": "Aucune correspondante adéquate détectée pour la relation de type {{ type }} entre ces 2 Items",
@@ -3796,7 +4258,7 @@
   "relationships.isAuthorOf.Person": "Auteurs (personnes)",
 
   // "relationships.isAuthorOf.OrgUnit": "Authors (organizational units)",
-  "relationships.isAuthorOf.OrgUnit": "Auteurs (structures)",
+  "relationships.isAuthorOf.OrgUnit": "Collectivités-auteurs",
 
   // "relationships.isIssueOf": "Journal Issues",
   "relationships.isIssueOf": "Numéros de revue",
@@ -3808,7 +4270,7 @@
   "relationships.isJournalOf": "Revues",
 
   // "relationships.isOrgUnitOf": "Organizational Units",
-  "relationships.isOrgUnitOf": "Structure organisationnelle",
+  "relationships.isOrgUnitOf": "Structures organisationnelles",
 
   // "relationships.isPersonOf": "Authors",
   "relationships.isPersonOf": "Auteurs",
@@ -3826,36 +4288,52 @@
   "relationships.isSingleJournalOf": "Revue",
 
   // "relationships.isSingleVolumeOf": "Journal Volume",
-  "relationships.isSingleVolumeOf": "Volume revue",
+  "relationships.isSingleVolumeOf": "Volume de revue",
 
   // "relationships.isVolumeOf": "Journal Volumes",
-  "relationships.isVolumeOf": "Volumes revue",
+  "relationships.isVolumeOf": "Volumes de revue",
 
   // "relationships.isContributorOf": "Contributors",
   "relationships.isContributorOf": "Contributeurs",
 
+  // "relationships.isContributorOf.OrgUnit": "Contributor (Organizational Unit)",
+  "relationships.isContributorOf.OrgUnit": "Collectivités contributrices",
 
+  // "relationships.isContributorOf.Person": "Contributor",
+  "relationships.isContributorOf.Person": "Contributeur",
+
+  // "relationships.isFundingAgencyOf.OrgUnit": "Funder",
+  "relationships.isFundingAgencyOf.OrgUnit": "Bailleur de fonds",
+
+  // "repository.image.logo": "Repository logo",
+  "repository.image.logo": "Logo du dépôt",
+
+  // "repository.title.prefix": "DSpace Angular :: ",
+  "repository.title.prefix": "DSpace Angular :: ",
+
+  // "repository.title.prefixDSpace": "DSpace Angular ::",
+  "repository.title.prefixDSpace": "DSpace Angular :: ",
 
   // "resource-policies.add.button": "Add",
   "resource-policies.add.button": "Ajouter",
 
   // "resource-policies.add.for.": "Add a new policy",
-  "resource-policies.add.for.": "Ajouter nouvelle règle",
+  "resource-policies.add.for.": "Ajouter une nouvelle règle",
 
   // "resource-policies.add.for.bitstream": "Add a new Bitstream policy",
-  "resource-policies.add.for.bitstream": "Ajouter une nouvelle règle Bitstream",
+  "resource-policies.add.for.bitstream": "Ajouter une nouvelle règle d'accès de Bitstream",
 
   // "resource-policies.add.for.bundle": "Add a new Bundle policy",
-  "resource-policies.add.for.bundle": "Ajouter une nouvelle règle Bundle",
+  "resource-policies.add.for.bundle": "Ajouter une nouvelle règle d'accès de Bundle",
 
   // "resource-policies.add.for.item": "Add a new Item policy",
-  "resource-policies.add.for.item": "Ajouter une nouvelle règle Item",
+  "resource-policies.add.for.item": "Ajouter une nouvelle règle d'accès Item",
 
   // "resource-policies.add.for.community": "Add a new Community policy",
-  "resource-policies.add.for.community": "Ajouter une nouvelle règle Communauté",
+  "resource-policies.add.for.community": "Ajouter une nouvelle règle d'accès de communauté",
 
   // "resource-policies.add.for.collection": "Add a new Collection policy",
-  "resource-policies.add.for.collection": "Ajouter une nouvelle règle Collection",
+  "resource-policies.add.for.collection": "Ajouter une nouvelle règle d'accès de collection",
 
   // "resource-policies.create.page.heading": "Create new resource policy for ",
   "resource-policies.create.page.heading": "Ajouter une nouvelle règle d'accès pour ",
@@ -3867,37 +4345,37 @@
   "resource-policies.create.page.success.content": "Règle créée avec succès",
 
   // "resource-policies.create.page.title": "Create new resource policy",
-  "resource-policies.create.page.title": "Créer nouvelle règle d'autorisation",
+  "resource-policies.create.page.title": "Créer une nouvelle règle d'accès",
 
   // "resource-policies.delete.btn": "Delete selected",
-  "resource-policies.delete.btn": "Supprimer sélection",
+  "resource-policies.delete.btn": "Supprimer la sélection",
 
   // "resource-policies.delete.btn.title": "Delete selected resource policies",
-  "resource-policies.delete.btn.title": "Supprimer les règles d'autorisation sélectionnées",
+  "resource-policies.delete.btn.title": "Supprimer les règles d'accès sélectionnées",
 
   // "resource-policies.delete.failure.content": "An error occurred while deleting selected resource policies.",
-  "resource-policies.delete.failure.content": "Une erreur s'est produite lors de la suppression des règles d'autorisation.",
+  "resource-policies.delete.failure.content": "Une erreur s'est produite lors de la suppression des règles d'accès.",
 
   // "resource-policies.delete.success.content": "Operation successful",
-  "resource-policies.delete.success.content": "Règle supprimée avec succès",
+  "resource-policies.delete.success.content": "Règle d'accès supprimée avec succès",
 
   // "resource-policies.edit.page.heading": "Edit resource policy ",
-  "resource-policies.edit.page.heading": "Éditer règle d'autorisation",
+  "resource-policies.edit.page.heading": "Éditer une règle d'accès",
 
   // "resource-policies.edit.page.failure.content": "An error occurred while editing the resource policy.",
-  "resource-policies.edit.page.failure.content": "Une erreur s'est produite lors de la modification de la règle d'autorisation.",
+  "resource-policies.edit.page.failure.content": "Une erreur s'est produite lors de la modification de la règle d'accès.",
 
   // "resource-policies.edit.page.success.content": "Operation successful",
-  "resource-policies.edit.page.success.content": "Règle mise à jour avec succès",
+  "resource-policies.edit.page.success.content": "Règle d'accès mise à jour avec succès",
 
   // "resource-policies.edit.page.title": "Edit resource policy",
-  "resource-policies.edit.page.title": "Éditer règle d'autorisation",
+  "resource-policies.edit.page.title": "Éditer une règle d'accès",
 
   // "resource-policies.form.action-type.label": "Select the action type",
   "resource-policies.form.action-type.label": "Sélectionner le type d'action",
 
   // "resource-policies.form.action-type.required": "You must select the resource policy action.",
-  "resource-policies.form.action-type.required": "Vous devez sélectioner l'action couverte par cette règle d'autorisation.",
+  "resource-policies.form.action-type.required": "Vous devez sélectioner l'action couverte par cette règle d'accès.",
 
   // "resource-policies.form.eperson-group-list.label": "The eperson or group that will be granted the permission",
   "resource-policies.form.eperson-group-list.label": "La permission sera octroyée à l'utilisateur Eperson ou le groupe",
@@ -3906,10 +4384,10 @@
   "resource-policies.form.eperson-group-list.select.btn": "Sélectionner",
 
   // "resource-policies.form.eperson-group-list.tab.eperson": "Search for a ePerson",
-  "resource-policies.form.eperson-group-list.tab.eperson": "Rechercher ePerson",
+  "resource-policies.form.eperson-group-list.tab.eperson": "Rechercher un.e Eperson",
 
   // "resource-policies.form.eperson-group-list.tab.group": "Search for a group",
-  "resource-policies.form.eperson-group-list.tab.group": "Rechercher groupe",
+  "resource-policies.form.eperson-group-list.tab.group": "Rechercher un groupe",
 
   // "resource-policies.form.eperson-group-list.table.headers.action": "Action",
   "resource-policies.form.eperson-group-list.table.headers.action": "Action",
@@ -3936,7 +4414,7 @@
   "resource-policies.form.policy-type.label": "Sélectionner le type de règle",
 
   // "resource-policies.form.policy-type.required": "You must select the resource policy type.",
-  "resource-policies.form.policy-type.required": "Vous devez sélectionner le type de règle d'autorisation.",
+  "resource-policies.form.policy-type.required": "Vous devez sélectionner le type de règle d'accès.",
 
   // "resource-policies.table.headers.action": "Action",
   "resource-policies.table.headers.action": "Action",
@@ -3951,10 +4429,10 @@
   "resource-policies.table.headers.edit": "Éditer",
 
   // "resource-policies.table.headers.edit.group": "Edit group",
-  "resource-policies.table.headers.edit.group": "Éditer groupe",
+  "resource-policies.table.headers.edit.group": "Éditer un groupe",
 
   // "resource-policies.table.headers.edit.policy": "Edit policy",
-  "resource-policies.table.headers.edit.policy": "Éditer règle",
+  "resource-policies.table.headers.edit.policy": "Éditer une règle",
 
   // "resource-policies.table.headers.eperson": "EPerson",
   "resource-policies.table.headers.eperson": "EPerson",
@@ -3972,21 +4450,19 @@
   "resource-policies.table.headers.policyType": "type",
 
   // "resource-policies.table.headers.title.for.bitstream": "Policies for Bitstream",
-  "resource-policies.table.headers.title.for.bitstream": "Règles Bitstream",
+  "resource-policies.table.headers.title.for.bitstream": "Règles de Bitstream",
 
   // "resource-policies.table.headers.title.for.bundle": "Policies for Bundle",
-  "resource-policies.table.headers.title.for.bundle": "Règles Bundle",
+  "resource-policies.table.headers.title.for.bundle": "Règles de Bundle",
 
   // "resource-policies.table.headers.title.for.item": "Policies for Item",
-  "resource-policies.table.headers.title.for.item": "Règles Item",
+  "resource-policies.table.headers.title.for.item": "Règles d'Item",
 
   // "resource-policies.table.headers.title.for.community": "Policies for Community",
-  "resource-policies.table.headers.title.for.community": "Règles Communauté",
+  "resource-policies.table.headers.title.for.community": "Règles de communauté",
 
   // "resource-policies.table.headers.title.for.collection": "Policies for Collection",
-  "resource-policies.table.headers.title.for.collection": "Règles Collection",
-
-
+  "resource-policies.table.headers.title.for.collection": "Règles de collection",
 
   // "search.description": "",
   "search.description": "",
@@ -3994,12 +4470,14 @@
   // "search.switch-configuration.title": "Show",
   "search.switch-configuration.title": "Afficher",
 
-  // "search.title": "DSpace Angular :: Search",
-  "search.title": "DSpace Angular :: Recherche",
+  // "search.title": "Search",
+  "search.title": "Recherche",
 
   // "search.breadcrumbs": "Search",
   "search.breadcrumbs": "Recherche",
 
+  // "search.search-form.placeholder": "Search the repository ...",
+  "search.search-form.placeholder": "Rechercher dans le dépôt...",
 
   // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "Auteur",
@@ -4038,15 +4516,13 @@
   "search.filters.applied.f.jobTitle": "Fonction",
 
   // "search.filters.applied.f.birthDate.max": "End birth date",
-  "search.filters.applied.f.birthDate.max": "Date de naissance max",
+  "search.filters.applied.f.birthDate.max": "Date de naissance (fin de l'intervalle)",
 
   // "search.filters.applied.f.birthDate.min": "Start birth date",
-  "search.filters.applied.f.birthDate.min": "Date de naissance min",
+  "search.filters.applied.f.birthDate.min": "Date de naissance (début de l'intervalle)",
 
   // "search.filters.applied.f.withdrawn": "Withdrawn",
   "search.filters.applied.f.withdrawn": "Retiré",
-
-
 
   // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Auteur",
@@ -4054,11 +4530,20 @@
   // "search.filters.filter.author.placeholder": "Author name",
   "search.filters.filter.author.placeholder": "Nom de l'auteur",
 
+  // "search.filters.filter.author.label": "Search author name",
+  "search.filters.filter.author.label": "Recherche du nom d'auteur",
+
   // "search.filters.filter.birthDate.head": "Birth Date",
   "search.filters.filter.birthDate.head": "Date de naissance",
 
   // "search.filters.filter.birthDate.placeholder": "Birth Date",
   "search.filters.filter.birthDate.placeholder": "Date de naissance",
+
+  // "search.filters.filter.birthDate.label": "Search birth date",
+  "search.filters.filter.birthDate.label": "Recherche d'une date de naissance",
+
+  // "search.filters.filter.collapse": "Collapse filter",
+  "search.filters.filter.collapse": "Filtre",
 
   // "search.filters.filter.creativeDatePublished.head": "Date Published",
   "search.filters.filter.creativeDatePublished.head": "Date de publication",
@@ -4066,11 +4551,17 @@
   // "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
   "search.filters.filter.creativeDatePublished.placeholder": "Date de publication",
 
+  // "search.filters.filter.creativeDatePublished.label": "Search date published",
+  "search.filters.filter.creativeDatePublished.label": "Recherche d'une date de publication",
+
   // "search.filters.filter.creativeWorkEditor.head": "Editor",
-  "search.filters.filter.creativeWorkEditor.head": "Rédacteur en chef",
+  "search.filters.filter.creativeWorkEditor.head": "Éditeur intellectuel",
 
   // "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
-  "search.filters.filter.creativeWorkEditor.placeholder": "Rédacteur en chef",
+  "search.filters.filter.creativeWorkEditor.placeholder": "Éditeur intellectuel",
+
+  // "search.filters.filter.creativeWorkEditor.label": "Search editor",
+  "search.filters.filter.creativeWorkEditor.label": "Recherche d'un éditeur intellectuel",
 
   // "search.filters.filter.creativeWorkKeywords.head": "Subject",
   "search.filters.filter.creativeWorkKeywords.head": "Sujet",
@@ -4078,26 +4569,41 @@
   // "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
   "search.filters.filter.creativeWorkKeywords.placeholder": "Sujet",
 
+  // "search.filters.filter.creativeWorkKeywords.label": "Search subject",
+  "search.filters.filter.creativeWorkKeywords.label": "Recherche d'un sujet",
+
   // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
   "search.filters.filter.creativeWorkPublisher.head": "Éditeur",
 
   // "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
   "search.filters.filter.creativeWorkPublisher.placeholder": "Éditeur",
 
+  // "search.filters.filter.creativeWorkPublisher.label": "Search publisher",
+  "search.filters.filter.creativeWorkPublisher.label": "Recherche d'un éditeur",
+ 
   // "search.filters.filter.dateIssued.head": "Date",
   "search.filters.filter.dateIssued.head": "Date",
 
-  // "search.filters.filter.dateIssued.max.placeholder": "Minimum Date",
+  // "search.filters.filter.dateIssued.max.placeholder": "Maximum Date",
   "search.filters.filter.dateIssued.max.placeholder": "Depuis",
 
-  // "search.filters.filter.dateIssued.min.placeholder": "Maximum Date",
+  // "search.filters.filter.dateIssued.max.label": "End",
+  "search.filters.filter.dateIssued.max.label": "Fin",
+
+  // "search.filters.filter.dateIssued.min.placeholder": "Minimum Date",
   "search.filters.filter.dateIssued.min.placeholder": "Jusque",
+
+  // "search.filters.filter.dateIssued.min.label": "Start",
+  "search.filters.filter.dateIssued.min.label": "Début",
 
   // "search.filters.filter.dateSubmitted.head": "Date submitted",
   "search.filters.filter.dateSubmitted.head": "Date de dépôt",
 
   // "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
   "search.filters.filter.dateSubmitted.placeholder": "Date de dépôt",
+
+  // "search.filters.filter.dateSubmitted.label": "Search date submitted",
+  "search.filters.filter.dateSubmitted.label": "Recherche d'une date de dépôt",
 
   // "search.filters.filter.discoverable.head": "Private",
   "search.filters.filter.discoverable.head": "Privé",
@@ -4106,10 +4612,16 @@
   "search.filters.filter.withdrawn.head": "Retiré",
 
   // "search.filters.filter.entityType.head": "Item Type",
-  "search.filters.filter.entityType.head": "Type d'Item",
+  "search.filters.filter.entityType.head": "Type",
 
   // "search.filters.filter.entityType.placeholder": "Item Type",
-  "search.filters.filter.entityType.placeholder": "Type d'Item",
+  "search.filters.filter.entityType.placeholder": "Type",
+
+  // "search.filters.filter.entityType.label": "Search item type",
+  "search.filters.filter.entityType.label": "Recherche d'un type",
+
+  // "search.filters.filter.expand": "Expand filter",
+  "search.filters.filter.expand": "Développer le filtre",
 
   // "search.filters.filter.has_content_in_original_bundle.head": "Has files",
   "search.filters.filter.has_content_in_original_bundle.head": "Fichier(s) présent(s)",
@@ -4120,17 +4632,26 @@
   // "search.filters.filter.itemtype.placeholder": "Type",
   "search.filters.filter.itemtype.placeholder": "Type",
 
+  // "search.filters.filter.itemtype.label": "Search type",
+  "search.filters.filter.itemtype.label": "Recherche d'un type",
+
   // "search.filters.filter.jobTitle.head": "Job Title",
   "search.filters.filter.jobTitle.head": "Fonction",
 
   // "search.filters.filter.jobTitle.placeholder": "Job Title",
   "search.filters.filter.jobTitle.placeholder": "Fonction",
 
+  // "search.filters.filter.jobTitle.label": "Search job title",
+  "search.filters.filter.jobTitle.label": "Recherche de fonctions",
+
   // "search.filters.filter.knowsLanguage.head": "Known language",
-  "search.filters.filter.knowsLanguage.head": "Langue(s)",
+  "search.filters.filter.knowsLanguage.head": "Langue parlée",
 
   // "search.filters.filter.knowsLanguage.placeholder": "Known language",
-  "search.filters.filter.knowsLanguage.placeholder": "Langue(s)",
+  "search.filters.filter.knowsLanguage.placeholder": "Langue parlée",
+
+  // "search.filters.filter.knowsLanguage.label": "Search known language",
+  "search.filters.filter.knowsLanguage.label": "Recherche d'une langue parlée",
 
   // "search.filters.filter.namedresourcetype.head": "Status",
   "search.filters.filter.namedresourcetype.head": "Statut",
@@ -4138,11 +4659,17 @@
   // "search.filters.filter.namedresourcetype.placeholder": "Status",
   "search.filters.filter.namedresourcetype.placeholder": "Statut",
 
+  // "search.filters.filter.namedresourcetype.label": "Search status",
+  "search.filters.filter.namedresourcetype.label": "Recherche d'un statut",
+
   // "search.filters.filter.objectpeople.head": "People",
   "search.filters.filter.objectpeople.head": "Personne",
 
   // "search.filters.filter.objectpeople.placeholder": "People",
   "search.filters.filter.objectpeople.placeholder": "Personne",
+
+  // "search.filters.filter.objectpeople.label": "Search people",
+  "search.filters.filter.objectpeople.label": "Recherche d'une personne",
 
   // "search.filters.filter.organizationAddressCountry.head": "Country",
   "search.filters.filter.organizationAddressCountry.head": "Pays",
@@ -4150,11 +4677,17 @@
   // "search.filters.filter.organizationAddressCountry.placeholder": "Country",
   "search.filters.filter.organizationAddressCountry.placeholder": "Pays",
 
+  // "search.filters.filter.organizationAddressCountry.label": "Search country",
+  "search.filters.filter.organizationAddressCountry.label": "Recherche d'un pays",
+
   // "search.filters.filter.organizationAddressLocality.head": "City",
   "search.filters.filter.organizationAddressLocality.head": "Ville",
 
   // "search.filters.filter.organizationAddressLocality.placeholder": "City",
   "search.filters.filter.organizationAddressLocality.placeholder": "Ville",
+
+  // "search.filters.filter.organizationAddressLocality.label": "Search city",
+  "search.filters.filter.organizationAddressLocality.label": "Recherche d'une ville",
 
   // "search.filters.filter.organizationFoundingDate.head": "Date Founded",
   "search.filters.filter.organizationFoundingDate.head": "Date de fondation",
@@ -4162,17 +4695,23 @@
   // "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
   "search.filters.filter.organizationFoundingDate.placeholder": "Date de fondation",
 
+  // "search.filters.filter.organizationFoundingDate.label": "Search date founded",
+  "search.filters.filter.organizationFoundingDate.label": "Recherche d'une date de fondation",
+
   // "search.filters.filter.scope.head": "Scope",
-  "search.filters.filter.scope.head": "Scope",
+  "search.filters.filter.scope.head": "Portée",
 
   // "search.filters.filter.scope.placeholder": "Scope filter",
-  "search.filters.filter.scope.placeholder": "Scope",
+  "search.filters.filter.scope.placeholder": "Filtre de portée",
+
+  // "search.filters.filter.scope.label": "Search scope filter",
+  "search.filters.filter.scope.label": "Recherche d'un filtre de portée",
 
   // "search.filters.filter.show-less": "Collapse",
-  "search.filters.filter.show-less": "Moins",
+  "search.filters.filter.show-less": "Afficher moins",
 
   // "search.filters.filter.show-more": "Show more",
-  "search.filters.filter.show-more": "Plus",
+  "search.filters.filter.show-more": "Afficher plus",
 
   // "search.filters.filter.subject.head": "Subject",
   "search.filters.filter.subject.head": "Sujet",
@@ -4180,13 +4719,17 @@
   // "search.filters.filter.subject.placeholder": "Subject",
   "search.filters.filter.subject.placeholder": "Sujet",
 
+  // "search.filters.filter.subject.label": "Search subject",
+  "search.filters.filter.subject.label": "Recherche d'un sujet",
+
   // "search.filters.filter.submitter.head": "Submitter",
   "search.filters.filter.submitter.head": "Déposant",
 
   // "search.filters.filter.submitter.placeholder": "Submitter",
   "search.filters.filter.submitter.placeholder": "Déposant",
 
-
+  // "search.filters.filter.submitter.label": "Search submitter",
+  "search.filters.filter.submitter.label": "Recherche d'un déposant",
 
   // "search.filters.entityType.JournalIssue": "Journal Issue",
   "search.filters.entityType.JournalIssue": "Numéro de revue",
@@ -4195,7 +4738,7 @@
   "search.filters.entityType.JournalVolume": "Volume de la revue",
 
   // "search.filters.entityType.OrgUnit": "Organizational Unit",
-  "search.filters.entityType.OrgUnit": "Structure",
+  "search.filters.entityType.OrgUnit": "Structure organisationnelle",
 
   // "search.filters.has_content_in_original_bundle.true": "Yes",
   "search.filters.has_content_in_original_bundle.true": "Oui",
@@ -4215,25 +4758,23 @@
   // "search.filters.withdrawn.false": "No",
   "search.filters.withdrawn.false": "Non",
 
-
   // "search.filters.head": "Filters",
   "search.filters.head": "Filtres",
 
   // "search.filters.reset": "Reset filters",
-  "search.filters.reset": "Réinitialiser filtres",
+  "search.filters.reset": "Réinitialiser les filtres",
 
-
+  // "search.filters.search.submit": "Submit",
+  "search.filters.search.submit": "Soumettre",
 
   // "search.form.search": "Search",
   "search.form.search": "Recherche",
 
-  // "search.form.search_dspace": "Search DSpace",
+  // "search.form.search_dspace": "All repository",
   "search.form.search_dspace": "Recherche dans DSpace",
 
-  // "search.form.search_mydspace": "Search MyDSpace",
-  "search.form.search_mydspace": "Recherche dans MyDSpace",
-
-
+  // "search.form.scope.all": "All of DSpace",
+  "search.form.scope.all": "Tout le dépôt DSpace",
 
   // "search.results.head": "Search Results",
   "search.results.head": "Résultats de recherche",
@@ -4246,8 +4787,12 @@
 
   // "search.results.empty": "Your search returned no results.",
   "search.results.empty": "Votre recherche n'a retourné aucun résultat.",
+  
+  // "search.results.view-result": "View",
+  "search.results.view-result": "Afficher",
 
-
+  // "default.search.results.head": "Search Results",
+  "default.search.results.head": "Résultats de recherche",
 
   // "search.sidebar.close": "Back to results",
   "search.sidebar.close": "Retour aux résultats",
@@ -4270,18 +4815,14 @@
   // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "Paramètres",
 
-
-
   // "search.view-switch.show-detail": "Show detail",
-  "search.view-switch.show-detail": "Afficher détail",
+  "search.view-switch.show-detail": "Afficher les détails",
 
   // "search.view-switch.show-grid": "Show as grid",
-  "search.view-switch.show-grid": "Affichage Grille",
+  "search.view-switch.show-grid": "Affichage en mode grille",
 
   // "search.view-switch.show-list": "Show as list",
-  "search.view-switch.show-list": "Affichage Liste",
-
-
+  "search.view-switch.show-list": "Affichage en mode liste",
 
   // "sorting.ASC": "Ascending",
   "sorting.ASC": "Croissant",
@@ -4297,29 +4838,28 @@
 
   // "sorting.score.ASC": "Least Relevant",
   "sorting.score.ASC": "Le moins pertinent",
-  
+
   // "sorting.score.DESC": "Most Relevant",
   "sorting.score.DESC": "Le plus pertinent",
-  
+
   // "sorting.dc.date.issued.ASC": "Date Issued Ascending",
   "sorting.dc.date.issued.ASC": "Date de publication (croissante)",
-  
-  //  "sorting.dc.date.issued.DESC": "Date Issued Descending",
- "sorting.dc.date.issued.DESC": "Date de publication (decroissante)",
-  
-   // "sorting.dc.date.accessioned.ASC": "Accessioned Date Ascending",
+
+  // "sorting.dc.date.issued.DESC": "Date Issued Descending",
+  "sorting.dc.date.issued.DESC": "Date de publication (décroissante)",
+
+  // "sorting.dc.date.accessioned.ASC": "Accessioned Date Ascending",
   "sorting.dc.date.accessioned.ASC": "Date de dépôt (croissante)",
-  
-  //  "sorting.dc.date.accessioned.DESC": "Accessioned Date Descending",
-  "sorting.dc.date.accessioned.DESC": "Date de dépôt (decroissante)",
-  
+
+  // "sorting.dc.date.accessioned.DESC": "Accessioned Date Descending",
+  "sorting.dc.date.accessioned.DESC": "Date de dépôt (décroissante)",
+
   // "sorting.lastModified.ASC": "Last modified Ascending",
   "sorting.lastModified.ASC": "Dernière modification (croissante)",
 
   // "sorting.lastModified.DESC": "Last modified Descending",
-  "sorting.lastModified.ASC": "Dernière modification (descroissante)",
-  
-  
+  "sorting.lastModified.DESC": "Dernière modification (décroissante)",
+
   // "statistics.title": "Statistics",
   "statistics.title": "Statistiques",
 
@@ -4336,10 +4876,10 @@
   "statistics.table.no-data": "Aucune donnée disponible",
 
   // "statistics.table.title.TotalVisits": "Total visits",
-  "statistics.table.title.TotalVisits": "Total visites",
+  "statistics.table.title.TotalVisits": "Nombre total de visites",
 
   // "statistics.table.title.TotalVisitsPerMonth": "Total visits per month",
-  "statistics.table.title.TotalVisitsPerMonth": "Total visites par mois",
+  "statistics.table.title.TotalVisitsPerMonth": "Nombre total de visites par mois",
 
   // "statistics.table.title.TotalDownloads": "File Visits",
   "statistics.table.title.TotalDownloads": "Téléchargements",
@@ -4353,13 +4893,17 @@
   // "statistics.table.header.views": "Views",
   "statistics.table.header.views": "Vues",
 
-
+  // "submission.edit.breadcrumbs": "Edit Submission",
+  "submission.edit.breadcrumbs": "Éditer la soumission",
 
   // "submission.edit.title": "Edit Submission",
-  "submission.edit.title": "Éditer dépôt",
+  "submission.edit.title": "Éditer la soumission",
+
+  // "submission.general.cancel": "Cancel",
+  "submission.general.cancel": "Annuler",
 
   // "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
-  "submission.general.cannot_submit": "Vous n'avez pas les droits requis pour réaliser un nouveau dépôt.",
+  "submission.general.cannot_submit": "Vous n'avez pas les droits requis pour faire une nouvelle soumission.",
 
   // "submission.general.deposit": "Deposit",
   "submission.general.deposit": "Déposer",
@@ -4368,16 +4912,22 @@
   "submission.general.discard.confirm.cancel": "Annuler",
 
   // "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
-  "submission.general.discard.confirm.info": "L'annulation est irréversible, les données du dépôt en cours seront perdues. Êtes-vous sûr(e) ?",
+  "submission.general.discard.confirm.info": "L'annulation est irréversible, les données de la soumission en cours seront perdues. Êtes-vous certain(e) ?",
 
   // "submission.general.discard.confirm.submit": "Yes, I'm sure",
-  "submission.general.discard.confirm.submit": "Oui, certain(e)",
+  "submission.general.discard.confirm.submit": "Oui, je suis certain(e)",
 
   // "submission.general.discard.confirm.title": "Discard submission",
-  "submission.general.discard.confirm.title": "Annuler dépôt",
+  "submission.general.discard.confirm.title": "Annuler la soumission",
 
   // "submission.general.discard.submit": "Discard",
   "submission.general.discard.submit": "Annuler",
+
+  // "submission.general.info.saved": "Saved",
+  "submission.general.info.saved": "Sauvegardées",
+
+  // "submission.general.info.pending-changes": "Unsaved changes",
+  "submission.general.info.pending-changes": "Modifications non sauvegardées",
 
   // "submission.general.save": "Save",
   "submission.general.save": "Sauvegarder",
@@ -4385,30 +4935,53 @@
   // "submission.general.save-later": "Save for later",
   "submission.general.save-later": "Sauvegarder pour plus tard",
 
-
   // "submission.import-external.page.title": "Import metadata from an external source",
   "submission.import-external.page.title": "Importer les métadonnées depuis une source externe",
 
   // "submission.import-external.title": "Import metadata from an external source",
   "submission.import-external.title": "Importer les métadonnées depuis une source externe",
 
+  // "submission.import-external.title.Journal": "Import a journal from an external source",
+  "submission.import-external.title.Journal": "Importer une revue depuis une source externe",
+
+  // "submission.import-external.title.JournalIssue": "Import a journal issue from an external source",
+  "submission.import-external.title.JournalIssue": "Importer un numéro de revue depuis une source externe",
+
+  // "submission.import-external.title.JournalVolume": "Import a journal volume from an external source",
+  "submission.import-external.title.JournalVolume": "Importer un volume de revue depuis une source externe",
+
+  // "submission.import-external.title.OrgUnit": "Import a publisher from an external source",
+  "submission.import-external.title.OrgUnit": "Importer un éditeur depuis une source externe",
+
+  // "submission.import-external.title.Person": "Import a person from an external source",
+  "submission.import-external.title.Person": "Importer une personne depuis une source externe",
+
+  // "submission.import-external.title.Project": "Import a project from an external source",
+  "submission.import-external.title.Project": "Importer un projet depuis une source externe",
+
+  // "submission.import-external.title.Publication": "Import a publication from an external source",
+  "submission.import-external.title.Publication": "Importer une publication depuis une source externe",
+
+  // "submission.import-external.title.none": "Import metadata from an external source",
+  "submission.import-external.title.none": "Importer les métadonnées depuis une source externe",
+
   // "submission.import-external.page.hint": "Enter a query above to find items from the web to import in to DSpace.",
-  "submission.import-external.page.hint": "Entrer votre recherche ci-dessus pour rechercher les publications à importer.",
+  "submission.import-external.page.hint": "Entrer votre recherche ci-dessus pour rechercher des éléments du web à importer dans DSpace",
 
   // "submission.import-external.back-to-my-dspace": "Back to MyDSpace",
-  "submission.import-external.back-to-my-dspace": "De retour vers MyDSpace",
+  "submission.import-external.back-to-my-dspace": "Retour à mon compte DSpace",
 
   // "submission.import-external.search.placeholder": "Search the external source",
-  "submission.import-external.search.placeholder": "Recherche source externe",
+  "submission.import-external.search.placeholder": "Recherche de la source externe",
 
   // "submission.import-external.search.button": "Search",
   "submission.import-external.search.button": "Rechercher",
 
   // "submission.import-external.search.button.hint": "Write some words to search",
-  "submission.import-external.search.button.hint": "Votre recherche",
+  "submission.import-external.search.button.hint": "Saisir quelques mots à rechercher",
 
   // "submission.import-external.search.source.hint": "Pick an external source",
-  "submission.import-external.search.source.hint": "Choisir source externe",
+  "submission.import-external.search.source.hint": "Choisir une source externe",
 
   // "submission.import-external.source.arxiv": "arXiv",
   "submission.import-external.source.arxiv": "arXiv",
@@ -4417,10 +4990,16 @@
   "submission.import-external.source.loading": "En cours de chargement ...",
 
   // "submission.import-external.source.sherpaJournal": "SHERPA Journals",
-  "submission.import-external.source.sherpaJournal": "Sherpa Journals",
+  "submission.import-external.source.sherpaJournal": "Revues SHERPA",
+
+  // "submission.import-external.source.sherpaJournalIssn": "SHERPA Journals by ISSN",
+  "submission.import-external.source.sherpaJournalIssn": "Revues SHERPA par ISSN",
 
   // "submission.import-external.source.sherpaPublisher": "SHERPA Publishers",
-  "submission.import-external.source.sherpaPublisher": "SHERPA Publishers",
+  "submission.import-external.source.sherpaPublisher": "Éditeurs SHERPA",
+
+  // "submission.import-external.source.openAIREFunding": "Funding OpenAIRE API",
+  "submission.import-external.source.openAIREFunding": "API OpenAIRE de financement",
 
   // "submission.import-external.source.orcid": "ORCID",
   "submission.import-external.source.orcid": "ORCID",
@@ -4429,22 +5008,22 @@
   "submission.import-external.source.pubmed": "Pubmed",
 
   // "submission.import-external.source.lcname": "Library of Congress Names",
-  "submission.import-external.source.lcname": "Library of Congress Names",
+  "submission.import-external.source.lcname": "Autorités de noms de la Bibliothèque du Congrès",
 
   // "submission.import-external.preview.title": "Item Preview",
-  "submission.import-external.preview.title": "Prévisualisation Item",
+  "submission.import-external.preview.title": "Prévisualisation de l'élément",
 
   // "submission.import-external.preview.subtitle": "The metadata below was imported from an external source. It will be pre-filled when you start the submission.",
-  "submission.import-external.preview.subtitle": "Les métadonnées ci-dessous ont été importées depuis une source externe. Le formulaire de dépôt sera pré-rempli avec ces métadonnées lorsque vous initierez le dépôt.",
+  "submission.import-external.preview.subtitle": "Les métadonnées ci-dessous ont été importées depuis une source externe. Le formulaire de dépôt sera pré-rempli avec ces métadonnées lorsque vous initierez la soumission.",
 
   // "submission.import-external.preview.button.import": "Start submission",
-  "submission.import-external.preview.button.import": "Démarrer dépôt",
+  "submission.import-external.preview.button.import": "Démarrer la soumission",
 
   // "submission.import-external.preview.error.import.title": "Submission error",
-  "submission.import-external.preview.error.import.title": "Erreur dépôt",
+  "submission.import-external.preview.error.import.title": "Erreur de soumission",
 
   // "submission.import-external.preview.error.import.body": "An error occurs during the external source entry import process.",
-  "submission.import-external.preview.error.import.body": "Une erreur s'est produite lors de l'import depuis la source externe.",
+  "submission.import-external.preview.error.import.body": "Une erreur s'est produite lors de l'importation depuis la source externe.",
 
   // "submission.sections.describe.relationship-lookup.close": "Close",
   "submission.sections.describe.relationship-lookup.close": "Fermer",
@@ -4453,25 +5032,37 @@
   "submission.sections.describe.relationship-lookup.external-source.added": "Entrée locale ajoutée avec succès à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Import remote author",
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Importer auteur externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Importer l'auteur.e externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Import remote journal",
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Importer revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Importer la revue externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Issue": "Import remote journal issue",
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Issue": "Importer numéro de revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Issue": "Importer le numéro de revue externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Import remote journal volume",
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Importer volume de revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Importer le volume de revue externe",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.isProjectOfPublication": "Project",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isProjectOfPublication": "Projet",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.added.new-entity": "New Entity Added!",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.added.new-entity": "Nouvelle entité ajoutée !",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.title": "Project",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.title": "Projet",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openAIREFunding": "Funding OpenAIRE API",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openAIREFunding": "API OpenAIRE de financement",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Import Remote Author",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Importer auteur externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Importer l'auteur externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Successfully added local author to the selection",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Auteur local ajouté avec succès à la sélection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Auteur.e local ajouté avec succès à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Successfully imported and added external author to the selection",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Auteur externe importé et ajouté à la sélection avec succès",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Auteur.e externe importé et ajouté à la sélection avec succès",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.authority": "Authority",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.authority": "Autorité",
@@ -4492,49 +5083,49 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.entities.new": "Importer en tant que nouvelle entité locale",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.lcname": "Importing from LC Name",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.lcname": "Import depuis LC Name en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.lcname": "Importation depuis les autorités de noms de la Bibliothèque du Congrès en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Importing from ORCID",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Import depuis ORCID en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Importation depuis ORCID en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Importing from Sherpa Journal",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Import depuis Sherpa Journal en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Importation depuis Revues SHERPA en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaPublisher": "Importing from Sherpa Publisher",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaPublisher": "Import depuis Sherpa Publisher en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaPublisher": "Importation depuis Éditeurs SHERPA en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Importing from PubMed",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Import depuis PubMed en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Importation depuis PubMed en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Importing from arXiv",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Import depuis arXiv en cours",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Importation depuis arXiv en cours",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Importer",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.title": "Import Remote Journal",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.title": "Importer revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.title": "Importer une revue externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.local-entity": "Successfully added local journal to the selection",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.local-entity": "Revue correctement ajoutée à la sélection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.local-entity": "Revue locale ajoutée à la sélection avec succès",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.new-entity": "Successfully imported and added external journal to the selection",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.new-entity": "Revue externe importée avec succès et ajoutée à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.title": "Import Remote Journal Issue",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.title": "Importer numéro de revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.title": "Importer un numéro de revue externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.local-entity": "Successfully added local journal issue to the selection",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.local-entity": "Numéro de revue correctement ajouté à la sélection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.local-entity": "Numéro de revue ajouté avec succès à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.new-entity": "Successfully imported and added external journal issue to the selection",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.new-entity": "Numéro de revue importé avec succès et ajouté à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.title": "Import Remote Journal Volume",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.title": "Importer volume de revue externe",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.title": "Importer un volume de revue externe",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.local-entity": "Successfully added local journal volume to the selection",
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.local-entity": "Volume de revue correctement ajouté à la sélection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.local-entity": "Volume de revue ajouté avec succès à la sélection",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.new-entity": "Successfully imported and added external journal volume to the selection",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.new-entity": "Volume de revue importé avec succès et ajouté à la sélection",
@@ -4557,6 +5148,9 @@
   // "submission.sections.describe.relationship-lookup.search-tab.search": "Go",
   "submission.sections.describe.relationship-lookup.search-tab.search": "Rechercher",
 
+  // "submission.sections.describe.relationship-lookup.search-tab.search-form.placeholder": "Search...",
+  "submission.sections.describe.relationship-lookup.search-tab.search-form.placeholder": "Rechercher...",
+
   // "submission.sections.describe.relationship-lookup.search-tab.select-all": "Select all",
   "submission.sections.describe.relationship-lookup.search-tab.select-all": "Sélectionner tout",
 
@@ -4564,13 +5158,14 @@
   "submission.sections.describe.relationship-lookup.search-tab.select-page": "Sélectionner page",
 
   // "submission.sections.describe.relationship-lookup.selected": "Selected {{ size }} items",
-  "submission.sections.describe.relationship-lookup.selected": "{{ size }} Items sélectionnés",
+  "submission.sections.describe.relationship-lookup.selected": "{{ size }} documents sélectionnés",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfPublication": "Local Authors ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfPublication": "Auteurs locaux ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Local Journals ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Revues locales ({{ count }})",
+  
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Local Projects ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Projects locaux ({{ count }})",
 
@@ -4594,25 +5189,27 @@
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalIssueOfPublication": "Local Journal Issues ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalIssueOfPublication": "Numéros de revue locaux ({{ count }})",
+  
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "Local Journal Issues ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "Numéros de revue locaux ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Local Journal Volumes ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Volumes de revues locaux ({{ count }})",
+  
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalVolume": "Local Journal Volumes ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalVolume": "Volumes de revues locaux ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournal": "Sherpa Journals ({{ count }})",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournal": "Revues Sherpa ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournal": "Revues SHERPA ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaPublisher": "Sherpa Publishers ({{ count }})",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaPublisher": "Éditeurs Sherpa ({{ count }})",
-
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaPublisher": "Éditeurs SHERPA ({{ count }})",
+  
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcid": "ORCID ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcid": "ORCID ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "LC Names ({{ count }})",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "LC Names ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "Autorités de noms de la Bibliothèque du Congrès ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.pubmed": "PubMed ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.pubmed": "PubMed ({{ count }})",
@@ -4621,24 +5218,50 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.arxiv": "arXiv ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Search for Funding Agencies",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Recherche Agence de financement",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Recherche d'agences de financement",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Search for Funding",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Recherche Financement",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Recherche de financement",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isChildOrgUnitOf": "Search for Organizational Units",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isChildOrgUnitOf": "Recherche Structures",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isChildOrgUnitOf": "Recherche de structures organisationnelles",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openAIREFunding": "Funding OpenAIRE API",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openAIREFunding": "API OpenAIRE de financement",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isProjectOfPublication": "Projects",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isProjectOfPublication": "Projets",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfProject": "Funder of the Project",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfProject": "Bailleur de fonds du projet",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openAIREFunding": "Funding OpenAIRE API",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openAIREFunding": "API OpenAIRE de financement",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Project",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Projet",
+
+  // "submission.sections.describe.relationship-lookup.title.isProjectOfPublication": "Projects",
+  "submission.sections.describe.relationship-lookup.title.isProjectOfPublication": "Projets",
+
+  // "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "Funder of the Project",
+  "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "Bailleur de fonds du projet",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Search...",
+  "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Rechercher...",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.tab-title": "Current Selection ({{ count }})",
   "submission.sections.describe.relationship-lookup.selection-tab.tab-title": "Sélection actuelle ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Journal Issues",
   "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Numéros de revue",
+  
   // "submission.sections.describe.relationship-lookup.title.JournalIssue": "Journal Issues",
   "submission.sections.describe.relationship-lookup.title.JournalIssue": "Numéros de revue",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Journal Volumes",
   "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Volumes de revue",
+  
   // "submission.sections.describe.relationship-lookup.title.JournalVolume": "Journal Volumes",
   "submission.sections.describe.relationship-lookup.title.JournalVolume": "Volumes de revue",
 
@@ -4650,6 +5273,7 @@
 
   // "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfPublication": "Funding Agency",
   "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfPublication": "Agence de financement",
+  
   // "submission.sections.describe.relationship-lookup.title.Project": "Projects",
   "submission.sections.describe.relationship-lookup.title.Project": "Projets",
 
@@ -4660,7 +5284,7 @@
   "submission.sections.describe.relationship-lookup.title.Person": "Auteurs",
 
   // "submission.sections.describe.relationship-lookup.title.OrgUnit": "Organizational Units",
-  "submission.sections.describe.relationship-lookup.title.OrgUnit": "Structures",
+  "submission.sections.describe.relationship-lookup.title.OrgUnit": "Structures organisationnelles",
 
   // "submission.sections.describe.relationship-lookup.title.DataPackage": "Data Packages",
   "submission.sections.describe.relationship-lookup.title.DataPackage": "Paquets de données",
@@ -4675,10 +5299,10 @@
   "submission.sections.describe.relationship-lookup.title.isFundingOfPublication": "Financement",
 
   // "submission.sections.describe.relationship-lookup.title.isChildOrgUnitOf": "Parent Organizational Unit",
-  "submission.sections.describe.relationship-lookup.title.isChildOrgUnitOf": "Structure parent",
+  "submission.sections.describe.relationship-lookup.title.isChildOrgUnitOf": "Structure organisationnelle mère",
 
   // "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Toggle dropdown",
-  "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Dérouler menu",
+  "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Dérouler le menu",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.settings": "Settings",
   "submission.sections.describe.relationship-lookup.selection-tab.settings": "Paramètres",
@@ -4694,11 +5318,12 @@
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Selected Journal Volume",
   "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Volumes de revue sélectionnés",
+  
   // "submission.sections.describe.relationship-lookup.selection-tab.title.Project": "Selected Projects",
   "submission.sections.describe.relationship-lookup.selection-tab.title.Project": "Projets sélectionnés",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Selected Publications",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Publications sélectionnés",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Publications sélectionnées",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Selected Authors",
   "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Auteurs sélectionnés",
@@ -4716,21 +5341,22 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.Journal": "Revues sélectionnées",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalIssueOfPublication": "Selected Issue",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalIssueOfPublication": "Numéros sélectionnés",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalIssueOfPublication": "Numéro sélectionné",
+  
   // "submission.sections.describe.relationship-lookup.selection-tab.title.JournalVolume": "Selected Journal Volume",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.JournalVolume": "Volumes de revue sélectionnés",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.JournalVolume": "Volume de revue sélectionné",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingAgencyOfPublication": "Selected Funding Agency",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingAgencyOfPublication": "Agences de financement sélectionnées",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingAgencyOfPublication": "Agence de financement sélectionnée",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingOfPublication": "Selected Funding",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingOfPublication": "Financements sélectionnés",
-
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingOfPublication": "Financement sélectionné",
+  
   // "submission.sections.describe.relationship-lookup.selection-tab.title.JournalIssue": "Selected Issue",
   "submission.sections.describe.relationship-lookup.selection-tab.title.JournalIssue": "Numéro sélectionné",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Selected Organizational Unit",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Structure sélectionnée",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Structure organisationnelle sélectionnée",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.sherpaJournal": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title.sherpaJournal": "Résultats de recherche",
@@ -4754,13 +5380,13 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.arxiv": "Résultats de recherche",
 
   // "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Would you like to save \"{{ value }}\" as a name variant for this person so you and others can reuse it for future submissions? If you don\'t you can still use it for this submission.",
-  "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Souhaitez vous sauvegarder \"{{ value }}\" en tant que nom alternatif pour cette personne afin que vous ou un autre utilisauteur puisse l'utiliser pour de futurs dépôts? Si vous ne le souhaitez pas, vous pouvez tout de même l'utiliser pour ce dépôt.",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Souhaitez-vous sauvegarder \"{{ value }}\" en tant que nom alternatif pour cette personne afin que vous ou un autre utilisateur puisse l'utiliser pour de futures soumissions ? Si vous ne le souhaitez pas, vous pouvez tout de même l'utiliser pour cette soumission.",
 
   // "submission.sections.describe.relationship-lookup.name-variant.notification.confirm": "Save a new name variant",
-  "submission.sections.describe.relationship-lookup.name-variant.notification.confirm": "Sauvegarder nom alternatif",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.confirm": "Sauvegarder un nouveau nom alternatif",
 
   // "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Use only for this submission",
-  "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Utiliser uniquement pour ce dépôt",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Utiliser uniquement pour cette soumission",
 
   // "submission.sections.ccLicense.type": "License Type",
   "submission.sections.ccLicense.type": "Type de licence",
@@ -4769,7 +5395,7 @@
   "submission.sections.ccLicense.select": "Sélectionner un type de licence...",
 
   // "submission.sections.ccLicense.change": "Change your license type…",
-  "submission.sections.ccLicense.change": "Changer type de licence...",
+  "submission.sections.ccLicense.change": "Changer votre type de licence...",
 
   // "submission.sections.ccLicense.none": "No licenses available",
   "submission.sections.ccLicense.none": "Pas de licence disponible",
@@ -4781,51 +5407,52 @@
   "submission.sections.ccLicense.link": "Vous avez sélectionné la licence suivante :",
 
   // "submission.sections.ccLicense.confirmation": "I grant the license above",
-  "submission.sections.ccLicense.confirmation": "Je confirme la licence ci-dessus",
+  "submission.sections.ccLicense.confirmation": "J'accorde  la licence ci-dessus",
 
   // "submission.sections.general.add-more": "Add more",
-  "submission.sections.general.add-more": "Ajouter section(s)",
+  "submission.sections.general.add-more": "Ajouter",
 
   // "submission.sections.general.collection": "Collection",
   "submission.sections.general.collection": "Collection",
 
   // "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
-  "submission.sections.general.deposit_error_notice": "Une erreur s'est produite lors du dépôt de l'Item, veuillez réessayer plus tard.",
+  "submission.sections.general.deposit_error_notice": "Une erreur s'est produite lors de la soumission de l'Item, veuillez réessayer plus tard.",
 
   // "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
-  "submission.sections.general.deposit_success_notice": "Dépôt réalisé avec succès.",
+  "submission.sections.general.deposit_success_notice": "Soumission déposée avec succès.",
 
   // "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
-  "submission.sections.general.discard_error_notice": "Une erreur s'est produite lors de la suppression du brouillon, veuillez réessayer plus tard.",
+  "submission.sections.general.discard_error_notice": "Une erreur s'est produite lors de la suppression de l'Item, veuillez réessayer plus tard.",
 
   // "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
-  "submission.sections.general.discard_success_notice": "Brouillon supprimé avec succès.",
+  "submission.sections.general.discard_success_notice": "Soumission supprimée avec succès.",
 
   // "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
   "submission.sections.general.metadata-extracted": "De nouvelles métadonnées ont été extraites et ajoutées à la section <strong>{{sectionId}}</strong>.",
 
   // "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
-  "submission.sections.general.metadata-extracted-new-section": "Nouvelle section <strong>{{sectionId}}</strong> ajoutée au dépôt.",
+  "submission.sections.general.metadata-extracted-new-section": "La nouvelle section <strong>{{sectionId}}</strong> a été ajoutée à la soumission.",
 
   // "submission.sections.general.no-collection": "No collection found",
-  "submission.sections.general.no-collection": "Aucune Collection disponible",
+  "submission.sections.general.no-collection": "Aucune collection disponible",
 
   // "submission.sections.general.no-sections": "No options available",
   "submission.sections.general.no-sections": "Aucune option disponible",
 
   // "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
-  "submission.sections.general.save_error_notice": "Une erreur s'est produite à la sauvegarde du dépôt, veuillez réessayer plus tard.",
+  "submission.sections.general.save_error_notice": "Une erreur s'est produite lors de la sauvegarde de la soumission, veuillez réessayer plus tard.",
 
   // "submission.sections.general.save_success_notice": "Submission saved successfully.",
-  "submission.sections.general.save_success_notice": "Dépôt sauvegardé avec succès.",
+  "submission.sections.general.save_success_notice": "Soumission sauvegardée avec succès.",
 
   // "submission.sections.general.search-collection": "Search for a collection",
-  "submission.sections.general.search-collection": "Rechercher une Collection",
+  "submission.sections.general.search-collection": "Rechercher une collection",
 
   // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
-  "submission.sections.general.sections_not_valid": "Section(s) incomplète(s).",
+  "submission.sections.general.sections_not_valid": "Sections incomplètes.",
 
-
+  // "submission.sections.submit.progressbar.accessCondition": "Item access conditions",
+  "submission.sections.submit.progressbar.accessCondition": "Autorisations d'accès à l'Item",  
 
   // "submission.sections.submit.progressbar.CClicense": "Creative commons license",
   "submission.sections.submit.progressbar.CClicense": "Licence Creative Commons",
@@ -4846,39 +5473,85 @@
   "submission.sections.submit.progressbar.detect-duplicate": "Doublon(s) potentiel(s)",
 
   // "submission.sections.submit.progressbar.license": "Deposit license",
-  "submission.sections.submit.progressbar.license": "Licence de dépôt",
+  "submission.sections.submit.progressbar.license": "Licence du dépôt",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
-  "submission.sections.submit.progressbar.upload": "Uploader",
+  "submission.sections.submit.progressbar.upload": "Télécharger des fichiers",
 
+  // "submission.sections.status.errors.title": "Errors",
+  "submission.sections.status.errors.title": "Erreurs",
 
+  // "submission.sections.status.valid.title": "Valid",
+  "submission.sections.status.valid.title": "Valide",
+
+  // "submission.sections.status.warnings.title": "Warnings",
+  "submission.sections.status.warnings.title": "Avertissements",
+
+  // "submission.sections.status.errors.aria": "has errors",
+  "submission.sections.status.errors.aria": "comporte des erreurs",
+
+  // "submission.sections.status.valid.aria": "is valid",
+  "submission.sections.status.valid.aria": "est valide",
+
+  // "submission.sections.status.warnings.aria": "has warnings",
+  "submission.sections.status.warnings.aria": "comporte des avertissements",
+
+  // "submission.sections.toggle.open": "Open section",
+  "submission.sections.toggle.open": "Section ouverte",
+
+  // "submission.sections.toggle.close": "Close section",
+  "submission.sections.toggle.close": "Section fermée",
+
+  // "submission.sections.toggle.aria.open": "Expand {{sectionHeader}} section",
+  "submission.sections.toggle.aria.open": "Développer la section {{sectionHeader}}",
+
+  // "submission.sections.toggle.aria.close": "Collapse {{sectionHeader}} section",
+  "submission.sections.toggle.aria.close": "Réduire la section {{sectionHeader}}",
 
   // "submission.sections.upload.delete.confirm.cancel": "Cancel",
   "submission.sections.upload.delete.confirm.cancel": "Annuler",
 
   // "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
-  "submission.sections.upload.delete.confirm.info": "Cette opération est irréversible. Êtes-vous sûr(e) ?",
+  "submission.sections.upload.delete.confirm.info": "Cette opération est irréversible. Êtes-vous certain(e) ?",
 
   // "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
-  "submission.sections.upload.delete.confirm.submit": "Oui, certain(e)",
+  "submission.sections.upload.delete.confirm.submit": "Oui, je suis certain(e)",
 
   // "submission.sections.upload.delete.confirm.title": "Delete bitstream",
-  "submission.sections.upload.delete.confirm.title": "Supprimer Bitstream",
+  "submission.sections.upload.delete.confirm.title": "Supprimer le Bitstream",
 
   // "submission.sections.upload.delete.submit": "Delete",
   "submission.sections.upload.delete.submit": "Supprimer",
 
+  // "submission.sections.upload.download.title": "Download bitstream",
+  "submission.sections.upload.download.title": "Télécharger un Bitstream",
+
   // "submission.sections.upload.drop-message": "Drop files to attach them to the item",
   "submission.sections.upload.drop-message": "Déposer des fichiers pour les lier à l'Item",
 
+  // "submission.sections.upload.edit.title": "Edit bitstream",
+  "submission.sections.upload.edit.title": "Éditer le Bitstream",
+
   // "submission.sections.upload.form.access-condition-label": "Access condition type",
-  "submission.sections.upload.form.access-condition-label": "Niveau d'accès",
+  "submission.sections.upload.form.access-condition-label": "Type d'autorisations d'accès",
+
+  // "submission.sections.upload.form.access-condition-hint": "Select an access condition to apply on the bitstream once the item is deposited",
+  "submission.sections.upload.form.access-condition-hint": "Sélectionner une autorisation d'accès à appliquer sur le Bitstream une fois l'Item déposé",
 
   // "submission.sections.upload.form.date-required": "Date is required.",
-  "submission.sections.upload.form.date-required": "Date obligatoire.",
+  "submission.sections.upload.form.date-required": "La date est obligatoire.",
+
+  // "submission.sections.upload.form.date-required-from": "Grant access from date is required.",
+  "submission.sections.upload.form.date-required-from": "L'autorisation d'accès à partir d'une date est obligatoire.",
+
+  // "submission.sections.upload.form.date-required-until": "Grant access until date is required.",
+  "submission.sections.upload.form.date-required-until": "L'autorisation d'accès jusqu'à une date est obligatoire",
 
   // "submission.sections.upload.form.from-label": "Grant access from",
-  "submission.sections.upload.form.from-label": "Accès accordé depuis",
+  "submission.sections.upload.form.from-label": "Accorder l'accès depuis",
+
+  // "submission.sections.upload.form.from-hint": "Select the date from which the related access condition is applied",
+  "submission.sections.upload.form.from-hint": "Sélectionner la date à partir de laquelle l'autorisation d'accès liée est appliquée.",
 
   // "submission.sections.upload.form.from-placeholder": "From",
   "submission.sections.upload.form.from-placeholder": "Depuis",
@@ -4887,53 +5560,100 @@
   "submission.sections.upload.form.group-label": "Groupe",
 
   // "submission.sections.upload.form.group-required": "Group is required.",
-  "submission.sections.upload.form.group-required": "Groupe requis.",
+  "submission.sections.upload.form.group-required": "Le groupe est requis.",
 
   // "submission.sections.upload.form.until-label": "Grant access until",
-  "submission.sections.upload.form.until-label": "Accès accordé jusque",
+  "submission.sections.upload.form.until-label": "Accorder l'accès jusqu'au",
+
+  // "submission.sections.upload.form.until-hint": "Select the date until which the related access condition is applied",
+  "submission.sections.upload.form.until-hint": "Sélectionner la date jusqu'à laquelle l'autorisation d'accès liée est appliquée.",
 
   // "submission.sections.upload.form.until-placeholder": "Until",
-  "submission.sections.upload.form.until-placeholder": "Jusque",
+  "submission.sections.upload.form.until-placeholder": "Jusqu'au",
 
   // "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
-  "submission.sections.upload.header.policy.default.nolist": "Les fichiers uploadés dans la Collection {{collectionName}} seront accessibles au(x) groupe(s) suivant(s) :",
+  "submission.sections.upload.header.policy.default.nolist": "Les fichiers téléchargés dans la collection {{collectionName}} seront accessibles au(x) groupe(s) suivant(s) :",
 
   // "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
-  "submission.sections.upload.header.policy.default.withlist": "Veuillez noter que, en complément des accès spécifiquement accordés pour le fichier, les fichiers uploadés dans la Collection {{collectionName}} seront accessibles par défaut au(x) groupe(s) suivant(s) :",
+  "submission.sections.upload.header.policy.default.withlist": "Veuillez noter que, en complément des accès spécifiquement accordés pour le fichier, les fichiers téléchargés dans la collection {{collectionName}} seront accessibles par défaut au(x) groupe(s) suivant(s) :",
 
   // "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the file metadata and access conditions or <strong>upload additional files just dragging & dropping them everywhere in the page</strong>",
-  "submission.sections.upload.info": "Vous trouverez ici tous les fichiers actuellement associés à l'Item. Vous pouvez éditer les métadonnés et les niveaux d'accès de ce(s) fichier(s) ou <strong>uploader des fichiers complémentaires simplement en les glissant n'importe où sur cette page</strong>",
+  "submission.sections.upload.info": "Vous trouverez ici tous les fichiers actuellement associés à l'Item. Vous pouvez éditer les métadonnés et les niveaux d'accès de ce(s) fichier(s) ou <strong>télécharger des fichiers complémentaires simplement en les glissant n'importe où sur cette page</strong>",
 
   // "submission.sections.upload.no-entry": "No",
   "submission.sections.upload.no-entry": "Non",
 
   // "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
-  "submission.sections.upload.no-file-uploaded": "Aucun fichier uploadé.",
+  "submission.sections.upload.no-file-uploaded": "Aucun fichier n'a encore été téléchargé.",
 
   // "submission.sections.upload.save-metadata": "Save metadata",
-  "submission.sections.upload.save-metadata": "Sauvegarder métadonnées",
+  "submission.sections.upload.save-metadata": "Sauvegarder les métadonnées",
 
   // "submission.sections.upload.undo": "Cancel",
   "submission.sections.upload.undo": "Annuler",
 
   // "submission.sections.upload.upload-failed": "Upload failed",
-  "submission.sections.upload.upload-failed": "Échec de l'upload",
+  "submission.sections.upload.upload-failed": "Échec du téléchargement",
 
   // "submission.sections.upload.upload-successful": "Upload successful",
-  "submission.sections.upload.upload-successful": "Upload réussi",
+  "submission.sections.upload.upload-successful": "Téléchargement réussi",
 
+  // "submission.sections.accesses.form.discoverable-description": "When checked, this item will be discoverable in search/browse. When unchecked, the item will only be available via a direct link and will never appear in search/browse.",
+  "submission.sections.accesses.form.discoverable-description": "Si cette case est cochée, cet Item pourra être découvert dans la recherche/index parcourir. Si cette case n'est pas cochée, l'Item ne sera disponible que via un lien direct et n'apparaîtra jamais dans la recherche/index parcourir.",
 
+  // "submission.sections.accesses.form.discoverable-label": "Discoverable",
+  "submission.sections.accesses.form.discoverable-label": "Découvrable",
 
-  // "submission.submit.title": "Submission",
-  "submission.submit.title": "Dépôt",
+  // "submission.sections.accesses.form.access-condition-label": "Access condition type",
+  "submission.sections.accesses.form.access-condition-label": "Type d'autorisations d'accès",
 
+  // "submission.sections.accesses.form.access-condition-hint": "Select an access condition to apply on the item once it is deposited",
+  "submission.sections.accesses.form.access-condition-hint": "Sélectionner une autorisation d'accès à appliquer une fois l'Item déposé.",
 
+  // "submission.sections.accesses.form.date-required": "Date is required.",
+  "submission.sections.accesses.form.date-required": "La date est obligatoire",
+
+  // "submission.sections.accesses.form.date-required-from": "Grant access from date is required.",
+  "submission.sections.accesses.form.date-required-from": "L'autorisation d'accès à partir d'une date est obligatoire.",
+
+  // "submission.sections.accesses.form.date-required-until": "Grant access until date is required.",
+  "submission.sections.accesses.form.date-required-until": "L'autorisation d'accès jusqu'à une date est obligatoire.",
+
+  // "submission.sections.accesses.form.from-label": "Grant access from",
+  "submission.sections.accesses.form.from-label": "Accorder l'accès à partir de",
+
+  // "submission.sections.accesses.form.from-hint": "Select the date from which the related access condition is applied",
+  "submission.sections.accesses.form.from-hint": "Sélectionner la date à partir de laquelle l'autorisation d'accès liée est appliquée.",
+
+  // "submission.sections.accesses.form.from-placeholder": "From",
+  "submission.sections.accesses.form.from-placeholder": "Depuis",
+
+  // "submission.sections.accesses.form.group-label": "Group",
+  "submission.sections.accesses.form.group-label": "Groupe",
+
+  // "submission.sections.accesses.form.group-required": "Group is required.",
+  "submission.sections.accesses.form.group-required": "Le groupe est obligatoire",
+
+  // "submission.sections.accesses.form.until-label": "Grant access until",
+  "submission.sections.accesses.form.until-label": "Accorder l'accès jusqu'au",
+
+  // "submission.sections.accesses.form.until-hint": "Select the date until which the related access condition is applied",
+  "submission.sections.accesses.form.until-hint": "Sélectionner la date jusqu'à laquelle l'autorisation d'accès liée est appliquée.",
+
+  // "submission.sections.accesses.form.until-placeholder": "Until",
+  "submission.sections.accesses.form.until-placeholder": "Jusqu'au",
+
+  // "submission.submit.breadcrumbs": "New submission",
+  "submission.submit.breadcrumbs": "Nouvelle soumission",
+
+  // "submission.submit.title": "New submission",
+  "submission.submit.title": "Nouvelle soumission",
 
   // "submission.workflow.generic.delete": "Delete",
   "submission.workflow.generic.delete": "Supprimer",
 
   // "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
-  "submission.workflow.generic.delete-help": "Si vous souhaitez supprimer cet Item, cliquez sur « Supprimer ». Une confirmation vous sera alors demandée.",
+  "submission.workflow.generic.delete-help": "Si vous souhaitez supprimer cet Item, cliquer sur « Supprimer ». Une confirmation vous sera alors demandée.",
 
   // "submission.workflow.generic.edit": "Edit",
   "submission.workflow.generic.edit": "Éditer",
@@ -4947,13 +5667,11 @@
   // "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
   "submission.workflow.generic.view-help": "Sélectionner cette option pour afficher les métadonnées de l'Item.",
 
-
-
   // "submission.workflow.tasks.claimed.approve": "Approve",
   "submission.workflow.tasks.claimed.approve": "Approuver",
 
   // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
-  "submission.workflow.tasks.claimed.approve_help": "Si vous avez contrôlé cet Item et qu'il peut être ajouté à la Collection, sélectionner l'option « Approuver ».",
+  "submission.workflow.tasks.claimed.approve_help": "Si vous avez bien révisé cet Item et qu'il peut être ajouté à la collection, sélectionner « Approuver ».",
 
   // "submission.workflow.tasks.claimed.edit": "Edit",
   "submission.workflow.tasks.claimed.edit": "Éditer",
@@ -4962,13 +5680,13 @@
   "submission.workflow.tasks.claimed.edit_help": "Sélectionner cette option pour modifier les métadonnées de l'Item.",
 
   // "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
-  "submission.workflow.tasks.claimed.reject.reason.info": "Veuillez spécifier la raison pour laquelle ce dépôt est rejeté dans le champ ci-dessous, en indicant si le déposant peut résoudre un problème et redéposer ensuite.",
+  "submission.workflow.tasks.claimed.reject.reason.info": "Veuillez spécifier la raison pour laquelle cette soumission est rejetée dans le champ ci-dessous, en indicant si le déposant peut résoudre le problème et redéposer ensuite.",
 
   // "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
   "submission.workflow.tasks.claimed.reject.reason.placeholder": "Décrire la raison du rejet",
 
   // "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
-  "submission.workflow.tasks.claimed.reject.reason.submit": "Rejeter Item",
+  "submission.workflow.tasks.claimed.reject.reason.submit": "Rejeter l'Item",
 
   // "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
   "submission.workflow.tasks.claimed.reject.reason.title": "Raison",
@@ -4977,15 +5695,13 @@
   "submission.workflow.tasks.claimed.reject.submit": "Rejeter",
 
   // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
-  "submission.workflow.tasks.claimed.reject_help": "Si vous avez contrôle cet Item et qu'il ne peut <strong>PAS</strong> être ajouté à la Collection, sélectionner l'option « Rejeter ».  Il vous sera alors demandé d'indiquer la raison de ce rejet et si le déposant peut apporter une correction avant de redéposer.",
+  "submission.workflow.tasks.claimed.reject_help": "Si vous avez bien révisé cet Item et qu'il ne peut <strong>PAS</strong> être ajouté à la collection, sélectionner l'option « Rejeter ».  Il vous sera alors demandé d'indiquer la raison de ce rejet et de préciser si le déposant peut apporter une correction avant de soumettre de nouveau.",
 
   // "submission.workflow.tasks.claimed.return": "Return to pool",
   "submission.workflow.tasks.claimed.return": "Se désassigner",
 
   // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
-  "submission.workflow.tasks.claimed.return_help": "Renvoyer la tâche dans le pool de validation pour qu'un autre utilisateur puisse en prendre soin.",
-
-
+  "submission.workflow.tasks.claimed.return_help": "Renvoyer la tâche dans l'équipe pour qu'un autre utilisateur puisse l'exécuter.",
 
   // "submission.workflow.tasks.generic.error": "Error occurred during operation...",
   "submission.workflow.tasks.generic.error": "Une erreur s'est produite au cours de l'opération...",
@@ -4999,26 +5715,44 @@
   // "submission.workflow.tasks.generic.success": "Operation successful",
   "submission.workflow.tasks.generic.success": "Opération exécutée avec succès",
 
-
-
   // "submission.workflow.tasks.pool.claim": "Claim",
   "submission.workflow.tasks.pool.claim": "Prendre en charge",
 
   // "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
-  "submission.workflow.tasks.pool.claim_help": "Assigner cette tâche à votre propre utilisateur.",
+  "submission.workflow.tasks.pool.claim_help": "Vous assigner cette tâche.",
 
   // "submission.workflow.tasks.pool.hide-detail": "Hide detail",
-  "submission.workflow.tasks.pool.hide-detail": "Masquer détails",
+  "submission.workflow.tasks.pool.hide-detail": "Masquer le détail",
 
   // "submission.workflow.tasks.pool.show-detail": "Show detail",
-  "submission.workflow.tasks.pool.show-detail": "Afficher détails",
+  "submission.workflow.tasks.pool.show-detail": "Afficher le détail",
 
+  // "thumbnail.default.alt": "Thumbnail Image",
+  "thumbnail.default.alt": "Vignette d'image",
 
+  // "thumbnail.default.placeholder": "No Thumbnail Available",
+  "thumbnail.default.placeholder": "Pas de vignette d'image disponible",
+
+  // "thumbnail.project.alt": "Project Logo",
+  "thumbnail.project.alt": "Logo du projet",
+
+  // "thumbnail.project.placeholder": "Project Placeholder Image",
+  "thumbnail.project.placeholder": "Image de remplacement du projet",
+
+  // "thumbnail.orgunit.alt": "OrgUnit Logo",
+  "thumbnail.orgunit.alt": "Logo de l'organisme",
+
+  // "thumbnail.orgunit.placeholder": "OrgUnit Placeholder Image",
+  "thumbnail.orgunit.placeholder": "Image de remplacement de l'organisme",
+
+  // "thumbnail.person.alt": "Profile Picture",
+  "thumbnail.person.alt": "Photo de profil",
+
+  // "thumbnail.person.placeholder": "No Profile Picture Available",
+  "thumbnail.person.placeholder": "Aucune photo de profil disponible",
 
   // "title": "DSpace",
   "title": "DSpace",
-
-
 
   // "vocabulary-treeview.header": "Hierarchical tree view",
   "vocabulary-treeview.header": "Arborescence hiérarchique",
@@ -5033,21 +5767,22 @@
   "vocabulary-treeview.search.form.search": "Rechercher",
 
   // "vocabulary-treeview.search.no-result": "There were no items to show",
-  "vocabulary-treeview.search.no-result": "Aucun résultat correspondant",
+  "vocabulary-treeview.search.no-result": "Aucun résultat à afficher",
 
   // "vocabulary-treeview.tree.description.nsi": "The Norwegian Science Index",
   "vocabulary-treeview.tree.description.nsi": "Norwegian Science Index",
 
   // "vocabulary-treeview.tree.description.srsc": "Research Subject Categories",
-  "vocabulary-treeview.tree.description.srsc": "Research Subject Categories",
-
-
+  "vocabulary-treeview.tree.description.srsc": "Recherche des catégories de sujets",
 
   // "uploader.browse": "browse",
   "uploader.browse": "parcourir",
 
   // "uploader.drag-message": "Drag & Drop your files here",
-  "uploader.drag-message": "Glisser & Déposer vos fichiers ici",
+  "uploader.drag-message": "Glisser-déposer vos fichiers ici",
+
+  // "uploader.delete.btn-title": "Delete",
+  "uploader.delete.btn-title": "Supprimer",
 
   // "uploader.or": ", or ",
   "uploader.or": ", ou ",
@@ -5067,30 +5802,38 @@
   // "virtual-metadata.delete-relationship.modal-head": "Select the items for which you want to save the virtual metadata as real metadata",
   "virtual-metadata.delete-relationship.modal-head": "Sélectionner les Items pour lesquels vous souhaitez sauvegarder les métadonnées virtuelles en tant que métadonnées réelles",
 
-
+  // "workspace.search.results.head": "Your submissions",
+  "workspace.search.results.head": "Vos soumissions",
 
   // "workflowAdmin.search.results.head": "Administer Workflow",
   "workflowAdmin.search.results.head": "Workflow Administrateur",
 
+  // "workflow.search.results.head": "Workflow tasks",
+  "workflow.search.results.head": "tâches du Workflow",
 
+  // "workflow-item.edit.breadcrumbs": "Edit workflowitem",
+  "workflow-item.edit.breadcrumbs": "Éditer l'Item du Workflow",
+
+  // "workflow-item.edit.title": "Edit workflowitem",
+  "workflow-item.edit.title": "Éditer l'Item du Workflow",
 
   // "workflow-item.delete.notification.success.title": "Deleted",
   "workflow-item.delete.notification.success.title": "Supprimé",
 
   // "workflow-item.delete.notification.success.content": "This workflow item was successfully deleted",
-  "workflow-item.delete.notification.success.content": "Cet Item a été supprimé avec succès",
+  "workflow-item.delete.notification.success.content": "Cet Item du Workflow a été supprimé avec succès",
 
   // "workflow-item.delete.notification.error.title": "Something went wrong",
   "workflow-item.delete.notification.error.title": "Une erreur s'est produite",
 
   // "workflow-item.delete.notification.error.content": "The workflow item could not be deleted",
-  "workflow-item.delete.notification.error.content": "L'item n'a pas pu être supprimé",
+  "workflow-item.delete.notification.error.content": "L'Item du Workflow n'a pas pu être supprimé",
 
   // "workflow-item.delete.title": "Delete workflow item",
-  "workflow-item.delete.title": "Supprimer Item du Workflow",
+  "workflow-item.delete.title": "Supprimer l'Item du Workflow",
 
   // "workflow-item.delete.header": "Delete workflow item",
-  "workflow-item.delete.header": "Supprimer Item du Workflow",
+  "workflow-item.delete.header": "Supprimer l'Item du Workflow",
 
   // "workflow-item.delete.button.cancel": "Cancel",
   "workflow-item.delete.button.cancel": "Annuler",
@@ -5098,30 +5841,43 @@
   // "workflow-item.delete.button.confirm": "Delete",
   "workflow-item.delete.button.confirm": "Supprimer",
 
-
   // "workflow-item.send-back.notification.success.title": "Sent back to submitter",
-  "workflow-item.send-back.notification.success.title": "Item renvoyé au déposant",
+  "workflow-item.send-back.notification.success.title": "Retourné au déposant",
 
   // "workflow-item.send-back.notification.success.content": "This workflow item was successfully sent back to the submitter",
-  "workflow-item.send-back.notification.success.content": "Cet Item a été renvoyé au déposant avec succès",
+  "workflow-item.send-back.notification.success.content": "Cet Item du Workflow a été retourné au déposant avec succès",
 
   // "workflow-item.send-back.notification.error.title": "Something went wrong",
   "workflow-item.send-back.notification.error.title": "Une erreur s'est produite",
 
   // "workflow-item.send-back.notification.error.content": "The workflow item could not be sent back to the submitter",
-  "workflow-item.send-back.notification.error.content": "Cet Item n'a pas pu être renvoyé au déposant",
+  "workflow-item.send-back.notification.error.content": "Cet Item du Workflow n'a pas pu être retourné au déposant",
 
   // "workflow-item.send-back.title": "Send workflow item back to submitter",
-  "workflow-item.send-back.title": "Renvoyer Item au déposant",
+  "workflow-item.send-back.title": "Retourner l'Item du Workflow au déposant",
 
   // "workflow-item.send-back.header": "Send workflow item back to submitter",
-  "workflow-item.send-back.header": "Renvoyer Item au déposant",
+  "workflow-item.send-back.header": "Retourner l'Item du Workflow au déposant",
 
   // "workflow-item.send-back.button.cancel": "Cancel",
   "workflow-item.send-back.button.cancel": "Annuler",
 
-  // "workflow-item.send-back.button.confirm": "Send back"
-  "workflow-item.send-back.button.confirm": "Renvoyer"
+  // "workflow-item.send-back.button.confirm": "Send back",
+  "workflow-item.send-back.button.confirm": "Renvoyer",
 
+  // "workflow-item.view.breadcrumbs": "Workflow View",
+  "workflow-item.view.breadcrumbs": "Vue d'ensemble du Workflow",
 
+  // "idle-modal.header": "Session will expire soon",
+  "idle-modal.header": "La session expirera bientôt",
+
+  // "idle-modal.info": "For security reasons, user sessions expire after {{ timeToExpire }} minutes of inactivity. Your session will expire soon. Would you like to extend it or log out?",
+  "idle-modal.info": "Pour des raisons de sécurité, les sessions des utilisateurs expirent après {{ timeToExpire }} minutes d'inactivité. Votre session va bientôt expirer. Souhaitez-vous la prolonger ou vous déconnecter ?",
+
+  // "idle-modal.log-out": "Log out",
+  "idle-modal.log-out": "Déconnexion",
+
+  // "idle-modal.extend-session": "Extend session"
+  "idle-modal.extend-session": "Prolonger la session"
 }
+

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -736,10 +736,10 @@
   "administrativeView.search.results.head": "Recherche Administrateur",
 
   // "admin.workflow.breadcrumbs": "Administer Workflow",
-  "admin.workflow.breadcrumbs": "Gestion du Workflow",
+  "admin.workflow.breadcrumbs": "Gestion des soumissions en Workflow",
 
   // "admin.workflow.title": "Administer Workflow",
-  "admin.workflow.title": "Gestion du Workflow",
+  "admin.workflow.title": "Gestion des soumissions en Workflow",
 
   // "admin.workflow.item.workflow": "Workflow",
   "admin.workflow.item.workflow": "Workflow",


### PR DESCRIPTION
**French translation reviewed and updated**

These are the main changes:

I have :

- added missing translations (more than ~300 variables)
- corrected the content of a few variables (partial translation and/or wrong translation or translation that deviated from the original); fixed a few typos (e.g. connexion instead of connection for "login")
- standardized the use of « some text » instead of "some text"
- standardized the spacing (among others : one blank before "?", ":", "!" (better yet would be to use a non-breaking space)
- removed the erroneous use of capital letters (e.g. "La Collections et la Communauté" => "La collection et la communauté")
- standardized the verb tenses for some variables (infinitive instead of imperative)
- added articles where they were missing (e.g. "Supprimer groupe" => "Supprimer le groupe")
- removed/corrected tupples : `item.page.edit` and `sorting.lastModified.ASC`

For information : I have kept the terms "Item", "Bundle", "Bitstream", "Eperson", "Workflow" (but I made sure that those words were capitalized to show they represent specific concepts) [In our local instance however, we localised the first three ones to, respectively, "document", "groupement", "fichier"].

Still to do:

- gender-inclusive writing (e.g. : "utilisateur.trice", "auteur.e" or more generic forms)

I was amused to find turns of phrase that I translated over 12 years ago (maybe more) with DSpace 1.8 :-) 

@pilasou : FYI.