### PR TITLE
remove hard-coded checkbox label in FormatFormComponent

### DIFF
--- a/src/app/admin/admin-registries/bitstream-formats/format-form/format-form.component.ts
+++ b/src/app/admin/admin-registries/bitstream-formats/format-form/format-form.component.ts
@@ -104,7 +104,7 @@ export class FormatFormComponent implements OnInit {
     new DynamicCheckboxModel({
       id: 'internal',
       name: 'internal',
-      label: 'Internal',
+      label: 'admin.registries.bitstream-formats.edit.internal.label',
       hint: 'admin.registries.bitstream-formats.edit.internal.hint',
     }),
     new DynamicFormArrayModel({


### PR DESCRIPTION
## Description

Use translation key `admin.registries.bitstream-formats.edit.internal.label` as checkbox label instead of hard-coded label value in `FormatFormComponent`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
