### PR TITLE
Use values from x-forwarded headers in getOrigin server side

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -75,6 +75,10 @@ export function app() {
    */
   const server = express();
 
+  // Tell Express to trust X-FORWARDED-* headers from proxies
+  // See https://expressjs.com/en/guide/behind-proxies.html
+  server.set('trust proxy', environment.ui.useProxies);
+
   /*
    * If production mode is enabled in the environment file:
    * - Enable Angular's production mode

--- a/src/app/core/services/browser-hard-redirect.service.spec.ts
+++ b/src/app/core/services/browser-hard-redirect.service.spec.ts
@@ -2,17 +2,25 @@ import { TestBed } from '@angular/core/testing';
 import { BrowserHardRedirectService } from './browser-hard-redirect.service';
 
 describe('BrowserHardRedirectService', () => {
-  const origin = 'https://test-host.com:4000';
-  const mockLocation = {
-    href: undefined,
-    pathname: '/pathname',
-    search: '/search',
-    origin
-  } as Location;
-
-  const service: BrowserHardRedirectService = new BrowserHardRedirectService(mockLocation);
+  let origin: string;
+  let mockLocation: Location;
+  let service: BrowserHardRedirectService;
 
   beforeEach(() => {
+    origin = 'https://test-host.com:4000';
+    mockLocation = {
+      href: undefined,
+      pathname: '/pathname',
+      search: '/search',
+      origin,
+      replace: (url: string) => {
+        mockLocation.href = url;
+      }
+    } as Location;
+    spyOn(mockLocation, 'replace');
+
+    service = new BrowserHardRedirectService(mockLocation);
+
     TestBed.configureTestingModule({});
   });
 
@@ -28,8 +36,8 @@ describe('BrowserHardRedirectService', () => {
       service.redirect(redirect);
     });
 
-    it('should update the location', () => {
-      expect(mockLocation.href).toEqual(redirect);
+    it('should call location.replace with the new url', () => {
+      expect(mockLocation.replace).toHaveBeenCalledWith(redirect);
     });
   });
 

--- a/src/app/core/services/browser-hard-redirect.service.ts
+++ b/src/app/core/services/browser-hard-redirect.service.ts
@@ -24,7 +24,7 @@ export class BrowserHardRedirectService extends HardRedirectService {
    * @param url
    */
   redirect(url: string) {
-    this.location.href = url;
+    this.location.replace(url);
   }
 
   /**

--- a/src/config/config.util.spec.ts
+++ b/src/config/config.util.spec.ts
@@ -10,6 +10,7 @@ describe('Config Util', () => {
       expect(appConfig.cache.msToLive.default).toEqual(15 * 60 * 1000); // 15 minute
       expect(appConfig.ui.rateLimiter.windowMs).toEqual(1 * 60 * 1000); // 1 minute
       expect(appConfig.ui.rateLimiter.max).toEqual(500);
+      expect(appConfig.ui.useProxies).toEqual(true);
 
       expect(appConfig.submission.autosave.metadata).toEqual([]);
 
@@ -24,6 +25,8 @@ describe('Config Util', () => {
         max: 1000
       };
       appConfig.ui.rateLimiter = rateLimiter;
+
+      appConfig.ui.useProxies = false;
 
       const autoSaveMetadata = [
         'dc.author',
@@ -44,6 +47,7 @@ describe('Config Util', () => {
       expect(environment.cache.msToLive.default).toEqual(msToLive);
       expect(environment.ui.rateLimiter.windowMs).toEqual(rateLimiter.windowMs);
       expect(environment.ui.rateLimiter.max).toEqual(rateLimiter.max);
+      expect(environment.ui.useProxies).toEqual(false);
       expect(environment.submission.autosave.metadata[0]).toEqual(autoSaveMetadata[0]);
       expect(environment.submission.autosave.metadata[1]).toEqual(autoSaveMetadata[1]);
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -37,7 +37,10 @@ export class DefaultAppConfig implements AppConfig {
     rateLimiter: {
       windowMs: 1 * 60 * 1000, // 1 minute
       max: 500 // limit each IP to 500 requests per windowMs
-    }
+    },
+
+    // Trust X-FORWARDED-* headers from proxies
+    useProxies: true,
   };
 
   // The REST API server settings

--- a/src/config/ui-server-config.interface.ts
+++ b/src/config/ui-server-config.interface.ts
@@ -11,4 +11,6 @@ export class UIServerConfig extends ServerConfig {
     max: number;
   };
 
+  // Trust X-FORWARDED-* headers from proxies
+  useProxies: boolean;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -25,7 +25,8 @@ export const environment: BuildConfig = {
     rateLimiter: {
       windowMs: 1 * 60 * 1000, // 1 minute
       max: 500 // limit each IP to 500 requests per windowMs
-    }
+    },
+    useProxies: true,
   },
 
   // The REST API server settings.


### PR DESCRIPTION
## References
* Fixes #1721
* Alternative to https://github.com/DSpace/dspace-angular/pull/1725

## Description
This PR fixes #1721 by checking for the presence of the `x-forwarded-proto` and `x-forwarded-host` headers server side, and using them instead of the default `host` and `protocol` properties on the request if they are available.

To stay on par with https://github.com/DSpace/dspace-angular/pull/1725, I also added the same small extra fix to ensure a redirect ends up in the browser's history

## Instructions for Reviewers
Run the app in prod mode. And test it with and without a proxy server in front that's configured to use the `x-forwarded` headers

Test that the `citation_pdf_url` on an item page always contains a URL that uses with the correct host and protocol, with and without using a proxy server .

To test the redirect change, download a file, and use the back button of your browser. You should end up back on the item page

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
