### PR TITLE
Ensure auth methods are re-fetched after an authentication error.

### DIFF
--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -178,6 +178,37 @@ describe('AuthEffects', () => {
 
   });
 
+  describe('authenticatedError$', () => {
+
+    describe('when token is valid', () => {
+      it('should not call checkAuthenticationToken', () => {
+        const authService = (authEffects as any).authService;
+        spyOn(authService, 'checkAuthenticationToken');
+        actions = hot('--a-', { a: new AuthenticatedSuccessAction(true, token, EPersonMock._links.self.href) });
+
+        const expected = cold('--b-', { b: new AuthenticatedSuccessAction(true, token, EPersonMock._links.self.href) });
+
+        authEffects.authenticatedError$.subscribe((n) => {
+          expect(authService.checkAuthenticationToken).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when token is not valid', () => {
+      it('should call checkAuthenticationToken', () => {
+        const authService = (authEffects as any).authService;
+        spyOn(authService, 'checkAuthenticationToken');
+        actions = hot('--a-', { a: new AuthenticatedErrorAction(new Error('Message Error test')) });
+
+        const expected = cold('--b-', { b: new AuthenticatedErrorAction(new Error('Message Error test')) });
+
+        authEffects.authenticatedError$.subscribe((n) => {
+          expect(authService.checkAuthenticationToken).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('checkToken$', () => {
 
     describe('when check token succeeded', () => {

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -119,7 +119,12 @@ export class AuthEffects {
   // It means "reacts to this action but don't send another"
   public authenticatedError$: Observable<Action> = createEffect(() => this.actions$.pipe(
     ofType(AuthActionTypes.AUTHENTICATED_ERROR),
-    tap((action: LogOutSuccessAction) => this.authService.removeToken())
+    tap((action: LogOutSuccessAction) => {
+      if (this.authService.hasToken()) {
+        this.authService.removeToken();
+        this.authService.checkAuthenticationToken();
+      }
+    }),
   ), { dispatch: false });
 
   public retrieveAuthenticatedEperson$: Observable<Action> = createEffect(() => this.actions$.pipe(

--- a/src/app/core/auth/auth.reducer.spec.ts
+++ b/src/app/core/auth/auth.reducer.spec.ts
@@ -561,7 +561,8 @@ describe('authReducer', () => {
       blocking: false,
       loading: true,
       authMethods: [],
-      idle: false
+      idle: false,
+      error: undefined,
     };
     expect(newState).toEqual(state);
   });

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -214,6 +214,7 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
     case AuthActionTypes.RETRIEVE_AUTH_METHODS:
       return Object.assign({}, state, {
         loading: true,
+        error: undefined,
       });
 
     case AuthActionTypes.RETRIEVE_AUTH_METHODS_SUCCESS:

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -374,6 +374,28 @@ describe('AuthService test', () => {
       expect(storage.remove).toHaveBeenCalled();
     });
 
+    describe('when the cookie contains a value', () => {
+      beforeEach(() => {
+        storage.get = jasmine.createSpy().and.returnValue(token);
+      });
+
+      it('should indicate token is present', () => {
+        const result = authService.hasToken();
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when the cookie contains no value', () => {
+      beforeEach(() => {
+        storage.get = jasmine.createSpy().and.returnValue(undefined);
+      });
+
+      it('should indicate token is not present', () => {
+        const result = authService.hasToken();
+        expect(result).toBe(false);
+      });
+    });
+
     it('should redirect to reload with redirect url', () => {
       authService.navigateToRedirectUrl('/collection/123');
       // Reload with redirect URL set to /collection/123

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -427,7 +427,14 @@ export class AuthService {
    * Remove authentication token info
    */
   public removeToken() {
-    return this.storage.remove(TOKENITEM);
+    this.storage.remove(TOKENITEM);
+  }
+
+  /**
+   * Check authentication token info
+   */
+  public hasToken(): boolean {
+    return hasValue(this.storage.get(TOKENITEM));
   }
 
   /**

--- a/src/app/shared/testing/auth-service.stub.ts
+++ b/src/app/shared/testing/auth-service.stub.ts
@@ -123,6 +123,14 @@ export class AuthServiceStub {
     return;
   }
 
+  hasToken(): boolean {
+    return true;
+  }
+
+  checkAuthenticationToken() {
+    return;
+  }
+
   retrieveAuthMethodsFromAuthStatus(status: AuthStatus) {
     return observableOf(authMethodsMock);
   }


### PR DESCRIPTION

## References
* Fixes #1793.

## Description
Make sure a `CheckAuthenticationTokenAction` is triggered if authentication fails (this happens when the backend is restarted while a non-expired token is in storage). This, in turn, refreshes the auth methods and avoids an empty non-functional authentication menu.

## Instructions for Reviewers
We must be careful not to trigger a `CheckAuthenticationTokenAction` recursively, which is why `hasToken` was added.

List of changes in this PR:
* add `AuthenticationService.hasToken` to check existence of a token
* make `removeToken` call conditional on the existence of a token
* trigger `CheckAuthenticationTokenAction` if authentication fails and there was a valid-looking token

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
