### PR TITLE
Fix disappearing "import" menu by aligning it with export menu code

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -440,9 +440,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
       //   } as LinkMenuItemModel,
       // }
     ];
-    menuList.forEach((menuSection) => this.menuService.addSection(this.menuID, Object.assign(menuSection, {
-      shouldPersistOnRouteChange: true
-    })));
+    menuList.forEach((menuSection) => this.menuService.addSection(this.menuID, menuSection));
 
     observableCombineLatest([
       this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
@@ -463,7 +461,8 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
             text: 'menu.section.import'
           } as TextMenuItemModel,
           icon: 'file-import',
-          index: 2
+          index: 2,
+          shouldPersistOnRouteChange: true
         });
       this.menuService.addSection(this.menuID, {
         id: 'import_metadata',


### PR DESCRIPTION
## References
* Fixed #1650 

## Description
This small PR aligns the code of the "import" menu with that of the "export" menu, by just moving the `shouldPersistOnRouteChange: true` to the proper place.

This fixes the disappearing "import" menu issue which was occurring in #1650.  See that ticket for details on how to reproduce the problem.
## Instructions for Reviewers
* Verify problem described in #1650 no longer occurs.