### PR TITLE
Filter webpack warnings

### DIFF
--- a/src/app/register-page/register-email/themed-register-email.component.ts
+++ b/src/app/register-page/register-email/themed-register-email.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { ThemedComponent } from '../../shared/theme-support/themed.component';
+import { RegisterEmailComponent } from './register-email.component';
+
+/**
+ * Themed wrapper for RegisterEmailComponent
+ */
+@Component({
+  selector: 'ds-themed-register-email',
+  styleUrls: [],
+  templateUrl: '../../shared/theme-support/themed.component.html',
+})
+export class ThemedRegisterEmailComponent extends ThemedComponent<RegisterEmailComponent> {
+  protected getComponentName(): string {
+    return 'RegisterEmailComponent';
+  }
+
+  protected importThemedComponent(themeName: string): Promise<any> {
+    return import(`../../../themes/${themeName}/app/register-page/register-email/register-email.component`);
+  }
+
+  protected importUnthemedComponent(): Promise<any> {
+    return import('./register-email.component');
+  }
+}

--- a/src/app/register-page/register-page-routing.module.ts
+++ b/src/app/register-page/register-page-routing.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { RegisterEmailComponent } from './register-email/register-email.component';
+import { ThemedRegisterEmailComponent } from './register-email/themed-register-email.component';
 import { ItemPageResolver } from '../item-page/item-page.resolver';
 import { EndUserAgreementCookieGuard } from '../core/end-user-agreement/end-user-agreement-cookie.guard';
 import { ThemedCreateProfileComponent } from './create-profile/themed-create-profile.component';
@@ -11,7 +11,7 @@ import { RegistrationGuard } from './registration.guard';
     RouterModule.forChild([
       {
         path: '',
-        component: RegisterEmailComponent,
+        component: ThemedRegisterEmailComponent,
         data: {title: 'register-email.title'},
       },
       {

--- a/src/app/register-page/register-page.module.ts
+++ b/src/app/register-page/register-page.module.ts
@@ -7,6 +7,7 @@ import { CreateProfileComponent } from './create-profile/create-profile.componen
 import { RegisterEmailFormModule } from '../register-email-form/register-email-form.module';
 import { ProfilePageModule } from '../profile-page/profile-page.module';
 import { ThemedCreateProfileComponent } from './create-profile/themed-create-profile.component';
+import { ThemedRegisterEmailComponent } from './register-email/themed-register-email.component';
 
 @NgModule({
   imports: [
@@ -18,6 +19,7 @@ import { ThemedCreateProfileComponent } from './create-profile/themed-create-pro
   ],
   declarations: [
     RegisterEmailComponent,
+    ThemedRegisterEmailComponent,
     CreateProfileComponent,
     ThemedCreateProfileComponent
   ],

--- a/webpack/webpack.common.ts
+++ b/webpack/webpack.common.ts
@@ -95,4 +95,7 @@ export const commonExports = {
       },
     ],
   },
+  ignoreWarnings: [
+    /src\/themes\/[^/]+\/.*theme.module.ts is part of the TypeScript compilation but it's unused/,
+  ]
 };


### PR DESCRIPTION
## Description
When customizing DSpace we tend to end up with two or three additional themes, all of which spam

```
WARNING: <theme module> is part of the TypeScript compilation but it's unused.
Add only entry points to the 'files' or 'include' properties in your tsconfig.
```

I've had a few situations where I've overlooked warnings because they were simply pushed off screen by all of the "normal" theme warnings; and if the build succeeds it's very easy to just move on.
Having those perpetual warnings conditions everyone to pay less attention to the relevant ones.



This PR introduces a filter via [Webpack's `ignoreWarnings` property](https://webpack.js.org/configuration/other-options/#ignorewarnings) to address this.



Case in point: adding this filter brings two warnings wrt. components of the `custom` theme into focus:

* A themed version of the `RegisterEmailComponent` was added [here](https://github.com/DSpace/dspace-angular/blob/d3dd8fb5654a1597d23553fa5b8fd1052e38ef30/src/themes/custom/app/register-page/register-email/register-email.component.ts), but it was never made themeable.

* `PublicationComponent` also complains about being excluded, probably because the `custom` theme unused by default and therefore not included in the `EagerThemesModule`

  We may want to explicitly exclude unused themes in `tsconfig.json` 


## Reviewing
Compare [this PR's build output](https://github.com/DSpace/dspace-angular/runs/7089755334?check_suite_focus=true#step:10:39) with [current main](https://github.com/DSpace/dspace-angular/runs/7046923189?check_suite_focus=true#step:10:34)
  * Spammy warnings should no longer be shown
  * Other warnings should still be there


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
