### PR TITLE
Fixes Collection Mapper by ensuring UI sends a valid sort option

### DIFF
--- a/src/app/core/pagination/pagination.service.spec.ts
+++ b/src/app/core/pagination/pagination.service.spec.ts
@@ -12,7 +12,7 @@ describe('PaginationService', () => {
   let routeService;
 
   const defaultPagination = new PaginationComponentOptions();
-  const defaultSort = new SortOptions('id', SortDirection.DESC);
+  const defaultSort = new SortOptions('dc.title', SortDirection.ASC);
   const defaultFindListOptions = new FindListOptions();
 
   beforeEach(() => {
@@ -39,7 +39,6 @@ describe('PaginationService', () => {
     service = new PaginationService(routeService, router);
   });
 
-
   describe('getCurrentPagination', () => {
     it('should retrieve the current pagination info from the routerService', () => {
       service.getCurrentPagination('test-id', defaultPagination).subscribe((currentPagination) => {
@@ -54,6 +53,26 @@ describe('PaginationService', () => {
     it('should retrieve the current sort info from the routerService', () => {
       service.getCurrentSort('test-id', defaultSort).subscribe((currentSort) => {
         expect(currentSort).toEqual(Object.assign(new SortOptions('score', SortDirection.ASC )));
+      });
+    });
+    it('should return default sort when no sort specified', () => {
+      // This is same as routeService (defined above), but returns no sort field or direction
+      routeService = {
+        getQueryParameterValue: (param) => {
+          let value;
+          if (param.endsWith('.page')) {
+            value = 5;
+          }
+          if (param.endsWith('.rpp')) {
+            value = 10;
+          }
+          return observableOf(value);
+        }
+      };
+      service = new PaginationService(routeService, router);
+
+      service.getCurrentSort('test-id', defaultSort).subscribe((currentSort) => {
+        expect(currentSort).toEqual(defaultSort);
       });
     });
   });

--- a/src/app/core/pagination/pagination.service.ts
+++ b/src/app/core/pagination/pagination.service.ts
@@ -24,7 +24,11 @@ import { isNumeric } from '../../shared/numeric.util';
  */
 export class PaginationService {
 
-  private defaultSortOptions = new SortOptions('id', SortDirection.ASC);
+  /**
+   * Sort on title ASC by default
+   * @type {SortOptions}
+   */
+  private defaultSortOptions = new SortOptions('dc.title', SortDirection.ASC);
 
   private clearParams = {};
 

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
@@ -28,6 +28,7 @@ import { SearchConfigurationService } from '../../../core/shared/search/search-c
 import { SearchService } from '../../../core/shared/search/search.service';
 import { NoContent } from '../../../core/shared/NoContent.model';
 import { getItemPageRoute } from '../../item-page-routing-paths';
+import { SortDirection, SortOptions } from '../../../core/cache/models/sort-options.model';
 
 @Component({
   selector: 'ds-item-collection-mapper',
@@ -72,6 +73,12 @@ export class ItemCollectionMapperComponent implements OnInit {
    * Collections that are not mapped to the item
    */
   mappedCollectionsRD$: Observable<RemoteData<PaginatedList<Collection>>>;
+
+  /**
+   * Sort on title ASC by default
+   * @type {SortOptions}
+   */
+   defaultSortOptions: SortOptions = new SortOptions('dc.title', SortDirection.ASC);
 
   /**
    * Firing this observable (shouldUpdate$.next(true)) forces the two lists to reload themselves
@@ -149,7 +156,8 @@ export class ItemCollectionMapperComponent implements OnInit {
       switchMap(([itemCollectionsRD, owningCollectionRD, searchOptions]) => {
         return this.searchService.search(Object.assign(new PaginatedSearchOptions(searchOptions), {
           query: this.buildQuery([...itemCollectionsRD.payload.page, owningCollectionRD.payload], searchOptions.query),
-          dsoTypes: [DSpaceObjectType.COLLECTION]
+          dsoTypes: [DSpaceObjectType.COLLECTION],
+          sort: this.defaultSortOptions
         }), 10000).pipe(
           toDSpaceObjectListRD(),
           startWith(undefined)

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
@@ -28,7 +28,6 @@ import { SearchConfigurationService } from '../../../core/shared/search/search-c
 import { SearchService } from '../../../core/shared/search/search.service';
 import { NoContent } from '../../../core/shared/NoContent.model';
 import { getItemPageRoute } from '../../item-page-routing-paths';
-import { SortDirection, SortOptions } from '../../../core/cache/models/sort-options.model';
 
 @Component({
   selector: 'ds-item-collection-mapper',
@@ -73,12 +72,6 @@ export class ItemCollectionMapperComponent implements OnInit {
    * Collections that are not mapped to the item
    */
   mappedCollectionsRD$: Observable<RemoteData<PaginatedList<Collection>>>;
-
-  /**
-   * Sort on title ASC by default
-   * @type {SortOptions}
-   */
-   defaultSortOptions: SortOptions = new SortOptions('dc.title', SortDirection.ASC);
 
   /**
    * Firing this observable (shouldUpdate$.next(true)) forces the two lists to reload themselves
@@ -156,8 +149,7 @@ export class ItemCollectionMapperComponent implements OnInit {
       switchMap(([itemCollectionsRD, owningCollectionRD, searchOptions]) => {
         return this.searchService.search(Object.assign(new PaginatedSearchOptions(searchOptions), {
           query: this.buildQuery([...itemCollectionsRD.payload.page, owningCollectionRD.payload], searchOptions.query),
-          dsoTypes: [DSpaceObjectType.COLLECTION],
-          sort: this.defaultSortOptions
+          dsoTypes: [DSpaceObjectType.COLLECTION]
         }), 10000).pipe(
           toDSpaceObjectListRD(),
           startWith(undefined)


### PR DESCRIPTION
## References
* Fixes #1675 

## Description
This small PR updates the Collection Mapper to work the same as the Item Mapper.  On `main` the Collection Mapper wasn't specifying a sort order, which defaulted to `sort=id` causing the 422 error described in #1675. This small PR just ensures a sort order is specified.

NOTE: I could not find any way to add specs for this. The [current specs have a mock which specify the sort order should be `title ASC`](https://github.com/DSpace/dspace-angular/blob/main/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts#L69), but then the current code failed to set itself up the same way.  So, this PR essentially just corrects the code to align with the existing mock in the specs.

## Instructions for Reviewers
* Ensure #1675 is no longer reproducible
