### PR TITLE
Displaying Recent Submissions on the homepage

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -260,7 +260,8 @@ info:
   enablePrivacyStatement: true
 # Home Page
 homePage:
+  recentSubmissions:
 	# The number of item showing in recent submission components
-  recentSubmissionsRpp: 5
+      pageSize: 5
 	# Sort record of recent submission
-  recentSubmissionsSortField: 'dc.date.accessioned'
+      sortField: 'dc.date.accessioned'

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -258,3 +258,9 @@ mediaViewer:
 info:
   enableEndUserAgreement: true
   enablePrivacyStatement: true
+# Home Page
+homePage:
+	# The number of item showing in recent submission components
+  recentSubmissionsRpp: 5
+	# Sort record of recent submission
+  recentSubmissionsSortField: 'dc.date.accessioned'

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -5,4 +5,5 @@
   </ng-container>
   <ds-search-form [inPlaceSearch]="false" [searchPlaceholder]="'home.search-form.placeholder' | translate"></ds-search-form>
   <ds-top-level-community-list></ds-top-level-community-list>
+  <ds-recent-item-list></ds-recent-item-list>
 </div>

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -5,5 +5,5 @@
   </ng-container>
   <ds-search-form [inPlaceSearch]="false" [searchPlaceholder]="'home.search-form.placeholder' | translate"></ds-search-form>
   <ds-top-level-community-list></ds-top-level-community-list>
