### PR TITLE
Option to force HTTPS in origin

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -15,6 +15,10 @@ ui:
     windowMs: 60000 # 1 minute
     max: 500 # limit each IP to 500 requests per windowMs
 
+  # The forceHTTPSInOrigin forces the protocol to HTTPS when the complete URL is needed in the UI
+  # NOTE: Defaults to true when in production mode, defaults to false when not in production mode
+  # forceHTTPSInOrigin: true
+
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually
 # 'synced' with the 'dspace.server.url' setting in your backend's local.cfg.

--- a/src/app/core/services/browser-hard-redirect.service.spec.ts
+++ b/src/app/core/services/browser-hard-redirect.service.spec.ts
@@ -11,7 +11,7 @@ describe('BrowserHardRedirectService', () => {
     search: '/search',
     origin,
     host,
-    replace: (url) => {mockLocation.href = url}
+    replace: (url: string) => {mockLocation.href = url;}
   } as Location;
 
   const service: BrowserHardRedirectService = new BrowserHardRedirectService(mockLocation);

--- a/src/app/core/services/browser-hard-redirect.service.spec.ts
+++ b/src/app/core/services/browser-hard-redirect.service.spec.ts
@@ -1,13 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import { BrowserHardRedirectService } from './browser-hard-redirect.service';
+import { environment } from '../../../environments/environment';
 
 describe('BrowserHardRedirectService', () => {
-  const origin = 'https://test-host.com:4000';
+  const origin = 'http://test-host.com:4000';
+  const host = 'test-host.com:4000';
   const mockLocation = {
     href: undefined,
     pathname: '/pathname',
     search: '/search',
-    origin
+    origin,
+    host,
+    replace: (url) => {mockLocation.href = url}
   } as Location;
 
   const service: BrowserHardRedirectService = new BrowserHardRedirectService(mockLocation);
@@ -47,4 +51,19 @@ describe('BrowserHardRedirectService', () => {
     });
   });
 
+  describe('when requesting the origin with forceHTTPSInOrigin set to true', () => {
+    let originalValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      (environment.ui as any).forceHTTPSInOrigin = true;
+    });
+
+    it('should return the location origin', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin.replace('http://', 'https://'));
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
+    });
+  });
 });

--- a/src/app/core/services/browser-hard-redirect.service.spec.ts
+++ b/src/app/core/services/browser-hard-redirect.service.spec.ts
@@ -66,4 +66,44 @@ describe('BrowserHardRedirectService', () => {
       (environment.ui as any).forceHTTPSInOrigin = originalValue;
     });
   });
+
+  describe('when requesting the origin with forceHTTPSInOrigin unset and production set to false', () => {
+    let originalValue;
+    let originalProdValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      originalProdValue = (environment as any).production;
+      (environment.ui as any).forceHTTPSInOrigin = undefined;
+      (environment as any).production = false;
+    });
+
+    it('should return the location origin with the original protocol', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin);
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
+      (environment as any).production = originalProdValue;
+    });
+  });
+
+  describe('when requesting the origin with forceHTTPSInOrigin unset and production set to true', () => {
+    let originalValue;
+    let originalProdValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      originalProdValue = (environment as any).production;
+      (environment.ui as any).forceHTTPSInOrigin = undefined;
+      (environment as any).production = true;
+    });
+
+    it('should return the location origin with https', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin.replace('http://', 'https://'));
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
+      (environment as any).production = originalProdValue;
+    });
+  });
 });

--- a/src/app/core/services/browser-hard-redirect.service.ts
+++ b/src/app/core/services/browser-hard-redirect.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { HardRedirectService } from './hard-redirect.service';
 import { environment } from '../../../environments/environment';
 import { UIServerConfig } from '../../../config/ui-server-config.interface';
+import { hasValue } from '../../shared/empty.util';
 
 export const LocationToken = new InjectionToken('Location');
 
@@ -44,7 +45,10 @@ export class BrowserHardRedirectService extends HardRedirectService {
    * the origin would be https://demo7.dspace.org
    */
   getCurrentOrigin(): string {
-    if ((environment.ui as UIServerConfig).forceHTTPSInOrigin) {
+    const forceHTTPsConfig = (environment.ui as UIServerConfig).forceHTTPSInOrigin;
+    const forceHTTPs = hasValue(forceHTTPsConfig) ? forceHTTPsConfig : environment.production;
+
+    if (forceHTTPs) {
       return 'https://' + this.location.host;
     } else {
       return this.location.origin;

--- a/src/app/core/services/browser-hard-redirect.service.ts
+++ b/src/app/core/services/browser-hard-redirect.service.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { HardRedirectService } from './hard-redirect.service';
+import { environment } from '../../../environments/environment';
+import { UIServerConfig } from '../../../config/ui-server-config.interface';
 
 export const LocationToken = new InjectionToken('Location');
 
@@ -24,7 +26,7 @@ export class BrowserHardRedirectService extends HardRedirectService {
    * @param url
    */
   redirect(url: string) {
-    this.location.href = url;
+    this.location.replace(url);
   }
 
   /**
@@ -42,6 +44,10 @@ export class BrowserHardRedirectService extends HardRedirectService {
    * the origin would be https://demo7.dspace.org
    */
   getCurrentOrigin(): string {
-    return this.location.origin;
+    if ((environment.ui as UIServerConfig).forceHTTPSInOrigin) {
+      return 'https://' + this.location.host;
+    } else {
+      return this.location.origin;
+    }
   }
 }

--- a/src/app/core/services/server-hard-redirect.service.spec.ts
+++ b/src/app/core/services/server-hard-redirect.service.spec.ts
@@ -71,4 +71,44 @@ describe('ServerHardRedirectService', () => {
     });
   });
 
+  describe('when requesting the origin with forceHTTPSInOrigin unset and production set to false', () => {
+    let originalValue;
+    let originalProdValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      originalProdValue = (environment as any).production;
+      (environment.ui as any).forceHTTPSInOrigin = undefined;
+      (environment as any).production = false;
+    });
+
+    it('should return the location origin with the original protocol', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin);
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
+      (environment as any).production = originalProdValue;
+    });
+  });
+
+  describe('when requesting the origin with forceHTTPSInOrigin unset and production set to true', () => {
+    let originalValue;
+    let originalProdValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      originalProdValue = (environment as any).production;
+      (environment.ui as any).forceHTTPSInOrigin = undefined;
+      (environment as any).production = true;
+    });
+
+    it('should return the location origin with https', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin.replace('http://', 'https://'));
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
+      (environment as any).production = originalProdValue;
+    });
+  });
+
 });

