### PR TITLE
Fix issue when deleting a member from a group

### DIFF
--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -209,7 +209,6 @@ export class MembersListComponent implements OnInit, OnDestroy {
       if (activeGroup != null) {
         const response = this.groupDataService.deleteMemberFromGroup(activeGroup, ePerson.eperson);
         this.showNotifications('deleteMember', response, ePerson.eperson.name, activeGroup);
-        this.search({ scope: this.currentSearchScope, query: this.currentSearchQuery });
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.noActiveGroup'));
       }
@@ -315,7 +314,6 @@ export class MembersListComponent implements OnInit, OnDestroy {
     response.pipe(getFirstCompletedRemoteData()).subscribe((rd: RemoteData<any>) => {
       if (rd.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.success.' + messageSuffix, { name: nameObject }));
-        this.ePersonDataService.clearLinkRequests(activeGroup._links.epersons.href);
       } else {
         this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.failure.' + messageSuffix, { name: nameObject }));
       }

--- a/src/app/core/eperson/group-data.service.spec.ts
+++ b/src/app/core/eperson/group-data.service.spec.ts
@@ -191,9 +191,7 @@ describe('GroupDataService', () => {
       callback();
 
       expect(objectCache.getByHref).toHaveBeenCalledWith(EPersonMock2._links.self.href);
-      expect(objectCache.getByHref).toHaveBeenCalledWith(GroupMock._links.self.href);
-      expect(requestService.setStaleByUUID).toHaveBeenCalledTimes(4);
-      expect(requestService.setStaleByUUID).toHaveBeenCalledWith('request1');
+      expect(requestService.setStaleByUUID).toHaveBeenCalledTimes(2);
       expect(requestService.setStaleByUUID).toHaveBeenCalledWith('request2');
     });
   });
@@ -218,9 +216,7 @@ describe('GroupDataService', () => {
       callback();
 
       expect(objectCache.getByHref).toHaveBeenCalledWith(EPersonMock._links.self.href);
-      expect(objectCache.getByHref).toHaveBeenCalledWith(GroupMock._links.self.href);
-      expect(requestService.setStaleByUUID).toHaveBeenCalledTimes(4);
-      expect(requestService.setStaleByUUID).toHaveBeenCalledWith('request1');
+      expect(requestService.setStaleByUUID).toHaveBeenCalledTimes(2);
       expect(requestService.setStaleByUUID).toHaveBeenCalledWith('request2');
     });
   });

--- a/src/app/core/eperson/group-data.service.ts
+++ b/src/app/core/eperson/group-data.service.ts
@@ -179,7 +179,6 @@ export class GroupDataService extends IdentifiableDataService<Group> implements 
 
     return this.rdbService.buildFromRequestUUIDAndAwait(requestId, () => observableZip(
       this.invalidateByHref(ePerson._links.self.href),
-      this.invalidateByHref(activeGroup._links.self.href),
       this.requestService.setStaleByHrefSubstring(ePerson._links.groups.href).pipe(take(1)),
       this.requestService.setStaleByHrefSubstring(activeGroup._links.epersons.href).pipe(take(1)),
     ));
@@ -198,7 +197,6 @@ export class GroupDataService extends IdentifiableDataService<Group> implements 
 
     return this.rdbService.buildFromRequestUUIDAndAwait(requestId, () => observableZip(
       this.invalidateByHref(ePerson._links.self.href),
-      this.invalidateByHref(activeGroup._links.self.href),
       this.requestService.setStaleByHrefSubstring(ePerson._links.groups.href).pipe(take(1)),
       this.requestService.setStaleByHrefSubstring(activeGroup._links.epersons.href).pipe(take(1)),
     ));


### PR DESCRIPTION
## References
* Fixes #1879

## Description
Similar to https://github.com/DSpace/dspace-angular/issues/1870, this issue was caused by an infinite loop of re-requests because both the group and the eperson had been manually invalidated in the past.

However because of https://github.com/DSpace/dspace-angular/pull/1846 this is no longer necessary. Removing the manual invalidation of the group fixes the issue

## Instructions for Reviewers
Verify that you can add and remove members to groups without problems. Keep an eye on the network tab to ensure the number of requests remains in check

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
