### PR TITLE
External provider query error

### DIFF
--- a/src/app/submission/import-external/submission-import-external.component.html
+++ b/src/app/submission/import-external/submission-import-external.component.html
@@ -24,8 +24,11 @@
         </ds-viewable-collection>
         <ds-themed-loading *ngIf="(isLoading$ | async)"
                     message="{{'loading.search-results' | translate}}"></ds-themed-loading>
-        <div *ngIf="!(isLoading$ | async) && entriesRD?.payload?.page?.length === 0" id="empty-external-entry-list">
+        <div *ngIf="!(isLoading$ | async) && entriesRD?.payload?.page?.length === 0" data-test="empty-external-entry-list">
           <ds-alert [type]="'alert-info'">{{ 'search.results.empty' | translate }}</ds-alert>
+        </div>
+        <div *ngIf="!(isLoading$ | async) && entriesRD.statusCode === 500" data-test="empty-external-error-500">
+          <ds-alert [type]="'alert-info'">{{ 'search.results.response.500' | translate }}</ds-alert>
         </div>
       </ng-container>
     </div>

--- a/src/app/submission/import-external/submission-import-external.component.spec.ts
+++ b/src/app/submission/import-external/submission-import-external.component.spec.ts
@@ -483,8 +483,7 @@ describe('SubmissionImportExternalComponent test suite', () => {
       mockExternalSourceService.getExternalSourceEntries.and.returnValue(createFailedRemoteDataObject$(
         errorObj.errorMessage,
         errorObj.statusCode,
-        errorObj.timeCompleted,
-        errorObj.errors
+        errorObj.timeCompleted
       ));
       spyOn(routeServiceStub, 'getQueryParameterValue').and.callFake((param) => {
         if (param === 'entity') {

--- a/src/app/submission/import-external/submission-import-external.component.spec.ts
+++ b/src/app/submission/import-external/submission-import-external.component.spec.ts
@@ -184,7 +184,7 @@ describe('SubmissionImportExternalComponent test suite', () => {
     });
   });
 
-  describe('handle BE response for search query', () => {
+  describe('handle backend response for search query', () => {
     const paginatedData: any = {
       'timeCompleted': 1657009282990,
       'msToLive': 900000,
@@ -203,20 +203,20 @@ describe('SubmissionImportExternalComponent test suite', () => {
         },
         '_links': {
           'first': {
-            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=0&size=10&sort=id,asc'
+            'href': 'https://example.com/server/api/integration/externalsources/scopus/entries?query=test&page=0&size=10&sort=id,asc'
           },
           'self': {
-            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?sort=id,ASC&page=0&size=10&query=test'
+            'href': 'https://example.com/server/api/integration/externalsources/scopus/entries?sort=id,ASC&page=0&size=10&query=test'
           },
           'next': {
-            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=1&size=10&sort=id,asc'
+            'href': 'https://example.com/server/api/integration/externalsources/scopus/entries?query=test&page=1&size=10&sort=id,asc'
           },
           'last': {
-            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=1197160&size=10&sort=id,asc'
+            'href': 'https://example.com/server/api/integration/externalsources/scopus/entries?query=test&page=1197160&size=10&sort=id,asc'
           },
           'page': [
             {
-              'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
+              'href': 'https://example.com/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
             }
           ]
         },
@@ -411,7 +411,7 @@ describe('SubmissionImportExternalComponent test suite', () => {
             },
             '_links': {
               'self': {
-                'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
+                'href': 'https://example.com/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
               }
             }
           }
@@ -421,7 +421,7 @@ describe('SubmissionImportExternalComponent test suite', () => {
     };
     const errorObj = {
       errorMessage: 'Http failure response for ' +
-        'https://dspacecris7.4science.cloud/server/api/integration/externalsources/pubmed/entries?sort=id,ASC&page=0&size=10&query=test: 500 OK',
+        'https://example.com/server/api/integration/externalsources/pubmed/entries?sort=id,ASC&page=0&size=10&query=test: 500 OK',
       statusCode: 500,
       timeCompleted: 1656950434666,
       errors: [{

--- a/src/app/submission/import-external/submission-import-external.component.spec.ts
+++ b/src/app/submission/import-external/submission-import-external.component.spec.ts
@@ -19,9 +19,15 @@ import { VarDirective } from '../../shared/utils/var.directive';
 import { routeServiceStub } from '../../shared/testing/route-service.stub';
 import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
-import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import {
+  createFailedRemoteDataObject$,
+  createSuccessfulRemoteDataObject,
+  createSuccessfulRemoteDataObject$
+} from '../../shared/remote-data.utils';
 import { ExternalSourceEntry } from '../../core/shared/external-source-entry.model';
 import { SubmissionImportExternalPreviewComponent } from './import-external-preview/submission-import-external-preview.component';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('SubmissionImportExternalComponent test suite', () => {
   let comp: SubmissionImportExternalComponent;
@@ -44,7 +50,8 @@ describe('SubmissionImportExternalComponent test suite', () => {
   beforeEach(waitForAsync (() => {
     TestBed.configureTestingModule({
       imports: [
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        BrowserAnimationsModule
       ],
       declarations: [
         SubmissionImportExternalComponent,
@@ -174,6 +181,327 @@ describe('SubmissionImportExternalComponent test suite', () => {
       compAsAny.selectLabel(label);
 
       expect(comp.label).toEqual(label);
+    });
+  });
+
+  describe('handle BE response for search query', () => {
+    const paginatedData: any = {
+      'timeCompleted': 1657009282990,
+      'msToLive': 900000,
+      'lastUpdated': 1657009282990,
+      'state': 'Success',
+      'errorMessage': null,
+      'payload': {
+        'type': {
+          'value': 'paginated-list'
+        },
+        'pageInfo': {
+          'elementsPerPage': 10,
+          'totalElements': 11971608,
+          'totalPages': 1197161,
+          'currentPage': 1
+        },
+        '_links': {
+          'first': {
+            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=0&size=10&sort=id,asc'
+          },
+          'self': {
+            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?sort=id,ASC&page=0&size=10&query=test'
+          },
+          'next': {
+            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=1&size=10&sort=id,asc'
+          },
+          'last': {
+            'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entries?query=test&page=1197160&size=10&sort=id,asc'
+          },
+          'page': [
+            {
+              'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
+            }
+          ]
+        },
+        'page': [
+          {
+            'id': '2-s2.0-85130258665',
+            'type': 'externalSourceEntry',
+            'display': 'Biological activities of endophytic fungi isolated from Annona muricata Linnaeus: a systematic review',
+            'value': 'Biological activities of endophytic fungi isolated from Annona muricata Linnaeus: a systematic review',
+            'externalSource': 'scopus',
+            'metadata': {
+              'dc.contributor.author': [
+                {
+                  'uuid': 'cbceba09-4c12-4968-ab02-2f77a985b422',
+                  'language': null,
+                  'value': 'Silva I.M.M.',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.date.issued': [
+                {
+                  'uuid': 'e8d3c306-ce21-43e2-8a80-5f257cc3b7ea',
+                  'language': null,
+                  'value': '2024-01-01',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.description.abstract': [
+                {
+                  'uuid': 'c9ee4076-c602-4c1d-ab1a-60bbdd0dd511',
+                  'language': null,
+                  'value': 'This systematic review integrates the data available in the literature regarding the biological activities of the extracts of endophytic fungi isolated from Annona muricata and their secondary metabolites. The search was performed using four electronic databases, and studies’ quality was evaluated using an adapted assessment tool. The initial database search yielded 436 results; ten studies were selected for inclusion. The leaf was the most studied part of the plant (in nine studies); Periconia sp. was the most tested fungus (n = 4); the most evaluated biological activity was anticancer (n = 6), followed by antiviral (n = 3). Antibacterial, antifungal, and antioxidant activities were also tested. Terpenoids or terpenoid hybrid compounds were the most abundant chemical metabolites. Phenolic compounds, esters, alkaloids, saturated and unsaturated fatty acids, aromatic compounds, and peptides were also reported. The selected studies highlighted the biotechnological potentiality of the endophytic fungi extracts from A. muricata. Consequently, it can be considered a promising source of biological compounds with antioxidant effects and active against different microorganisms and cancer cells. Further research is needed involving different plant tissues, other microorganisms, such as SARS-CoV-2, and different cancer cells.',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.identifier.doi': [
+                {
+                  'uuid': '95ec26be-c1b4-4c4a-b12d-12421a4f181d',
+                  'language': null,
+                  'value': '10.1590/1519-6984.259525',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.identifier.pmid': [
+                {
+                  'uuid': 'd6913cd6-1007-4013-b486-3f07192bc739',
+                  'language': null,
+                  'value': '35588520',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.identifier.scopus': [
+                {
+                  'uuid': '6386a1f6-84ba-431d-a583-e16d19af8db0',
+                  'language': null,
+                  'value': '2-s2.0-85130258665',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.relation.grantno': [
+                {
+                  'uuid': 'bcafd7b0-827d-4abb-8608-95dc40a8e58a',
+                  'language': null,
+                  'value': 'undefined',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.relation.ispartof': [
+                {
+                  'uuid': '680819c8-c143-405f-9d09-f84d2d5cd338',
+                  'language': null,
+                  'value': 'Brazilian Journal of Biology',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.relation.ispartofseries': [
+                {
+                  'uuid': '06634104-127b-44f6-9dcc-efae24b74bd1',
+                  'language': null,
+                  'value': 'Brazilian Journal of Biology',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.relation.issn': [
+                {
+                  'uuid': '5f6cce46-2538-49e9-8ed0-a3988dcac6c5',
+                  'language': null,
+                  'value': '15196984',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.subject': [
+                {
+                  'uuid': '0b6fbc77-de54-4f4a-b317-3d74a429f22a',
+                  'language': null,
+                  'value': 'biological products | biotechnology | mycology | soursop',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.title': [
+                {
+                  'uuid': '4c0fa3d3-1a8c-4302-a772-4a4d0408df35',
+                  'language': null,
+                  'value': 'Biological activities of endophytic fungi isolated from Annona muricata Linnaeus: a systematic review',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'dc.type': [
+                {
+                  'uuid': '5b6e0337-6f79-4574-a720-536816d1dc6e',
+                  'language': null,
+                  'value': 'Journal',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'oaire.citation.volume': [
+                {
+                  'uuid': 'b88b0246-61a9-4aca-917f-68afc8ead7d8',
+                  'language': null,
+                  'value': '84',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'oairecerif.affiliation.orgunit': [
+                {
+                  'uuid': '487c0fbc-3622-4cc7-a5fa-4edf780c6a21',
+                  'language': null,
+                  'value': 'Universidade Federal do Reconcavo da Bahia',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'oairecerif.citation.number': [
+                {
+                  'uuid': '90808bdd-f456-4ba3-91aa-b82fb3c453f6',
+                  'language': null,
+                  'value': 'e259525',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'person.identifier.orcid': [
+                {
+                  'uuid': 'e533d0d2-cf26-4c3e-b5ae-cabf497dfb6b',
+                  'language': null,
+                  'value': '#PLACEHOLDER_PARENT_METADATA_VALUE#',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ],
+              'person.identifier.scopus-author-id': [
+                {
+                  'uuid': '4faf0be5-0226-4d4f-92a0-938397c4ec02',
+                  'language': null,
+                  'value': '42561627000',
+                  'place': -1,
+                  'authority': null,
+                  'confidence': -1
+                }
+              ]
+            },
+            '_links': {
+              'self': {
+                'href': 'https://dspacecris7.4science.cloud/server/api/integration/externalsources/scopus/entryValues/2-s2.0-85130258665'
+              }
+            }
+          }
+        ]
+      },
+      'statusCode': 200
+    };
+    const errorObj = {
+      errorMessage: 'Http failure response for ' +
+        'https://dspacecris7.4science.cloud/server/api/integration/externalsources/pubmed/entries?sort=id,ASC&page=0&size=10&query=test: 500 OK',
+      statusCode: 500,
+      timeCompleted: 1656950434666,
+      errors: [{
+        'message': 'Internal Server Error', 'paths': ['/server/api/integration/externalsources/pubmed/entries']
+      }]
+    };
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SubmissionImportExternalComponent);
+      comp = fixture.componentInstance;
+      compAsAny = comp;
+      scheduler = getTestScheduler();
+    });
+
+    afterEach(() => {
+      fixture.destroy();
+      comp = null;
+      compAsAny = null;
+    });
+
+    it('REST endpoint returns a 200 response with valid content', () => {
+      mockExternalSourceService.getExternalSourceEntries.and.returnValue(createSuccessfulRemoteDataObject$(paginatedData.payload));
+      const expectedEntries = createSuccessfulRemoteDataObject(paginatedData.payload);
+      spyOn(routeServiceStub, 'getQueryParameterValue').and.callFake((param) => {
+        if (param === 'entity') {
+          return observableOf('Publication');
+        } else if (param === 'sourceId') {
+          return observableOf('scopus');
+        } else if (param === 'query') {
+          return observableOf('test');
+        }
+        return observableOf({});
+      });
+      fixture.detectChanges();
+
+      expect(comp.isLoading$.value).toBe(false);
+      expect(comp.entriesRD$.value).toEqual(expectedEntries);
+      const viewableCollection = fixture.debugElement.query(By.css('ds-viewable-collection'));
+      expect(viewableCollection).toBeTruthy();
+    });
+
+    it('REST endpoint returns a 200 response with no results', () => {
+      mockExternalSourceService.getExternalSourceEntries.and.returnValue(createSuccessfulRemoteDataObject$(createPaginatedList([])));
+      const expectedEntries = createSuccessfulRemoteDataObject(createPaginatedList([]));
+      spyOn(routeServiceStub, 'getQueryParameterValue').and.callFake((param) => {
+        if (param === 'entity') {
+          return observableOf('Publication');
+        }
+        return observableOf({});
+      });
+      fixture.detectChanges();
+
+      expect(comp.isLoading$.value).toBe(false);
+      expect(comp.entriesRD$.value).toEqual(expectedEntries);
+      const noDataAlert = fixture.debugElement.query(By.css('[data-test="empty-external-entry-list"]'));
+      expect(noDataAlert).toBeTruthy();
+    });
+
+    it('REST endpoint returns a 500 error', () => {
+      mockExternalSourceService.getExternalSourceEntries.and.returnValue(createFailedRemoteDataObject$(
+        errorObj.errorMessage,
+        errorObj.statusCode,
+        errorObj.timeCompleted,
+        errorObj.errors
+      ));
+      spyOn(routeServiceStub, 'getQueryParameterValue').and.callFake((param) => {
+        if (param === 'entity') {
+          return observableOf('Publication');
+        } else if (param === 'sourceId') {
+          return observableOf('pubmed');
+        } else if (param === 'query') {
+          return observableOf('test');
+        }
+        return observableOf({});
+      });
+      fixture.detectChanges();
+
+      expect(comp.isLoading$.value).toBe(false);
+      expect(comp.entriesRD$.value.statusCode).toEqual(500);
+      const noDataAlert = fixture.debugElement.query(By.css('[data-test="empty-external-error-500"]'));
+      expect(noDataAlert).toBeTruthy();
     });
   });
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3583,6 +3583,7 @@
 
   "search.results.view-result": "View",
 
+  "search.results.response.500": "An error occurred during query execution, please try again later",
 
   "default.search.results.head": "Search Results",
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1678

## Description
Short summary of changes (1-2 sentences).
a new `<div>` has been added to html component for import from external sources, displaying an ad-hoc error message whenever REST call to query external system returns a 500 http error code.


List of changes in this PR:
* added a `div` providing an error message in case of 500 http error code returned by REST endpoint performing live import query
* added a test to check correct display of above mentioned `div` in case of 500 error.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
The 500 error code behavior is hard to reproduce, depending on possible error on third party systems. A proper test is provided to check correct behavior when REST call performing the live import query returns such an error.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
