### PR TITLE
Docker Fixes: Ensure multiple architecture build is disabled for PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,10 @@ jobs:
       # We turn off 'latest' tag by default.
       TAGS_FLAVOR: |
         latest=false
+      # Architectures / Platforms for which we will build Docker images
+      # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+      # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
+      PLATFORMS: linux/amd64${{ github.event_name != 'pull_request' && ', linux/arm64' || '' }}
 
     steps:
       # https://github.com/actions/checkout
@@ -42,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
+      - name: Set up QEMU emulation to build for multiple architectures
         uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/login-action
@@ -74,7 +78,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## References
Port of https://github.com/DSpace/DSpace/pull/8315 over to `dspace-angular`

## Description
Like https://github.com/DSpace/DSpace/pull/8315, this PR ensures that future PRs will only trigger an AMD64 build. The ARM64 build will only occur when a PR is merged into main or when a new tag is created.

There's unfortunately no way to fully test this without merging this PR.