### PR TITLE
Enable Swedish language

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -150,6 +150,9 @@ languages:
   - code: fi
     label: Suomi
     active: true
+  - code: sv
+    label: Svenska
+    active: true
   - code: tr
     label: Türkçe
     active: true

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -193,6 +193,7 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'pt-PT', label: 'Português', active: true },
     { code: 'pt-BR', label: 'Português do Brasil', active: true },
     { code: 'fi', label: 'Suomi', active: true },
+    { code: 'sv', label: 'Svenska', active: true },
     { code: 'tr', label: 'Türkçe', active: true },
     { code: 'bn', label: 'বাংলা', active: true }
   ];


### PR DESCRIPTION
## Description
Small PR to enable the Swedish language pack contributed by @jokermanse in #1673 

## Instructions for Reviewers
I've already tested this locally & it works.  It's a very minor default configuration change to ensure that Swedish (Svenska) appears as an option in the language menu. I'll merge it immediately once tests all pass.