### PR TITLE
[CST-5418] Improve notification when cannot deposit

### DIFF
--- a/src/app/submission/objects/submission-objects.effects.spec.ts
+++ b/src/app/submission/objects/submission-objects.effects.spec.ts
@@ -884,6 +884,7 @@ describe('SubmissionObjectEffects test suite', () => {
       });
 
       expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
+      expect(notificationsServiceStub.warning).not.toHaveBeenCalled();
     });
 
     it('should return a SAVE_SUBMISSION_FORM_SUCCESS action when there are errors', () => {
@@ -910,10 +911,11 @@ describe('SubmissionObjectEffects test suite', () => {
       submissionJsonPatchOperationsServiceStub.jsonPatchByResourceType.and.returnValue(observableOf(response));
 
       const expected = cold('--b-', {
-        b: new SaveSubmissionFormSuccessAction(submissionId, response as any[])
+        b: new SaveSubmissionFormSuccessAction(submissionId, response as any[], false)
       });
 
       expect(submissionObjectEffects.saveAndDeposit$).toBeObservable(expected);
+      expect(notificationsServiceStub.warning).toHaveBeenCalled();
     });
 
     it('should catch errors and return a SAVE_SUBMISSION_FORM_ERROR', () => {

--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -215,7 +215,13 @@ export class SubmissionObjectEffects {
           if (this.canDeposit(response)) {
             return new DepositSubmissionAction(action.payload.submissionId);
           } else {
-            return new SaveSubmissionFormSuccessAction(action.payload.submissionId, response);
+            this.notificationsService.warning(
+              null,
+              this.translate.instant('submission.sections.general.cannot_deposit'),
+              null,
+              true
+            );
+            return new SaveSubmissionFormSuccessAction(action.payload.submissionId, response, false);
           }
         }),
         catchError(() => observableOf(new SaveSubmissionFormErrorAction(action.payload.submissionId))));

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3828,6 +3828,8 @@
 
   "submission.sections.general.add-more": "Add more",
 
+  "submission.sections.general.cannot_deposit": "Deposit cannot be completed due to missing mandatory information.<br>Please add them for final submission.",
+
   "submission.sections.general.collection": "Collection",
 
   "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",


### PR DESCRIPTION
## References
* Fixes #1543

## Description
Improve the notification showed when during the submission the deposit can't be done due to missing fields

## Instructions for Reviewers
Create a new submission and without filling all the require fields click on deposit button. The new warning notification should be shown

![Schermata da 2022-04-20 16-16-05](https://user-images.githubusercontent.com/2486489/164251133-a269348f-79dd-411d-86c2-ac58934545e5.png)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
