### PR TITLE
Bug fix for multiple IIIF image property

### DIFF
--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.spec.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.spec.ts
@@ -12,6 +12,7 @@ import { createPaginatedList } from '../../shared/testing/utils.test';
 import { of as observableOf } from 'rxjs';
 import { MiradorViewerService } from './mirador-viewer.service';
 import { HostWindowService } from '../../shared/host-window.service';
+import { BundleDataService } from '../../core/data/bundle-data.service';
 
 
 function getItem(metadata: MetadataMap) {
@@ -46,6 +47,7 @@ describe('MiradorViewerComponent with search', () => {
       declarations: [MiradorViewerComponent],
       providers: [
         { provide: BitstreamDataService, useValue: {} },
+        { provide: BundleDataService, useValue: {} },
         { provide: HostWindowService, useValue: mockHostWindowService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -108,6 +110,7 @@ describe('MiradorViewerComponent with multiple images', () => {
       declarations: [MiradorViewerComponent],
       providers: [
         { provide: BitstreamDataService, useValue: {} },
+        { provide: BundleDataService, useValue: {} },
         { provide: HostWindowService, useValue: mockHostWindowService  }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -167,6 +170,7 @@ describe('MiradorViewerComponent with a single image', () => {
       declarations: [MiradorViewerComponent],
       providers: [
         { provide: BitstreamDataService, useValue: {} },
+        { provide: BundleDataService, useValue: {} },
         { provide: HostWindowService, useValue: mockHostWindowService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -225,6 +229,7 @@ describe('MiradorViewerComponent in development mode', () => {
       set: {
         providers: [
           { provide: MiradorViewerService, useValue: viewerService },
+          { provide: BundleDataService, useValue: {} },
           { provide: HostWindowService, useValue: mockHostWindowService  }
         ]
       }

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -109,10 +109,10 @@ export class MiradorViewerComponent implements OnInit {
             this.notMobile = !(category === WidthCategory.XS || category === WidthCategory.SM);
           });
 
-      // We need to set the multi property to true if the
-      // item is searchable or when the ORIGINAL bundle contains more
-      // than 1 image. (The multi property determines whether the
-      // Mirador side thumbnail navigation panel is shown.)
+      // Set the multi property. The default mirador configuration adds a right
+      // thumbnail navigation panel to the viewer when multi is 'true'.
+
+      // Set the multi property to 'true' if the item is searchable.
       if (this.searchable) {
         this.multi = true;
         const observable = of('');
@@ -122,8 +122,8 @@ export class MiradorViewerComponent implements OnInit {
           })
         );
       } else {
-        // Sets the multi value based on the image count. Any count greater than 1
-        // will add the right thumbnail navigation panel to the viewer.
+        // Set the multi property based on the image count in IIIF-eligible bundles.
+        // Any count greater than 1 sets the value to 'true'.
         this.iframeViewerUrl = this.viewerService.getImageCount(
           this.object,
           this.bitstreamDataService,

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -8,6 +8,7 @@ import { map, take } from 'rxjs/operators';
 import { isPlatformBrowser } from '@angular/common';
 import { MiradorViewerService } from './mirador-viewer.service';
 import { HostWindowService, WidthCategory } from '../../shared/host-window.service';
+import { BundleDataService } from '../../core/data/bundle-data.service';
 
 @Component({
   selector: 'ds-mirador-viewer',
@@ -55,6 +56,7 @@ export class MiradorViewerComponent implements OnInit {
   constructor(private sanitizer: DomSanitizer,
               private viewerService: MiradorViewerService,
               private bitstreamDataService: BitstreamDataService,
+              private bundleDataService: BundleDataService,
               private hostWindowService: HostWindowService,
               @Inject(PLATFORM_ID) private platformId: any) {
   }
@@ -120,8 +122,12 @@ export class MiradorViewerComponent implements OnInit {
           })
         );
       } else {
-        // Sets the multi value based on the image count.
-        this.iframeViewerUrl = this.viewerService.getImageCount(this.object, this.bitstreamDataService).pipe(
+        // Sets the multi value based on the image count. Any count greater than 1
+        // will add the right thumbnail navigation panel to the viewer.
+        this.iframeViewerUrl = this.viewerService.getImageCount(
+          this.object,
+          this.bitstreamDataService,
+          this.bundleDataService).pipe(
           map(c => {
             if (c > 1) {
               this.multi = true;

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -28,12 +28,12 @@ export class MiradorViewerService {
   }
 
   /**
-   * Returns observable of the number of images found in eligible IIIF bundles. This checks
-   * only the first 5 bitstreams in each bundle since any count greater than one is
-   * enough to set the IIIF viewer to use the "multi" image layout.
+   * Returns observable of the number of images found in eligible IIIF bundles. Checks
+   * the mimetype of the first 5 bitstreams in each bundle.
    * @param item
    * @param bitstreamDataService
    * @param bundleDataService
+   * @returns the total image count
    */
   getImageCount(item: Item, bitstreamDataService: BitstreamDataService, bundleDataService: BundleDataService):
     Observable<number> {

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, isDevMode } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Item } from '../../core/shared/item.model';
-import { getFirstCompletedRemoteData, getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
-import { filter, last, map, switchMap } from 'rxjs/operators';
+import {
+    getFirstCompletedRemoteData,
+} from '../../core/shared/operators';
+import { filter, last, map, mergeMap, switchMap } from 'rxjs/operators';
 import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { Bitstream } from '../../core/shared/bitstream.model';
@@ -36,36 +38,44 @@ export class MiradorViewerService {
    * @returns the total image count
    */
   getImageCount(item: Item, bitstreamDataService: BitstreamDataService, bundleDataService: BundleDataService):
-    Observable<number> {
-    let count = 0;
-    return bundleDataService.findAllByItem(item).pipe(
-      getFirstCompletedRemoteData(),
-      map((bundlesRD: RemoteData<PaginatedList<Bundle>>) => bundlesRD.payload),
-      map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
-      switchMap((bundles: Bundle[]) => bundles),
-      filter((b: Bundle) => this.isIiifBundle(b.name)),
-      switchMap((bundle: Bundle) => {
-        return bitstreamDataService.findAllByItemAndBundleName(item, bundle.name, {
-          currentPage: 1,
-          elementsPerPage: 5
-        }, true, true, ...this.LINKS_TO_FOLLOW).pipe(
+      Observable<number> {
+      let count = 0;
+      return bundleDataService.findAllByItem(item).pipe(
           getFirstCompletedRemoteData(),
-          map((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => bitstreamsRD.payload),
-          map((paginatedList: PaginatedList<Bitstream>) => paginatedList.page),
-          switchMap((bitstreams: Bitstream[]) => bitstreams),
-          switchMap((bitstream: Bitstream) => bitstream.format.pipe(
-            getFirstSucceededRemoteDataPayload(),
-            map((format: BitstreamFormat) => format)
-          )),
-          map((format: BitstreamFormat) => {
-            if (format.mimetype.includes('image')) {
-              count++;
-            }
-            return count;
+          map((bundlesRD: RemoteData<PaginatedList<Bundle>>) => {
+              return bundlesRD.payload
+          }),
+          map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
+          switchMap((bundles: Bundle[]) => bundles),
+          filter((b: Bundle) => this.isIiifBundle(b.name)),
+          mergeMap((bundle: Bundle) => {
+              return bitstreamDataService.findAllByItemAndBundleName(item, bundle.name, {
+                  currentPage: 1,
+                  elementsPerPage: 5
+              }, true, true, ...this.LINKS_TO_FOLLOW).pipe(
+                  getFirstCompletedRemoteData(),
+                  map((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
+                      return bitstreamsRD.payload;
+                  }),
+                  map((paginatedList: PaginatedList<Bitstream>) => paginatedList.page),
+                  switchMap((bitstreams: Bitstream[]) => bitstreams),
+                  switchMap((bitstream: Bitstream) => bitstream.format.pipe(
+                          getFirstCompletedRemoteData(),
+                          map((formatRD: RemoteData<BitstreamFormat>) => {
+                              return formatRD.payload
+                          }),
+                          map((format: BitstreamFormat) => {
+                              if (format.mimetype.includes('image')) {
+                                  count++;
+                              }
+                              return count;
+                          }),
+                      )
+                  )
+              );
           }),
           last()
-        );
-      }));
+      );
   }
 
   isIiifBundle(bundleName: string): boolean {

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -2,13 +2,15 @@ import { Injectable, isDevMode } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Item } from '../../core/shared/item.model';
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
-import { last, map, switchMap } from 'rxjs/operators';
+import { filter, last, map, switchMap } from 'rxjs/operators';
 import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { Bitstream } from '../../core/shared/bitstream.model';
 import { BitstreamFormat } from '../../core/shared/bitstream-format.model';
 import { BitstreamDataService } from '../../core/data/bitstream-data.service';
 import { followLink, FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
+import { Bundle } from '../../core/shared/bundle.model';
+import { BundleDataService } from '../../core/data/bundle-data.service';
 
 @Injectable()
 export class MiradorViewerService {
@@ -26,32 +28,56 @@ export class MiradorViewerService {
   }
 
   /**
-   * Returns observable of the number of images in the ORIGINAL bundle
+   * Returns observable of the number of images found in eligible IIIF bundles. This checks
+   * only the first 5 bitstreams in each bundle since any count greater than one is
+   * enough to set the IIIF viewer to use the "multi" image layout.
    * @param item
    * @param bitstreamDataService
+   * @param bundleDataService
    */
-  getImageCount(item: Item, bitstreamDataService: BitstreamDataService): Observable<number> {
+  getImageCount(item: Item, bitstreamDataService: BitstreamDataService, bundleDataService: BundleDataService):
+    Observable<number> {
     let count = 0;
-    return bitstreamDataService.findAllByItemAndBundleName(item, 'ORIGINAL', {
-      currentPage: 1,
-      elementsPerPage: 10
-    }, true, true, ...this.LINKS_TO_FOLLOW)
-      .pipe(
-        getFirstCompletedRemoteData(),
-        map((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => bitstreamsRD.payload),
-        map((paginatedList: PaginatedList<Bitstream>) => paginatedList.page),
-        switchMap((bitstreams: Bitstream[]) => bitstreams),
-        switchMap((bitstream: Bitstream) => bitstream.format.pipe(
-          getFirstSucceededRemoteDataPayload(),
-          map((format: BitstreamFormat) => format)
-        )),
-        map((format: BitstreamFormat) => {
-          if (format.mimetype.includes('image')) {
-          count++;
-          }
-          return count;
-        }),
-        last()
-      );
+    return bundleDataService.findAllByItem(item).pipe(
+      getFirstCompletedRemoteData(),
+      map((bundlesRD: RemoteData<PaginatedList<Bundle>>) => bundlesRD.payload),
+      map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
+      switchMap((bundles: Bundle[]) => bundles),
+      filter((b: Bundle) => this.isIiifBundle(b.name)),
+      switchMap((bundle: Bundle) => {
+        return bitstreamDataService.findAllByItemAndBundleName(item, bundle.name, {
+          currentPage: 1,
+          elementsPerPage: 5
+        }, true, true, ...this.LINKS_TO_FOLLOW).pipe(
+          getFirstCompletedRemoteData(),
+          map((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => bitstreamsRD.payload),
+          map((paginatedList: PaginatedList<Bitstream>) => paginatedList.page),
+          switchMap((bitstreams: Bitstream[]) => bitstreams),
+          switchMap((bitstream: Bitstream) => bitstream.format.pipe(
+            getFirstSucceededRemoteDataPayload(),
+            map((format: BitstreamFormat) => format)
+          )),
+          map((format: BitstreamFormat) => {
+            if (format.mimetype.includes('image')) {
+              count++;
+            }
+            return count;
+          }),
+          last()
+        );
+      }));
   }
+
+  isIiifBundle(bundleName: string): boolean {
+    return !(
+      bundleName === 'OtherContent' ||
+      bundleName === 'LICENSE' ||
+      bundleName === 'THUMBNAIL' ||
+      bundleName === 'TEXT' ||
+      bundleName === 'METADATA' ||
+      bundleName === 'CC-LICENSE' ||
+      bundleName === 'BRANDED_PREVIEW'
+    );
+  }
+
 }

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -43,7 +43,7 @@ export class MiradorViewerService {
       return bundleDataService.findAllByItem(item).pipe(
           getFirstCompletedRemoteData(),
           map((bundlesRD: RemoteData<PaginatedList<Bundle>>) => {
-              return bundlesRD.payload
+              return bundlesRD.payload;
           }),
           map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
           switchMap((bundles: Bundle[]) => bundles),
@@ -62,7 +62,7 @@ export class MiradorViewerService {
                   switchMap((bitstream: Bitstream) => bitstream.format.pipe(
                           getFirstCompletedRemoteData(),
                           map((formatRD: RemoteData<BitstreamFormat>) => {
-                              return formatRD.payload
+                              return formatRD.payload;
                           }),
                           map((format: BitstreamFormat) => {
                               if (format.mimetype.includes('image')) {


### PR DESCRIPTION
## Description
Fixes a bug in `mirador-viewer.component` that incorrectly sets the `multi` property when images are added to bundles other than `ORIGINAL`.

The PR modifies the Angular UI to look for images in ALL eligible Bundles, not just  ORIGINAL.

**Some quick background:** the `multi` property is set by the `mirador-viewer.component` component and is passed to the Mirador viewer, which in turn uses the property to create internal configuration at startup. (The default Mirador behavior is to add right thumbnail navigation when `multi` is 'true.') `multi` should be true whenever the Item has multiple image bitstreams.

_Sorry! I just realized I didn't submit this bug fix earlier!! It's a fairly minor fix so if it can make it into 7.4 that would be great._

## Instructions for Reviewers
* Create an IIIF-enabled Item with more than one image bitstream. Upload the images into a custom bundle (e.g. TestBundle).
* View the Item and check to be sure the images are found in the custom bundle by checking for right navigation thumbnail images in the Mirador viewer (see below). Remember that (unfortunately) the viewer can only be tested in `production` mode.

<img width="1091" alt="Screen Shot 2022-09-21 at 1 00 26 PM" src="https://user-images.githubusercontent.com/1308551/191599351-a06b850a-ca2e-4baf-9fba-29a4dc412cab.png">

 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
