### PR TITLE
Enable Kazakh translation by default

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -156,6 +156,9 @@ languages:
   - code: tr
     label: Türkçe
     active: true
+  - code: kk
+    label: Қазақ
+    active: true
   - code: bn
     label: বাংলা
     active: true

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -195,6 +195,7 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'fi', label: 'Suomi', active: true },
     { code: 'sv', label: 'Svenska', active: true },
     { code: 'tr', label: 'Türkçe', active: true },
+    { code: 'kk', label: 'Қазақ', active: true },
     { code: 'bn', label: 'বাংলা', active: true }
   ];
 


### PR DESCRIPTION
## Description
This is a small PR to enable the Kazakh translation provided by @myrza1 in #1297

As it's simply a configuration change, I'll merge it after tests succeed.