-  <ds-recent-item-list></ds-recent-item-list>
+  <ds-recent-item-list *ngIf="recentSubmissionspageSize>0"></ds-recent-item-list>
 </div>

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Site } from '../core/shared/site.model';
-
+import { environment } from '../../environments/environment';
 @Component({
   selector: 'ds-home-page',
   styleUrls: ['./home-page.component.scss'],
@@ -12,10 +12,11 @@ import { Site } from '../core/shared/site.model';
 export class HomePageComponent implements OnInit {
 
   site$: Observable<Site>;
-
+  recentSubmissionspageSize: number;
   constructor(
     private route: ActivatedRoute,
   ) {
+    this.recentSubmissionspageSize = environment.homePage.recentSubmissions.pageSize;
   }
 
   ngOnInit(): void {

--- a/src/app/home-page/home-page.module.ts
+++ b/src/app/home-page/home-page.module.ts
@@ -9,13 +9,14 @@ import { TopLevelCommunityListComponent } from './top-level-community-list/top-l
 import { StatisticsModule } from '../statistics/statistics.module';
 import { ThemedHomeNewsComponent } from './home-news/themed-home-news.component';
 import { ThemedHomePageComponent } from './themed-home-page.component';
-
+import { RecentItemListComponent } from './recent-item-list/recent-item-list.component';
 const DECLARATIONS = [
   HomePageComponent,
   ThemedHomePageComponent,
   TopLevelCommunityListComponent,
   ThemedHomeNewsComponent,
   HomeNewsComponent,
+  RecentItemListComponent
 ];
 
 @NgModule({

--- a/src/app/home-page/recent-item-list/recent-item-list.component.html
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.html
@@ -1,0 +1,15 @@
+<ng-container *ngVar="(itemRD$ | async) as itemRD">
+        <div class="mt-4" *ngIf="itemRD?.hasSucceeded && itemRD?.payload?.page.length > 0" @fadeIn>
+                <div class="d-flex flex-row border-bottom mb-4 pb-4 ng-tns-c416-2"></div>
+                <h2> {{'home.recent-submissions.head' | translate}}</h2>
+                <div class="my-4" *ngFor="let item of itemRD?.payload?.page">
+                        <ds-listable-object-component-loader [object]="item" [viewMode]="viewMode" class="pb-4">
+                        </ds-listable-object-component-loader>
+                </div>
+                <button (click)="onLoadMore()" class="btn btn-primary search-button mt-4 float-left ng-tns-c290-40">Load
+                        more...</button>
+        </div>
+        <ds-error *ngIf="itemRD?.hasFailed" message="{{'error.recent-submissions' | translate}}"></ds-error>
+        <ds-loading *ngIf="!itemRD || itemRD.isLoading" message="{{'loading.recent-submissions' | translate}}">
+        </ds-loading>
+</ng-container>

--- a/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { SearchService } from 'src/app/core/shared/search/search.service';
+import { createSuccessfulRemoteDataObject } from 'src/app/shared/remote-data.utils';
+import { SearchServiceStub } from 'src/app/shared/testing/search-service.stub';
+import { createPaginatedList } from 'src/app/shared/testing/utils.test';
+import { PaginationService } from '../../core/pagination/pagination.service';
+import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
+import { RecentItemListComponent } from './recent-item-list.component';
+import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
+import { SearchConfigurationServiceStub } from '../../shared/testing/search-configuration-service.stub';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
+import { ViewMode } from 'src/app/core/shared/view-mode.model';
+
+describe('RecentItemListComponent', () => {
+  let component: RecentItemListComponent;
+  let fixture: ComponentFixture<RecentItemListComponent>;
+  const emptyList = createSuccessfulRemoteDataObject(createPaginatedList([]));
+  let paginationService;
+  let searchConfigService: SearchConfigurationService;
+  const searchServiceStub = Object.assign(new SearchServiceStub(), {
+    search: () => observableOf(emptyList),
+    /* eslint-disable no-empty,@typescript-eslint/no-empty-function */
+    clearDiscoveryRequests: () => {}
+    /* eslint-enable no-empty,@typescript-eslint/no-empty-function */
+  });
+  paginationService = new PaginationServiceStub();
+  const mockSearchOptions = observableOf(new PaginatedSearchOptions({
+    pagination: Object.assign(new PaginationComponentOptions(), {
+      id: 'search-page-configuration',
+      pageSize: 10,
+      currentPage: 1
+    }),
+    sort: new SortOptions('dc.date.accessioned', SortDirection.DESC),
+   
+  }));
+  const searchConfigServiceStub = {
+    paginatedSearchOptions: mockSearchOptions
+  };
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RecentItemListComponent],
+      providers: [
+        { provide: SearchService, useValue: searchServiceStub },
+        { provide: PaginationService, useValue: paginationService },
+        { provide: SearchConfigurationService, useValue: searchConfigServiceStub },
+      ],
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecentItemListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call the navigate method on the Router with view mode list parameter as a parameter when setViewMode is called', () => {
+    component.onLoadMore();
+    expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('page-id', ['/search'], {page: 1},{ view: ViewMode.ListElement }
+    );
+  });
+});
+function observableOf(emptyList: any): any {
+  throw new Error('Function not implemented.');
+}
+

--- a/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
 import { SearchService } from 'src/app/core/shared/search/search.service';
 import { createSuccessfulRemoteDataObject } from 'src/app/shared/remote-data.utils';
 import { SearchServiceStub } from 'src/app/shared/testing/search-service.stub';
@@ -9,7 +7,6 @@ import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
 import { RecentItemListComponent } from './recent-item-list.component';
 import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
-import { SearchConfigurationServiceStub } from '../../shared/testing/search-configuration-service.stub';
 import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
 import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
@@ -35,7 +32,6 @@ describe('RecentItemListComponent', () => {
       currentPage: 1
     }),
     sort: new SortOptions('dc.date.accessioned', SortDirection.DESC),
-   
   }));
   const searchConfigServiceStub = {
     paginatedSearchOptions: mockSearchOptions

--- a/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.spec.ts
@@ -11,13 +11,12 @@ import { PaginatedSearchOptions } from '../../shared/search/models/paginated-sea
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
 import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
 import { ViewMode } from 'src/app/core/shared/view-mode.model';
-
+import { of as observableOf } from 'rxjs';
 describe('RecentItemListComponent', () => {
   let component: RecentItemListComponent;
   let fixture: ComponentFixture<RecentItemListComponent>;
   const emptyList = createSuccessfulRemoteDataObject(createPaginatedList([]));
   let paginationService;
-  let searchConfigService: SearchConfigurationService;
   const searchServiceStub = Object.assign(new SearchServiceStub(), {
     search: () => observableOf(emptyList),
     /* eslint-disable no-empty,@typescript-eslint/no-empty-function */
@@ -60,11 +59,8 @@ describe('RecentItemListComponent', () => {
 
   it('should call the navigate method on the Router with view mode list parameter as a parameter when setViewMode is called', () => {
     component.onLoadMore();
-    expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('page-id', ['/search'], {page: 1},{ view: ViewMode.ListElement }
-    );
+    expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith(undefined, ['search'], Object({ sortField: 'dc.date.accessioned', sortDirection: 'DESC', page: 1 }));
   });
 });
-function observableOf(emptyList: any): any {
-  throw new Error('Function not implemented.');
-}
+
 

--- a/src/app/home-page/recent-item-list/recent-item-list.component.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.ts
@@ -43,11 +43,11 @@ export class RecentItemListComponent implements OnInit {
 
     this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
       id: 'hp',
-      pageSize: environment.homePage.recentSubmissionsRpp,
+      pageSize: environment.homePage.recentSubmissions.pageSize,
       currentPage: 1,
       maxSize: 1
     });
-    this.sortConfig = new SortOptions(environment.homePage.recentSubmissionsSortField, SortDirection.DESC);
+    this.sortConfig = new SortOptions(environment.homePage.recentSubmissions.sortField, SortDirection.DESC);
   }
   ngOnInit(): void {
     this.itemRD$ = this.searchService.search(
@@ -62,7 +62,7 @@ export class RecentItemListComponent implements OnInit {
   }
   onLoadMore(): void {
     this.paginationService.updateRouteWithUrl(this.searchConfigurationService.paginationID, ['search'], {
-      sortField: environment.homePage.recentSubmissionsSortField,
+      sortField: environment.homePage.recentSubmissions.sortField,
       sortDirection: 'DESC' as SortDirection,
       page: 1
     });

--- a/src/app/home-page/recent-item-list/recent-item-list.component.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.ts
@@ -1,0 +1,72 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { fadeIn, fadeInOut } from '../../shared/animations/fade';
+import { RemoteData } from '../../core/data/remote-data';
+import { PaginatedList } from '../../core/data/paginated-list.model';
+import { Item } from '../../core/shared/item.model';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { PaginationService } from '../../core/pagination/pagination.service';
+import { SearchService } from '../../core/shared/search/search.service';
+import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
+import { environment } from '../../../environments/environment';
+import { ViewMode } from '../../core/shared/view-mode.model';
+import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
+import {
+  toDSpaceObjectListRD
+} from '../../core/shared/operators';
+import {
+  Observable,
+} from 'rxjs';
+@Component({
+  selector: 'ds-recent-item-list',
+  templateUrl: './recent-item-list.component.html',
+  styleUrls: ['./recent-item-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    fadeIn,
+    fadeInOut
+  ]
+})
+export class RecentItemListComponent implements OnInit {
+  itemRD$: Observable<RemoteData<PaginatedList<Item>>>;
+  paginationConfig: PaginationComponentOptions;
+  sortConfig: SortOptions;
+  /**
+ * The view-mode we're currently on
+ * @type {ViewMode}
+ */
+  viewMode = ViewMode.ListElement;
+  constructor(private searchService: SearchService,
+    private paginationService: PaginationService,
+    public searchConfigurationService: SearchConfigurationService
+  ) {
+
+    this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
+      id: 'hp',
+      pageSize: environment.homePage.recentSubmissionsRpp,
+      currentPage: 1,
+      maxSize: 1
+    });
+    this.sortConfig = new SortOptions(environment.homePage.recentSubmissionsSortField, SortDirection.DESC);
+  }
+  ngOnInit(): void {
+    this.itemRD$ = this.searchService.search(
+      new PaginatedSearchOptions({
+        pagination: this.paginationConfig,
+        sort: this.sortConfig,
+      }),
+    ).pipe(toDSpaceObjectListRD()) as Observable<RemoteData<PaginatedList<Item>>>;
+  }
+  ngOnDestroy(): void {
+    this.paginationService.clearPagination(this.paginationConfig.id);
+  }
+  onLoadMore(): void {
+    this.paginationService.updateRouteWithUrl(this.searchConfigurationService.paginationID, ['search'], {
+      sortField: environment.homePage.recentSubmissionsSortField,
+      sortDirection: 'DESC' as SortDirection,
+      page: 1
+    });
+  }
+
+}
+

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4727,5 +4727,6 @@
   "person.orcid.registry.queue": "ORCID Registry Queue",
 
   "person.orcid.registry.auth": "ORCID Authorizations",
+  "home.recent-submissions.head": "Recent Submissions",
 
 }

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -17,7 +17,7 @@ import { BrowseByConfig } from './browse-by-config.interface';
 import { BundleConfig } from './bundle-config.interface';
 import { ActuatorsConfig } from './actuators.config';
 import { InfoConfig } from './info-config.interface';
-
+import { HomeConfig } from './homepage-config.interface';
 interface AppConfig extends Config {
   ui: UIServerConfig;
   rest: ServerConfig;
@@ -38,6 +38,7 @@ interface AppConfig extends Config {
   bundle: BundleConfig;
   actuators: ActuatorsConfig
   info: InfoConfig;
+  homePage: HomeConfig;
 }
 
 const APP_CONFIG = new InjectionToken<AppConfig>('APP_CONFIG');

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -340,9 +340,11 @@ export class DefaultAppConfig implements AppConfig {
   };
   // Home Pages
   homePage: HomeConfig = {
-    //The number of item showing in recent submission components
-    recentSubmissionsRpp: 5,
-    //sort record of recent submission
-    recentSubmissionsSortField: 'dc.date.accessioned',
+    recentSubmissions: {
+      //The number of item showing in recent submission components
+      pageSize: 5,
+      //sort record of recent submission
+      sortField: 'dc.date.accessioned',
+    }
   };
 }

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -17,7 +17,7 @@ import { UIServerConfig } from './ui-server-config.interface';
 import { BundleConfig } from './bundle-config.interface';
 import { ActuatorsConfig } from './actuators.config';
 import { InfoConfig } from './info-config.interface';
-
+import { HomeConfig } from './homepage-config.interface';
 export class DefaultAppConfig implements AppConfig {
   production = false;
 
@@ -337,5 +337,12 @@ export class DefaultAppConfig implements AppConfig {
   info: InfoConfig = {
     enableEndUserAgreement: true,
     enablePrivacyStatement: true
+  };
+  // Home Pages
+  homePage: HomeConfig = {
+    //The number of item showing in recent submission components
+    recentSubmissionsRpp: 5,
+    //sort record of recent submission
+    recentSubmissionsSortField: 'dc.date.accessioned',
   };
 }

--- a/src/config/homepage-config.interface.ts
+++ b/src/config/homepage-config.interface.ts
@@ -4,14 +4,17 @@ import { Config } from './config.interface';
  * Config that determines how the dropdown list of years are created for browse-by-date components
  */
 export interface HomeConfig extends Config {
-  /**
+  recentSubmissions: {
+    /**
    * The number of item showing in recent submission components
    */
-   recentSubmissionsRpp: number;
+    pageSize: number;
 
-  /**
-   * sort record of recent submission
-   */
-   recentSubmissionsSortField: string;
+    /**
+     * sort record of recent submission
+     */
+    sortField: string;
+  }
+
 
 }

--- a/src/config/homepage-config.interface.ts
+++ b/src/config/homepage-config.interface.ts
@@ -1,0 +1,17 @@
+import { Config } from './config.interface';
+
+/**
+ * Config that determines how the dropdown list of years are created for browse-by-date components
+ */
+export interface HomeConfig extends Config {
+  /**
+   * The number of item showing in recent submission components
+   */
+   recentSubmissionsRpp: number;
+
+  /**
+   * sort record of recent submission
+   */
+   recentSubmissionsSortField: string;
+
+}

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -247,5 +247,12 @@ export const environment: BuildConfig = {
   info: {
     enableEndUserAgreement: true,
     enablePrivacyStatement: true,
+  },
+  //Home Page
+  homePage: {
+    //The number of item showing in recent submission components
+    recentSubmissionsRpp: 5,
+    //sort record of recent submission
+    recentSubmissionsSortField: 'dc.date.accessioned',
   }
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -250,9 +250,10 @@ export const environment: BuildConfig = {
   },
   //Home Page
   homePage: {
-    //The number of item showing in recent submission components
-    recentSubmissionsRpp: 5,
-    //sort record of recent submission
-    recentSubmissionsSortField: 'dc.date.accessioned',
+    recentSubmissions: {
+      pageSize: 5,
+      //sort record of recent submission
+      sortField: 'dc.date.accessioned',
+    }
   }
 };


### PR DESCRIPTION
## References
#667 
* Fixes #667 


## Description
Displaying Recent Submissions on the Repository's homepage with option of configuring number of items required to be displayed.
## Instructions for Reviewers
Update the "rpp" variable in the config.example.yml with the item count that needs to be displayed in the Recent Submission section.
If you do not want to display any item under the Recent Submission section, keep the "rpp" count = 0.
Restart the server for the change to take effect, and no need to re-build the application.
Home page will show the Recent Submission section below the community list with the latest items submitted.
Upon clicking the Load more button, users will be redirected to the search results page, and items will list in descending order based on the submission date.
If there is no item submitted in the repository or rpp = 0, then Recent Submission should not appear.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
