### PR TITLE
Fix RSS accessibility issue: link has no discernible text

### DIFF
--- a/src/app/shared/rss-feed/rss.component.html
+++ b/src/app/shared/rss-feed/rss.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(isEnabled$ | async) && (hasRoute('home') || hasRoute('collections') || hasRoute('communities'))">
   <div *ngIf="route$ | async as route" class="d-inline-block float-right margin-right">
-    <a [href]="route" class="btn btn-secondary"><i class="fas fa-rss-square"></i></a>
+    <a [href]="route" class="btn btn-secondary" [title]="'feed.description' | translate" [attr.aria-label]="'feed.description' | translate"><i class="fas fa-rss-square"></i></a>
   </div>
 </ng-container>

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1401,6 +1401,9 @@
   "error.validation.groupExists": "This group already exists",
 
 
+  "feed.description": "Syndication feed",
+
+
   "file-section.error.header": "Error obtaining files for this item",
 
 


### PR DESCRIPTION
## References
* Follow-up to #1444 

## Description
After merging #1444, the `main` branch no longer passes e2e tests because of accessibility failures detected: https://github.com/DSpace/dspace-angular/runs/6428607199?check_suite_focus=true

I'm not sure how these were not detected in #1444's build, but this small PR fixes the issue by ensuring the new button/link has discernible text.

Assuming this passes automated CI, I'm going to merge this immediately as otherwise all e2e will fail until this is fixed.