--- a/src/app/core/services/server-hard-redirect.service.spec.ts
+++ b/src/app/core/services/server-hard-redirect.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { ServerHardRedirectService } from './server-hard-redirect.service';
+import { environment } from '../../../environments/environment';
 
 describe('ServerHardRedirectService', () => {
 
@@ -7,10 +8,10 @@ describe('ServerHardRedirectService', () => {
   const mockResponse = jasmine.createSpyObj(['redirect', 'end']);
 
   const service: ServerHardRedirectService = new ServerHardRedirectService(mockRequest, mockResponse);
-  const origin = 'https://test-host.com:4000';
+  const origin = 'http://test-host.com:4000';
 
   beforeEach(() => {
-    mockRequest.protocol = 'https';
+    mockRequest.protocol = 'http';
     mockRequest.headers = {
       host: 'test-host.com:4000',
     };
@@ -51,6 +52,22 @@ describe('ServerHardRedirectService', () => {
 
     it('should return the location origin', () => {
       expect(service.getCurrentOrigin()).toEqual(origin);
+    });
+  });
+
+  describe('when requesting the origin with forceHTTPSInOrigin set to true', () => {
+    let originalValue;
+    beforeEach(() => {
+      originalValue = (environment.ui as any).forceHTTPSInOrigin;
+      (environment.ui as any).forceHTTPSInOrigin = true;
+    });
+
+    it('should return the location origin with HTTPS', () => {
+      expect(service.getCurrentOrigin()).toEqual(origin.replace('http://', 'https://'));
+    });
+
+    afterEach(() => {
+      (environment.ui as any).forceHTTPSInOrigin = originalValue;
     });
   });
 

--- a/src/app/core/services/server-hard-redirect.service.ts
+++ b/src/app/core/services/server-hard-redirect.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@angular/core';
 import { Request, Response } from 'express';
 import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 import { HardRedirectService } from './hard-redirect.service';
+import { environment } from '../../../environments/environment';
+import { UIServerConfig } from '../../../config/ui-server-config.interface';
 
 /**
  * Service for performing hard redirects within the server app module
@@ -68,6 +70,10 @@ export class ServerHardRedirectService extends HardRedirectService {
    * the origin would be https://demo7.dspace.org
    */
   getCurrentOrigin(): string {
-    return this.req.protocol + '://' + this.req.headers.host;
+    if ((environment.ui as UIServerConfig).forceHTTPSInOrigin) {
+      return 'https://' + this.req.headers.host;
+    } else {
+      return this.req.protocol + '://' + this.req.headers.host;
+    }
   }
 }

--- a/src/app/core/services/server-hard-redirect.service.ts
+++ b/src/app/core/services/server-hard-redirect.service.ts
@@ -4,6 +4,7 @@ import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 import { HardRedirectService } from './hard-redirect.service';
 import { environment } from '../../../environments/environment';
 import { UIServerConfig } from '../../../config/ui-server-config.interface';
+import { hasValue } from '../../shared/empty.util';
 
 /**
  * Service for performing hard redirects within the server app module
@@ -70,7 +71,10 @@ export class ServerHardRedirectService extends HardRedirectService {
    * the origin would be https://demo7.dspace.org
    */
   getCurrentOrigin(): string {
-    if ((environment.ui as UIServerConfig).forceHTTPSInOrigin) {
+    const forceHTTPsConfig = (environment.ui as UIServerConfig).forceHTTPSInOrigin;
+    const forceHTTPs = hasValue(forceHTTPsConfig) ? forceHTTPsConfig : environment.production;
+
+    if (forceHTTPs) {
       return 'https://' + this.req.headers.host;
     } else {
       return this.req.protocol + '://' + this.req.headers.host;

--- a/src/config/ui-server-config.interface.ts
+++ b/src/config/ui-server-config.interface.ts
@@ -10,5 +10,6 @@ export class UIServerConfig extends ServerConfig {
     windowMs: number;
     max: number;
   };
-
+  // this sets the protocol to HTTPS when the complete URL is needed in the UI
+  forceHTTPSInOrigin?: boolean;
 }


### PR DESCRIPTION
## References
* Fixes #1721
* Alternative to https://github.com/DSpace/dspace-angular/pull/1850

## Description
This PR adds a new configuration parameter `forceHTTPSInOrigin` to force to return the origin URL with the `https://` protocol. This PR also uses the `location.replace()` function to redirect and make sure the browser can keep track of the browse history.

## Instructions for Reviewers
In the environment variables, in the list of `ui` configurations set `forceHTTPSInOrigin` to `true`.
Test that the `citation_pdf_url` on an item page and make sure it always returns a URL that starts with `https://`.

To test the redirect change, download a file, and use the back button of your browser. You should end up back on the item page

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
