### PR TITLE
Regression fixes

### DIFF
--- a/src/app/core/auth/auth-request.service.spec.ts
+++ b/src/app/core/auth/auth-request.service.spec.ts
@@ -111,7 +111,6 @@ describe(`AuthRequestService`, () => {
             body: undefined,
             options,
           }));
-          expect((service as any).fetchRequest).toHaveBeenCalledWith(requestID);
         });
       });
     });
@@ -151,7 +150,6 @@ describe(`AuthRequestService`, () => {
             body: { content: 'something' },
             options,
           }));
-          expect((service as any).fetchRequest).toHaveBeenCalledWith(requestID);
         });
       });
     });

--- a/src/app/core/auth/auth-request.service.ts
+++ b/src/app/core/auth/auth-request.service.ts
@@ -58,7 +58,9 @@ export abstract class AuthRequestService {
   public postToEndpoint(method: string, body?: any, options?: HttpOptions): Observable<RemoteData<AuthStatus>> {
     const requestId = this.requestService.generateRequestId();
 
-    this.halService.getEndpoint(this.linkName).pipe(
+    const endpoint$ = this.halService.getEndpoint(this.linkName);
+
+    endpoint$.pipe(
       filter((href: string) => isNotEmpty(href)),
       map((endpointURL) => this.getEndpointByMethod(endpointURL, method)),
       distinctUntilChanged(),
@@ -68,7 +70,9 @@ export abstract class AuthRequestService {
       this.requestService.send(request);
     });
 
-    return this.fetchRequest(requestId);
+    return endpoint$.pipe(
+      switchMap(() => this.fetchRequest(requestId)),
+    );
   }
 
   /**
@@ -79,7 +83,9 @@ export abstract class AuthRequestService {
   public getRequest(method: string, options?: HttpOptions, ...linksToFollow: FollowLinkConfig<any>[]): Observable<RemoteData<AuthStatus>> {
     const requestId = this.requestService.generateRequestId();
 
-    this.halService.getEndpoint(this.linkName).pipe(
+    const endpoint$ = this.halService.getEndpoint(this.linkName);
+
+    endpoint$.pipe(
       filter((href: string) => isNotEmpty(href)),
       map((endpointURL) => this.getEndpointByMethod(endpointURL, method, ...linksToFollow)),
       distinctUntilChanged(),
@@ -89,7 +95,9 @@ export abstract class AuthRequestService {
       this.requestService.send(request);
     });
 
-    return this.fetchRequest(requestId, ...linksToFollow);
+    return endpoint$.pipe(
+      switchMap(() => this.fetchRequest(requestId, ...linksToFollow)),
+    );
   }
   /**
    * Factory function to create the request object to send. This needs to be a POST client side and

--- a/src/app/page-error/themed-page-error.component.ts
+++ b/src/app/page-error/themed-page-error.component.ts
@@ -6,7 +6,7 @@ import { PageErrorComponent } from './page-error.component';
  * Themed wrapper for PageErrorComponent
  */
 @Component({
-  selector: 'ds-themed-search-page',
+  selector: 'ds-themed-page-error',
   styleUrls: [],
   templateUrl: '../shared/theme-support/themed.component.html',
 })

--- a/src/app/page-internal-server-error/themed-page-internal-server-error.component.ts
+++ b/src/app/page-internal-server-error/themed-page-internal-server-error.component.ts
@@ -6,7 +6,7 @@ import { PageInternalServerErrorComponent } from './page-internal-server-error.c
  * Themed wrapper for PageInternalServerErrorComponent
  */
 @Component({
-  selector: 'ds-themed-search-page',
+  selector: 'ds-themed-page-internal-server-error',
   styleUrls: [],
   templateUrl: '../shared/theme-support/themed.component.html',
 })

--- a/src/app/pagenotfound/themed-pagenotfound.component.ts
+++ b/src/app/pagenotfound/themed-pagenotfound.component.ts
@@ -6,7 +6,7 @@ import { PageNotFoundComponent } from './pagenotfound.component';
  * Themed wrapper for PageNotFoundComponent
  */
 @Component({
-  selector: 'ds-themed-search-page',
+  selector: 'ds-themed-pagenotfound',
   styleUrls: [],
   templateUrl: '../shared/theme-support/themed.component.html',
 })

--- a/src/app/shared/theme-support/theme.service.spec.ts
+++ b/src/app/shared/theme-support/theme.service.spec.ts
@@ -413,7 +413,7 @@ describe('ThemeService', () => {
       link.setAttribute('rel', 'stylesheet');
       link.setAttribute('type', 'text/css');
       link.setAttribute('class', 'theme-css');
-      link.setAttribute('href', '/custom-theme.css');
+      link.setAttribute('href', 'custom-theme.css');
 
       expect(headSpy.appendChild).toHaveBeenCalledWith(link);
     });

--- a/src/app/shared/theme-support/theme.service.ts
+++ b/src/app/shared/theme-support/theme.service.ts
@@ -182,7 +182,7 @@ export class ThemeService {
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
     link.setAttribute('class', 'theme-css');
-    link.setAttribute('href', `/${encodeURIComponent(themeName)}-theme.css`);
+    link.setAttribute('href', `${encodeURIComponent(themeName)}-theme.css`);
     // wait for the new css to download before removing the old one to prevent a
     // flash of unstyled content
     link.onload = () => {


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1829
* Fixes #1830



## Description

This PR bundles fixes for a few bugs that were (re)introduced recently:

* Theme CSS not loading when `ui.nameSpace` is set
  * Stylesheet links were added with an absolute path instead of relative
  * This was originally fixed in #1642 [here](https://github.com/DSpace/dspace-angular/pull/1642/files#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR271) and reintroduced in #1741 when that method was moved to `theme.service.ts`.
* Blank page instead of error page when REST server is down
  * The `checkTokenCookie$` NgRx effect would 
  * This was introduced in #1805 by refactoring authentication requests to follow the pattern we use for equivalent DataService methods, highlighting a potential issue: #1849



While investigating the above I also noticed the themed component wrappers for error pages were created with the wrong HTML selectors.



## Instructions for Reviewers

Confirm that the referenced issues can no longer be reproduced.



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.