### PR TITLE
Add the default baseHref value to angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -63,7 +63,8 @@
                 "bundleName": "dspace-theme"
               }
             ],
-            "scripts": []
+            "scripts": [],
+            "baseHref": "/"
           },
           "configurations": {
             "development": {


### PR DESCRIPTION
## References
* Issue introduced by https://github.com/DSpace/dspace-angular/pull/1642

## Description
If you run `yarn run start:dev` you'll see that the baseHref in your config is automatically added to angular.json. As a result angular.json almost always have a change when you commit.

This PR adds the default baseHref of `/` to angular.json to ensure that change only occurs when you use a custom nameSpace in your dev config.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
