### PR TITLE
Update CI process to use Node 14 & 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       # Create a matrix of Node versions to test against (in parallel)
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
       # Do NOT exit immediately if one matrix job fails
       fail-fast: false
     # These are the actual CI steps to perform per job
@@ -82,11 +82,11 @@ jobs:
         run: yarn run test:headless
 
       # NOTE: Angular CLI only supports code coverage for specs. See https://github.com/angular/angular-cli/issues/6286
-      # Upload coverage reports to Codecov (for Node v12 only)
+      # Upload coverage reports to Codecov (for one version of Node only)
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
         uses: codecov/codecov-action@v2
-        if: matrix.node-version == '12.x'
+        if: matrix.node-version == '16.x'
 
       # Using docker-compose start backend using CI configuration
       # and load assetstore from a cached copy

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace
 Quick start
 -----------
 
-**Ensure you're running [Node](https://nodejs.org) `v12.x`, `v14.x` or `v16.x`, [npm](https://www.npmjs.com/) >= `v5.x` and [yarn](https://yarnpkg.com) == `v1.x`**
+**Ensure you're running [Node](https://nodejs.org) `v14.x` or `v16.x`, [npm](https://www.npmjs.com/) >= `v5.x` and [yarn](https://yarnpkg.com) == `v1.x`**
 
 ```bash
 # clone the repo
@@ -90,7 +90,7 @@ Requirements
 ------------
 
 -	[Node.js](https://nodejs.org) and [yarn](https://yarnpkg.com)
--	Ensure you're running node `v12.x`, `v14.x` or `v16.x` and yarn == `v1.x`
+-	Ensure you're running node `v14.x` or `v16.x` and yarn == `v1.x`
 
 If you have [`nvm`](https://github.com/creationix/nvm#install-script) or [`nvm-windows`](https://github.com/coreybutler/nvm-windows) installed, which is highly recommended, you can run `nvm install --lts && nvm use` to install and start using the latest Node LTS.
 


### PR DESCRIPTION
## Description
This is a small PR to update our GitHub CI process to use Node v14 and v16, as those are the two current LTS releases.  Also makes minor updates to README to drop Node v12, as that release is EOL.  See https://nodejs.org/en/about/releases/

I've also already updated the Installation docs to note that we don't recommend Node v12 anymore: https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace#InstallingDSpace-Node.js(v14.xorv16.x)