### PR TITLE
Moved 3rd party css imports to separate file

### DIFF
--- a/src/styles/_vendor.scss
+++ b/src/styles/_vendor.scss
@@ -1,0 +1,5 @@
+// node_modules imports meant for all the themes
+
+@import '~node_modules/bootstrap/scss/bootstrap.scss';
+@import '~node_modules/nouislider/distribute/nouislider.min';
+@import '~node_modules/ngx-ui-switch/ui-switch.component.scss';

--- a/src/styles/base-theme.scss
+++ b/src/styles/base-theme.scss
@@ -1,8 +1,6 @@
 @import './helpers/font_awesome_imports.scss';
-@import '../../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../../node_modules/nouislider/distribute/nouislider.min';
+@import './_vendor.scss';
 @import './_custom_variables.scss';
 @import './bootstrap_variables_mapping.scss';
 @import './_truncatable-part.component.scss';
 @import './_global-styles.scss';
-@import '../../node_modules/ngx-ui-switch/ui-switch.component.scss';

--- a/src/themes/custom/styles/theme.scss
+++ b/src/themes/custom/styles/theme.scss
@@ -4,11 +4,9 @@
 @import '../../../styles/_variables.scss';
 @import '../../../styles/_mixins.scss';
 @import '../../../styles/helpers/font_awesome_imports.scss';
-@import '../../../../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../../../../node_modules/nouislider/distribute/nouislider.min';
+@import '../../../styles/_vendor.scss';
 @import '../../../styles/_custom_variables.scss';
 @import './_theme_css_variable_overrides.scss';
 @import '../../../styles/bootstrap_variables_mapping.scss';
 @import '../../../styles/_truncatable-part.component.scss';
 @import './_global-styles.scss';
-@import '../../../../node_modules/ngx-ui-switch/ui-switch.component.scss';

--- a/src/themes/dspace/styles/theme.scss
+++ b/src/themes/dspace/styles/theme.scss
@@ -4,11 +4,9 @@
 @import '../../../styles/_variables.scss';
 @import '../../../styles/_mixins.scss';
 @import '../../../styles/helpers/font_awesome_imports.scss';
-@import '../../../../node_modules/bootstrap/scss/bootstrap.scss';
-@import '../../../../node_modules/nouislider/distribute/nouislider.min';
+@import '../../../styles/_vendor.scss';
 @import '../../../styles/_custom_variables.scss';
 @import './_theme_css_variable_overrides.scss';
 @import '../../../styles/bootstrap_variables_mapping.scss';
 @import '../../../styles/_truncatable-part.component.scss';
 @import './_global-styles.scss';
-@import '../../../../node_modules/ngx-ui-switch/ui-switch.component.scss';


### PR DESCRIPTION
## References
* Fixes #1679

## Description
Moved `node_modules` imports from the `theme.scss` files into `_vendor.scss` and imported that file in the `theme.scss` files

## Instructions for Reviewers
- Created a file called `_vendor.scss` in the /src/style folder
- Moved all imports with `node_modules` in their path from `base-theme.scss` to that file
- Put the vendor import at the place where the topmost `node_modules` import was in `base-theme.scss`
- Dif the same for theme.scss in the dspace and custom themes

**Include guidance for how to test or review your PR.**
- Build in production mode and look that everything still looks the same in all themes

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.