### PR TITLE
Removed thumbnails from relationship modal

### DIFF
--- a/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.html
+++ b/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.html
@@ -1,4 +1,4 @@
-<div>
+<div [ngClass]="showThumbnails ? 'hide-modal-thumbnail-column' : ''">
     <div class="modal-header">{{'virtual-metadata.delete-relationship.modal-head' | translate}}
         <button type="button" class="close" (click)="close.emit()" aria-label="Close">
             <span aria-hidden="true">×</span>

--- a/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.spec.ts
+++ b/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.spec.ts
@@ -7,6 +7,8 @@ import { VirtualMetadataComponent } from './virtual-metadata.component';
 import { Item } from '../../../core/shared/item.model';
 import { ObjectUpdatesService } from '../../../core/data/object-updates/object-updates.service';
 import { VarDirective } from '../../../shared/utils/var.directive';
+import { APP_CONFIG } from '../../../../config/app-config.interface';
+import { environment } from '../../../../environments/environment';
 
 describe('VirtualMetadataComponent', () => {
 
@@ -46,6 +48,7 @@ describe('VirtualMetadataComponent', () => {
       declarations: [VirtualMetadataComponent, VarDirective],
       providers: [
         { provide: ObjectUpdatesService, useValue: objectUpdatesService },
+        { provide: APP_CONFIG, useValue: environment }
       ], schemas: [
         NO_ERRORS_SCHEMA
       ]

--- a/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.ts
+++ b/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.ts
@@ -1,8 +1,9 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
 import {Observable} from 'rxjs';
 import {Item} from '../../../core/shared/item.model';
 import {MetadataValue} from '../../../core/shared/metadata.models';
 import {ObjectUpdatesService} from '../../../core/data/object-updates/object-updates.service';
+import { APP_CONFIG, AppConfig } from '../../../../config/app-config.interface';
 
 @Component({
   selector: 'ds-virtual-metadata',
@@ -46,6 +47,11 @@ export class VirtualMetadataComponent implements OnInit {
   @Output() save = new EventEmitter();
 
   /**
+   * Display thumbnails if required by configuration
+   */
+  showThumbnails: boolean;
+
+  /**
    * Get an array of the left and the right item of the relationship to be deleted.
    */
   get items() {
@@ -56,7 +62,9 @@ export class VirtualMetadataComponent implements OnInit {
 
   constructor(
     protected objectUpdatesService: ObjectUpdatesService,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) {
+    this.showThumbnails = this.appConfig.browseBy.showThumbnails;
   }
 
   /**

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -138,6 +138,29 @@ ds-dynamic-form-control-container.d-none {
 .btn-dark {
   background-color: var(--ds-admin-sidebar-bg);
 }
+
+.preserve-line-breaks {
+  white-space: pre-line;
+}
+
+/* Thumbnail styles */
+.hide-placeholder-text {
+  .thumbnail-placeholder {
+    color: transparent !important;
+  }
+}
+
+/* Used to hide the thumbnail column in modals. */
+.hide-modal-thumbnail-column {
+  .modal-body ds-listable-object-component-loader div.row > div:first-child {
+    display: none;
+  }
+  .modal-body ds-listable-object-component-loader div.row > div:nth-child(2) {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+
 /* The font sizes used in "no thumbnail" placeholder */
 .thumb-font-0 {
   .thumbnail-placeholder {
@@ -153,13 +176,6 @@ ds-dynamic-form-control-container.d-none {
     padding: 0.1rem;
   }
 }
-
-.hide-placeholder-text {
-  .thumbnail-placeholder {
-    color: transparent !important;
-  }
-}
-
 .thumb-font-1 {
   .thumbnail-placeholder {
     @media screen and (max-width: map-get($grid-breakpoints, sm)) {
@@ -170,7 +186,7 @@ ds-dynamic-form-control-container.d-none {
       font-size: 0.4rem;
       padding: 0.1rem;
     }
-    font-size: 0.6rem;
+    font-size: 0.5rem;
     padding: 0.125rem;
   }
 }
@@ -187,6 +203,4 @@ ds-dynamic-form-control-container.d-none {
   }
 }
 
-.preserve-line-breaks {
-  white-space: pre-line;
-}
+


### PR DESCRIPTION
## References
* Fixes #1883

## Description
This PR hides the thumbnail column in the modal for saving virtual metadata as real metadata. I looked at keeping the thumbnails, but updating the modal layout by removing the thumb looks like a quicker solution.

<img width="507" alt="Screen Shot 2022-10-05 at 3 18 18 PM" src="https://user-images.githubusercontent.com/1308551/194174312-59677ca8-cc90-4b0e-b371-7c5cc8c5c37f.png">

## Instructions for Reviewers

- Login as an Admin
- Edit an Entity which has existing relationships. For example, edit "Simmons, Cameron" or one of their Publications
- On the "Relationships" tab, attempt to delete a relationship. You should now see a popup modal like the above screenshot.



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
