### PR TITLE
Fix route-matching themes not resolving on first load/refresh

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -228,6 +228,12 @@ export class AppComponent implements OnInit, AfterViewInit {
     });
   }
 
+  /**
+   * Update the theme according to the current route, if applicable.
+   * @param urlAfterRedirects the current URL after redirects
+   * @param snapshot          the current route snapshot
+   * @private
+   */
   private updateTheme(urlAfterRedirects: string, snapshot: ActivatedRouteSnapshot): void {
     this.themeService.updateThemeOnRouteChange$(urlAfterRedirects, snapshot).pipe(
       switchMap((changed) => {


### PR DESCRIPTION
## References
* Introduced in #1627
* Fixes #1668

## Description
Initial loading or refreshing no longer emits `ResolveEnd`, therefore route-matching themes are never resolved. On navigation this event _is_ emitted.

Since `ResolveEnd` is emitted before `NavigationEnd` during regular navigation we want to keep the current case; therefore I'm adding a separate case for `NavigationEnd` when `ResolveEnd` is _not_ found.

## Instructions for Reviewers
Confirm that #1668 can no longer be reproduced

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
