### PR TITLE
Repair config issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:prod": "yarn run build:prod && cross-env NODE_ENV=production yarn run serve:ssr",
     "start:mirador:prod": "yarn run build:mirador && yarn run start:prod",
     "preserve": "yarn base-href",
-    "serve": "ng serve --configuration development",
+    "serve": "ts-node --project ./tsconfig.ts-node.json scripts/serve.ts",
     "serve:ssr": "node dist/server/main",
     "analyze": "webpack-bundle-analyzer dist/browser/stats.json",
     "build": "ng build --configuration development",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "0.0.0",
+  "version": "7.4.0-next.0",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "7.4.0-next.0",
+  "version": "7.4.0-next",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -10,6 +10,6 @@ const appConfig: AppConfig = buildAppConfig();
  * Any CLI arguments given to this script are patched through to `ng serve` as well.
  */
 child.spawn(
-  `ng serve --host ${appConfig.ui.host} --port ${appConfig.ui.port} --serve-path ${appConfig.ui.nameSpace} --ssl ${appConfig.ui.ssl} ${process.argv.slice(2).join(' ')}`,
+  `ng serve --host ${appConfig.ui.host} --port ${appConfig.ui.port} --serve-path ${appConfig.ui.nameSpace} --ssl ${appConfig.ui.ssl} ${process.argv.slice(2).join(' ')} --configuration development`,
   { stdio: 'inherit', shell: true }
 );

--- a/server.ts
+++ b/server.ts
@@ -48,6 +48,7 @@ import { ServerAppModule } from './src/main.server';
 import { buildAppConfig } from './src/config/config.server';
 import { APP_CONFIG, AppConfig } from './src/config/app-config.interface';
 import { extendEnvironmentWithAppConfig } from './src/config/config.util';
