### PR TITLE
Fix search field on search hierarchy filter component

### DIFF
--- a/src/app/shared/input-suggestions/filter-suggestions/filter-input-suggestions.component.html
+++ b/src/app/shared/input-suggestions/filter-suggestions/filter-input-suggestions.component.html
@@ -4,7 +4,7 @@
       (keydown.arrowup)="shiftFocusUp($event)" (keydown.esc)="close()"
       (dsClickOutside)="close();">
   <div class="form-group mb-0">
-    <label *ngIf="label; else searchInput">
+    <label *ngIf="label; else searchInput" class="mb-0">
       <span class="font-weight-bold">
         {{label}}
       </span>

--- a/src/app/shared/input-suggestions/input-suggestions.component.scss
+++ b/src/app/shared/input-suggestions/input-suggestions.component.scss
@@ -13,8 +13,4 @@
 
 form {
     position: relative;
-    .dropdown-menu {
-        position: absolute;
-        top: 40px;
-    }
 }

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.spec.ts
@@ -162,7 +162,7 @@ describe('SearchFacetSelectedOptionComponent', () => {
       comp.removeQueryParams = {};
       (comp as any).updateRemoveParams(selectedValues);
       expect(comp.removeQueryParams).toEqual({
-        [mockFilterConfig.paramName]: [value1],
+        [mockFilterConfig.paramName]: [`${value1},equals`],
         ['page-id.page']: 1
       });
     });

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.spec.ts
@@ -197,7 +197,6 @@ describe('SearchFacetFilterComponent', () => {
   describe('when the onSubmit method is called with data', () => {
     const searchUrl = '/search/path';
     const testValue = 'test';
-    const data = testValue;
 
     beforeEach(() => {
       comp.selectedValues$ = observableOf(selectedValues.map((value) =>
@@ -207,14 +206,24 @@ describe('SearchFacetFilterComponent', () => {
         })));
       fixture.detectChanges();
       spyOn(comp, 'getSearchLink').and.returnValue(searchUrl);
-      comp.onSubmit(data);
     });
 
-    it('should call navigate on the router with the right searchlink and parameters', () => {
+    it('should call navigate on the router with the right searchlink and parameters when the filter is provided with a valid operator', () => {
+      comp.onSubmit(testValue + ',equals');
       expect(router.navigate).toHaveBeenCalledWith(searchUrl.split('/'), {
-        queryParams: { [mockFilterConfig.paramName]: [...selectedValues.map((value) => `${value},equals`), testValue] },
+        queryParams: { [mockFilterConfig.paramName]: [...selectedValues.map((value) => `${value},equals`), `${testValue},equals`] },
         queryParamsHandling: 'merge'
       });
+    });
+
+    it('should not call navigate on the router when the filter is not provided with a valid operator', () => {
+      comp.onSubmit(testValue);
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('should not call navigate on the router when the empty string is given as filter', () => {
+      comp.onSubmit(',equals');
+      expect(router.navigate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
@@ -154,7 +154,8 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
                 if (hasValue(fValue)) {
                   return fValue;
                 }
-                return Object.assign(new FacetValue(), { label: stripOperatorFromFilterValue(value), value: value });
+                const filterValue = stripOperatorFromFilterValue(value);
+                return Object.assign(new FacetValue(), { label: filterValue, value: filterValue });
               });
             })
           );

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
@@ -230,27 +230,29 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Submits a new active custom value to the filter from the input field
+   * Submits a new active custom value to the filter from the input field when the input field isn't empty.
    * @param data The string from the input field
    */
   onSubmit(data: any) {
-    this.selectedValues$.pipe(take(1)).subscribe((selectedValues) => {
-        if (isNotEmpty(data)) {
-          this.router.navigate(this.getSearchLinkParts(), {
-            queryParams:
-              {
-                [this.filterConfig.paramName]: [
-                  ...selectedValues.map((facet) => this.getFacetValue(facet)),
-                  data
-                ]
-              },
-            queryParamsHandling: 'merge'
-          });
-          this.filter = '';
+    if (data.match(new RegExp(`^.+,(equals|query|authority)$`))) {
+      this.selectedValues$.pipe(take(1)).subscribe((selectedValues) => {
+          if (isNotEmpty(data)) {
+            this.router.navigate(this.getSearchLinkParts(), {
+              queryParams:
+                {
+                  [this.filterConfig.paramName]: [
+                    ...selectedValues.map((facet) => this.getFacetValue(facet)),
+                    data
+                  ]
+                },
+              queryParamsHandling: 'merge'
+            });
+            this.filter = '';
+          }
+          this.filterSearchResults = observableOf([]);
         }
-        this.filterSearchResults = observableOf([]);
-      }
-    );
+      );
+    }
   }
 
   /**

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.spec.ts
@@ -1,0 +1,153 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { SearchHierarchyFilterComponent } from './search-hierarchy-filter.component';
+import { SearchService } from '../../../../../core/shared/search/search.service';
+import {
+  SearchFilterService,
+  FILTER_CONFIG,
+  IN_PLACE_SEARCH
+} from '../../../../../core/shared/search/search-filter.service';
+import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
+import { SearchFiltersComponent } from '../../search-filters.component';
+import { Router } from '@angular/router';
+import { RouterStub } from '../../../../testing/router.stub';
+import { SearchServiceStub } from '../../../../testing/search-service.stub';
+import { of as observableOf, Observable } from 'rxjs';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../my-dspace-page/my-dspace-page.component';
+import { SearchConfigurationServiceStub } from '../../../../testing/search-configuration-service.stub';
+import { SearchFilterConfig } from '../../../models/search-filter-config.model';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  FilterInputSuggestionsComponent
+} from '../../../../input-suggestions/filter-suggestions/filter-input-suggestions.component';
+import { FormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { NO_ERRORS_SCHEMA, ChangeDetectionStrategy } from '@angular/core';
+import { createSuccessfulRemoteDataObject$ } from '../../../../remote-data.utils';
+import { FacetValue } from '../../../models/facet-value.model';
+import { FilterType } from '../../../models/filter-type.model';
+import { createPaginatedList } from '../../../../testing/utils.test';
+import { RemoteData } from '../../../../../core/data/remote-data';
+import { PaginatedList } from '../../../../../core/data/paginated-list.model';
+
+describe('SearchHierarchyFilterComponent', () => {
+  let comp: SearchHierarchyFilterComponent;
+  let fixture: ComponentFixture<SearchHierarchyFilterComponent>;
+  let searchService: SearchService;
+  let router;
+
+  const value1 = 'testvalue1';
+  const value2 = 'test2';
+  const value3 = 'another value3';
+  const values: FacetValue[] = [
+    {
+      label: value1,
+      value: value1,
+      count: 52,
+      _links: {
+        self: {
+          href: ''
+        },
+        search: {
+          href: ''
+        }
+      }
+    }, {
+      label: value2,
+      value: value2,
+      count: 20,
+      _links: {
+        self: {
+          href: ''
+        },
+        search: {
+          href: ''
+        }
+      }
+    }, {
+      label: value3,
+      value: value3,
+      count: 5,
+      _links: {
+        self: {
+          href: ''
+        },
+        search: {
+          href: ''
+        }
+      }
+    }
+  ];
+  const mockValues = createSuccessfulRemoteDataObject$(createPaginatedList(values));
+
+  const searchFilterServiceStub = {
+    getSelectedValuesForFilter(_filterConfig: SearchFilterConfig): Observable<string[]> {
+      return observableOf(values.map((value: FacetValue) => value.value));
+    },
+    getPage(_paramName: string): Observable<number> {
+      return observableOf(0);
+    },
+    resetPage(_filterName: string): void {
+      // empty
+    }
+  };
+
+  const remoteDataBuildServiceStub = {
+    aggregate(_input: Observable<RemoteData<FacetValue>>[]): Observable<RemoteData<PaginatedList<FacetValue>[]>> {
+      return createSuccessfulRemoteDataObject$([createPaginatedList(values)]);
+    }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), NoopAnimationsModule, FormsModule],
+      declarations: [
+        SearchHierarchyFilterComponent,
+        SearchFiltersComponent,
+        FilterInputSuggestionsComponent
+      ],
+      providers: [
+        { provide: SearchService, useValue: new SearchServiceStub() },
+        { provide: SearchFilterService, useValue: searchFilterServiceStub },
+        { provide: RemoteDataBuildService, useValue: remoteDataBuildServiceStub },
+        { provide: Router, useValue: new RouterStub() },
+        { provide: SEARCH_CONFIG_SERVICE, useValue: new SearchConfigurationServiceStub() },
+        { provide: IN_PLACE_SEARCH, useValue: false },
+        { provide: FILTER_CONFIG, useValue: new SearchFilterConfig() }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).overrideComponent(SearchHierarchyFilterComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default }
+    }).compileComponents();
+  })
+  ;
+  const mockFilterConfig: SearchFilterConfig = Object.assign(new SearchFilterConfig(), {
+    name: 'filterName1',
+    filterType: FilterType.text,
+    hasFacets: false,
+    isOpenByDefault: false,
+    pageSize: 2
+  });
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(SearchHierarchyFilterComponent);
+    comp = fixture.componentInstance; // SearchHierarchyFilterComponent test instance
+    comp.filterConfig = mockFilterConfig;
+    searchService = (comp as any).searchService;
+    // @ts-ignore
+    spyOn(searchService, 'getFacetValuesFor').and.returnValue(mockValues);
+    router = (comp as any).router;
+    fixture.detectChanges();
+  });
+
+  it('should navigate to the correct filter with the query operator', () => {
+    expect((comp as any).searchService.getFacetValuesFor).toHaveBeenCalledWith(comp.filterConfig, 0, {});
+
+    const searchQuery = 'MARVEL';
+    comp.onSubmit(searchQuery);
+
+    expect(router.navigate).toHaveBeenCalledWith(['', 'search'], Object({
+      queryParams: Object({ [mockFilterConfig.paramName]: [...values.map((value: FacetValue) => `${value.value},equals`), `${searchQuery},query`] }),
+      queryParamsHandling: 'merge'
+    }));
+  });
+});

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FilterType } from '../../../models/filter-type.model';
 import { renderFacetFor } from '../search-filter-type-decorator';
 import { facetLoad, SearchFacetFilterComponent } from '../search-facet-filter/search-facet-filter.component';
+import { addOperatorToFilterValue } from '../../../search.utils';
 
 @Component({
   selector: 'ds-search-hierarchy-filter',
@@ -15,4 +16,12 @@ import { facetLoad, SearchFacetFilterComponent } from '../search-facet-filter/se
  */
 @renderFacetFor(FilterType.hierarchy)
 export class SearchHierarchyFilterComponent extends SearchFacetFilterComponent implements OnInit {
+  /**
+   * Submits a new active custom value to the filter from the input field
+   * Overwritten method from parent component, adds the "query" operator to the received data before passing it on
+   * @param data The string from the input field
+   */
+  onSubmit(data: any) {
+    super.onSubmit(addOperatorToFilterValue(data, 'query'));
+  }
 }

--- a/src/app/shared/search/search.utils.spec.ts
+++ b/src/app/shared/search/search.utils.spec.ts
@@ -50,8 +50,17 @@ describe('Search Utils', () => {
   });
 
   describe('stripOperatorFromFilterValue', () => {
-    it('should strip the operator from the value', () => {
-      expect(stripOperatorFromFilterValue('value,operator')).toEqual('value');
+    it('should strip equals operator from the value', () => {
+      expect(stripOperatorFromFilterValue('value,equals')).toEqual('value');
+    });
+    it('should strip query operator from the value', () => {
+      expect(stripOperatorFromFilterValue('value,query')).toEqual('value');
+    });
+    it('should strip authority operator from the value', () => {
+      expect(stripOperatorFromFilterValue('value,authority')).toEqual('value');
+    });
+    it('should not strip a the part after the last , from a value if it isn\'t a valid operator', () => {
+      expect(stripOperatorFromFilterValue('value,invalid_operator')).toEqual('value,invalid_operator');
     });
   });
 

--- a/src/app/shared/search/search.utils.spec.ts
+++ b/src/app/shared/search/search.utils.spec.ts
@@ -37,7 +37,7 @@ describe('Search Utils', () => {
     });
 
     it('should retrieve the correct value from the search href', () => {
-      expect(getFacetValueForType(facetValueWithSearchHref, searchFilterConfig)).toEqual('Value with search href,operator');
+      expect(getFacetValueForType(facetValueWithSearchHref, searchFilterConfig)).toEqual('Value with search href,equals');
     });
 
     it('should retrieve the correct value from the Facet', () => {

--- a/src/app/shared/search/search.utils.ts
+++ b/src/app/shared/search/search.utils.ts
@@ -9,11 +9,11 @@ import { isNotEmpty } from '../empty.util';
  * @param searchFilterConfig
  */
 export function getFacetValueForType(facetValue: FacetValue, searchFilterConfig: SearchFilterConfig): string {
-  const regex = new RegExp(`[?|&]${escapeRegExp(searchFilterConfig.paramName)}=(${escapeRegExp(facetValue.value)}[^&]*)`, 'g');
+  const regex = new RegExp(`[?|&]${escapeRegExp(encodeURIComponent(searchFilterConfig.paramName))}=(${escapeRegExp(encodeURIComponent(facetValue.value))}[^&]*)`, 'g');
   if (isNotEmpty(facetValue._links)) {
     const values = regex.exec(facetValue._links.search.href);
     if (isNotEmpty(values)) {
-      return values[1];
+      return decodeURIComponent(values[1]);
     }
   }
   if (facetValue.authorityKey) {

--- a/src/app/shared/search/search.utils.ts
+++ b/src/app/shared/search/search.utils.ts
@@ -33,12 +33,11 @@ export function escapeRegExp(input: string): string {
 }
 
 /**
- * Strip the operator from a filter value
- * Warning: This expects the value to end with an operator, otherwise it might strip unwanted content
- * @param value
+ * Strip the operator (equals, query or authority) from a filter value.
+ * @param value The value from which the operator should be stripped.
  */
 export function stripOperatorFromFilterValue(value: string) {
-  if (value.lastIndexOf(',') > -1) {
+  if (value.match(new RegExp(`.+,(equals|query|authority)$`))) {
     return value.substring(0, value.lastIndexOf(','));
   }
   return value;


### PR DESCRIPTION
## References
* Fixes #1575

## Description
Fixed problem which made it impossible to use the search input filed to add new subject filters, fixed the layout of how the suggestions are displayed and prevented empty filters from being added.

## Instructions for Reviewers

List of changes in this PR:
* Fixed error where subject filters selected from the input field would not generate a correct Solr search query (`,query` needed to be appended to the url).
* Fixed an error where removing a filter caused the operator to be appended to the filter name (caused by previous fix).
   * Use the search input field to add 2 filters
   * Remove one filter
   * `,Query` has been appended to search filter name in side navigation and in url
* Fixed CSS bug where the suggestions would be displayed over the input field.
* Fixed selected filter from still being displayed in the clickable filter suggestions.
* Prevent empty filters from being submitted
![Suggestion box is displayed on top of  search field](https://user-images.githubusercontent.com/87638927/159679600-a7a2f88e-a7ca-4c60-a230-0b8af8840523.png)

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.