### PR TITLE
Fix for PR#1822 - Adjusted two equality checks for scope type which always return false.

### DIFF
--- a/src/app/core/eperson/models/workspaceitem.resource-type.ts
+++ b/src/app/core/eperson/models/workspaceitem.resource-type.ts
@@ -1,0 +1,3 @@
+import { ResourceType } from '../../shared/resource-type';
+
+export const WORKSPACEITEM = new ResourceType('workspaceitem');

--- a/src/app/core/submission/models/workspaceitem.model.ts
+++ b/src/app/core/submission/models/workspaceitem.model.ts
@@ -2,7 +2,7 @@ import { deserializeAs, inheritSerialization } from 'cerialize';
 import { inheritLinkAnnotations, typedObject } from '../../cache/builders/build-decorators';
 import { IDToUUIDSerializer } from '../../cache/id-to-uuid-serializer';
 import { SubmissionObject } from './submission-object.model';
-import { ResourceType } from '../../shared/resource-type';
+import { WORKSPACEITEM } from '../../eperson/models/workspaceitem.resource-type';
 
 /**
  * A model class for a WorkspaceItem.
@@ -11,7 +11,7 @@ import { ResourceType } from '../../shared/resource-type';
 @inheritSerialization(SubmissionObject)
 @inheritLinkAnnotations(SubmissionObject)
 export class WorkspaceItem extends SubmissionObject {
-  static type = new ResourceType('workspaceitem');
+  static type = WORKSPACEITEM;
 
   /**
    * The universally unique identifier of this WorkspaceItem

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -357,7 +357,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
       describe('in workspace scope', () => {
         beforeEach(() => {
           // @ts-ignore
-          comp.submissionObject = { type: WorkspaceItem.type };
+          comp.submissionObject = { type: WorkspaceItem.type.value };
         });
 
         it('should return true for unscoped fields', () => {
@@ -376,7 +376,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
       describe('in workflow scope', () => {
         beforeEach(() => {
           // @ts-ignore
-          comp.submissionObject = { type: WorkflowItem.type };
+          comp.submissionObject = { type: WorkflowItem.type.value };
         });
 
         it('should return true when field is unscoped', () => {

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -261,10 +261,10 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
 
     switch (scope) {
       case SubmissionScopeType.WorkspaceItem: {
-        return this.submissionObject.type === WorkspaceItem.type;
+        return (this.submissionObject as any).type === WorkspaceItem.type.value;
       }
       case SubmissionScopeType.WorkflowItem: {
-        return this.submissionObject.type === WorkflowItem.type;
+        return (this.submissionObject as any).type === WorkflowItem.type.value;
       }
       default: {
         return true;


### PR DESCRIPTION
## References
* Fixes #1822

## Description
During workflow, after selecting an entity in a metadata (i.e dc.contributor.author) the value is not displayed in the UI but the relation is effectivelly created.

Currently there are two strict equality comparisions which always return false in section-form-component.ts when checking for submission scope. The patch allow proper comparision between values.

There are similar patches using boxing elsewere in the code. I think this is caused by the deserialisation of the response by angular which type submissionObject.type as string instead of an instance of the class «ResourceType». Casting submissionObject allow us to compare the strings.

A more robust solution would likely be to adjust how angular deserialise the response into a submissionObject. However it would also require some changes everywere similar patches where applied.

## Instructions for Reviewers
List of changes in this PR:
* Main fix is in section-form-component.ts. 
* Added workspaceitem.resource-type.ts and modified workspaceitem.model.ts for uniformity with other similar models.
* Modified unit test to check for value.

Complete guide for how to reproduce the bug is in the linked issue (#1822).

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [n/a] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
