### PR TITLE
Fix continuous integration e2e backend failures

### DIFF
--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -25,7 +25,7 @@ services:
     ### OVERRIDE default 'entrypoint' in 'docker-compose-rest.yml' ####
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables
+    # 2. Then, run database migration to init database tables  (including any out-of-order ignored migrations, if any)
     # 3. (Custom for Entities) enable Entity-specific collection submission mappings in item-submission.xml
     #    This 'sed' command inserts the sample configurations specific to the Entities data set, see:
     #    https://github.com/DSpace/DSpace/blob/main/dspace/config/item-submission.xml#L36-L49
@@ -35,7 +35,7 @@ services:
       - '-c'
       - |
         while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-        /dspace/bin/dspace database migrate
+        /dspace/bin/dspace database migrate ignored
         sed -i '/name-map collection-handle="default".*/a \\n <name-map collection-handle="123456789/3" submission-name="Publication"/> \
           <name-map collection-handle="123456789/4" submission-name="Publication"/> \
           <name-map collection-handle="123456789/281" submission-name="Publication"/> \

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -46,14 +46,14 @@ services:
     - solr_configs:/dspace/solr
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables
+    # 2. Then, run database migration to init database tables (including any out-of-order ignored migrations, if any)
     # 3. Finally, start Tomcat
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-      /dspace/bin/dspace database migrate
+      /dspace/bin/dspace database migrate ignored
       catalina.sh run
   # DSpace database container
   # NOTE: This is customized to use our loadsql image, so that we are using a database with existing test data


### PR DESCRIPTION
Ensure CI docker backend always runs DB migrations, even when out of order.  In other words, this PR updates the CI process to now run `./dspace database migrate ignored` instead of simply `./dspace database migrate`. This ensures that the database backend also applies any migrations which run "out of order" (based on the name of the migration).

Small PR to debug/fix the current issues with e2e tests.  Currently the Docker backend that e2e tests require is failing to start up properly.

This has fixed the issue!
