### PR TITLE
Fix error validation for required `name` fields in submission

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -22,7 +22,7 @@
       <div *ngIf="context?.index !== null
               && (!showErrorMessages || errorMessages.length === 0)" class="clearfix w-100 mb-2"></div>
 
-      <div *ngIf="!model.hideRequiredHint && showErrorMessages" [id]="id + '_errors'"
+      <div *ngIf="!model.hideErrorMessages && showErrorMessages" [id]="id + '_errors'"
            [ngClass]="[getClass('element', 'errors'), getClass('grid', 'errors')]">
         <small *ngFor="let message of errorMessages" class="invalid-feedback d-block">{{ message | translate: model.validators }}</small>
       </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -22,7 +22,7 @@
       <div *ngIf="context?.index !== null
               && (!showErrorMessages || errorMessages.length === 0)" class="clearfix w-100 mb-2"></div>
 
-      <div *ngIf="showErrorMessages" [id]="id + '_errors'"
+      <div *ngIf="!model.hideRequiredHint && showErrorMessages" [id]="id + '_errors'"
            [ngClass]="[getClass('element', 'errors'), getClass('grid', 'errors')]">
         <small *ngFor="let message of errorMessages" class="invalid-feedback d-block">{{ message | translate: model.validators }}</small>
       </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
