### PR TITLE
Add an optional `NavigationExtras` argument to `PaginationService.updateRoute`

### DIFF
--- a/src/app/core/pagination/pagination.service.spec.ts
+++ b/src/app/core/pagination/pagination.service.spec.ts
@@ -101,6 +101,17 @@ describe('PaginationService', () => {
 
       expect(router.navigate).toHaveBeenCalledWith([], {queryParams: navigateParams, queryParamsHandling: 'merge'});
     });
+    it('should pass on navigationExtras to router.navigate', () => {
+      service.updateRoute('test', {page: 2}, undefined, undefined, { queryParamsHandling: 'preserve', replaceUrl: true, preserveFragment: true });
+
+      const navigateParams = {};
+      navigateParams[`test.page`] = `2`;
+      navigateParams[`test.rpp`] = `10`;
+      navigateParams[`test.sf`] = `score`;
+      navigateParams[`test.sd`] = `ASC`;
+
+      expect(router.navigate).toHaveBeenCalledWith([], {queryParams: navigateParams, queryParamsHandling: 'preserve', replaceUrl: true, preserveFragment: true });
+    });
   });
   describe('updateRouteWithUrl', () => {
     it('should update the route with the provided page params and url', () => {
@@ -125,7 +136,17 @@ describe('PaginationService', () => {
 
       expect(router.navigate).toHaveBeenCalledWith(['someUrl'], {queryParams: navigateParams, queryParamsHandling: 'merge'});
     });
+    it('should pass on navigationExtras to router.navigate', () => {
+      service.updateRouteWithUrl('test',['someUrl'], {page: 2}, undefined, undefined, { queryParamsHandling: 'preserve', replaceUrl: true, preserveFragment: true });
 
+      const navigateParams = {};
+      navigateParams[`test.page`] = `2`;
+      navigateParams[`test.rpp`] = `10`;
+      navigateParams[`test.sf`] = `score`;
+      navigateParams[`test.sd`] = `ASC`;
+
+      expect(router.navigate).toHaveBeenCalledWith(['someUrl'], {queryParams: navigateParams, queryParamsHandling: 'preserve', replaceUrl: true, preserveFragment: true });
+    });
   });
   describe('clearPagination', () => {
     it('should clear the pagination next time the updateRoute/updateRouteWithUrl method is called', () => {

--- a/src/app/core/pagination/pagination.service.ts
+++ b/src/app/core/pagination/pagination.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationExtras, Router } from '@angular/router';
 import { RouteService } from '../services/route.service';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
 import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
@@ -114,15 +114,22 @@ export class PaginationService {
    * @param params - The page related params to update in the route
    * @param extraParams - Addition params unrelated to the pagination that need to be added to the route
    * @param retainScrollPosition - Scroll to the pagination component after updating the route instead of the top of the page
+   * @param navigationExtras - Extra parameters to pass on to `router.navigate`. Can be used to override values set by this service.
    */
-  updateRoute(paginationId: string, params: {
-    page?: number
-    pageSize?: number
-    sortField?: string
-    sortDirection?: SortDirection
-  }, extraParams?, retainScrollPosition?: boolean) {
+  updateRoute(
+    paginationId: string,
+    params: {
+      page?: number
+      pageSize?: number
+      sortField?: string
+      sortDirection?: SortDirection
+    },
+    extraParams?,
+    retainScrollPosition?: boolean,
+    navigationExtras?: NavigationExtras,
+  ) {
 
-    this.updateRouteWithUrl(paginationId, [], params, extraParams, retainScrollPosition);
+    this.updateRouteWithUrl(paginationId, [], params, extraParams, retainScrollPosition, navigationExtras);
   }
 
   /**
@@ -132,13 +139,21 @@ export class PaginationService {
    * @param params - The page related params to update in the route
    * @param extraParams - Addition params unrelated to the pagination that need to be added to the route
    * @param retainScrollPosition - Scroll to the pagination component after updating the route instead of the top of the page
+   * @param navigationExtras - Extra parameters to pass on to `router.navigate`. Can be used to override values set by this service.
    */
-  updateRouteWithUrl(paginationId: string, url: string[], params: {
-    page?: number
-    pageSize?: number
-    sortField?: string
-    sortDirection?: SortDirection
-  }, extraParams?, retainScrollPosition?: boolean) {
+  updateRouteWithUrl(
+    paginationId: string,
+    url: string[],
+    params: {
+      page?: number
+      pageSize?: number
+      sortField?: string
+      sortDirection?: SortDirection
+    },
+    extraParams?,
+    retainScrollPosition?: boolean,
+    navigationExtras?: NavigationExtras,
+  ) {
     this.getCurrentRouting(paginationId).subscribe((currentFindListOptions) => {
       const currentParametersWithIdName = this.getParametersWithIdName(paginationId, currentFindListOptions);
       const parametersWithIdName = this.getParametersWithIdName(paginationId, params);
@@ -149,12 +164,14 @@ export class PaginationService {
           this.router.navigate(url, {
             queryParams: queryParams,
             queryParamsHandling: 'merge',
-            fragment: `p-${paginationId}`
+            fragment: `p-${paginationId}`,
+            ...navigationExtras,
           });
         } else {
           this.router.navigate(url, {
             queryParams: queryParams,
-            queryParamsHandling: 'merge'
+            queryParamsHandling: 'merge',
+            ...navigationExtras,
           });
         }
         this.clearParams = {};


### PR DESCRIPTION

## Description
This PR adds an optional `NavigationExtras` argument to `PaginationService.updateRoute()`, allowing for some more flexibility.

In particular, we needed this change in one of our client repositories in order to support pagination within tabbed views on a single page. Without `replaceUrl: true`, `PaginationService.updateRoute()` resulted in two location history entries for every on page. 

As far as I'm aware we don't have any similar issues in base DSpace yet, but this little change is worthwile in case we ever do -- and to improve extensibility.



## Instructions for Reviewers
Confirm that this change is useful and won't affect any current uses of `PaginationService` (it's opt-in only)



## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.