### PR TITLE
Truncatable toggle: spacing between icon & label as margin instead of whitespace

### DIFF
--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
@@ -3,7 +3,11 @@
     <ng-content></ng-content>
   </div>
   <button class="btn btn-link p-0 expandButton" dsDragClick (actualClick)="toggle()">
-    <i class="fas fa-angle-down"></i> {{ 'item.truncatable-part.show-more' | translate }}</button>
+    <i class="fas fa-angle-down"></i>
+    <span class="ml-1">{{ 'item.truncatable-part.show-more' | translate }}</span>
+  </button>
   <button class="btn btn-link p-0 collapseButton" dsDragClick (actualClick)="toggle()" *ngIf="expand && expandable">
-    <i class="fas fa-angle-up"></i> {{ 'item.truncatable-part.show-less' | translate }}</button>
+    <i class="fas fa-angle-up"></i>
+    <span class="ml-1">{{ 'item.truncatable-part.show-less' | translate }}</span>
+  </button>
 </div>


### PR DESCRIPTION
## References
* Introduced in #1619

## Description
The new truncatable toggle buttons use a single space for the gap with their icons.
This becomes noticeable when hovering over the button

* Before this PR:
  ![20220613-194307](https://user-images.githubusercontent.com/31547038/173414004-b912c82e-f109-4027-8b0b-fb7a96c22df8.png)
* After this PR:
  ![20220613-194157](https://user-images.githubusercontent.com/31547038/173413994-5705fb90-6e8c-4891-99bb-40d9e2e5a6be.png)


## Instructions for Reviewers
Confirm that the hover decoration issue shown above doesn't occur.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
