### PR TITLE
Add spacing before handle on comcol pages

### DIFF
--- a/src/app/shared/comcol/comcol-page-handle/comcol-page-handle.component.html
+++ b/src/app/shared/comcol/comcol-page-handle/comcol-page-handle.component.html
@@ -1,4 +1,4 @@
 <div *ngIf="content" class="content-with-optional-title mb-2">
     <h2 class="d-inline-block h6" *ngIf="title">{{ title | translate }}</h2>
-    <div  class="d-inline-block "><a href="{{getHandle()}}">{{getHandle()}}</a></div>
+    <div class="d-inline-block px-2"><a href="{{getHandle()}}">{{getHandle()}}</a></div>
 </div>


### PR DESCRIPTION
## Description
During final testing of 7.3, I discovered that Handles are being displayed on Community/Collection pages without a space before the link. Screenshot:
![no-space](https://user-images.githubusercontent.com/483997/175386134-f63323fd-7b59-448c-85d7-4fa71e097cc9.png)

This tiny PR fixes that issue.