### PR TITLE
Add admin option to export all fields in the metadata export

### DIFF
--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.spec.ts
@@ -20,6 +20,7 @@ import {
   createSuccessfulRemoteDataObject$
 } from '../../../remote-data.utils';
 import { ExportMetadataSelectorComponent } from './export-metadata-selector.component';
+import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
 
 // No way to add entryComponents yet to testbed; alternative implemented; source: https://stackoverflow.com/questions/41689468/how-to-shallow-test-a-component-with-an-entrycomponents
 @NgModule({
@@ -47,6 +48,7 @@ describe('ExportMetadataSelectorComponent', () => {
   let router;
   let notificationService: NotificationsServiceStub;
   let scriptService;
+  let authorizationDataService;
 
   const mockItem = Object.assign(new Item(), {
     id: 'fake-id',
@@ -95,6 +97,9 @@ describe('ExportMetadataSelectorComponent', () => {
         invoke: createSuccessfulRemoteDataObject$({ processId: '45' })
       }
     );
+    authorizationDataService = jasmine.createSpyObj('authorizationDataService', {
+      isAuthorized: observableOf(true)
+    });
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), ModelTestModule],
       declarations: [ExportMetadataSelectorComponent],
@@ -102,6 +107,7 @@ describe('ExportMetadataSelectorComponent', () => {
         { provide: NgbActiveModal, useValue: modalStub },
         { provide: NotificationsService, useValue: notificationService },
         { provide: ScriptDataService, useValue: scriptService },
+        { provide: AuthorizationDataService, useValue: authorizationDataService },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -150,7 +156,7 @@ describe('ExportMetadataSelectorComponent', () => {
     });
   });
 
-  describe('if collection is selected', () => {
+  describe('if collection is selected and is admin', () => {
     let scriptRequestSucceeded;
     beforeEach((done) => {
       spyOn((component as any).modalService, 'open').and.returnValue(modalRef);
@@ -159,7 +165,32 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('should invoke the metadata-export script with option -i uuid', () => {
+    it('should invoke the metadata-export script with option -i uuid and -a option', () => {
+      const parameterValues: ProcessParameter[] = [
+        Object.assign(new ProcessParameter(), { name: '-i', value: mockCollection.uuid }),
+        Object.assign(new ProcessParameter(), { name: '-a' }),
+      ];
+      expect(scriptService.invoke).toHaveBeenCalledWith(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
+    });
+    it('success notification is shown', () => {
+      expect(scriptRequestSucceeded).toBeTrue();
+      expect(notificationService.success).toHaveBeenCalled();
+    });
+    it('redirected to process page', () => {
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/processes/45');
+    });
+  });
+  describe('if collection is selected and is not admin', () => {
+    let scriptRequestSucceeded;
+    beforeEach((done) => {
+      (authorizationDataService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+      spyOn((component as any).modalService, 'open').and.returnValue(modalRef);
+      component.navigate(mockCollection).subscribe((succeeded: boolean) => {
+        scriptRequestSucceeded = succeeded;
+        done();
+      });
+    });
+    it('should invoke the metadata-export script with option -i uuid without the -a option', () => {
       const parameterValues: ProcessParameter[] = [
         Object.assign(new ProcessParameter(), { name: '-i', value: mockCollection.uuid }),
       ];
@@ -174,7 +205,7 @@ describe('ExportMetadataSelectorComponent', () => {
     });
   });
 
-  describe('if community is selected', () => {
+  describe('if community is selected and is an admin', () => {
     let scriptRequestSucceeded;
     beforeEach((done) => {
       spyOn((component as any).modalService, 'open').and.returnValue(modalRef);
@@ -183,7 +214,32 @@ describe('ExportMetadataSelectorComponent', () => {
         done();
       });
     });
-    it('should invoke the metadata-export script with option -i uuid', () => {
+    it('should invoke the metadata-export script with option -i uuid and -a option if the user is an admin', () => {
+      const parameterValues: ProcessParameter[] = [
+        Object.assign(new ProcessParameter(), { name: '-i', value: mockCommunity.uuid }),
+        Object.assign(new ProcessParameter(), { name: '-a' }),
+      ];
+      expect(scriptService.invoke).toHaveBeenCalledWith(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
+    });
+    it('success notification is shown', () => {
+      expect(scriptRequestSucceeded).toBeTrue();
+      expect(notificationService.success).toHaveBeenCalled();
+    });
+    it('redirected to process page', () => {
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/processes/45');
+    });
+  });
+  describe('if community is selected and is not an admin', () => {
+    let scriptRequestSucceeded;
+    beforeEach((done) => {
+      (authorizationDataService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+      spyOn((component as any).modalService, 'open').and.returnValue(modalRef);
+      component.navigate(mockCommunity).subscribe((succeeded: boolean) => {
+        scriptRequestSucceeded = succeeded;
+        done();
+      });
+    });
+    it('should invoke the metadata-export script with option -i uuid without the -a option', () => {
       const parameterValues: ProcessParameter[] = [
         Object.assign(new ProcessParameter(), { name: '-i', value: mockCommunity.uuid }),
       ];

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
@@ -19,6 +19,8 @@ import { getFirstCompletedRemoteData } from '../../../../core/shared/operators';
 import { Process } from '../../../../process-page/processes/process.model';
 import { RemoteData } from '../../../../core/data/remote-data';
 import { getProcessDetailRoute } from '../../../../process-page/process-page-routing.paths';
+import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../../core/data/feature-authorization/feature-id';
 
 /**
  * Component to wrap a list of existing dso's inside a modal
@@ -36,6 +38,7 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
   constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router,
               protected notificationsService: NotificationsService, protected translationService: TranslateService,
               protected scriptDataService: ScriptDataService,
+              protected authorizationDataService: AuthorizationDataService,
               private modalService: NgbModal) {
     super(activeModal, route);
   }
@@ -82,24 +85,30 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
     const parameterValues: ProcessParameter[] = [
       Object.assign(new ProcessParameter(), { name: '-i', value: dso.uuid }),
     ];
-    return this.scriptDataService.invoke(METADATA_EXPORT_SCRIPT_NAME, parameterValues, [])
-      .pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<Process>) => {
-          if (rd.hasSucceeded) {
-            const title = this.translationService.get('process.new.notification.success.title');
-            const content = this.translationService.get('process.new.notification.success.content');
-            this.notificationsService.success(title, content);
-            if (isNotEmpty(rd.payload)) {
-              this.router.navigateByUrl(getProcessDetailRoute(rd.payload.processId));
-            }
-            return true;
-          } else {
-            const title = this.translationService.get('process.new.notification.error.title');
-            const content = this.translationService.get('process.new.notification.error.content');
-            this.notificationsService.error(title, content);
-            return false;
+    return this.authorizationDataService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      switchMap((isAdmin) => {
+        if (isAdmin) {
+          parameterValues.push(Object.assign(new ProcessParameter(), {name: '-a'}));
+        }
+        console.log(isAdmin, parameterValues);
+        return this.scriptDataService.invoke(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
+      }),
+      getFirstCompletedRemoteData(),
+      map((rd: RemoteData<Process>) => {
+        if (rd.hasSucceeded) {
+          const title = this.translationService.get('process.new.notification.success.title');
+          const content = this.translationService.get('process.new.notification.success.content');
+          this.notificationsService.success(title, content);
+          if (isNotEmpty(rd.payload)) {
+            this.router.navigateByUrl(getProcessDetailRoute(rd.payload.processId));
           }
-        }));
+          return true;
+        } else {
+          const title = this.translationService.get('process.new.notification.error.title');
+          const content = this.translationService.get('process.new.notification.error.content');
+          this.notificationsService.error(title, content);
+          return false;
+        }
+      }));
   }
 }

--- a/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/export-metadata-selector/export-metadata-selector.component.ts
@@ -90,7 +90,6 @@ export class ExportMetadataSelectorComponent extends DSOSelectorModalWrapperComp
         if (isAdmin) {
           parameterValues.push(Object.assign(new ProcessParameter(), {name: '-a'}));
         }
-        console.log(isAdmin, parameterValues);
         return this.scriptDataService.invoke(METADATA_EXPORT_SCRIPT_NAME, parameterValues, []);
       }),
       getFirstCompletedRemoteData(),


### PR DESCRIPTION
## Description
The current metadata export does not export the hidden fields. This PR fixes that issue by adding the `-a` option to the script that is invoked.

## Instructions for Reviewers
Export the metadata of a collection or community.
Verify that hidden metadata such as dc.description.provenance is exported together with the other metadata. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
