### PR TITLE
Enable Turkish lang pack in dropdown list

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -148,6 +148,9 @@ languages:
   - code: fi
     label: Suomi
     active: true
+  - code: tr
+    label: Türkçe
+    active: true
   - code: bn
     label: বাংলা
     active: true

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -184,6 +184,7 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'pt-PT', label: 'Português', active: true },
     { code: 'pt-BR', label: 'Português do Brasil', active: true },
     { code: 'fi', label: 'Suomi', active: true },
+    { code: 'tr', label: 'Türkçe', active: true },
     { code: 'bn', label: 'বাংলা', active: true }
   ];
 


### PR DESCRIPTION
## References
* Follow-up to #1519 (which was just merged)

## Description
This tiny PR just ensures that the new Turkish translation is available in our language dropdowns. 

Because this is a tiny configuration change & I've tested it myself, I'm going to merge this immediately after CI succeeds.
