### PR TITLE
Fix for embargoed file links on Google Scholar Meta Tag "citation_pdf_url" 

### DIFF
--- a/src/app/core/metadata/metadata.service.spec.ts
+++ b/src/app/core/metadata/metadata.service.spec.ts
@@ -3,7 +3,7 @@ import { Meta, Title } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 
 import { TranslateService } from '@ngx-translate/core';
-import { Observable, of } from 'rxjs';
+import { Observable, of as observableOf, of } from 'rxjs';
 
 import { RemoteData } from '../data/remote-data';
 import { Item } from '../shared/item.model';
@@ -23,6 +23,7 @@ import { DSONameService } from '../breadcrumbs/dso-name.service';
 import { HardRedirectService } from '../services/hard-redirect.service';
 import { getMockStore } from '@ngrx/store/testing';
 import { AddMetaTagAction, ClearMetaTagAction } from './meta-tag.actions';
+import { AuthorizationDataService } from '../data/feature-authorization/authorization-data.service';
 
 describe('MetadataService', () => {
   let metadataService: MetadataService;
@@ -38,6 +39,7 @@ describe('MetadataService', () => {
   let rootService: RootDataService;
   let translateService: TranslateService;
   let hardRedirectService: HardRedirectService;
+  let authorizationService: AuthorizationDataService;
 
   let router: Router;
   let store;
@@ -76,6 +78,9 @@ describe('MetadataService', () => {
     hardRedirectService = jasmine.createSpyObj( {
       getCurrentOrigin: 'https://request.org',
     });
+    authorizationService = jasmine.createSpyObj('authorizationService', {
+      isAuthorized: observableOf(true)
+    });
 
     // @ts-ignore
     store = getMockStore({ initialState });
@@ -92,7 +97,8 @@ describe('MetadataService', () => {
       undefined,
       rootService,
       store,
-      hardRedirectService
+      hardRedirectService,
+      authorizationService
     );
   });
 
@@ -299,6 +305,24 @@ describe('MetadataService', () => {
         content: 'https://request.org/bitstreams/4db100c1-e1f5-4055-9404-9bc3e2d15f29/download'
       });
     }));
+
+    describe('bitstream not download allowed', () => {
+      it('should not have citation_pdf_url', fakeAsync(() => {
+        (bundleDataService.findByItemAndName as jasmine.Spy).and.returnValue(mockBundleRD$([MockBitstream3]));
+        (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+
+        (metadataService as any).processRouteChange({
+          data: {
+            value: {
+              dso: createSuccessfulRemoteDataObject(ItemMock),
+            }
+          }
+        });
+        tick();
+        expect(meta.addTag).not.toHaveBeenCalledWith(jasmine.objectContaining({ name: 'citation_pdf_url' }));
+      }));
+
+    });
 
     describe('no primary Bitstream', () => {
       it('should link to first and only Bitstream regardless of format', fakeAsync(() => {

--- a/src/app/core/metadata/metadata.service.ts
+++ b/src/app/core/metadata/metadata.service.ts
@@ -18,7 +18,11 @@ import { BitstreamFormat } from '../shared/bitstream-format.model';
 import { Bitstream } from '../shared/bitstream.model';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { Item } from '../shared/item.model';
-import { getFirstCompletedRemoteData, getFirstSucceededRemoteDataPayload } from '../shared/operators';
+import {
+  getFirstCompletedRemoteData,
+  getFirstSucceededRemoteDataPayload,
+  getDownloadableBitstream
+} from '../shared/operators';
 import { RootDataService } from '../data/root-data.service';
 import { getBitstreamDownloadRoute } from '../../app-routing-paths';
 import { BundleDataService } from '../data/bundle-data.service';
@@ -32,6 +36,7 @@ import { createSelector, select, Store } from '@ngrx/store';
 import { AddMetaTagAction, ClearMetaTagAction } from './meta-tag.actions';
 import { coreSelector } from '../core.selectors';
 import { CoreState } from '../core.reducers';
+import { AuthorizationDataService } from '../data/feature-authorization/authorization-data.service';
 
 /**
  * The base selector function to select the metaTag section in the store
@@ -82,6 +87,7 @@ export class MetadataService {
     private rootService: RootDataService,
     private store: Store<CoreState>,
     private hardRedirectService: HardRedirectService,
+    private authorizationService: AuthorizationDataService
   ) {
   }
 
@@ -296,7 +302,6 @@ export class MetadataService {
       ).pipe(
         getFirstSucceededRemoteDataPayload(),
         switchMap((bundle: Bundle) =>
-
           // First try the primary bitstream
           bundle.primaryBitstream.pipe(
             getFirstCompletedRemoteData(),
@@ -307,13 +312,14 @@ export class MetadataService {
                 return null;
               }
             }),
+            getDownloadableBitstream(this.authorizationService),
             // return the bundle as well so we can use it again if there's no primary bitstream
             map((bitstream: Bitstream) => [bundle, bitstream])
           )
         ),
         switchMap(([bundle, primaryBitstream]: [Bundle, Bitstream]) => {
           if (hasValue(primaryBitstream)) {
-            // If there was a primary bitstream, emit its link
+            // If there was a downloadable primary bitstream, emit its link
             return [getBitstreamDownloadRoute(primaryBitstream)];
           } else {
             // Otherwise consider the regular bitstreams in the bundle
@@ -321,8 +327,8 @@ export class MetadataService {
               getFirstCompletedRemoteData(),
               switchMap((bitstreamRd: RemoteData<PaginatedList<Bitstream>>) => {
                 if (hasValue(bitstreamRd.payload) && bitstreamRd.payload.totalElements === 1) {
-                  // If there's only one bitstream in the bundle, emit its link
-                  return [getBitstreamDownloadRoute(bitstreamRd.payload.page[0])];
+                  // If there's only one bitstream in the bundle, emit its link if its downloadable
+                  return this.getBitLinkIfDownloadable(bitstreamRd.payload.page[0], bitstreamRd);
                 } else {
                   // Otherwise check all bitstreams to see if one matches the format whitelist
                   return this.getFirstAllowedFormatBitstreamLink(bitstreamRd);
@@ -340,6 +346,20 @@ export class MetadataService {
         );
       });
     }
+  }
+
+  getBitLinkIfDownloadable(bitstream: Bitstream, bitstreamRd: RemoteData<PaginatedList<Bitstream>>): Observable<string> {
+    return observableOf(bitstream).pipe(
+      getDownloadableBitstream(this.authorizationService),
+      switchMap((bit: Bitstream) => {
+        if (hasValue(bit)) {
+          return [getBitstreamDownloadRoute(bit)];
+        } else {
+          // Otherwise check all bitstreams to see if one matches the format whitelist
+          return this.getFirstAllowedFormatBitstreamLink(bitstreamRd);
+        }
+      })
+    );
   }
 
   /**
@@ -388,9 +408,14 @@ export class MetadataService {
         // for the link at the end
         map((format: BitstreamFormat) => [bitstream, format])
       )),
-      // Filter out only pairs with whitelisted formats
-      filter(([, format]: [Bitstream, BitstreamFormat]) =>
-        hasValue(format) && this.CITATION_PDF_URL_MIMETYPES.includes(format.mimetype)),
+      // Check if bitstream downloadable
+      switchMap(([bitstream, format]: [Bitstream, BitstreamFormat]) => observableOf(bitstream).pipe(
+        getDownloadableBitstream(this.authorizationService),
+        map((bit: Bitstream) => [bit, format])
+      )),
+      // Filter out only pairs with whitelisted formats and non-null bitstreams, null from download check
+      filter(([bitstream, format]: [Bitstream, BitstreamFormat]) =>
+        hasValue(format) && hasValue(bitstream) && this.CITATION_PDF_URL_MIMETYPES.includes(format.mimetype)),
       // We only need 1
       take(1),
       // Emit the link of the match


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8205

## Description
There is a check done for the 3 cases (primary bitstream, only bitstream, first bitstream with valid format) where a file download link is added to the Google Scholar Meta tag "citation_pdf_url", that verifies bitstream is "downloadable", i.e. that checks `AuthorizationDataService.isAuthorized(FeatureID.CanDownload, {bitstreamSelfLink})`. This ensures embargoed files, or files that are not accessible without login, their download link does not end up under this tag.

## Instructions for Reviewers

In production mode:
- Go to an item with an embargoed file, e.g. [7da772e5-0493-4380-b08d-512b827ae5e5](https://demo7.dspace.org/entities/publication/7da772e5-0493-4380-b08d-512b827ae5e5)
- [View source](view-source:https://demo7.dspace.org/entities/publication/7da772e5-0493-4380-b08d-512b827ae5e5) (prefix `view-source:`) => That embargoed file download link should no longer be present under Google Scholar Meta tag "citation_pdf_url"

- For items with non-embargoed files, their primary/only or first bitstream with valid format, must still be have the file download link under "citation_pdf_url"
  - E.g. [01c5f86f-806a-41a8-840d-8373e697eb20](https://demo7.dspace.org/entities/publication/01c5f86f-806a-41a8-840d-8373e697eb20)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
