### PR TITLE
Fix Dockerfile for Angular 13 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,9 @@ EXPOSE 4000
 # We run yarn install with an increased network timeout (5min) to avoid "ESOCKETTIMEDOUT" errors from hub.docker.com
 # See, for example https://github.com/yarnpkg/yarn/issues/5540
 RUN yarn install --network-timeout 300000
-CMD yarn run start:dev
+
+# On startup, run in DEVELOPMENT mode (this defaults to live reloading enabled, etc).
+# Listen / accept connections from all IP addresses.
+# NOTE: At this time it is only possible to run Docker container in Production mode
+# if you have a public IP. See https://github.com/DSpace/dspace-angular/issues/1485
+CMD yarn serve --host 0.0.0.0


### PR DESCRIPTION
## References
Related to discussion on Slack where @kshepherd noticed our `dspace-angular` Docker container was only listening on `localhost`.  This caused the UI to be unresponsive _unless_ you accessed it from within the running Docker container (via wget or similar)

## Description
During the Angular 13 upgrade (#1567), the `yarn serve` command (which is used to run the app in dev mode) was updated to use `ng serve` (Angular) instead of `node`.  This had the unfortunate side effect of limiting the `dspace-angular` docker container to listening only on `localhost` instead of on `0.0.0.0` (default for `node`) because `ng serve` defaults to localhost, see https://angular.io/cli/serve

This small PR fixes our `Dockerfile` to specify `--host 0.0.0.0` to ensure it listens to all IP addresses, and not only to `localhost`.

## Instructions for Reviewers
Using this PR, try the following:
* Rebuild your local `dspace-angular` Docker container: `docker-compose -p d7 -f docker/docker-compose.yml build`
* Spin it up & verify the UI now works: `docker-compose -p d7 -f docker/docker-compose.yml up -d`