@@ -27,7 +27,7 @@ export interface DsDynamicInputModelConfig extends DynamicInputModelConfig {
   hasSelectableMetadata: boolean;
   metadataValue?: FormFieldMetadataValueObject;
   isModelOfInnerForm?: boolean;
-  hideRequiredHint?: boolean;
+  hideErrorMessages?: boolean;
 }
 
 export class DsDynamicInputModel extends DynamicInputModel {
@@ -46,7 +46,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
   @serializable() hasSelectableMetadata: boolean;
   @serializable() metadataValue: FormFieldMetadataValueObject;
   @serializable() isModelOfInnerForm: boolean;
-  @serializable() hideRequiredHint?: boolean;
+  @serializable() hideErrorMessages?: boolean;
 
 
   constructor(config: DsDynamicInputModelConfig, layout?: DynamicFormControlLayout) {
@@ -62,7 +62,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
     this.metadataValue = config.metadataValue;
     this.place = config.place;
     this.isModelOfInnerForm = (hasValue(config.isModelOfInnerForm) ? config.isModelOfInnerForm : false);
-    this.hideRequiredHint = config.hideRequiredHint;
+    this.hideErrorMessages = config.hideErrorMessages;
 
     this.language = config.language;
     if (!this.language) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
@@ -27,7 +27,7 @@ export interface DsDynamicInputModelConfig extends DynamicInputModelConfig {
   hasSelectableMetadata: boolean;
   metadataValue?: FormFieldMetadataValueObject;
   isModelOfInnerForm?: boolean;
-
+  hideRequiredHint?: boolean;
 }
 
 export class DsDynamicInputModel extends DynamicInputModel {
@@ -46,6 +46,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
   @serializable() hasSelectableMetadata: boolean;
   @serializable() metadataValue: FormFieldMetadataValueObject;
   @serializable() isModelOfInnerForm: boolean;
+  @serializable() hideRequiredHint?: boolean;
 
 
   constructor(config: DsDynamicInputModelConfig, layout?: DynamicFormControlLayout) {
@@ -61,6 +62,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
     this.metadataValue = config.metadataValue;
     this.place = config.place;
     this.isModelOfInnerForm = (hasValue(config.isModelOfInnerForm) ? config.isModelOfInnerForm : false);
+    this.hideRequiredHint = config.hideRequiredHint;
 
     this.language = config.language;
     if (!this.language) {

--- a/src/app/shared/form/builder/form-builder.service.spec.ts
+++ b/src/app/shared/form/builder/form-builder.service.spec.ts
@@ -325,6 +325,14 @@ describe('FormBuilderService test suite', () => {
           typeBindRelations: [{ match: 'VISIBLE', operator: 'OR', when: [{id: 'dc.type', value: 'Book' }]}]
         },
       ),
+
+      new DynamicConcatModel({
+        id: 'testConcatGroup_CONCAT_GROUP',
+        group: [
+          new DynamicInputModel({ id: 'testConcatGroup_CONCAT_FIRST_INPUT' }),
+          new DynamicInputModel({ id: 'testConcatGroup_CONCAT_SECOND_INPUT' }),
+        ]
+      } as any)
     ];
 
     testFormConfiguration = {
@@ -463,6 +471,7 @@ describe('FormBuilderService test suite', () => {
     expect(service.findById('testTimePicker', testModel) instanceof DynamicTimePickerModel).toBe(true);
     expect(service.findById('testRating', testModel) instanceof DynamicRatingModel).toBe(true);
     expect(service.findById('testColorPicker', testModel) instanceof DynamicColorPickerModel).toBe(true);
+    expect(service.findById('testConcatGroup', testModel) instanceof DynamicConcatModel).toBe(true);
   });
 
   it('should find a nested dynamic form control model by id', () => {

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -116,8 +116,8 @@ export class FormBuilderService extends DynamicFormService {
         }
 
         if (this.isConcatGroup(controlModel)) {
-          if (controlModel.id.match(new RegExp(findId + CONCAT_GROUP_SUFFIX + `_\\d+$`))) {
-            result = (controlModel as DynamicConcatModel).group[0];
+          if (controlModel.id.match(new RegExp(findId + CONCAT_GROUP_SUFFIX))) {
+            result = (controlModel as DynamicConcatModel);
             break;
           }
         }

--- a/src/app/shared/form/builder/parsers/concat-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/concat-field-parser.ts
@@ -70,8 +70,8 @@ export class ConcatFieldParser extends FieldParser {
       false
     );
 
-    input1ModelConfig.hideRequiredHint = true;
-    input2ModelConfig.hideRequiredHint = true;
+    input1ModelConfig.hideErrorMessages = true;
+    input2ModelConfig.hideErrorMessages = true;
 
     if (hasNoValue(concatGroup.hint) && hasValue(input1ModelConfig.hint) && hasNoValue(input2ModelConfig.hint)) {
       concatGroup.hint = input1ModelConfig.hint;

--- a/src/app/shared/form/builder/parsers/concat-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/concat-field-parser.ts
@@ -1,11 +1,7 @@
 import {Inject} from '@angular/core';
 import { FormFieldModel } from '../models/form-field.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
-import {
-  DynamicFormControlLayout,
-  DynamicInputModel,
-  DynamicInputModelConfig
-} from '@ng-dynamic-forms/core';
+import { DynamicFormControlLayout, } from '@ng-dynamic-forms/core';
 import {
   CONCAT_FIRST_INPUT_SUFFIX,
   CONCAT_GROUP_SUFFIX,
@@ -22,6 +18,7 @@ import {
   PARSER_OPTIONS,
   SUBMISSION_ID
 } from './field-parser';
+import { DsDynamicInputModel, DsDynamicInputModelConfig } from '../ds-dynamic-form-ui/models/ds-dynamic-input.model';
 
 export class ConcatFieldParser extends FieldParser {
 
@@ -58,20 +55,23 @@ export class ConcatFieldParser extends FieldParser {
     concatGroup.group = [];
     concatGroup.separator = this.separator;
 
-    const input1ModelConfig: DynamicInputModelConfig = this.initModel(
+    const input1ModelConfig: DsDynamicInputModelConfig = this.initModel(
       id + CONCAT_FIRST_INPUT_SUFFIX,
       false,
       true,
       true,
       false
     );
-    const input2ModelConfig: DynamicInputModelConfig = this.initModel(
+    const input2ModelConfig: DsDynamicInputModelConfig = this.initModel(
       id + CONCAT_SECOND_INPUT_SUFFIX,
       false,
       true,
       true,
       false
     );
+
+    input1ModelConfig.hideRequiredHint = true;
+    input2ModelConfig.hideRequiredHint = true;
 
     if (hasNoValue(concatGroup.hint) && hasValue(input1ModelConfig.hint) && hasNoValue(input2ModelConfig.hint)) {
       concatGroup.hint = input1ModelConfig.hint;
@@ -98,8 +98,8 @@ export class ConcatFieldParser extends FieldParser {
       input2ModelConfig.placeholder = placeholder[1];
     }
 
-    const model1 = new DynamicInputModel(input1ModelConfig, clsInput);
-    const model2 = new DynamicInputModel(input2ModelConfig, clsInput);
+    const model1 = new DsDynamicInputModel(input1ModelConfig, clsInput);
+    const model2 = new DsDynamicInputModel(input2ModelConfig, clsInput);
     concatGroup.group.push(model1);
     concatGroup.group.push(model2);
 

--- a/src/app/shared/form/form.service.spec.ts
+++ b/src/app/shared/form/form.service.spec.ts
@@ -108,8 +108,15 @@ describe('FormService test suite', () => {
       const title: AbstractControl = new FormControl(undefined, Validators.required);
       const date: AbstractControl = new FormControl(undefined);
       const description: AbstractControl = new FormControl(undefined);
-      formGroup = new FormGroup({ author, title, date, description });
-      controls = { author, title, date, description };
+
+      const addressLocation: FormGroup = new FormGroup({
+        zipCode: new FormControl(undefined),
+        state: new FormControl(undefined),
+        city: new FormControl(undefined),
+      });
+
+      formGroup = new FormGroup({ author, title, date, description, addressLocation });
+      controls = { author, title, date, description , addressLocation };
       service = new FormService(builderService, store);
     })
   )
@@ -179,6 +186,30 @@ describe('FormService test suite', () => {
     expect(formGroup.controls.description.touched).toBe(true);
   });
 
+  it('should add errors to fields of group', () => {
+    let control = controls.addressLocation;
+    let model = formModel.find((mdl: DynamicFormControlModel) => mdl.id === 'addressLocation');
+    let errorKeys: string[];
+
+    service.addErrorToField(control, model, 'Test error message');
+
+    // the group itself should get an error
+    errorKeys = Object.keys(control.errors);
+    expect(errorKeys.length).toBe(1);
+    expect(control.hasError(errorKeys[0])).toBe(true);
+
+    expect(control.touched).toBe(true);
+
+    // the group's inputs should get an error
+    Object.values(control.controls).forEach((subControl: AbstractControl) => {
+      errorKeys = Object.keys(subControl.errors);
+      expect(errorKeys.length).toBe(1);
+      expect(subControl.hasError(errorKeys[0])).toBe(true);
+      expect(subControl.touched).toBe(true);
+    });
+
+  });
+
   it('should remove error from field', () => {
     let control = controls.description;
     let model = formModel.find((mdl: DynamicFormControlModel) => mdl.id === 'description');
@@ -207,6 +238,30 @@ describe('FormService test suite', () => {
     expect(control.hasError(errorKeys[0])).toBe(false);
 
     expect(formGroup.controls.description.touched).toBe(false);
+  });
+
+  it('should remove errors from fields of group', () => {
+    let control = controls.addressLocation;
+    let model = formModel.find((mdl: DynamicFormControlModel) => mdl.id === 'addressLocation');
+    let errorKeys: string[];
+
+    service.addErrorToField(control, model, 'Test error message');
+    errorKeys = Object.keys(control.errors);
+
+    service.removeErrorFromField(control, model, errorKeys[0]);
+
+    // the group itself should no longer have an error
+    expect(errorKeys.length).toBe(1);
+    expect(control.hasError(errorKeys[0])).toBe(false);
+    expect(control.touched).toBe(false);
+
+    // the group's inputs should no longer have an error
+    Object.values(control.controls).forEach((subControl: AbstractControl) => {
+      errorKeys = Object.keys(subControl.errors);
+      expect(errorKeys.length).toBe(1);
+      expect(subControl.hasError(errorKeys[0])).toBe(false);
+      expect(subControl.touched).toBe(false);
+    });
   });
 
   it('should reset form group', () => {

--- a/src/app/shared/form/form.service.spec.ts
+++ b/src/app/shared/form/form.service.spec.ts
@@ -186,7 +186,9 @@ describe('FormService test suite', () => {
     expect(formGroup.controls.description.touched).toBe(true);
   });
 
-  it('should add errors to fields of group', () => {
+  it('should add errors to fields of concat group', () => {
+    (builderService as any).isConcatGroup.and.returnValue(true);
+
     let control = controls.addressLocation;
     let model = formModel.find((mdl: DynamicFormControlModel) => mdl.id === 'addressLocation');
     let errorKeys: string[];
@@ -240,7 +242,9 @@ describe('FormService test suite', () => {
     expect(formGroup.controls.description.touched).toBe(false);
   });
 
-  it('should remove errors from fields of group', () => {
+  it('should remove errors from fields of concat group', () => {
+    (builderService as any).isConcatGroup.and.returnValue(true);
+
     let control = controls.addressLocation;
     let model = formModel.find((mdl: DynamicFormControlModel) => mdl.id === 'addressLocation');
     let errorKeys: string[];

--- a/src/app/shared/form/form.service.ts
+++ b/src/app/shared/form/form.service.ts
@@ -161,8 +161,8 @@ export class FormService {
       field.setErrors(error);
     }
 
-    // if the field in question is a group, pass down the error to its fields
-    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel) {
+    // if the field in question is a concat group, pass down the error to its fields
+    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel && this.formBuilderService.isConcatGroup(model)) {
       model.group.forEach((subModel) => {
         const subField = field.controls[subModel.id];
 
@@ -182,8 +182,8 @@ export class FormService {
       field.setErrors(error);
     }
 
-    // if the field in question is a group, clear the error from its fields
-    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel) {
+    // if the field in question is a concat group, clear the error from its fields
+    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel && this.formBuilderService.isConcatGroup(model)) {
       model.group.forEach((subModel) => {
         const subField = field.controls[subModel.id];
 

--- a/src/app/shared/form/form.service.ts
+++ b/src/app/shared/form/form.service.ts
@@ -7,7 +7,7 @@ import { select, Store } from '@ngrx/store';
 import { AppState } from '../../app.reducer';
 import { formObjectFromIdSelector } from './selectors';
 import { FormBuilderService } from './builder/form-builder.service';
-import { DynamicFormControlEvent, DynamicFormControlModel } from '@ng-dynamic-forms/core';
+import { DynamicFormControlEvent, DynamicFormControlModel, DynamicFormGroupModel } from '@ng-dynamic-forms/core';
 import { isEmpty, isNotUndefined } from '../empty.util';
 import { uniqueId } from 'lodash';
 import {
@@ -161,6 +161,15 @@ export class FormService {
       field.setErrors(error);
     }
 
+    // if the field in question is a group, pass down the error to its fields
+    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel) {
+      model.group.forEach((subModel) => {
+        const subField = field.controls[subModel.id];
+
+        this.addErrorToField(subField, subModel, message);
+      });
+    }
+
     field.markAsTouched();
   }
 
@@ -171,6 +180,15 @@ export class FormService {
     if (field.hasError(errorKey)) {
       error[errorKey] = null;
       field.setErrors(error);
+    }
+
+    // if the field in question is a group, clear the error from its fields
+    if (field instanceof FormGroup && model instanceof DynamicFormGroupModel) {
+      model.group.forEach((subModel) => {
+        const subField = field.controls[subModel.id];
+
+        this.removeErrorFromField(subField, subModel, messageKey);
+      });
     }
 
     field.markAsUntouched();

--- a/src/app/shared/mocks/form-builder-service.mock.ts
+++ b/src/app/shared/mocks/form-builder-service.mock.ts
@@ -19,6 +19,7 @@ export function getMockFormBuilderService(): FormBuilderService {
     isQualdropGroup: false,
     isModelInCustomGroup: true,
     isRelationGroup: true,
+    isConcatGroup: false,
     hasArrayGroupValue: true,
     getTypeBindModel: new DsDynamicInputModel({
         name: 'dc.type',


### PR DESCRIPTION
## References
* Fixes #1353

## Description
Currently, `name` fields in submission forms are not flagged as invalid when they return as a server error (i.e.: empty required field)
Came across three separate tiny issues while debugging & fixing this
* `FormBuilderService.findById` was expecting the `id` of one of the group's inputs to end in a numeric suffix. I haven't been able to track down where this extra suffix would be set, so I'm assuming this was a bug.
  IMO, for the field to be flagged "correctly", we should flag the _group_ itself so that _both_ inputs show an error
* When a whole group is marked as invalid, its inputs should also be marked invalid. As far as I'm aware this will only affect the case of invalidation via server errors.
* With these "concat fields", the individual inputs will _also_ get an error hint when invalid. Added a basic mechanism to disable them.


## Instructions for Reviewers
1. Evaluate whether the changes could have adverse effects on other submission forms/groups/fields/...

1. Confirm that the original issue is addressed; after the fixes in this PR
    * `name` fields should be flagged as invalid if required & left empty on save/deposit
    * when the field is invalid, the two inputs it contains should also be marked as invalid
    * the error hint should only be shown once, at the `FormGroup` level
    
<img width="550" alt="20220908-094809" src="https://user-images.githubusercontent.com/31547038/189066999-85e2d604-0545-485f-82ca-afeb956e88b0.png">

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

