### PR TITLE
Cache redesign part 3: simplify the invalidation of cached objects

### DIFF
--- a/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
@@ -2,10 +2,10 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule, FormArray, FormControl, FormGroup,Validators, NG_VALIDATORS, NG_ASYNC_VALIDATORS } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngrx/store';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Observable, of as observableOf } from 'rxjs';
@@ -27,7 +27,7 @@ import { FormBuilderService } from '../../../shared/form/builder/form-builder.se
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { GroupMock, GroupMock2 } from '../../../shared/testing/group-mock';
 import { GroupFormComponent } from './group-form.component';
-import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
+import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { getMockFormBuilderService } from '../../../shared/mocks/form-builder-service.mock';
 import { getMockTranslateService } from '../../../shared/mocks/translate.service.mock';
 import { TranslateLoaderMock } from '../../../shared/testing/translate-loader.mock';
@@ -354,8 +354,6 @@ describe('GroupFormComponent', () => {
 
   describe('delete', () => {
     let deleteButton;
-    let confirmButton;
-    let cancelButton;
 
     beforeEach(() => {
       component.initialisePage();
@@ -373,31 +371,25 @@ describe('GroupFormComponent', () => {
     });
 
     describe('if confirmed via modal', () => {
-      beforeEach(() => {
+      beforeEach(waitForAsync(() => {
         deleteButton.click();
         fixture.detectChanges();
-        confirmButton = (document as any).querySelector('.modal-footer .confirm');
-      });
+        (document as any).querySelector('.modal-footer .confirm').click();
+      }));
 
       it('should call GroupDataService.delete', () => {
-        confirmButton.click();
-        fixture.detectChanges();
-
         expect(groupsDataServiceStub.delete).toHaveBeenCalledWith('active-group');
       });
     });
 
     describe('if canceled via modal', () => {
-      beforeEach(() => {
+      beforeEach(waitForAsync(() => {
         deleteButton.click();
         fixture.detectChanges();
-        cancelButton = (document as any).querySelector('.modal-footer .cancel');
-      });
+        (document as any).querySelector('.modal-footer .cancel').click();
+      }));
 
       it('should not call GroupDataService.delete', () => {
-        cancelButton.click();
-        fixture.detectChanges();
-
         expect(groupsDataServiceStub.delete).not.toHaveBeenCalled();
       });
     });

--- a/src/app/access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.ts
@@ -426,7 +426,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
               .subscribe((rd: RemoteData<NoContent>) => {
                 if (rd.hasSucceeded) {
                   this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.deleted.success', { name: group.name }));
-                  this.reset();
+                  this.onCancel();
                 } else {
                   this.notificationsService.error(
                     this.translateService.get(this.messagePrefix + '.notification.deleted.failure.title', { name: group.name }),
@@ -437,16 +437,6 @@ export class GroupFormComponent implements OnInit, OnDestroy {
         }
       });
     });
-  }
-
-  /**
-   * This method will ensure that the page gets reset and that the cache is cleared
-   */
-  reset() {
-    this.groupDataService.getBrowseEndpoint().pipe(take(1)).subscribe((href: string) => {
-      this.requestService.removeByHrefSubstring(href);
-    });
-    this.onCancel();
   }
 
   /**

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -79,7 +79,7 @@
                     </button>
                   </ng-container>
                   <button *ngIf="!groupDto.group?.permanent && groupDto.ableToDelete"
-                          (click)="deleteGroup(groupDto)" class="btn btn-outline-danger btn-sm"
+                          (click)="deleteGroup(groupDto)" class="btn btn-outline-danger btn-sm btn-delete"
                           title="{{messagePrefix + 'table.edit.buttons.remove' | translate: {name: groupDto.group.name} }}">
                     <i class="fas fa-trash-alt fa-fw"></i>
                   </button>

--- a/src/app/access-control/group-registry/groups-registry.component.spec.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.spec.ts
@@ -31,6 +31,7 @@ import { RouterMock } from '../../shared/mocks/router.mock';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
 import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { NoContent } from '../../core/shared/NoContent.model';
 
 describe('GroupRegistryComponent', () => {
   let component: GroupsRegistryComponent;
@@ -145,7 +146,10 @@ describe('GroupRegistryComponent', () => {
           totalPages: 1,
           currentPage: 1
         }), [result]));
-      }
+      },
+      delete(objectId: string, copyVirtualMetadata?: string[]): Observable<RemoteData<NoContent>> {
+        return createSuccessfulRemoteDataObject$({});
+      },
     };
     dsoDataServiceStub = {
       findByHref(href: string): Observable<RemoteData<DSpaceObject>> {
@@ -299,6 +303,31 @@ describe('GroupRegistryComponent', () => {
           return (foundEl.nativeElement.textContent.trim() === GroupMock2.uuid);
         })).toBeTruthy();
       });
+    });
+  });
+
+  describe('delete', () => {
+    let deleteButton;
+
+    beforeEach(fakeAsync(() => {
+      spyOn(groupsDataServiceStub, 'delete').and.callThrough();
+
+      setIsAuthorized(true, true);
+
+      // force rerender after setup changes
+      component.search({ query: '' });
+      tick();
+      fixture.detectChanges();
+
+      // only mockGroup[0] is deletable, so we should only get one button
+      deleteButton = fixture.debugElement.query(By.css('.btn-delete')).nativeElement;
+    }));
+
+    it('should call GroupDataService.delete', () => {
+      deleteButton.click();
+      fixture.detectChanges();
+
+      expect(groupsDataServiceStub.delete).toHaveBeenCalledWith(mockGroups[0].id);
     });
   });
 });

--- a/src/app/access-control/group-registry/groups-registry.component.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.ts
@@ -199,7 +199,6 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
           if (rd.hasSucceeded) {
             this.deletedGroupsIds = [...this.deletedGroupsIds, group.group.id];
             this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: group.group.name }));
-            this.reset();
           } else {
             this.notificationsService.error(
               this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: group.group.name }),
@@ -207,17 +206,6 @@ export class GroupsRegistryComponent implements OnInit, OnDestroy {
           }
       });
     }
-  }
-
-  /**
-   * This method will set everything to stale, which will cause the lists on this page to update.
-   */
-  reset() {
-    this.groupService.getBrowseEndpoint().pipe(
-      take(1)
-    ).subscribe((href: string) => {
-      this.requestService.setStaleByHrefSubstring(href);
-    });
   }
 
   /**

--- a/src/app/access-control/group-registry/groups-registry.component.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.ts
@@ -9,7 +9,7 @@ import {
   of as observableOf,
   Subscription
 } from 'rxjs';
-import { catchError, map, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { DSpaceObjectDataService } from '../../core/data/dspace-object-data.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '../../core/data/feature-authorization/feature-id';

--- a/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.ts
+++ b/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.ts
@@ -128,7 +128,6 @@ export class MetadataRegistryComponent {
    * Delete all the selected metadata schemas
    */
   deleteSchemas() {
-    this.registryService.clearMetadataSchemaRequests().subscribe();
     this.registryService.getSelectedMetadataSchemas().pipe(take(1)).subscribe(
       (schemas) => {
         const tasks$ = [];
@@ -148,7 +147,6 @@ export class MetadataRegistryComponent {
           }
           this.registryService.deselectAllMetadataSchema();
           this.registryService.cancelEditMetadataSchema();
-          this.forceUpdateSchemas();
         });
       }
     );

--- a/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.ts
+++ b/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.ts
@@ -174,15 +174,12 @@ export class MetadataSchemaComponent implements OnInit {
           const failedResponses = responses.filter((response: RemoteData<NoContent>) => response.hasFailed);
           if (successResponses.length > 0) {
             this.showNotification(true, successResponses.length);
-            this.registryService.clearMetadataFieldRequests();
-
           }
           if (failedResponses.length > 0) {
             this.showNotification(false, failedResponses.length);
           }
           this.registryService.deselectAllMetadataField();
           this.registryService.cancelEditMetadataField();
-          this.forceUpdateFields();
         });
       }
     );

--- a/src/app/collection-page/delete-collection-page/delete-collection-page.component.ts
+++ b/src/app/collection-page/delete-collection-page/delete-collection-page.component.ts
@@ -5,7 +5,6 @@ import { NotificationsService } from '../../shared/notifications/notifications.s
 import { CollectionDataService } from '../../core/data/collection-data.service';
 import { Collection } from '../../core/shared/collection.model';
 import { TranslateService } from '@ngx-translate/core';
-import { RequestService } from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can delete an existing Collection

--- a/src/app/collection-page/delete-collection-page/delete-collection-page.component.ts
+++ b/src/app/collection-page/delete-collection-page/delete-collection-page.component.ts
@@ -24,8 +24,7 @@ export class DeleteCollectionPageComponent extends DeleteComColPageComponent<Col
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
     protected translate: TranslateService,
-    protected requestService: RequestService
   ) {
-    super(dsoDataService, router, route, notifications, translate, requestService);
+    super(dsoDataService, router, route, notifications, translate);
   }
 }

