### PR TITLE
Show notifications when failing to create/delete role Groups

### DIFF
--- a/src/app/collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
+++ b/src/app/collection-page/edit-collection-page/collection-roles/collection-roles.component.spec.ts
@@ -13,6 +13,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComcolModule } from '../../../shared/comcol/comcol.module';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 
 describe('CollectionRolesComponent', () => {
 
@@ -79,6 +81,7 @@ describe('CollectionRolesComponent', () => {
         { provide: ActivatedRoute, useValue: route },
         { provide: RequestService, useValue: requestService },
         { provide: GroupDataService, useValue: groupDataService },
+        { provide: NotificationsService, useClass: NotificationsServiceStub }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/community-page/edit-community-page/community-roles/community-roles.component.spec.ts
+++ b/src/app/community-page/edit-community-page/community-roles/community-roles.component.spec.ts
@@ -13,6 +13,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComcolModule } from '../../../shared/comcol/comcol.module';
+import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 
 describe('CommunityRolesComponent', () => {
 
@@ -64,6 +66,7 @@ describe('CommunityRolesComponent', () => {
         { provide: ActivatedRoute, useValue: route },
         { provide: RequestService, useValue: requestService },
         { provide: GroupDataService, useValue: groupDataService },
+        { provide: NotificationsService, useClass: NotificationsServiceStub }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.html
@@ -4,7 +4,7 @@
        *ngVar="group$ | async as group">
 
     <h5 class="w-100">
-      {{'comcol-role.edit.' + (comcolRole$ | async)?.name + '.name' | translate}}
+      {{ roleName$ | async }}
     </h5>
 
     <div class="mt-2 mb-2">

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -10,6 +10,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../../../remote-data.utils';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComcolModule } from '../../../comcol.module';
+import { NotificationsService } from '../../../../notifications/notifications.service';
+import { NotificationsServiceStub } from '../../../../testing/notifications-service.stub';
 
 describe('ComcolRoleComponent', () => {
 
@@ -20,6 +22,7 @@ describe('ComcolRoleComponent', () => {
   let group;
   let statusCode;
   let comcolRole;
+  let notificationsService;
 
   const requestService = { hasByHref$: () => observableOf(true) };
 
@@ -40,6 +43,7 @@ describe('ComcolRoleComponent', () => {
       providers: [
         { provide: GroupDataService, useValue: groupService },
         { provide: RequestService, useValue: requestService },
+        { provide: NotificationsService, useClass: NotificationsServiceStub }
       ], schemas: [
         NO_ERRORS_SCHEMA
       ]
@@ -59,12 +63,14 @@ describe('ComcolRoleComponent', () => {
       fixture = TestBed.createComponent(ComcolRoleComponent);
       comp = fixture.componentInstance;
       de = fixture.debugElement;
+      notificationsService = TestBed.inject(NotificationsService);
 
       comcolRole = {
         name: 'test role name',
         href: 'test role link',
       };
       comp.comcolRole = comcolRole;
+      comp.roleName$ = observableOf(comcolRole.name);
 
       fixture.detectChanges();
     });
@@ -98,6 +104,18 @@ describe('ComcolRoleComponent', () => {
 
       it('should call the groupService create method', (done) => {
         expect(groupService.createComcolGroup).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    describe('when a group cannot be created', () => {
+      beforeEach(() => {
+        groupService.createComcolGroup.and.returnValue(createFailedRemoteDataObject$());
+        de.query(By.css('.btn.create')).nativeElement.click();
+      });
+
+      it('should show an error notification', (done) => {
+        expect(notificationsService.error).toHaveBeenCalled();
         done();
       });
     });
@@ -166,6 +184,18 @@ describe('ComcolRoleComponent', () => {
 
       it('should call the groupService delete method', (done) => {
         expect(groupService.deleteComcolGroup).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    describe('when a group cannot be deleted', () => {
+      beforeEach(() => {
+        groupService.deleteComcolGroup.and.returnValue(createFailedRemoteDataObject$());
+        de.query(By.css('.btn.delete')).nativeElement.click();
+      });
+
+      it('should show an error notification', (done) => {
+        expect(notificationsService.error).toHaveBeenCalled();
         done();
       });
     });

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
@@ -12,6 +12,8 @@ import { HALLink } from '../../../../../core/shared/hal-link.model';
 import { getGroupEditRoute } from '../../../../../access-control/access-control-routing-paths';
 import { hasNoValue, hasValue } from '../../../../empty.util';
 import { NoContent } from '../../../../../core/shared/NoContent.model';
+import { NotificationsService } from '../../../../notifications/notifications.service';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Component for managing a community or collection role.
@@ -64,9 +66,16 @@ export class ComcolRoleComponent implements OnInit {
    */
   hasCustomGroup$: Observable<boolean>;
 
+  /**
+   * The human-readable name of this role
+   */
+  roleName$: Observable<string>;
+
   constructor(
     protected requestService: RequestService,
     protected groupService: GroupDataService,
+    protected notificationsService: NotificationsService,
+    protected translateService: TranslateService,
   ) {
   }
 
@@ -101,7 +110,12 @@ export class ComcolRoleComponent implements OnInit {
         this.groupService.clearGroupsRequests();
         this.requestService.setStaleByHrefSubstring(this.comcolRole.href);
       } else {
-        // TODO show error notification
+        this.notificationsService.error(
+          this.roleName$.pipe(
+            switchMap(role => this.translateService.get('comcol-role.edit.create.error.title', { role }))
+          ),
+          `${rd.statusCode} ${rd.errorMessage}`
+        );
       }
     });
   }
@@ -117,7 +131,12 @@ export class ComcolRoleComponent implements OnInit {
         this.groupService.clearGroupsRequests();
         this.requestService.setStaleByHrefSubstring(this.comcolRole.href);
       } else {
-        // TODO show error notification
+        this.notificationsService.error(
+          this.roleName$.pipe(
+            switchMap(role => this.translateService.get('comcol-role.edit.delete.error.title', { role }))
+          ),
+          rd.errorMessage
+        );
       }
     });
   }
@@ -154,5 +173,7 @@ export class ComcolRoleComponent implements OnInit {
     this.hasCustomGroup$ = this.group$.pipe(
       map((group: Group) => hasValue(group) && group.name !== 'Anonymous'),
     );
+
+    this.roleName$ = this.translateService.get(`comcol-role.edit.${this.comcolRole.name}.name`);
   }
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1082,9 +1082,13 @@
 
   "comcol-role.edit.create": "Create",
 
+  "comcol-role.edit.create.error.title": "Failed to create a group for the '{{ role }}' role",
+
   "comcol-role.edit.restrict": "Restrict",
 
   "comcol-role.edit.delete": "Delete",
+
+  "comcol-role.edit.delete.error.title": "Failed to delete the '{{ role }}' role's group",
 
 
   "comcol-role.edit.community-admin.name": "Administrators",


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1557
* Backend PR: https://github.com/DSpace/DSpace/pull/8286

## Description
Show error notifications when Community/Collection role Group creation/deletion fails.

## Instructions for Reviewers
1. Run a local DSpace instance at the backend PR's branch
2. Select (or create) a Collection with the admin account assigned to the first workflow role
3. Deposit a new submission, confirm that it appears in the admin account's pool on `/mydspace`
4. Edit the Collection: attempt to delete the first role' Group
   * A notification should pop up informing you that this can't be done

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.