### PR TITLE
Make label and error messages for license-step accept-checkbox translatable

### DIFF
--- a/src/app/submission/sections/license/section-license.component.ts
+++ b/src/app/submission/sections/license/section-license.component.ts
@@ -29,6 +29,7 @@ import { renderSectionFor } from '../sections-decorator';
 import { SectionsType } from '../sections-type';
 import { SectionsService } from '../sections.service';
 import { SECTION_LICENSE_FORM_LAYOUT, SECTION_LICENSE_FORM_MODEL } from './section-license.model';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * This component represents a section that contains the submission license form.
@@ -99,6 +100,7 @@ export class SubmissionSectionLicenseComponent extends SectionModelComponent {
    * @param {JsonPatchOperationsBuilder} operationsBuilder
    * @param {SectionsService} sectionService
    * @param {SubmissionService} submissionService
+   * @param {TranslateService} translateService
    * @param {string} injectedCollectionId
    * @param {SectionDataObject} injectedSectionData
    * @param {string} injectedSubmissionId
@@ -111,6 +113,7 @@ export class SubmissionSectionLicenseComponent extends SectionModelComponent {
               protected operationsBuilder: JsonPatchOperationsBuilder,
               protected sectionService: SectionsService,
               protected submissionService: SubmissionService,
+              protected translateService: TranslateService,
               @Inject('collectionIdProvider') public injectedCollectionId: string,
               @Inject('sectionDataProvider') public injectedSectionData: SectionDataObject,
               @Inject('submissionIdProvider') public injectedSubmissionId: string) {
@@ -125,6 +128,9 @@ export class SubmissionSectionLicenseComponent extends SectionModelComponent {
     this.formId = this.formService.getUniqueId(this.sectionData.id);
     this.formModel = this.formBuilderService.fromJSON(SECTION_LICENSE_FORM_MODEL);
     const model = this.formBuilderService.findById('granted', this.formModel);
+
+    // Translate checkbox label
+    model.label = this.translateService.instant(model.label);
 
     // Retrieve license accepted status
     (model as DynamicCheckboxModel).value = (this.sectionData.data as WorkspaceitemSectionLicenseObject).granted;

--- a/src/app/submission/sections/license/section-license.model.ts
+++ b/src/app/submission/sections/license/section-license.model.ts
@@ -13,15 +13,15 @@ export const SECTION_LICENSE_FORM_LAYOUT = {
 export const SECTION_LICENSE_FORM_MODEL = [
   {
     id: 'granted',
-    label: 'I confirm the license above',
+    label: 'submission.sections.license.granted-label',
     required: true,
     value: false,
     validators: {
       required: null
     },
     errorMessages: {
-      required: 'You must accept the license',
-      notgranted: 'You must accept the license'
+      required: 'submission.sections.license.required',
+      notgranted: 'submission.sections.license.notgranted'
     },
     type: 'CHECKBOX',
   }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4234,6 +4234,12 @@
 
   "submission.sections.accesses.form.until-placeholder": "Until",
 
+  "submission.sections.license.granted-label": "I confirm the license above",
+
+  "submission.sections.license.required": "You must accept the license",
+
+  "submission.sections.license.notgranted":  "You must accept the license",
+
 
   "submission.sections.sherpa.publication.information": "Publication information",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -5314,7 +5314,14 @@
 	// "submission.sections.upload.upload-successful": "Upload successful",
 	"submission.sections.upload.upload-successful": "Subida exitosa",
 
+  // "submission.sections.license.granted-label": "I confirm the license above",
+  "submission.sections.license.granted-label": "Confirmo la licencia",
 
+  // "submission.sections.license.required": "You must accept the license",
+  "submission.sections.license.required": "Debe aceptar la licencia",
+
+  // "submission.sections.license.notgranted":  "You must accept the license",
+  "submission.sections.license.notgranted":  "Debe aceptar la licencia",
 
 	// "submission.submit.breadcrumbs": "New submission",
 	"submission.submit.breadcrumbs": "Nuevo envío",


### PR DESCRIPTION
## References
* Fixes #1487

## Description
Make label and error messages for license-step accept-checkbox translatable and add translation for English and Spanish.

## Instructions for Reviewers

List of changes in this PR:
* Apply the changes suggested by @atarix83  in this comment to add the i18n keys: https://github.com/DSpace/dspace-angular/issues/1487#issuecomment-1011082613
* Add the translation for English and Spanish
* Use the TranslateService in onSectionInit function to force the translation of the checkbox label

**Include guidance for how to test or review your PR.** 

Start a new submission and check that the checkbox label and the error message that appears when the checkbox is unchecked are translated for Spanish and English.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
