### PR TITLE
Creative Commons selector is not loading

### DIFF
--- a/src/app/core/submission/submission-cc-license-data.service.spec.ts
+++ b/src/app/core/submission/submission-cc-license-data.service.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import { SubmissionCcLicenseDataService } from './submission-cc-license-data.service';
+import { testFindAllDataImplementation } from '../data/base/find-all-data.spec';
+
+describe('SubmissionCcLicenseDataService', () => {
+
+  describe('composition', () => {
+    const initService = () => new SubmissionCcLicenseDataService(null, null, null, null);
+    testFindAllDataImplementation(initService);
+  });
+});

--- a/src/app/core/submission/submission-cc-license-data.service.ts
+++ b/src/app/core/submission/submission-cc-license-data.service.ts
@@ -6,7 +6,7 @@ import { RequestService } from '../data/request.service';
 import { SUBMISSION_CC_LICENSE } from './models/submission-cc-licence.resource-type';
 import { SubmissionCcLicence } from './models/submission-cc-license.model';
 import { BaseDataService } from '../data/base/base-data.service';
-import { FindAllData } from '../data/base/find-all-data';
+import {FindAllData, FindAllDataImpl} from '../data/base/find-all-data';
 import { FindListOptions } from '../data/find-list-options.model';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { Observable } from 'rxjs';
@@ -19,6 +19,7 @@ import { dataService } from '../data/base/data-service.decorator';
 export class SubmissionCcLicenseDataService extends BaseDataService<SubmissionCcLicence> implements FindAllData<SubmissionCcLicence> {
 
   protected linkPath = 'submissioncclicenses';
+  private findAllData: FindAllData<SubmissionCcLicence>;
 
   constructor(
     protected requestService: RequestService,
@@ -27,6 +28,8 @@ export class SubmissionCcLicenseDataService extends BaseDataService<SubmissionCc
     protected halService: HALEndpointService,
   ) {
     super('submissioncclicenses', requestService, rdbService, objectCache, halService);
+
+    this.findAllData = new FindAllDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
   }
 
   /**
@@ -44,6 +47,6 @@ export class SubmissionCcLicenseDataService extends BaseDataService<SubmissionCc
    *    Return an observable that emits object list
    */
   public findAll(options?: FindListOptions, useCachedVersionIfAvailable?: boolean, reRequestOnStale?: boolean, ...linksToFollow: FollowLinkConfig<SubmissionCcLicence>[]): Observable<RemoteData<PaginatedList<SubmissionCcLicence>>> {
-    return undefined;
+    return this.findAllData.findAll(options, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
 }


### PR DESCRIPTION
## Description
Testing an issue on the current main branch, I have seen that the Creative Commons selector of the submit form is not loading. The problem seems to be an unimplemented function findAll in SubmissionCcLicenseDataService after applying PR #1791  

I have tried to fix the problem by implementing the function in a similar way to other data services and it seems to work fine.

## Instructions for Reviewers

* Activate the cclicense step in item-submission.xml
* Check that the cc selector is not loaded in a new submission and the javascript console shows an error
* Apply the patch and test again


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
