### PR TITLE
Workaround missing navbar @768px for dspace and custom templates

### DIFF
--- a/src/app/navbar/navbar.component.scss
+++ b/src/app/navbar/navbar.component.scss
@@ -4,7 +4,7 @@ nav.navbar {
 }
 
 /** Mobile menu styling **/
-@media screen and (max-width: map-get($grid-breakpoints, md)) {
+@media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
     .navbar {
         width: 100vw;
         background-color: var(--bs-white);
@@ -26,7 +26,7 @@ nav.navbar {
 
 /* TODO remove when https://github.com/twbs/bootstrap/issues/24726 is fixed */
 .navbar-expand-md.navbar-container {
-    @media screen and (max-width: map-get($grid-breakpoints, md)) {
+    @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
         > .container {
             padding: 0 var(--bs-spacer);
         }

--- a/src/themes/dspace/app/navbar/navbar.component.scss
+++ b/src/themes/dspace/app/navbar/navbar.component.scss
@@ -6,7 +6,7 @@ nav.navbar {
 }
 
 /** Mobile menu styling **/
-@media screen and (max-width: map-get($grid-breakpoints, md)) {
+@media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
   .navbar {
     width: 100%;
     background-color: var(--bs-white);
@@ -28,7 +28,7 @@ nav.navbar {
 
 /* TODO remove when https://github.com/twbs/bootstrap/issues/24726 is fixed */
 .navbar-expand-md.navbar-container {
-  @media screen and (max-width: map-get($grid-breakpoints, md)) {
+  @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
     > .container {
       padding: 0 var(--bs-spacer);
       a.navbar-brand {


### PR DESCRIPTION
## Description
Workaround: missing navbar @768px in dspace and custom templates

## Instructions for Reviewers

If the screen is 768px wide, the navbar is not showing.

The treatment of the bootstrap breakpoints in DSpace is inconsistent. 

md is defined as 768px <= md < 992px.

The statement

`@media screen and (max-width: map-get($grid-breakpoints, md)) {}`

which is in some instances used at the moment for referencing break intervals BELOW md, includes the lower md border which should be excluded. 

The sass mixin
`@include media-breakpoint-down($name, $grid-breakpoints) {}`

or function
`breakpoint-max($name, $grid-breakpoints)`

which are meant to be used in this case, for some unknown reason don't seem to work atm, so the usage of 

`@media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {} `

is a solution for the moment, but this is only a workaround.
The usage of "-0.02" instead of e.g. "-0.01" is a workaround for a rounding error in Safari.

See also:
https://getbootstrap.com/docs/4.6/layout/overview/

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
