### PR TITLE
Flexible additional metadata for MyDSpace items

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -285,3 +285,13 @@ mediaViewer:
 info:
   enableEndUserAgreement: true
   enablePrivacyStatement: true
+
+# MyDSpace Config
+myDSpace:
+  # Add additional metadatas to display at the end of the item component. By default, this is an empty list.
+  additionalMetadatas: []
+  # Replace the empty list by some values here.
+  # additionalMetadatas:
+    # - value: metadata.1
+    # - value: metadata.2
+    # - ...

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -288,10 +288,10 @@ info:
 
 # MyDSpace Config
 myDSpace:
-  # Add additional metadatas to display at the end of the item component. By default, this is an empty list.
-  additionalMetadatas: []
+  # Add additional metadata fields to display at the end of the item component. By default, this is an empty list.
+  additionalMetadataFields: []
   # Replace the empty list by some values here.
-  # additionalMetadatas:
-    # - value: metadata.1
-    # - value: metadata.2
+  # additionalMetadataFields:
+    # - metadata.1
+    # - metadata.2
     # - ...

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
@@ -53,6 +53,11 @@
         <div>
           <ng-content></ng-content>
         </div>
+        <div *ngIf="additionalMetadatas" class="item-list-additional">
+          <ng-container *ngFor="let meta of item.allMetadataValues(additionalMetadatas)">
+            <span class='text-muted item-additional' [innerHTML]="meta"></span>
+          </ng-container>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
@@ -53,8 +53,8 @@
         <div>
           <ng-content></ng-content>
         </div>
