### PR TITLE
Ensure `yarn test:rest` reads all JSON data, not just first chunk

### DIFF
--- a/scripts/test-rest.ts
+++ b/scripts/test-rest.ts
@@ -22,7 +22,13 @@ console.log(`...Testing connection to REST API at ${restUrl}...\n`);
 if (appConfig.rest.ssl) {
     const req = https.request(restUrl, (res) => {
         console.log(`RESPONSE: ${res.statusCode} ${res.statusMessage} \n`);
-        res.on('data', (data) => {
+        // We will keep reading data until the 'end' event fires.
+        // This ensures we don't just read the first chunk.
+        let data = '';
+        res.on('data', (chunk) => {
+            data += chunk;
+        });
+        res.on('end', () => {
             checkJSONResponse(data);
         });
     });
@@ -35,7 +41,13 @@ if (appConfig.rest.ssl) {
 } else {
     const req = http.request(restUrl, (res) => {
         console.log(`RESPONSE: ${res.statusCode} ${res.statusMessage} \n`);
-        res.on('data', (data) => {
+        // We will keep reading data until the 'end' event fires.
+        // This ensures we don't just read the first chunk.
+        let data = '';
+        res.on('data', (chunk) => {
+            data += chunk;
+        });
+        res.on('end', () => {
             checkJSONResponse(data);
         });
     });


### PR DESCRIPTION
## References
Fixes issue reported in https://groups.google.com/g/dspace-tech/c/XU7KFZGOr94/m/aeAlQZo5BQAJ 

## Description
Some proxies (namely nginx) may chunk JSON data in responses from the REST API.  This tiny PR ensures that the `yarn test:rest` script can handle chunked data.

Simply put, it updates the existing code to use the 'data' and 'end' events to ensure that we don't just read the first chunk of data, and instead keep reading until the 'end' event fires.  See the docs on `http.ClientRequest` for more details: https://nodejs.org/api/http.html#class-httpclientrequest

## Instructions for Reviewers
* Review the changes
* Test `yarn test:rest` on a valid REST API and ensure it works.  If you happen to have a REST API where data is returned in chunks that'd be even better. 

This PR is based heavily on code sent to me by Sean Kalynuk (U of Manitoba) who reported to have this fix in this thread: https://groups.google.com/g/dspace-tech/c/XU7KFZGOr94/m/yZPYL6xBCgAJ