### PR TITLE
Mirador webpack build fix.

### DIFF
--- a/src/mirador-viewer/mirador.html
+++ b/src/mirador-viewer/mirador.html
@@ -6,5 +6,6 @@
 </head>
 <body>
 <div id="mirador"></div>
+<script src="mirador.js"></script>
 </body>
 </html>

--- a/webpack/webpack.mirador.config.ts
+++ b/webpack/webpack.mirador.config.ts
@@ -1,4 +1,4 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
 
 module.exports = {
@@ -10,19 +10,16 @@ module.exports = {
     path: path.resolve(__dirname, '..' , 'dist/iiif/mirador'),
     filename: '[name].js'
   },
-  module: {
-    rules: [
-      {
-        test: /\.html$/i,
-        loader: 'html-loader',
-      },
-    ],
-  },
   devServer: {
     contentBase: '../dist/iiif/mirador',
   },
-  plugins: [new HtmlWebpackPlugin({
-    filename: 'index.html',
-    template: './src/mirador-viewer/mirador.html'
+  resolve: {
+    fallback: {
+      url: false
+    }},
+  plugins: [new CopyWebpackPlugin({
+    patterns: [
+      {from: './src/mirador-viewer/mirador.html', to: './index.html'}
+    ]
   })]
 };


### PR DESCRIPTION
## References
* Fixes #1611

## Description
The webpack build for Mirador was failing after we upgraded to webpack version 5. It complained about a missing node dependency. This fixes the problem by updating the `webpack.mirador.config` with a fallback.

The "url" dependency is actually not required since Mirador includes a polyfill in its own dependencies, so the fallback is just an empty module: { url: false }. 

We were also missing a webpack dependency: `html-webpack-plugin`.  It appears to be removed from package.json at some point, but frankly it was unnecessary. I just modified the webpack configuration to use the existing `copy-webpack-plugin` instead.

## Instructions for Reviewers
Build Mirador (yarn run build:mirador). The build should succeed and you should be able to see the embedded Mirador viewer inside an iiif-enabled view.

List of changes in this PR:
* Updated webpack.mirador.config.ts with resolve.fallback
* Updated webpack.mirador.config.ts to use copy-webpack-plugin


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