-        <div *ngIf="additionalMetadatas" class="item-list-additional">
-          <ng-container *ngFor="let meta of item.allMetadataValues(additionalMetadatas)">
+        <div *ngIf="additionalMetadataFields" class="item-list-additional">
+          <ng-container *ngFor="let meta of item.allMetadataValues(additionalMetadataFields)">
             <span class='text-muted item-additional' [innerHTML]="meta"></span>
           </ng-container>
         </div>

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
@@ -133,7 +133,7 @@ describe('ItemDetailPreviewComponent', () => {
   }));
 
   afterEach(() => {
-    environment.myDSpace.additionalMetadatas = []
+    environment.myDSpace.additionalMetadatas = [];
   });
 
   describe('When the component is initialized', () => {
@@ -162,7 +162,7 @@ describe('ItemDetailPreviewComponent', () => {
 
   describe('When the config has one additional metadata with no match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }]
+      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }];
       fixture.detectChanges();
     });
 
@@ -179,7 +179,7 @@ describe('ItemDetailPreviewComponent', () => {
 
   describe('When the config has one additional metadata with a match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'dc.description.additional' }]
+      environment.myDSpace.additionalMetadatas = [{ value: 'dc.description.additional' }];
       fixture.detectChanges();
     });
 

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
@@ -133,7 +133,7 @@ describe('ItemDetailPreviewComponent', () => {
   }));
 
   afterEach(() => {
-    environment.myDSpace.additionalMetadatas = [];
+    environment.myDSpace.additionalMetadataFields = [];
   });
 
   describe('When the component is initialized', () => {
@@ -162,7 +162,7 @@ describe('ItemDetailPreviewComponent', () => {
 
   describe('When the config has one additional metadata with no match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }];
+      environment.myDSpace.additionalMetadataFields = ['fake'];
       fixture.detectChanges();
     });
 
@@ -179,7 +179,7 @@ describe('ItemDetailPreviewComponent', () => {
 
   describe('When the config has one additional metadata with a match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'dc.description.additional' }];
+      environment.myDSpace.additionalMetadataFields = ['dc.description.additional'];
       fixture.detectChanges();
     });
 

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
@@ -32,6 +32,8 @@ import { ItemDetailPreviewFieldComponent } from './item-detail-preview-field/ite
 import { ItemDetailPreviewComponent } from './item-detail-preview.component';
 import { createPaginatedList } from '../../../testing/utils.test';
 import { FindListOptions } from '../../../../core/data/find-list-options.model';
+import { environment } from 'src/environments/environment';
+import { By } from '@angular/platform-browser';
 
 function getMockFileService(): FileService {
   return jasmine.createSpyObj('FileService', {
@@ -68,6 +70,12 @@ const mockItem: Item = Object.assign(new Item(), {
       {
         language: null,
         value: 'Article'
+      }
+    ],
+    'dc.description.additional': [
+      {
+        language: null,
+        value: 'This is an additional description metadata.'
       }
     ]
   }
@@ -122,14 +130,62 @@ describe('ItemDetailPreviewComponent', () => {
     component.item = mockItem;
     component.separator = ', ';
     // spyOn(component.item, 'getFiles').and.returnValue(mockItem.bundles as any);
-    fixture.detectChanges();
-
   }));
 
-  it('should get item bitstreams', (done) => {
-    component.getFiles().subscribe((bitstreams) => {
-      expect(bitstreams).toBeDefined();
-      done();
+  afterEach(() => {
+    environment.myDSpace.additionalMetadatas = []
+  });
+
+  describe('When the component is initialized', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should get item bitstreams', (done) => {
+      component.getFiles().subscribe((bitstreams) => {
+        expect(bitstreams).toBeDefined();
+        done();
+      });
+    });
+  });
+
+  describe('When the config has no additional metadata', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should not show the additional section', () => {
+      const additionalSection = fixture.debugElement.query(By.css('div.item-list-additional'));
+      expect(additionalSection).toBeNull();
+    });
+  });
+
+  describe('When the config has one additional metadata with no match', () => {
+    beforeEach(() => {
+      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }]
+      fixture.detectChanges();
+    });
+
+    it('should show the additional section', () => {
+      const additionalSection = fixture.debugElement.query(By.css('div.item-list-additional'));
+      expect(additionalSection).not.toBeNull();
+    });
+
+    it('should not show the additional metadata span', () => {
+      const additionalSpan = fixture.debugElement.query(By.css('span.item-additional'));
+      expect(additionalSpan).toBeNull();
+    });
+  });
+
+  describe('When the config has one additional metadata with a match', () => {
+    beforeEach(() => {
+      environment.myDSpace.additionalMetadatas = [{ value: 'dc.description.additional' }]
+      fixture.detectChanges();
+    });
+
+    it('should show the additional metadata span', () => {
+      const additionalSpan = fixture.debugElement.query(By.css('span.item-additional'));
+      expect(additionalSpan).not.toBeNull();
     });
   });
 });

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
@@ -47,9 +47,9 @@ export class ItemDetailPreviewComponent {
   @Input() showSubmitter = false;
 
   /**
-   * A list of additional metadatas to display
+   * A list of additional metadata fields to display
    */
-  public additionalMetadatas: string[];
+  public additionalMetadataFields: string[];
 
   /**
    * The item's thumbnail
@@ -74,8 +74,8 @@ export class ItemDetailPreviewComponent {
   }
 
   ngOnInit() {
-    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadatas)) {
-      this.additionalMetadatas = environment.myDSpace.additionalMetadatas.map(m => m.value);
+    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadataFields)) {
+      this.additionalMetadataFields = environment.myDSpace.additionalMetadataFields;
     }
   }
 

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
@@ -12,6 +12,8 @@ import { Bitstream } from '../../../../core/shared/bitstream.model';
 import { FileService } from '../../../../core/shared/file.service';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { SearchResult } from '../../../search/models/search-result.model';
+import { environment } from 'src/environments/environment';
+import { hasValue, isNotEmpty } from 'src/app/shared/empty.util';
 
 /**
  * This component show metadata for the given item object in the detail view.
@@ -45,6 +47,11 @@ export class ItemDetailPreviewComponent {
   @Input() showSubmitter = false;
 
   /**
+   * A list of additional metadatas to display
+   */
+  public additionalMetadatas: string[];
+
+  /**
    * The item's thumbnail
    */
   public bitstreams$: Observable<Bitstream[]>;
@@ -64,6 +71,12 @@ export class ItemDetailPreviewComponent {
   constructor(private fileService: FileService,
               private halService: HALEndpointService,
               private bitstreamDataService: BitstreamDataService) {
+  }
+
+  ngOnInit() {
+    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadatas)) {
+      this.additionalMetadatas = environment.myDSpace.additionalMetadatas.map(m => m.value);
+    }
   }
 
   /**

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
@@ -31,15 +31,18 @@
                 <span *ngIf="!last">; </span>
               </span>
           </span>
-
-          </ds-truncatable-part>
+        </ds-truncatable-part>
       </span>
 
           <ds-truncatable-part [id]="item.id" [minLines]="1" class="item-list-abstract">
         <span [ngClass]="{'text-muted': !item.firstMetadataValue('dc.description.abstract')}"
               [innerHTML]="(item.firstMetadataValue('dc.description.abstract')) || ('mydspace.results.no-abstract' | translate)"></span>
           </ds-truncatable-part>
-
+          <div *ngIf="additionalMetadatas" class="item-list-additional">
+            <ds-truncatable-part *ngFor="let meta of item.allMetadataValues(additionalMetadatas)" [id]="item.id" [minLines]="1">
+              <span class='text-muted item-additional' [innerHTML]="meta"></span>
+            </ds-truncatable-part>
+          </div>
         </div>
       </ds-truncatable>
       <ds-item-submitter *ngIf="showSubmitter" [object]="object.indexableObject"></ds-item-submitter>

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
@@ -38,8 +38,8 @@
         <span [ngClass]="{'text-muted': !item.firstMetadataValue('dc.description.abstract')}"
               [innerHTML]="(item.firstMetadataValue('dc.description.abstract')) || ('mydspace.results.no-abstract' | translate)"></span>
           </ds-truncatable-part>
-          <div *ngIf="additionalMetadatas" class="item-list-additional">
-            <ds-truncatable-part *ngFor="let meta of item.allMetadataValues(additionalMetadatas)" [id]="item.id" [minLines]="1">
+          <div *ngIf="additionalMetadataFields" class="item-list-additional">
+            <ds-truncatable-part *ngFor="let meta of item.allMetadataValues(additionalMetadataFields)" [id]="item.id" [minLines]="1">
               <span class='text-muted item-additional' [innerHTML]="meta"></span>
             </ds-truncatable-part>
           </div>

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
@@ -132,7 +132,7 @@ describe('ItemListPreviewComponent', () => {
   });
 
   afterEach(() => {
-    environment.myDSpace.additionalMetadatas = [];
+    environment.myDSpace.additionalMetadataFields = [];
   });
 
   describe('When showThumbnails is true', () => {
@@ -220,7 +220,7 @@ describe('ItemListPreviewComponent', () => {
 
   describe('When the config has one additional metadata with no match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }];
+      environment.myDSpace.additionalMetadataFields = ['fake'];
       component.item = mockItemWithAdditionalMeta;
       fixture.detectChanges();
     });
@@ -238,7 +238,7 @@ describe('ItemListPreviewComponent', () => {
 
   describe('When the config has one additional metadata with a match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'dspace.description.additional' }];
+      environment.myDSpace.additionalMetadataFields = ['dspace.description.additional'];
       component.item = mockItemWithAdditionalMeta;
       fixture.detectChanges();
     });

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
@@ -11,6 +11,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateLoaderMock } from '../../../mocks/translate-loader.mock';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { APP_CONFIG } from '../../../../../config/app-config.interface';
+import { environment } from 'src/environments/environment';
 
 let component: ItemListPreviewComponent;
 let fixture: ComponentFixture<ItemListPreviewComponent>;
@@ -66,6 +67,23 @@ const mockItemWithEntityType: Item = Object.assign(new Item(), {
     ]
   }
 });
+const mockItemWithAdditionalMeta: Item = Object.assign(new Item(), {
+  bundles: observableOf({}),
+  metadata: {
+    'dc.title': [
+      {
+        language: 'en_US',
+        value: 'This is just another title'
+      }
+    ],
+    'dspace.description.additional': [
+      {
+        language: null,
+        value: 'This is an additional description metadata.'
+      }
+    ]
+  }
+});
 
 const environmentUseThumbs = {
   browseBy: {
@@ -111,6 +129,10 @@ describe('ItemListPreviewComponent', () => {
 
   beforeEach(() => {
     component.object = { hitHighlights: {} } as any;
+  });
+
+  afterEach(() => {
+    environment.myDSpace.additionalMetadatas = []
   });
 
   describe('When showThumbnails is true', () => {
@@ -181,6 +203,49 @@ describe('ItemListPreviewComponent', () => {
     it('should show the entity type span', () => {
       const entityField = fixture.debugElement.query(By.css('ds-type-badge'));
       expect(entityField).not.toBeNull();
+    });
+  });
+
+  describe('When the config has no additional metadata', () => {
+    beforeEach(() => {
+      component.item = mockItemWithAdditionalMeta;
+      fixture.detectChanges();
+    });
+
+    it('should not show the additional section', () => {
+      const additionalSection = fixture.debugElement.query(By.css('div.item-list-additional'));
+      expect(additionalSection).toBeNull();
+    });
+  });
+
+  describe('When the config has one additional metadata with no match', () => {
+    beforeEach(() => {
+      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }]
+      component.item = mockItemWithAdditionalMeta;
+      fixture.detectChanges();
+    });
+
+    it('should show the additional section', () => {
+      const additionalSection = fixture.debugElement.query(By.css('div.item-list-additional'));
+      expect(additionalSection).not.toBeNull();
+    });
+
+    it('should not show the additional metadata span', () => {
+      const additionalSpan = fixture.debugElement.query(By.css('span.item-additional'));
+      expect(additionalSpan).toBeNull();
+    });
+  });
+
+  describe('When the config has one additional metadata with a match', () => {
+    beforeEach(() => {
+      environment.myDSpace.additionalMetadatas = [{ value: 'dspace.description.additional' }]
+      component.item = mockItemWithAdditionalMeta;
+      fixture.detectChanges();
+    });
+
+    it('should show the additional metadata span', () => {
+      const additionalSpan = fixture.debugElement.query(By.css('span.item-additional'));
+      expect(additionalSpan).not.toBeNull();
     });
   });
 });

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.spec.ts
@@ -132,7 +132,7 @@ describe('ItemListPreviewComponent', () => {
   });
 
   afterEach(() => {
-    environment.myDSpace.additionalMetadatas = []
+    environment.myDSpace.additionalMetadatas = [];
   });
 
   describe('When showThumbnails is true', () => {
@@ -220,7 +220,7 @@ describe('ItemListPreviewComponent', () => {
 
   describe('When the config has one additional metadata with no match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }]
+      environment.myDSpace.additionalMetadatas = [{ value: 'fake' }];
       component.item = mockItemWithAdditionalMeta;
       fixture.detectChanges();
     });
@@ -238,7 +238,7 @@ describe('ItemListPreviewComponent', () => {
 
   describe('When the config has one additional metadata with a match', () => {
     beforeEach(() => {
-      environment.myDSpace.additionalMetadatas = [{ value: 'dspace.description.additional' }]
+      environment.myDSpace.additionalMetadatas = [{ value: 'dspace.description.additional' }];
       component.item = mockItemWithAdditionalMeta;
       fixture.detectChanges();
     });

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
-
+import { hasValue, isNotEmpty } from 'src/app/shared/empty.util';
+import { environment } from 'src/environments/environment';
 import { Item } from '../../../../core/shared/item.model';
 import { fadeInOut } from '../../../animations/fade';
 import {
@@ -41,6 +42,11 @@ export class ItemListPreviewComponent implements OnInit {
   @Input() showSubmitter = false;
 
   /**
+   * A list of additional metadatas to display
+   */
+  public additionalMetadatas: string[];
+
+  /**
    * Display thumbnails if required by configuration
    */
   showThumbnails: boolean;
@@ -56,6 +62,9 @@ export class ItemListPreviewComponent implements OnInit {
   ngOnInit(): void {
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;
     this.dsoTitle = this.dsoNameService.getName(this.item);
+    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadatas)) {
+      this.additionalMetadatas = environment.myDSpace.additionalMetadatas.map(m => m.value);
+    }
   }
 
 

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
@@ -42,9 +42,9 @@ export class ItemListPreviewComponent implements OnInit {
   @Input() showSubmitter = false;
 
   /**
-   * A list of additional metadatas to display
+   * A list of additional metadata fields to display
    */
-  public additionalMetadatas: string[];
+  public additionalMetadataFields: string[];
 
   /**
    * Display thumbnails if required by configuration
@@ -62,8 +62,8 @@ export class ItemListPreviewComponent implements OnInit {
   ngOnInit(): void {
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;
     this.dsoTitle = this.dsoNameService.getName(this.item);
-    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadatas)) {
-      this.additionalMetadatas = environment.myDSpace.additionalMetadatas.map(m => m.value);
+    if (hasValue(environment.myDSpace) && isNotEmpty(environment.myDSpace.additionalMetadataFields)) {
+      this.additionalMetadataFields = environment.myDSpace.additionalMetadataFields;
     }
   }
 

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -19,6 +19,7 @@ import { ActuatorsConfig } from './actuators.config';
 import { InfoConfig } from './info-config.interface';
 import { CommunityListConfig } from './community-list-config.interface';
 import { HomeConfig } from './homepage-config.interface';
+import { MyDSpaceConfig } from './my-dspace.interface';
 
 interface AppConfig extends Config {
   ui: UIServerConfig;
@@ -42,6 +43,7 @@ interface AppConfig extends Config {
   bundle: BundleConfig;
   actuators: ActuatorsConfig
   info: InfoConfig;
+  myDSpace: MyDSpaceConfig;
 }
 
 /**

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -367,6 +367,6 @@ export class DefaultAppConfig implements AppConfig {
   };
   // The default MyDSpace Config
   myDSpace: MyDSpaceConfig = {
-    additionalMetadatas: []
+    additionalMetadataFields: []
   };
 }

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -9,6 +9,7 @@ import { FormConfig } from './form-config.interfaces';
 import { ItemConfig } from './item-config.interface';
 import { LangConfig } from './lang-config.interface';
 import { MediaViewerConfig } from './media-viewer-config.interface';
+import { MyDSpaceConfig } from './my-dspace.interface';
 import { INotificationBoardOptions } from './notifications-config.interfaces';
 import { ServerConfig } from './server-config.interface';
 import { SubmissionConfig } from './submission-config.interface';
@@ -363,5 +364,9 @@ export class DefaultAppConfig implements AppConfig {
   info: InfoConfig = {
     enableEndUserAgreement: true,
     enablePrivacyStatement: true
+  };
+  // The default MyDSpace Config
+  myDSpace: MyDSpaceConfig = {
+    additionalMetadatas: []
   };
 }

--- a/src/config/my-dspace.interface.ts
+++ b/src/config/my-dspace.interface.ts
@@ -5,7 +5,7 @@ import { Config } from './config.interface';
  */
 export interface MyDSpaceConfig extends Config {
   /**
-   * The list of additional metadatas to display at then end of the item component
+   * The list of additional metadatas to display at the end of the item component
    */
   additionalMetadatas: AdditionalMetaConfig[]
 }

--- a/src/config/my-dspace.interface.ts
+++ b/src/config/my-dspace.interface.ts
@@ -5,15 +5,8 @@ import { Config } from './config.interface';
  */
 export interface MyDSpaceConfig extends Config {
   /**
-   * The list of additional metadatas to display at the end of the item component
+   * The list of additional metadata fields to display at the end of the item component
    */
-  additionalMetadatas: AdditionalMetaConfig[]
+   additionalMetadataFields:  string[]
 }
 
-/**
- * Config that represents an additional metadata.
- * Contains a value matching a metadata code.
- */
-export interface AdditionalMetaConfig extends Config {
-  value: string;
-}

--- a/src/config/my-dspace.interface.ts
+++ b/src/config/my-dspace.interface.ts
@@ -1,0 +1,19 @@
+import { Config } from './config.interface';
+
+/**
+ * Config that determines some aspects of the MyDSpace section
+ */
+export interface MyDSpaceConfig extends Config {
+  /**
+   * The list of additional metadatas to display at then end of the item component
+   */
+  additionalMetadatas: AdditionalMetaConfig[]
+}
+
+/**
+ * Config that represents an additional metadata.
+ * Contains a value matching a metadata code.
+ */
+export interface AdditionalMetaConfig extends Config {
+  value: string;
+}

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -271,4 +271,7 @@ export const environment: BuildConfig = {
     enableEndUserAgreement: true,
     enablePrivacyStatement: true,
   },
+  myDSpace: {
+    additionalMetadatas: []
+  }
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -272,6 +272,6 @@ export const environment: BuildConfig = {
     enablePrivacyStatement: true,
   },
   myDSpace: {
-    additionalMetadatas: []
+    additionalMetadataFields: []
   }
 };


### PR DESCRIPTION
## References
* Fixes #1591

## Description
Added a configuration section to insert one or multiple metadata at the end of an item description shown in the MyDSpace section.

## Instructions for Reviewers

List of changes in this PR:
* Added the `myDSpace` configuration section to list all additional metadata.
* Added a new section in both `item-detail-preview.component.spec.ts` and `item-list-preview.component.html` to display every metadata present in the configuration.
* Updated existing unit tests to ensure the new information is displayed properly.

**To display additional values, you can set the configuration to something like:**
```
myDSpace:
  additionalMetadataFields:
    - dc.identifier.uri
    - dc.description.provenance
```

It is only an example, you can set any value(s) you want at this point. By default, no additional metadata will be displayed.

_Note that private metadata (dc.description.provenance) will only be displayed for the administrators, as intended._

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
