### PR TITLE
After drag & drop: Redirect the user and remove the notification

### DIFF
--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
@@ -8,15 +8,14 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AuthService } from '../../core/auth/auth.service';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
-import { NotificationOptions } from '../../shared/notifications/models/notification-options.model';
 import { UploaderOptions } from '../../shared/uploader/uploader-options.model';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
-import { NotificationType } from '../../shared/notifications/models/notification-type';
 import { hasValue } from '../../shared/empty.util';
 import { SearchResult } from '../../shared/search/models/search-result.model';
 import { CollectionSelectorComponent } from '../collection-selector/collection-selector.component';
 import { UploaderComponent } from '../../shared/uploader/uploader.component';
 import { UploaderError } from '../../shared/uploader/uploader-error.model';
+import { Router } from '@angular/router';
 
 /**
  * This component represents the whole mydspace page header
@@ -62,7 +61,8 @@ export class MyDSpaceNewSubmissionComponent implements OnDestroy, OnInit {
               private halService: HALEndpointService,
               private notificationsService: NotificationsService,
               private translate: TranslateService,
-              private modalService: NgbModal) {
+              private modalService: NgbModal,
+              private router: Router) {
   }
 
   /**
@@ -87,16 +87,9 @@ export class MyDSpaceNewSubmissionComponent implements OnDestroy, OnInit {
       this.uploadEnd.emit(workspaceitems);
 
       if (workspaceitems.length === 1) {
-        const options = new NotificationOptions();
-        options.timeOut = 0;
         const link = '/workspaceitems/' + workspaceitems[0].id + '/edit';
-        this.notificationsService.notificationWithAnchor(
-          NotificationType.Success,
-          options,
-          link,
-          'mydspace.general.text-here',
-          'mydspace.upload.upload-successful',
-          'here');
+        // To avoid confusion and ambiguity, redirect the user on the publication page.
+        this.router.navigateByUrl(link);
       } else if (workspaceitems.length > 1) {
         this.notificationsService.success(null, this.translate.get('mydspace.upload.upload-multiple-successful', {qty: workspaceitems.length}));
       }

--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
@@ -55,6 +55,7 @@ export class MyDSpaceNewSubmissionComponent implements OnDestroy, OnInit {
    * @param {NotificationsService} notificationsService
    * @param {TranslateService} translate
    * @param {NgbModal} modalService
+   * @param {Router} router
    */
   constructor(private authService: AuthService,
               private changeDetectorRef: ChangeDetectorRef,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2734,8 +2734,6 @@
 
   "mydspace.description": "",
 
-  "mydspace.general.text-here": "here",
-
   "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
 
   "mydspace.messages.description-placeholder": "Insert your message here...",
@@ -2811,8 +2809,6 @@
   "mydspace.upload.upload-failed-moreonefile": "Unprocessable request. Only one file is allowed.",
 
   "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
-
-  "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
 
   "mydspace.view-btn": "View",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -3627,9 +3627,6 @@
   // "mydspace.description": "",
   "mydspace.description": "",
 
-  // "mydspace.general.text-here": "here",
-  "mydspace.general.text-here": "ici",
-
   // "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
   "mydspace.messages.controller-help": "Sélectionner cette option pour envoyer un message au déposant.",
 
@@ -3743,9 +3740,6 @@
 
   // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
   "mydspace.upload.upload-multiple-successful": "{{qty}} nouveaux Items créés dans l'espace de travail.",
-
-  // "mydspace.upload.upload-successful": "New workspace item created. Click {{here}} for edit it.",
-  "mydspace.upload.upload-successful": "Nouvel item créé dans l'espace de travail. Cliquer {{here}} pour l'éditer.",
 
   // "mydspace.view-btn": "View",
   "mydspace.view-btn": "Afficher",


### PR DESCRIPTION
## References
* Fixes #1765

## Description
Send the user directly to the submission page instead of showing a potential misleading notification.

## Instructions for Reviewers
List of changes in this PR:
* Removed the notification when uploading a single file in `my-dspace-new-submission.component.ts`.
* Redirect the user to the generated link instead.
* Removed unused translations in `en.json5` and `fr.json5`.

**See #1765 for more information about the problem and how to reproduce it.**

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