--- a/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.spec.ts
+++ b/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.spec.ts
@@ -49,9 +49,6 @@ describe('CollectionMetadataComponent', () => {
     success: {},
     error: {}
   });
-  const objectCache = jasmine.createSpyObj('objectCache', {
-    remove: {}
-  });
   const requestService = jasmine.createSpyObj('requestService', {
     setStaleByHrefSubstring: {}
   });
@@ -65,8 +62,7 @@ describe('CollectionMetadataComponent', () => {
         { provide: ItemTemplateDataService, useValue: itemTemplateServiceStub },
         { provide: ActivatedRoute, useValue: { parent: { data: observableOf({ dso: createSuccessfulRemoteDataObject(collection) }) } } },
         { provide: NotificationsService, useValue: notificationsService },
-        { provide: ObjectCacheService, useValue: objectCache },
-        { provide: RequestService, useValue: requestService }
+        { provide: RequestService, useValue: requestService },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -95,20 +91,18 @@ describe('CollectionMetadataComponent', () => {
   });
 
   describe('deleteItemTemplate', () => {
-    describe('when delete returns a success', () => {
-      beforeEach(() => {
-        (itemTemplateService.deleteByCollectionID as jasmine.Spy).and.returnValue(observableOf(true));
-        comp.deleteItemTemplate();
-      });
+    beforeEach(() => {
+      (itemTemplateService.deleteByCollectionID as jasmine.Spy).and.returnValue(observableOf(true));
+      comp.deleteItemTemplate();
+    });
 
+    it('should call ItemTemplateService.deleteByCollectionID', () => {
+      expect(itemTemplateService.deleteByCollectionID).toHaveBeenCalledWith(template, 'collection-id');
+    });
+
+    describe('when delete returns a success', () => {
       it('should display a success notification', () => {
         expect(notificationsService.success).toHaveBeenCalled();
-      });
-
-      it('should reset related object and request cache', () => {
-        expect(requestService.setStaleByHrefSubstring).toHaveBeenCalledWith(collectionTemplateHref);
-        expect(requestService.setStaleByHrefSubstring).toHaveBeenCalledWith(template.self);
-        expect(requestService.setStaleByHrefSubstring).toHaveBeenCalledWith(collection.self);
       });
     });
 

--- a/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.spec.ts
+++ b/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.spec.ts
@@ -12,7 +12,6 @@ import { NotificationsService } from '../../../shared/notifications/notification
 import { Item } from '../../../core/shared/item.model';
 import { ItemTemplateDataService } from '../../../core/data/item-template-data.service';
 import { Collection } from '../../../core/shared/collection.model';
-import { ObjectCacheService } from '../../../core/cache/object-cache.service';
 import { RequestService } from '../../../core/data/request.service';
 import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { getCollectionItemTemplateRoute } from '../../collection-page-routing-paths';

--- a/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
@@ -8,10 +8,9 @@ import { combineLatest as combineLatestObservable, Observable } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { Item } from '../../../core/shared/item.model';
 import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
-import { switchMap, tap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
-import { ObjectCacheService } from '../../../core/cache/object-cache.service';
 import { RequestService } from '../../../core/data/request.service';
 import { getCollectionItemTemplateRoute } from '../../collection-page-routing-paths';
 

--- a/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
@@ -38,8 +38,7 @@ export class CollectionMetadataComponent extends ComcolMetadataComponent<Collect
     protected route: ActivatedRoute,
     protected notificationsService: NotificationsService,
     protected translate: TranslateService,
-    protected objectCache: ObjectCacheService,
-    protected requestService: RequestService
+    protected requestService: RequestService,
   ) {
     super(collectionDataService, router, route, notificationsService, translate);
   }
@@ -93,23 +92,9 @@ export class CollectionMetadataComponent extends ComcolMetadataComponent<Collect
         getFirstSucceededRemoteDataPayload(),
       )),
     );
-    const templateHref$ = collection$.pipe(
-      switchMap((collection) => this.itemTemplateService.getCollectionEndpoint(collection.id)),
-    );
-
-    combineLatestObservable(collection$, template$, templateHref$).pipe(
-      switchMap(([collection, template, templateHref]) => {
-        return this.itemTemplateService.deleteByCollectionID(template, collection.uuid).pipe(
-          tap((success: boolean) => {
-            if (success) {
-              this.objectCache.remove(templateHref);
-              this.objectCache.remove(template.self);
-              this.requestService.setStaleByHrefSubstring(template.self);
-              this.requestService.setStaleByHrefSubstring(templateHref);
-              this.requestService.setStaleByHrefSubstring(collection.self);
-            }
-          })
-        );
+    combineLatestObservable(collection$, template$).pipe(
+      switchMap(([collection, template]) => {
+        return this.itemTemplateService.deleteByCollectionID(template, collection.uuid);
       })
     ).subscribe((success: boolean) => {
       if (success) {

--- a/src/app/community-page/delete-community-page/delete-community-page.component.ts
+++ b/src/app/community-page/delete-community-page/delete-community-page.component.ts
@@ -24,9 +24,8 @@ export class DeleteCommunityPageComponent extends DeleteComColPageComponent<Comm
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
     protected translate: TranslateService,
-    protected requestService: RequestService
   ) {
-    super(dsoDataService, router, route, notifications, translate, requestService);
+    super(dsoDataService, router, route, notifications, translate);
   }
 
 }

--- a/src/app/community-page/delete-community-page/delete-community-page.component.ts
+++ b/src/app/community-page/delete-community-page/delete-community-page.component.ts
@@ -5,7 +5,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DeleteComColPageComponent } from '../../shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
-import { RequestService } from '../../core/data/request.service';
 
 /**
  * Component that represents the page where a user can delete an existing Community

--- a/src/app/core/cache/object-cache.reducer.spec.ts
+++ b/src/app/core/cache/object-cache.reducer.spec.ts
@@ -41,7 +41,7 @@ describe('objectCacheReducer', () => {
       alternativeLinks: [altLink1, altLink2],
       timeCompleted: new Date().getTime(),
       msToLive: 900000,
-      requestUUID: requestUUID1,
+      requestUUIDs: [requestUUID1],
       patches: [],
       isDirty: false,
     },
@@ -55,7 +55,7 @@ describe('objectCacheReducer', () => {
       alternativeLinks: [altLink3, altLink4],
       timeCompleted: new Date().getTime(),
       msToLive: 900000,
-      requestUUID: selfLink2,
+      requestUUIDs: [selfLink2],
       patches: [],
       isDirty: false
     }

--- a/src/app/core/cache/object-cache.reducer.ts
+++ b/src/app/core/cache/object-cache.reducer.ts
@@ -63,9 +63,11 @@ export class ObjectCacheEntry implements CacheEntry {
   msToLive: number;
 
   /**
-   * The UUID of the request that caused this entry to be added
+   * The UUIDs of the requests that caused this entry to be added
+   * New UUIDs should be added to the front of the array
+   * to make retrieving the latest UUID easier.
    */
-  requestUUID: string;
+  requestUUIDs: string[];
 
   /**
    * An array of patches that were made on the client side to this entry, but haven't been sent to the server yet
@@ -156,11 +158,11 @@ function addToObjectCache(state: ObjectCacheState, action: AddToObjectCacheActio
       data: action.payload.objectToCache,
       timeCompleted: action.payload.timeCompleted,
       msToLive: action.payload.msToLive,
-      requestUUID: action.payload.requestUUID,
+      requestUUIDs: [action.payload.requestUUID, ...(existing.requestUUIDs || [])],
       isDirty: isNotEmpty(existing.patches),
       patches: existing.patches || [],
       alternativeLinks: [...(existing.alternativeLinks || []), ...newAltLinks]
-    }
+    } as ObjectCacheEntry
   });
 }
 

--- a/src/app/core/cache/object-cache.service.spec.ts
+++ b/src/app/core/cache/object-cache.service.spec.ts
@@ -211,25 +211,69 @@ describe('ObjectCacheService', () => {
     });
   });
 
-  describe('has', () => {
+  describe('hasByHref', () => {
+    describe('with requestUUID not specified', () => {
+      describe('getByHref emits an object', () => {
+        beforeEach(() => {
+          spyOn(service, 'getByHref').and.returnValue(observableOf(cacheEntry));
+        });
 
-    describe('getByHref emits an object', () => {
-      beforeEach(() => {
-        spyOn(service, 'getByHref').and.returnValue(observableOf(cacheEntry));
+        it('should return true', () => {
+          expect(service.hasByHref(selfLink)).toBe(true);
+        });
       });
 
-      it('should return true', () => {
-        expect(service.hasByHref(selfLink)).toBe(true);
+      describe('getByHref emits nothing', () => {
+        beforeEach(() => {
+          spyOn(service, 'getByHref').and.returnValue(empty());
+        });
+
+        it('should return false', () => {
+          expect(service.hasByHref(selfLink)).toBe(false);
+        });
       });
     });
 
-    describe('getByHref emits nothing', () => {
-      beforeEach(() => {
-        spyOn(service, 'getByHref').and.returnValue(empty());
+    describe('with requestUUID specified', () => {
+      describe('getByHref emits an object that includes the specified requestUUID', () => {
+        beforeEach(() => {
+          spyOn(service, 'getByHref').and.returnValue(observableOf(Object.assign(cacheEntry, {
+            requestUUIDs: [
+              'something',
+              'something-else',
+              'specific-request',
+            ]
+          })));
+        });
+
+        it('should return true', () => {
+          expect(service.hasByHref(selfLink, 'specific-request')).toBe(true);
+        });
       });
 
-      it('should return false', () => {
-        expect(service.hasByHref(selfLink)).toBe(false);
+      describe('getByHref emits an object that doesn\'t include the specified requestUUID', () => {
+        beforeEach(() => {
+          spyOn(service, 'getByHref').and.returnValue(observableOf(Object.assign(cacheEntry, {
+            requestUUIDs: [
+              'something',
+              'something-else',
+            ]
+          })));
+        });
+
+        it('should return true', () => {
+          expect(service.hasByHref(selfLink, 'specific-request')).toBe(false);
+        });
+      });
+
+      describe('getByHref emits nothing', () => {
+        beforeEach(() => {
+          spyOn(service, 'getByHref').and.returnValue(empty());
+        });
+
+        it('should return false', () => {
+          expect(service.hasByHref(selfLink, 'specific-request')).toBe(false);
+        });
       });
     });
   });

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -282,7 +282,7 @@ export class ObjectCacheService {
     let result = false;
     this.getByHref(href).subscribe((entry: ObjectCacheEntry) => {
       if (isNotEmpty(requestUUID)) {
-        result = entry.requestUUIDs[0] === requestUUID;  // todo: may make more sense to do entry.requestUUIDs.includes(requestUUID) instead
+        result = entry.requestUUIDs.includes(requestUUID);
       } else {
         result = true;
       }

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -197,7 +197,7 @@ export class ObjectCacheService {
    */
   getRequestUUIDBySelfLink(selfLink: string): Observable<string> {
     return this.getByHref(selfLink).pipe(
-      map((entry: ObjectCacheEntry) => entry.requestUUID),
+      map((entry: ObjectCacheEntry) => entry.requestUUIDs[0]),
       distinctUntilChanged());
   }
 
@@ -282,7 +282,7 @@ export class ObjectCacheService {
     let result = false;
     this.getByHref(href).subscribe((entry: ObjectCacheEntry) => {
       if (isNotEmpty(requestUUID)) {
-        result = entry.requestUUID === requestUUID;
+        result = entry.requestUUIDs[0] === requestUUID;  // todo: may make more sense to do entry.requestUUIDs.includes(requestUUID) instead
       } else {
         result = true;
       }

--- a/src/app/core/data/bitstream-format-data.service.spec.ts
+++ b/src/app/core/data/bitstream-format-data.service.spec.ts
@@ -37,7 +37,12 @@ describe('BitstreamFormatDataService', () => {
     }
   } as Store<CoreState>;
 
-  const objectCache = {} as ObjectCacheService;
+  const requestUUIDs = ['some', 'uuid'];
+
+  const objectCache = jasmine.createSpyObj('objectCache', {
+    getByHref: observableOf({ requestUUIDs })
+  }) as ObjectCacheService;
+
   const halEndpointService = {
     getEndpoint(linkPath: string): Observable<string> {
       return cold('a', { a: bitstreamFormatsEndpoint });
@@ -76,6 +81,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -96,6 +102,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -118,6 +125,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -139,6 +147,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -163,6 +172,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -186,6 +196,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -209,6 +220,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -231,6 +243,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -253,6 +266,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: cold('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });
@@ -273,6 +287,7 @@ describe('BitstreamFormatDataService', () => {
         send: {},
         getByHref: observableOf(responseCacheEntry),
         getByUUID: hot('a', { a: responseCacheEntry }),
+        setStaleByUUID: observableOf(true),
         generateRequestId: 'request-id',
         removeByHrefSubstring: {}
       });

--- a/src/app/core/data/comcol-data.service.spec.ts
+++ b/src/app/core/data/comcol-data.service.spec.ts
@@ -22,7 +22,6 @@ import {
 import { BitstreamDataService } from './bitstream-data.service';
 import { CoreState } from '../core-state.model';
 import { FindListOptions } from './find-list-options.model';
-import { DSpaceObject } from '../shared/dspace-object.model';
 import { Bitstream } from '../shared/bitstream.model';
 
 const LINK_NAME = 'test';

--- a/src/app/core/data/data.service.spec.ts
+++ b/src/app/core/data/data.service.spec.ts
@@ -29,6 +29,7 @@ import { RemoteData } from './remote-data';
 import { RequestEntryState } from './request-entry-state.model';
 import { CoreState } from '../core-state.model';
 import { FindListOptions } from './find-list-options.model';
+import { fakeAsync, tick } from '@angular/core/testing';
 
 const endpoint = 'https://rest.api/core';
 

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -320,8 +320,8 @@ export class RequestService {
     this.store.dispatch(new RequestStaleAction(uuid));
 
     return this.getByUUID(uuid).pipe(
-      map(request => isStale(request.state)),
-      filter(stale => stale === true),
+      map((request: RequestEntry) => isStale(request.state)),
+      filter((stale: boolean) => stale),
       take(1),
     );
   }

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -312,6 +312,21 @@ export class RequestService {
   }
 
   /**
+   * Mark a request as stale
+   * @param uuid  the UUID of the request
+   * @return      an Observable that will emit true once the Request becomes stale
+   */
+  setStaleByUUID(uuid: string): Observable<boolean> {
+    this.store.dispatch(new RequestStaleAction(uuid));
+
+    return this.getByUUID(uuid).pipe(
+      map(request => isStale(request.state)),
+      filter(stale => stale === true),
+      take(1),
+    );
+  }
+
+  /**
    * Check if a GET request is in the cache or if it's still pending
    * @param {GetRequest} request The request to check
    * @param {boolean} useCachedVersionIfAvailable Whether or not to allow the use of a cached version
@@ -339,7 +354,7 @@ export class RequestService {
           .subscribe((entry: ObjectCacheEntry) => {
             // if the object cache has a match, check if the request that the object came with is
             // still valid
-            inObjCache = this.hasByUUID(entry.requestUUID);
+            inObjCache = this.hasByUUID(entry.requestUUIDs[0]);
           }).unsubscribe();
 
         // we should send the request if it isn't cached

--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -21,7 +21,7 @@ import { EPersonDataService } from './eperson-data.service';
 import { EPerson } from './models/eperson.model';
 import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson.mock';
 import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service.stub';
-import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { createNoContentRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { getMockRemoteDataBuildServiceHrefMap } from '../../shared/mocks/remote-data-build.service.mock';
 import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
 import { getMockRequestService } from '../../shared/mocks/request.service.mock';
@@ -287,13 +287,12 @@ describe('EPersonDataService', () => {
 
   describe('deleteEPerson', () => {
     beforeEach(() => {
-      spyOn(service, 'findById').and.returnValue(createSuccessfulRemoteDataObject$(EPersonMock));
+      spyOn(service, 'delete').and.returnValue(createNoContentRemoteDataObject$());
       service.deleteEPerson(EPersonMock).subscribe();
     });
 
-    it('should send DeleteRequest', () => {
-      const expected = new DeleteRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid);
-      expect(requestService.send).toHaveBeenCalledWith(expected);
+    it('should call DataService.delete with the EPerson\'s UUID', () => {
+      expect(service.delete).toHaveBeenCalledWith(EPersonMock.id);
     });
   });
 

--- a/src/app/core/registry/registry.service.spec.ts
+++ b/src/app/core/registry/registry.service.spec.ts
@@ -386,6 +386,10 @@ describe('RegistryService', () => {
       result = registryService.deleteMetadataSchema(mockSchemasList[0].id);
     });
 
+    it('should defer to MetadataSchemaDataService.delete', () => {
+      expect(metadataSchemaService.delete).toHaveBeenCalledWith(`${mockSchemasList[0].id}`);
+    });
+
     it('should return a successful response', () => {
       result.subscribe((response: RemoteData<NoContent>) => {
         expect(response.hasSucceeded).toBe(true);
@@ -398,6 +402,10 @@ describe('RegistryService', () => {
 
     beforeEach(() => {
       result = registryService.deleteMetadataField(mockFieldsList[0].id);
+    });
+
+    it('should defer to MetadataFieldDataService.delete', () => {
+      expect(metadataFieldService.delete).toHaveBeenCalledWith(`${mockFieldsList[0].id}`);
     });
 
     it('should return a successful response', () => {

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
@@ -147,7 +147,6 @@ export class ItemBitstreamsComponent extends AbstractItemUpdateComponent impleme
     // Perform the setup actions from above in order and display notifications
     removedResponses$.pipe(take(1)).subscribe((responses: RemoteData<NoContent>[]) => {
       this.displayNotifications('item.edit.bitstreams.notifications.remove', responses);
-      this.reset();
       this.submitting = false;
     });
   }
@@ -240,27 +239,6 @@ export class ItemBitstreamsComponent extends AbstractItemUpdateComponent impleme
       switchMap((bundles: Bundle[]) => observableZip(...bundles.map((bundle: Bundle) => this.objectUpdatesService.hasUpdates(bundle.self)))),
       map((hasChanges: boolean[]) => hasChanges.includes(true))
     );
-  }
-
-  /**
-   * De-cache the current item (it should automatically reload due to itemUpdateSubscription)
-   */
-  reset() {
-    this.refreshItemCache();
-  }
-
-  /**
-   * Remove the current item's cache from object- and request-cache
-   */
-  refreshItemCache() {
-    this.bundles$.pipe(take(1)).subscribe((bundles: Bundle[]) => {
-      bundles.forEach((bundle: Bundle) => {
-        this.objectCache.remove(bundle.self);
-        this.requestService.removeByHrefSubstring(bundle.self);
-      });
-      this.objectCache.remove(this.item.self);
-      this.requestService.removeByHrefSubstring(this.item.self);
-    });
   }
 
   /**

--- a/src/app/item-page/simple/item-types/versioned-item/versioned-item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/versioned-item/versioned-item.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VersionedItemComponent } from './versioned-item.component';
 import { VersionHistoryDataService } from '../../../../core/data/version-history-data.service';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { VersionDataService } from '../../../../core/data/version-data.service';
 import { NotificationsService } from '../../../../shared/notifications/notifications.service';
 import { ItemVersionsSharedService } from '../../../../shared/item/item-versions/item-versions-shared.service';
@@ -19,6 +19,7 @@ import { SearchService } from '../../../../core/shared/search/search.service';
 import { ItemDataService } from '../../../../core/data/item-data.service';
 import { Version } from '../../../../core/shared/version.model';
 import { RouteService } from '../../../../core/services/route.service';
+import { TranslateLoaderMock } from '../../../../shared/testing/translate-loader.mock';
 
 const mockItem: Item = Object.assign(new Item(), {
   bundles: createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo(), [])),
@@ -57,10 +58,17 @@ describe('VersionedItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [VersionedItemComponent, DummyComponent],
-      imports: [RouterTestingModule],
+      imports: [
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          }
+        }),
+      ],
       providers: [
         { provide: VersionHistoryDataService, useValue: versionHistoryServiceSpy },
-        { provide: TranslateService, useValue: {} },
         { provide: VersionDataService, useValue: versionServiceSpy },
         { provide: NotificationsService, useValue: {} },
         { provide: ItemVersionsSharedService, useValue: {} },

--- a/src/app/shared/comcol/comcol-forms/comcol-form/comcol-form.component.spec.ts
+++ b/src/app/shared/comcol/comcol-forms/comcol-form/comcol-form.component.spec.ts
@@ -55,6 +55,9 @@ describe('ComColFormComponent', () => {
     })
   ];
 
+  const logo = {
+    id: 'logo'
+  };
   const logoEndpoint = 'rest/api/logo/endpoint';
   const dsoService = Object.assign({
     getLogoEndpoint: () => observableOf(logoEndpoint),
@@ -207,7 +210,7 @@ describe('ComColFormComponent', () => {
       beforeEach(() => {
         initComponent(Object.assign(new Community(), {
           id: 'community-id',
-          logo: createSuccessfulRemoteDataObject$({}),
+          logo: createSuccessfulRemoteDataObject$(logo),
           _links: {
             self: { href: 'community-self' },
             logo: { href: 'community-logo' },
@@ -225,28 +228,31 @@ describe('ComColFormComponent', () => {
 
       describe('submit with logo marked for deletion', () => {
         beforeEach(() => {
+          spyOn(dsoService, 'deleteLogo').and.callThrough();
           comp.markLogoForDeletion = true;
+        });
+
+        it('should call dsoService.deleteLogo on the DSO', () => {
+          comp.onSubmit();
+          fixture.detectChanges();
+
+          expect(dsoService.deleteLogo).toHaveBeenCalledWith(comp.dso);
         });
 
         describe('when dsoService.deleteLogo returns a successful response', () => {
           beforeEach(() => {
-            spyOn(dsoService, 'deleteLogo').and.returnValue(createSuccessfulRemoteDataObject$({}));
+            dsoService.deleteLogo.and.returnValue(createSuccessfulRemoteDataObject$({}));
             comp.onSubmit();
           });
 
           it('should display a success notification', () => {
             expect(notificationsService.success).toHaveBeenCalled();
           });
-
-          it('should remove the object\'s cache', () => {
-            expect(requestServiceStub.removeByHrefSubstring).toHaveBeenCalled();
-            expect(objectCacheStub.remove).toHaveBeenCalled();
-          });
         });
 
         describe('when dsoService.deleteLogo returns an error response', () => {
           beforeEach(() => {
-            spyOn(dsoService, 'deleteLogo').and.returnValue(createFailedRemoteDataObject$('Error', 500));
+            dsoService.deleteLogo.and.returnValue(createFailedRemoteDataObject$('Error', 500));
             comp.onSubmit();
           });
 

--- a/src/app/shared/comcol/comcol-forms/comcol-form/comcol-form.component.ts
+++ b/src/app/shared/comcol/comcol-forms/comcol-form/comcol-form.component.ts
@@ -184,7 +184,6 @@ export class ComColFormComponent<T extends Collection | Community> implements On
         }
         this.dso.logo = undefined;
         this.uploadFilesOptions.method = RestRequestMethod.POST;
-        this.refreshCache();
         this.finish.emit();
       });
     }

--- a/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.spec.ts
@@ -68,7 +68,6 @@ describe('DeleteComColPageComponent', () => {
       {
         delete: createNoContentRemoteDataObject$(),
         findByHref: jasmine.createSpy('findByHref'),
-        refreshCache: jasmine.createSpy('refreshCache')
       });
 
     routerStub = {
@@ -78,10 +77,6 @@ describe('DeleteComColPageComponent', () => {
     routeStub = {
       data: observableOf(community)
     };
-
-    requestServiceStub = jasmine.createSpyObj('RequestService', {
-      removeByHrefSubstring: jasmine.createSpy('removeByHrefSubstring')
-    });
 
     translateServiceStub = jasmine.createSpyObj('TranslateService', {
       instant: jasmine.createSpy('instant')
@@ -99,7 +94,6 @@ describe('DeleteComColPageComponent', () => {
         { provide: ActivatedRoute, useValue: routeStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: TranslateService, useValue: translateServiceStub },
-        { provide: RequestService, useValue: requestServiceStub }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -159,7 +153,6 @@ describe('DeleteComColPageComponent', () => {
       scheduler.flush();
       fixture.detectChanges();
       expect(notificationsService.error).toHaveBeenCalled();
-      expect(dsoDataService.refreshCache).not.toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalled();
     });
 
@@ -169,7 +162,6 @@ describe('DeleteComColPageComponent', () => {
       scheduler.flush();
       fixture.detectChanges();
       expect(notificationsService.success).toHaveBeenCalled();
-      expect(dsoDataService.refreshCache).toHaveBeenCalled();
       expect(router.navigate).toHaveBeenCalled();
     });
 

--- a/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -41,7 +41,6 @@ export class DeleteComColPageComponent<TDomain extends Community | Collection> i
     protected route: ActivatedRoute,
     protected notifications: NotificationsService,
     protected translate: TranslateService,
-    protected requestService: RequestService
   ) {
   }
 
@@ -61,7 +60,6 @@ export class DeleteComColPageComponent<TDomain extends Community | Collection> i
         if (response.hasSucceeded) {
           const successMessage = this.translate.instant((dso as any).type + '.delete.notification.success');
           this.notifications.success(successMessage);
-          this.dsoDataService.refreshCache(dso);
         } else {
           const errorMessage = this.translate.instant((dso as any).type + '.delete.notification.fail');
           this.notifications.error(errorMessage);

--- a/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
+++ b/src/app/shared/comcol/comcol-forms/delete-comcol-page/delete-comcol-page.component.ts
@@ -7,7 +7,6 @@ import { NotificationsService } from '../../../notifications/notifications.servi
 import { TranslateService } from '@ngx-translate/core';
 import { getFirstCompletedRemoteData } from '../../../../core/shared/operators';
 import { NoContent } from '../../../../core/shared/NoContent.model';
-import { RequestService } from '../../../../core/data/request.service';
 import { ComColDataService } from '../../../../core/data/comcol-data.service';
 import { Community } from '../../../../core/shared/community.model';
 import { Collection } from '../../../../core/shared/collection.model';

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
@@ -46,27 +46,27 @@ describe('ConfirmationModalComponent', () => {
 
   describe('confirmPressed', () => {
     beforeEach(() => {
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       component.confirmPressed();
     });
     it('should call the close method on the active modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
     });
-    it('behaviour subject should have true as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(true);
+    it('behaviour subject should emit true', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(true);
     });
   });
 
   describe('cancelPressed', () => {
     beforeEach(() => {
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       component.cancelPressed();
     });
     it('should call the close method on the active modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
     });
-    it('behaviour subject should have false as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(false);
+    it('behaviour subject should emit false', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(false);
     });
   });
 
@@ -88,7 +88,7 @@ describe('ConfirmationModalComponent', () => {
   describe('when the click method emits on cancel button', () => {
     beforeEach(fakeAsync(() => {
       spyOn(component, 'close');
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       debugElement.query(By.css('button.cancel')).triggerEventHandler('click', {
         preventDefault: () => {/**/
         }
@@ -99,15 +99,15 @@ describe('ConfirmationModalComponent', () => {
     it('should call the close method on the component', () => {
       expect(component.close).toHaveBeenCalled();
     });
-    it('behaviour subject should have false as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(false);
+    it('behaviour subject should emit false', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(false);
     });
   });
 
   describe('when the click method emits on confirm button', () => {
     beforeEach(fakeAsync(() => {
       spyOn(component, 'close');
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       debugElement.query(By.css('button.confirm')).triggerEventHandler('click', {
         preventDefault: () => {/**/
         }
@@ -118,8 +118,8 @@ describe('ConfirmationModalComponent', () => {
     it('should call the close method on the component', () => {
       expect(component.close).toHaveBeenCalled();
     });
-    it('behaviour subject should have true as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(true);
+    it('behaviour subject should emit false', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(true);
     });
   });
 

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Subject } from 'rxjs';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
 
 @Component({
@@ -24,7 +23,7 @@ export class ConfirmationModalComponent {
    * An event fired when the cancel or confirm button is clicked, with respectively false or true
    */
   @Output()
-  response: Subject<boolean> = new Subject();
+  response = new EventEmitter<boolean>();
 
   constructor(protected activeModal: NgbActiveModal) {
   }
@@ -33,7 +32,7 @@ export class ConfirmationModalComponent {
    * Confirm the action that led to the modal
    */
   confirmPressed() {
-    this.response.next(true);
+    this.response.emit(true);
     this.close();
   }
 
@@ -41,7 +40,7 @@ export class ConfirmationModalComponent {
    * Cancel the action that led to the modal and close modal
    */
   cancelPressed() {
-    this.response.next(false);
+    this.response.emit(false);
     this.close();
   }
 

--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -46,7 +46,7 @@ describe('IdleModalComponent', () => {
 
   describe('extendSessionPressed', () => {
     beforeEach(fakeAsync(() => {
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       component.extendSessionPressed();
     }));
     it('should set idle to false', () => {
@@ -55,8 +55,8 @@ describe('IdleModalComponent', () => {
     it('should close the modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
     });
-    it('response \'closed\' should have true as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(true);
+    it('response \'closed\' should emit true', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(true);
     });
   });
 
@@ -74,7 +74,7 @@ describe('IdleModalComponent', () => {
 
   describe('closePressed', () => {
     beforeEach(fakeAsync(() => {
-      spyOn(component.response, 'next');
+      spyOn(component.response, 'emit');
       component.closePressed();
     }));
     it('should set idle to false', () => {
@@ -83,8 +83,8 @@ describe('IdleModalComponent', () => {
     it('should close the modal', () => {
       expect(modalStub.close).toHaveBeenCalled();
     });
-    it('response \'closed\' should have true as next', () => {
-      expect(component.response.next).toHaveBeenCalledWith(true);
+    it('response \'closed\' should emit true', () => {
+      expect(component.response.emit).toHaveBeenCalledWith(true);
     });
   });
 

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../core/auth/auth.service';
-import { Subject } from 'rxjs';
 import { hasValue } from '../empty.util';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../app.reducer';
@@ -29,7 +28,7 @@ export class IdleModalComponent implements OnInit {
    * An event fired when the modal is closed
    */
   @Output()
-  response: Subject<boolean> = new Subject();
+  response = new EventEmitter<boolean>();
 
   constructor(private activeModal: NgbActiveModal,
               private authService: AuthService,
@@ -84,6 +83,6 @@ export class IdleModalComponent implements OnInit {
    */
   closeModal() {
     this.activeModal.close();
-    this.response.next(true);
+    this.response.emit(true);
   }
 }

--- a/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.html
+++ b/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.html
@@ -8,12 +8,12 @@
     <p class="pb-2">{{ "item.version.delete.modal.text" | translate : {version: versionNumber} }}</p>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-outline-secondary btn-sm"
+    <button class="btn btn-outline-secondary btn-sm cancel"
             (click)="onModalClose()"
             title="{{'item.version.delete.modal.button.cancel.tooltip' | translate}}">
       <i class="fas fa-times fa-fw"></i> {{'item.version.delete.modal.button.cancel' | translate}}
     </button>
-    <button class="btn btn-danger btn-sm"
+    <button class="btn btn-danger btn-sm confirm"
             (click)="onModalSubmit()"
             title="{{'item.version.delete.modal.button.confirm.tooltip' | translate}}">
       <i class="fas fa-check fa-fw"></i> {{'item.version.delete.modal.button.confirm' | translate}}

--- a/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.ts
+++ b/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, Output } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'ds-item-versions-delete-modal',
@@ -7,6 +8,11 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
   styleUrls: ['./item-versions-delete-modal.component.scss']
 })
 export class ItemVersionsDeleteModalComponent {
+  /**
+   * An event fired when the cancel or confirm button is clicked, with respectively false or true
+   */
+  @Output()
+  response: Subject<boolean> = new Subject();
 
   versionNumber: number;
 
@@ -15,10 +21,12 @@ export class ItemVersionsDeleteModalComponent {
   }
 
   onModalClose() {
+    this.response.next(false);
     this.activeModal.dismiss();
   }
 
   onModalSubmit() {
+    this.response.next(true);
     this.activeModal.close();
   }
 

--- a/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.ts
+++ b/src/app/shared/item/item-versions/item-versions-delete-modal/item-versions-delete-modal.component.ts
@@ -1,6 +1,5 @@
-import { Component, Output } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Subject } from 'rxjs';
 
 @Component({
   selector: 'ds-item-versions-delete-modal',
@@ -12,7 +11,7 @@ export class ItemVersionsDeleteModalComponent {
    * An event fired when the cancel or confirm button is clicked, with respectively false or true
    */
   @Output()
-  response: Subject<boolean> = new Subject();
+  response = new EventEmitter<boolean>();
 
   versionNumber: number;
 
@@ -21,12 +20,12 @@ export class ItemVersionsDeleteModalComponent {
   }
 
   onModalClose() {
-    this.response.next(false);
+    this.response.emit(false);
     this.activeModal.dismiss();
   }
 
   onModalSubmit() {
-    this.response.next(true);
+    this.response.emit(true);
     this.activeModal.close();
   }
 

--- a/src/app/shared/item/item-versions/item-versions.component.spec.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.spec.ts
@@ -297,8 +297,6 @@ describe('ItemVersionsComponent', () => {
 
   describe('when deleting a version', () => {
     let deleteButton;
-    let confirmButton;
-    let cancelButton;
 
     beforeEach(() => {
       const canDelete = (featureID: FeatureID, url: string ) => of(featureID === FeatureID.CanDeleteVersion);
@@ -313,31 +311,25 @@ describe('ItemVersionsComponent', () => {
     });
 
     describe('if confirmed via modal', () => {
-      beforeEach(() => {
+      beforeEach(waitForAsync(() => {
         deleteButton.click();
         fixture.detectChanges();
-        confirmButton = (document as any).querySelector('.modal-footer .confirm');
-      });
+        (document as any).querySelector('.modal-footer .confirm').click();
+      }));
 
       it('should call ItemService.delete', () => {
-        confirmButton.click();
-        fixture.detectChanges();
-
         expect(itemDataServiceSpy.delete).toHaveBeenCalledWith(item2.id);
       });
     });
 
     describe('if canceled via modal', () => {
-      beforeEach(() => {
+      beforeEach(waitForAsync(() => {
         deleteButton.click();
         fixture.detectChanges();
-        cancelButton = (document as any).querySelector('.modal-footer .cancel');
-      });
+        (document as any).querySelector('.modal-footer .cancel').click();
+      }));
 
       it('should not call ItemService.delete', () => {
-        cancelButton.click();
-        fixture.detectChanges();
-
         expect(itemDataServiceSpy.delete).not.toHaveBeenCalled();
       });
     });

--- a/src/app/shared/item/item-versions/item-versions.component.spec.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.spec.ts
@@ -1,10 +1,9 @@
 import { ItemVersionsComponent } from './item-versions.component';
 import {
-  ComponentFixture, discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, TestBed, tick, waitForAsync
+  ComponentFixture, TestBed, waitForAsync
 } from '@angular/core/testing';
 import { VarDirective } from '../../utils/var.directive';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Item } from '../../../core/shared/item.model';
 import { Version } from '../../../core/shared/version.model';
@@ -27,10 +26,8 @@ import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
 import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
-import { Group } from '../../../core/eperson/models/group.model';
 import { Router } from '@angular/router';
-import { RouterStub } from '../../testing/router.stub';
-import { NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { CommonModule } from '@angular/common';
 
 describe('ItemVersionsComponent', () => {

--- a/src/app/shared/item/item-versions/item-versions.component.spec.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.spec.ts
@@ -1,5 +1,7 @@
 import { ItemVersionsComponent } from './item-versions.component';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture, discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, TestBed, tick, waitForAsync
+} from '@angular/core/testing';
 import { VarDirective } from '../../utils/var.directive';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -8,7 +10,7 @@ import { Item } from '../../../core/shared/item.model';
 import { Version } from '../../../core/shared/version.model';
 import { VersionHistory } from '../../../core/shared/version-history.model';
 import { VersionHistoryDataService } from '../../../core/data/version-history-data.service';
-import { By } from '@angular/platform-browser';
+import { BrowserModule, By } from '@angular/platform-browser';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
 import { createPaginatedList } from '../../testing/utils.test';
 import { EMPTY, of, of as observableOf } from 'rxjs';
@@ -17,7 +19,7 @@ import { PaginationServiceStub } from '../../testing/pagination-service.stub';
 import { AuthService } from '../../../core/auth/auth.service';
 import { VersionDataService } from '../../../core/data/version-data.service';
 import { ItemDataService } from '../../../core/data/item-data.service';
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { NotificationsServiceStub } from '../../testing/notifications-service.stub';
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
@@ -25,6 +27,11 @@ import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
 import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
+import { Group } from '../../../core/eperson/models/group.model';
+import { Router } from '@angular/router';
+import { RouterStub } from '../../testing/router.stub';
+import { NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { CommonModule } from '@angular/common';
 
 describe('ItemVersionsComponent', () => {
   let component: ItemVersionsComponent;
@@ -70,6 +77,7 @@ describe('ItemVersionsComponent', () => {
   versionHistory.versions = createSuccessfulRemoteDataObject$(createPaginatedList(versions));
 
   const item1 = Object.assign(new Item(), { // is a workspace item
+    id: 'item-identifier-1',
     uuid: 'item-identifier-1',
     handle: '123456789/1',
     version: createSuccessfulRemoteDataObject$(version1),
@@ -80,6 +88,7 @@ describe('ItemVersionsComponent', () => {
     }
   });
   const item2 = Object.assign(new Item(), {
+    id: 'item-identifier-2',
     uuid: 'item-identifier-2',
     handle: '123456789/2',
     version: createSuccessfulRemoteDataObject$(version2),
@@ -95,6 +104,8 @@ describe('ItemVersionsComponent', () => {
 
   const versionHistoryServiceSpy = jasmine.createSpyObj('versionHistoryService', {
     getVersions: createSuccessfulRemoteDataObject$(createPaginatedList(versions)),
+    getVersionHistoryFromVersion$: of(versionHistory),
+    getLatestVersionItemFromHistory$: of(item1),  // called when version2 is deleted
   });
   const authenticationServiceSpy = jasmine.createSpyObj('authenticationService', {
     isAuthenticated: observableOf(true),
@@ -115,11 +126,19 @@ describe('ItemVersionsComponent', () => {
     findByPropertyName: of(true),
   });
 
+  const itemDataServiceSpy = jasmine.createSpyObj('itemDataService', {
+    delete: createSuccessfulRemoteDataObject$({}),
+  });
+
+  const routerSpy = jasmine.createSpyObj('router', {
+    navigateByUrl: null,
+  });
+
   beforeEach(waitForAsync(() => {
 
     TestBed.configureTestingModule({
       declarations: [ItemVersionsComponent, VarDirective],
-      imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([])],
+      imports: [TranslateModule.forRoot(), CommonModule, NgbModule, FormsModule, ReactiveFormsModule, BrowserModule],
       providers: [
         {provide: PaginationService, useValue: new PaginationServiceStub()},
         {provide: FormBuilder, useValue: new FormBuilder()},
@@ -127,11 +146,12 @@ describe('ItemVersionsComponent', () => {
         {provide: AuthService, useValue: authenticationServiceSpy},
         {provide: AuthorizationDataService, useValue: authorizationServiceSpy},
         {provide: VersionHistoryDataService, useValue: versionHistoryServiceSpy},
-        {provide: ItemDataService, useValue: {}},
+        {provide: ItemDataService, useValue: itemDataServiceSpy},
         {provide: VersionDataService, useValue: versionServiceSpy},
         {provide: WorkspaceitemDataService, useValue: workspaceItemDataServiceSpy},
         {provide: WorkflowItemDataService, useValue: workflowItemDataServiceSpy},
         {provide: ConfigurationDataService, useValue: configurationServiceSpy},
+        { provide: Router, useValue: routerSpy },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -275,4 +295,51 @@ describe('ItemVersionsComponent', () => {
     });
   });
 
+  describe('when deleting a version', () => {
+    let deleteButton;
+    let confirmButton;
+    let cancelButton;
+
+    beforeEach(() => {
+      const canDelete = (featureID: FeatureID, url: string ) => of(featureID === FeatureID.CanDeleteVersion);
+      authorizationServiceSpy.isAuthorized.and.callFake(canDelete);
+
+      fixture.detectChanges();
+
+      // delete the last version in the table (version2 → item2)
+      deleteButton = fixture.debugElement.queryAll(By.css('.version-row-element-delete'))[1].nativeElement;
+
+      itemDataServiceSpy.delete.calls.reset();
+    });
+
+    describe('if confirmed via modal', () => {
+      beforeEach(() => {
+        deleteButton.click();
+        fixture.detectChanges();
+        confirmButton = (document as any).querySelector('.modal-footer .confirm');
+      });
+
+      it('should call ItemService.delete', () => {
+        confirmButton.click();
+        fixture.detectChanges();
+
+        expect(itemDataServiceSpy.delete).toHaveBeenCalledWith(item2.id);
+      });
+    });
+
+    describe('if canceled via modal', () => {
+      beforeEach(() => {
+        deleteButton.click();
+        fixture.detectChanges();
+        cancelButton = (document as any).querySelector('.modal-footer .cancel');
+      });
+
+      it('should not call ItemService.delete', () => {
+        cancelButton.click();
+        fixture.detectChanges();
+
+        expect(itemDataServiceSpy.delete).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/src/app/shared/item/item-versions/item-versions.component.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.ts
@@ -283,44 +283,42 @@ export class ItemVersionsComponent implements OnInit {
     activeModal.componentInstance.firstVersion = false;
 
     // On modal submit/dismiss
-    activeModal.result.then(() => {
-      versionItem$.pipe(
-        getFirstSucceededRemoteDataPayload<Item>(),
-        // Retrieve version history and invalidate cache
-        mergeMap((item: Item) => combineLatest([
-          of(item),
-          this.versionHistoryService.getVersionHistoryFromVersion$(version).pipe(
-            tap((versionHistory: VersionHistory) => {
-              this.versionHistoryService.invalidateVersionHistoryCache(versionHistory.id);
-            })
-          )
-        ])),
-        // Delete item
-        mergeMap(([item, versionHistory]: [Item, VersionHistory]) => combineLatest([
-          this.deleteItemAndGetResult$(item),
-          of(versionHistory)
-        ])),
-        // Retrieve new latest version
-        mergeMap(([deleteItemResult, versionHistory]: [boolean, VersionHistory]) => combineLatest([
-          of(deleteItemResult),
-          this.versionHistoryService.getLatestVersionItemFromHistory$(versionHistory).pipe(
-            tap(() => {
-              this.getAllVersions(of(versionHistory));
-            }),
-          )
-        ])),
-      ).subscribe(([deleteHasSucceeded, newLatestVersionItem]: [boolean, Item]) => {
-        // Notify operation result and redirect to latest item
-        if (deleteHasSucceeded) {
-          this.notificationsService.success(null, this.translateService.get(successMessageKey, {'version': versionNumber}));
-        } else {
-          this.notificationsService.error(null, this.translateService.get(failureMessageKey, {'version': versionNumber}));
-        }
-        if (redirectToLatest) {
-          const path = getItemEditVersionhistoryRoute(newLatestVersionItem);
-          this.router.navigateByUrl(path);
-        }
-      });
+    activeModal.componentInstance.response.pipe(take(1)).subscribe((ok) => {
+      if (ok) {
+        versionItem$.pipe(
+          getFirstSucceededRemoteDataPayload<Item>(),
+          // Retrieve version history
+          mergeMap((item: Item) => combineLatest([
+            of(item),
+            this.versionHistoryService.getVersionHistoryFromVersion$(version)
+          ])),
+          // Delete item
+          mergeMap(([item, versionHistory]: [Item, VersionHistory]) => combineLatest([
+            this.deleteItemAndGetResult$(item),
+            of(versionHistory)
+          ])),
+          // Retrieve new latest version
+          mergeMap(([deleteItemResult, versionHistory]: [boolean, VersionHistory]) => combineLatest([
+            of(deleteItemResult),
+            this.versionHistoryService.getLatestVersionItemFromHistory$(versionHistory).pipe(
+              tap(() => {
+                this.getAllVersions(of(versionHistory));
+              }),
+            )
+          ])),
+        ).subscribe(([deleteHasSucceeded, newLatestVersionItem]: [boolean, Item]) => {
+          // Notify operation result and redirect to latest item
+          if (deleteHasSucceeded) {
+            this.notificationsService.success(null, this.translateService.get(successMessageKey, {'version': versionNumber}));
+          } else {
+            this.notificationsService.error(null, this.translateService.get(failureMessageKey, {'version': versionNumber}));
+          }
+          if (redirectToLatest) {
+            const path = getItemEditVersionhistoryRoute(newLatestVersionItem);
+            this.router.navigateByUrl(path);
+          }
+        });
+      }
     });
   }
 

--- a/src/app/shared/mocks/request.service.mock.ts
+++ b/src/app/shared/mocks/request.service.mock.ts
@@ -13,6 +13,7 @@ export function getMockRequestService(requestEntry$: Observable<RequestEntry> = 
     isCachedOrPending: false,
     removeByHrefSubstring: observableOf(true),
     setStaleByHrefSubstring: observableOf(true),
+    setStaleByUUID: observableOf(true),
     hasByHref$: observableOf(false)
   });
 }

--- a/src/app/shared/resource-policies/resource-policies.component.spec.ts
+++ b/src/app/shared/resource-policies/resource-policies.component.spec.ts
@@ -343,6 +343,16 @@ describe('ResourcePoliciesComponent test suite', () => {
         fixture.detectChanges();
       });
 
+      it('should call ResourcePolicyService.delete for the checked policies', () => {
+        resourcePolicyService.delete.and.returnValue(observableOf(true));
+        scheduler = getTestScheduler();
+        scheduler.schedule(() => comp.deleteSelectedResourcePolicies());
+        scheduler.flush();
+
+        // only the first one is checked
+        expect(resourcePolicyService.delete).toHaveBeenCalledWith(resourcePolicy.id);
+      });
+
       it('should notify success when delete is successful', () => {
 
         resourcePolicyService.delete.and.returnValue(observableOf(true));

--- a/src/app/shared/resource-policies/resource-policies.component.ts
+++ b/src/app/shared/resource-policies/resource-policies.component.ts
@@ -157,7 +157,6 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
         } else {
           this.notificationsService.error(null, this.translate.get('resource-policies.delete.failure.content'));
         }
-        this.requestService.setStaleByHrefSubstring(this.resourceUUID);
         this.processingDelete$.next(false);
       })
     );

--- a/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.spec.ts
+++ b/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.spec.ts
@@ -84,7 +84,7 @@ describe('SearchSwitchConfigurationComponent', () => {
     expect(childElements.length).toEqual(comp.configurationList.length);
   });
 
-  it('should call onSelect method when selecting an option', () => {
+  it('should call onSelect method when selecting an option', waitForAsync(() => {
     fixture.whenStable().then(() => {
       spyOn(comp, 'onSelect');
       select = fixture.debugElement.query(By.css('select'));
@@ -94,8 +94,7 @@ describe('SearchSwitchConfigurationComponent', () => {
       fixture.detectChanges();
       expect(comp.onSelect).toHaveBeenCalled();
     });
-
-  });
+  }));
 
   it('should navigate to the route when selecting an option', () => {
     spyOn((comp as any), 'getSearchLinkParts').and.returnValue([MYDSPACE_ROUTE]);

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,6 +7,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 declare const require: any;
 
@@ -17,9 +18,11 @@ getTestBed().initTestEnvironment(
   { teardown: { destroyAfterEach: false } }
 );
 
-// If store is mocked, reset state after each test (see https://ngrx.io/guide/migration/v13)
 jasmine.getEnv().afterEach(() => {
+  // If store is mocked, reset state after each test (see https://ngrx.io/guide/migration/v13)
   getTestBed().inject(MockStore, null)?.resetSelectors();
+  // Close any leftover modals
+  getTestBed().inject(NgbModal, null)?.dismissAll?.();
 });
 
 // Then we find all the tests.


### PR DESCRIPTION

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #741

## Description
Simplified object invalidation on delete

* The object cache now keeps track of *all* requests related to an object
* Introduced a new method to mark all of these requests as stale: `DataService.invalidateByHref`
* Made `DataService.delete` call `invalidateByHref` for automatic clean-up
* Removed manual clean-up code where applicable

## Instructions for Reviewers
Confirm that deleting objects still works as it should on the following routes:

* `/communities/<:uuid>/delete`
* `/communities/<:uuid>/edit/metadata` (logo)
* `/communities/<:uuid>/edit/authorizations`
* `/collections/<:uuid>/delete`
* `/collections/<:uuid>/edit/metadata` (Item template & logo)
* `/collections/<:uuid>/edit/authorizations`
* `/items/<:uuid>/edit/delete`
* `/items/<:uuid>/edit/versionhistory`
* `/items/<:uuid>/edit/authorizations`
* `/admin/registries/metadata`
* `/access-control/epeople`
* `/access-control/groups`
* `/access-control/groups/<:uuid>`
* `/admin/registries/metadata/<:schema>`
* `/admin/registries/bitstream-formats`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.