### PR TITLE
Fix entitytype redirect encoding issue

### DIFF
--- a/src/app/item-page/item-page.resolver.spec.ts
+++ b/src/app/item-page/item-page.resolver.spec.ts
@@ -1,0 +1,87 @@
+import { ItemPageResolver } from './item-page.resolver';
+import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
+import { DSpaceObject } from '../core/shared/dspace-object.model';
+import { MetadataValueFilter } from '../core/shared/metadata.models';
+import { first } from 'rxjs/operators';
+import { Router } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('ItemPageResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([{
+        path: 'entities/:entity-type/:id',
+        component: {} as any
+      }])]
+    });
+  });
+
+  describe('resolve', () => {
+    let resolver: ItemPageResolver;
+    let itemService: any;
+    let store: any;
+    let router: any;
+
+    const uuid = '1234-65487-12354-1235';
+    let item: DSpaceObject;
+
+    function runTestsWithEntityType(entityType: string) {
+      beforeEach(() => {
+        router = TestBed.inject(Router);
+        item = Object.assign(new DSpaceObject(), {
+          uuid: uuid,
+          firstMetadataValue(_keyOrKeys: string | string[], _valueFilter?: MetadataValueFilter): string {
+            return entityType;
+          }
+        });
+        itemService = {
+          findById: (_id: string) => createSuccessfulRemoteDataObject$(item)
+        };
+        store = jasmine.createSpyObj('store', {
+          dispatch: {},
+        });
+        resolver = new ItemPageResolver(itemService, store, router);
+      });
+
+      it('should redirect to the correct route for the entity type', (done) => {
+        spyOn(item, 'firstMetadataValue').and.returnValue(entityType);
+        spyOn(router, 'navigateByUrl').and.callThrough();
+
+        resolver.resolve({ params: { id: uuid } } as any, { url: router.parseUrl(`/items/${uuid}`).toString() } as any)
+          .pipe(first())
+          .subscribe(
+            () => {
+              expect(router.navigateByUrl).toHaveBeenCalledWith(router.parseUrl(`/entities/${entityType}/${uuid}`).toString());
+              done();
+            }
+          );
+      });
+
+      it('should not redirect if we’re already on the correct route', (done) => {
+        spyOn(item, 'firstMetadataValue').and.returnValue(entityType);
+        spyOn(router, 'navigateByUrl').and.callThrough();
+
+        resolver.resolve({ params: { id: uuid } } as any, { url: router.parseUrl(`/entities/${entityType}/${uuid}`).toString() } as any)
+          .pipe(first())
+          .subscribe(
+            () => {
+              expect(router.navigateByUrl).not.toHaveBeenCalled();
+              done();
+            }
+          );
+      });
+    }
+
+    describe('when normal entity type is provided', () => {
+      runTestsWithEntityType('publication');
+    });
+
+    describe('when entity type contains a special character', () => {
+      runTestsWithEntityType('alligator,loki');
+      runTestsWithEntityType('🐊');
+      runTestsWithEntityType(' ');
+    });
+
+  });
+});

--- a/src/app/item-page/item-page.resolver.ts
+++ b/src/app/item-page/item-page.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { RemoteData } from '../core/data/remote-data';
 import { ItemDataService } from '../core/data/item-data.service';
@@ -35,8 +35,14 @@ export class ItemPageResolver extends ItemResolver {
     return super.resolve(route, state).pipe(
       map((rd: RemoteData<Item>) => {
         if (rd.hasSucceeded && hasValue(rd.payload)) {
-          const itemRoute = getItemPageRoute(rd.payload);
           const thisRoute = state.url;
+
+          // Angular uses a custom function for encodeURIComponent, (e.g. it doesn't encode commas
+          // or semicolons) and thisRoute has been encoded with that function. If we want to compare
+          // it with itemRoute, we have to run itemRoute through Angular's version as well to ensure
+          // the same characters are encoded the same way.
+          const itemRoute = this.router.parseUrl(getItemPageRoute(rd.payload)).toString();
+
           if (!thisRoute.startsWith(itemRoute)) {
             const itemId = rd.payload.uuid;
             const subRoute = thisRoute.substring(thisRoute.indexOf(itemId) + itemId.length, thisRoute.length);


### PR DESCRIPTION
## References
* Fixes #1654 

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
List of changes in this PR:
* Parsed the itemRoute through angular’s URL serializer, and serializing it again afterwards before comparing them
* Added tests to prove it works

**Include guidance for how to test or review your PR.**
Set the `dspace.entity.type` of an Item to a string containing a comma and search for that Item. If you aren't already on the page the resolver will trigger the navigate and it shouldn't throw errors anymore and you should be able to view the page correctly.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
