### PR TITLE
Enable Bengali by default

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -148,6 +148,9 @@ languages:
   - code: fi
     label: Suomi
     active: true
+  - code: bn
+    label: বাংলা
+    active: true
 
 # Browse-By Pages
 browseBy:

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -182,7 +182,8 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'nl', label: 'Nederlands', active: true },
     { code: 'pt-PT', label: 'Português', active: true },
     { code: 'pt-BR', label: 'Português do Brasil', active: true },
-    { code: 'fi', label: 'Suomi', active: true }
+    { code: 'fi', label: 'Suomi', active: true },
+    { code: 'bn', label: 'বাংলা', active: true }
   ];
 
   // Browse-By Pages

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -178,13 +178,11 @@ export const environment: BuildConfig = {
     code: 'lv',
     label: 'Latviešu',
     active: true,
-  }
-  // {
-  //   code: 'bn',
-  //   label: 'বাংলা',
-  //   active: true,
-  // }
-  ],
+  }, {
+    code: 'bn',
+    label: 'বাংলা',
+    active: true,
+  }],
 
   // Browse-By Pages
   browseBy: {


### PR DESCRIPTION
## References
Follow up to #1573 from @raihantopu

## Description
This is a small PR to enable Bengali by default in the Angular UI.  I used this to test #1573, so I know it works.   So, once GitHub CI approves, I plan to merge this immediately.