+import { logStartupMessage } from './startup-message';
 
 /*
  * Set path for the browser application's dist folder
@@ -281,6 +282,8 @@ function run() {
 }
 
 function start() {
+  logStartupMessage(environment);
+
   /*
   * If SSL is enabled
   * - Read credentials from configuration files

--- a/src/app/init.service.ts
+++ b/src/app/init.service.ts
@@ -143,10 +143,6 @@ export abstract class InitService {
     if (environment.debug) {
       console.info(environment);
     }
-
-    const env: string = environment.production ? 'Production' : 'Development';
-    const color: string = environment.production ? 'red' : 'green';
-    console.info(`Environment: %c${env}`, `color: ${color}; font-weight: bold;`);
   }
 
   /**

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -54,13 +54,27 @@ const getEnvironment = (): Environment => {
   return environment;
 };
 
-const getLocalConfigPath = (env: Environment) => {
-  // default to config/config.yml
-  let localConfigPath = join(CONFIG_PATH, 'config.yml');
+/**
+ * Get the path of the default config file.
+ */
+const getDefaultConfigPath = () => {
 
-  if (!fs.existsSync(localConfigPath)) {
-    localConfigPath = join(CONFIG_PATH, 'config.yaml');
+  // default to config/config.yml
+  let defaultConfigPath = join(CONFIG_PATH, 'config.yml');
+
+  if (!fs.existsSync(defaultConfigPath)) {
+    defaultConfigPath = join(CONFIG_PATH, 'config.yaml');
   }
+
+  return defaultConfigPath;
+};
+
+/**
+ * Get the path of an environment-specific config file.
+ *
+ * @param env   the environment to get the config file for
+ */
+const getEnvConfigFilePath = (env: Environment) => {
 
   // determine app config filename variations
   let envVariations;
@@ -76,22 +90,21 @@ const getLocalConfigPath = (env: Environment) => {
       envVariations = ['dev', 'development'];
   }
 
+  let envLocalConfigPath;
+
   // check if any environment variations of app config exist
   for (const envVariation of envVariations) {
-    let envLocalConfigPath = join(CONFIG_PATH, `config.${envVariation}.yml`);
+    envLocalConfigPath = join(CONFIG_PATH, `config.${envVariation}.yml`);
     if (fs.existsSync(envLocalConfigPath)) {
-      localConfigPath = envLocalConfigPath;
       break;
-    } else {
-      envLocalConfigPath = join(CONFIG_PATH, `config.${envVariation}.yaml`);
-      if (fs.existsSync(envLocalConfigPath)) {
-        localConfigPath = envLocalConfigPath;
-        break;
-      }
+    }
+    envLocalConfigPath = join(CONFIG_PATH, `config.${envVariation}.yaml`);
+    if (fs.existsSync(envLocalConfigPath)) {
+      break;
     }
   }
 
-  return localConfigPath;
+  return envLocalConfigPath;
 };
 
 const overrideWithConfig = (config: Config, pathToConfig: string) => {
@@ -174,12 +187,20 @@ export const buildAppConfig = (destConfigPath?: string): AppConfig => {
       console.log(`Building ${colors.green.bold(`development`)} app config`);
   }
 
-  // override with dist config
-  const localConfigPath = getLocalConfigPath(env);
+  // override with default config
+  const defaultConfigPath = getDefaultConfigPath();
+  if (fs.existsSync(defaultConfigPath)) {
+    overrideWithConfig(appConfig, defaultConfigPath);
+  } else {
+    console.warn(`Unable to find default config file at ${defaultConfigPath}`);
+  }
+
+  // override with env config
+  const localConfigPath = getEnvConfigFilePath(env);
   if (fs.existsSync(localConfigPath)) {
     overrideWithConfig(appConfig, localConfigPath);
   } else {
-    console.warn(`Unable to find dist config file at ${localConfigPath}`);
+    console.warn(`Unable to find env config file at ${localConfigPath}`);
   }
 
   // override with external config if specified by environment variable `DSPACE_APP_CONFIG_PATH`

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -28,6 +28,7 @@ import { StoreAction, StoreActionTypes } from '../../app/store.actions';
 import { coreSelector } from '../../app/core/core.selectors';
 import { find, map } from 'rxjs/operators';
 import { isNotEmpty } from '../../app/shared/empty.util';
+import { logStartupMessage } from '../../../startup-message';
 
 /**
  * Performs client-side initialization.
@@ -79,6 +80,7 @@ export class BrowserInitService extends InitService {
       this.initCorrelationId();
 
       this.checkEnvironment();
+      logStartupMessage(environment);
 
       this.initI18n();
       this.initAngulartics();

--- a/startup-message.ts
+++ b/startup-message.ts
@@ -1,0 +1,19 @@
+import PACKAGE_JSON from './package.json';
+import { BuildConfig } from './src/config/build-config.interface';
+
+/**
+ * Log a message at the start of the application containing the version number and the environment.
+ *
+ * @param environment   the environment configuration
+ */
+export const logStartupMessage = (environment: Partial<BuildConfig>) => {
+  const env: string = environment.production ? 'Production' : 'Development';
+  const color: string = environment.production ? 'red' : 'green';
+
+  console.info('');
+  console.info(`%cdspace-angular`, `font-weight: bold;`);
+  console.info(`Version: %c${PACKAGE_JSON.version}`, `font-weight: bold;`);
+  console.info(`Environment: %c${env}`, `color: ${color}; font-weight: bold;`);
+  console.info('');
+
+}


### PR DESCRIPTION
## References
* Fixes #1778
* Fixes #1795
## Description
Issue #1795: The config building mechanism has been updated to always include the default config from config.yml first. This config is then overwritten by environment config (e.g. config.dev.yml).
Issue #1795: : The 'yarn run serve' command has been repaired to use the proper 'ui' config.
## Instructions for Reviewers
### List of changes in this PR:
* The 'buildAppConfig' method in config.server.ts has been updated to always use the default config.yml first
* Getting the default config.dev.yml path has been moved to a separate method 'getDefaultConfigPath', the 'getLocalConfigPath' method has been renamed to 'getEnvConfigFilePath'.
* The 'yarn run serve' command has been updated to use the serve.ts file
* The cli parameters in this file have been updated with '--configuration development'
* The version in package.json has been updated: 7.4.0-next.0 instead of 0.0.0 (this follows the Angular versioning system)
* This version has been added to the message which prints the environment (Production/Development)
* Printing this message has been moved, so it is no longer printed at every request for the server app
### Expected results:
* If there exist both a config.yml and a config.dev.yml file, when running the project in the development environment, the config from both files should be used. The config from config.dev.yml has priority though. Same principle for test and prod environments.
* When running 'yarn run serve' or 'yarn start:dev', the proper ui config should be used according to the principle above.
* When running 'yarn run serve' or 'yarn start:dev', the source files should be available in the dev tools debugger.
* When running the project in test or prod mode, the file 'serve.ts' should not be used.
* The version (7.4.0-next.0) should be printed in the console, above the environment message
## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.