### PR TITLE
Use docker.io prefix for images on Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace-angular
 # See https://github.com/DSpace/dspace-angular/tree/main/docker for usage details
 
-FROM node:18-alpine
+FROM docker.io/node:18-alpine
 WORKDIR /app
 ADD . /app/
 EXPOSE 4000

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -16,7 +16,7 @@ version: "3.7"
 
 services:
   dspace-cli:
-    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
+    image: "docker.io/${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
     container_name: dspace-cli
     environment:
       # Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -16,7 +16,7 @@ version: "3.7"
 
 services:
   dspacedb:
-    image: dspace/dspace-postgres-pgcrypto:loadsql
+    image: docker.io/dspace/dspace-postgres-pgcrypto:loadsql
     environment:
       # This LOADSQL should be kept in sync with the URL in DSpace/DSpace
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -32,7 +32,7 @@ services:
       solr__P__server: http://dspacesolr:8983/solr
     depends_on:
     - dspacedb
-    image: dspace/dspace:dspace-7_x-test
+    image: docker.io/dspace/dspace:dspace-7_x-test
     networks:
       dspacenet:
     ports:
@@ -65,7 +65,7 @@ services:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       LOADSQL: https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql
       PGDATA: /pgdata
-    image: dspace/dspace-postgres-pgcrypto:loadsql
+    image: docker.io/dspace/dspace-postgres-pgcrypto:loadsql
     networks:
       dspacenet:
     stdin_open: true
@@ -76,7 +76,7 @@ services:
   dspacesolr:
     container_name: dspacesolr
     # Uses official Solr image at https://hub.docker.com/_/solr/
-    image: solr:8.11-slim
+    image: docker.io/solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
     - dspace

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -39,7 +39,7 @@ services:
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests 
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: '172.23.0'
-    image: dspace/dspace:dspace-7_x-test
+    image: docker.io/dspace/dspace:dspace-7_x-test
     depends_on:
     - dspacedb
     networks:
@@ -69,7 +69,7 @@ services:
     container_name: dspacedb
     environment:
       PGDATA: /pgdata
-    image: dspace/dspace-postgres-pgcrypto
+    image: docker.io/dspace/dspace-postgres-pgcrypto
     networks:
       dspacenet:
     ports:
@@ -83,7 +83,7 @@ services:
   dspacesolr:
     container_name: dspacesolr
     # Uses official Solr image at https://hub.docker.com/_/solr/
-    image: solr:8.11-slim
+    image: docker.io/solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
     - dspace

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:dspace-7_x
+    image: docker.io/dspace/dspace-angular:dspace-7_x
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1686

## Description
Docker assumes images are hosted on docker.io by default, but there are other container runtimes (for example Podman). It is better to use fully-qualified image names to support other runtime environments in the future.

## Instructions for Reviewers
Try `docker-compose -f docker-compose.yml build`, up, down, etc for each Docker compose file. 

List of changes in this PR:
* First, change the prefix for all images to docker.io.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.