### PR TITLE
Issue 1920 - "data-service.decorator.spec.ts" tests fails intermittently

### DIFF
--- a/src/app/core/data/base/data-service.decorator.spec.ts
+++ b/src/app/core/data/base/data-service.decorator.spec.ts
@@ -10,6 +10,7 @@ import { ResourceType } from '../../shared/resource-type';
 import { BaseDataService } from './base-data.service';
 import { HALDataService } from './hal-data-service.interface';
 import { dataService, getDataServiceFor } from './data-service.decorator';
+import { v4 as uuidv4 } from 'uuid';
 
 class TestService extends BaseDataService<any> {
 }
@@ -28,7 +29,7 @@ let testType;
 
 describe('@dataService/getDataServiceFor', () => {
   beforeEach(() => {
-    testType = new ResourceType('testType-' + new Date().getTime());
+    testType = new ResourceType(`testType-${uuidv4()}`);
   });
 
   it('should register a resourcetype for a dataservice', () => {


### PR DESCRIPTION
## References
* Fixes #1920

## Description

Replaced the timestamp (intended to produce unique "testType" instances) with UUID, because intermittent failures are occurring when tests are running quickly enough that the "new Data().getTime()" function is returning the same timestamp for multiple tests.

## Instructions for Reviewers

List of changes in this PR:
* In "src/app/core/data/base/data-service.decorator.spec.ts", replaced the use of timestamps to create unique "testType" objects in the "beforeEach" with UUIDs, to ensure that unique "testType" objects are created even if the tests complete in under a millisecond.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

The test failures described in #1920 are intermittent, and may not occur on all workstations.

One scenario in which the "data-service.decorator.spec.ts" tests fail are when the following two events occur:

1) The "should register a resourcetype for a dataservice" test is run first, followed by the "when there already is a registered dataservice for a resourcetype" test.

2) The two tests run quickly enough that "new Date().getTime()" call in the "beforeEach" returns the same millisecond time instance for both tests, resulting in the "testType" instances having the same value.

When these two events occur, the "when there already is a registered dataservice for a resourcetype" test fails at line 49, because the the "testType" being registered already exists.

These events happen intermittently because the tests are run in random order, and it depends on the exact timing at which the tests are run.

There are at least two possible fixes:

1) Move the creation of the "testType" instance into each test (removing the "beforeEach"), and give each "testType" a unique name.

2) Change the way the "testType" instances are created in the "beforeEach" to ensure uniqueness, such as by using a UUID, instead of a timestamp.

The first approach requires unique names to be created for each test – not really a problem as there are only three tests, but could become an issue if more tests are added.

The second approach was preferred because:

* The "uuid" package is already a project dependency, and is used in other tests.
* Changing the timestamp to a UUID is straightforward, and preserves the basic layout of the tests.

For verification see the steps in #1920:

1. Clone the "dspace-angular" repository, and install the dependencies:

```
# clone the repo
git clone https://github.com/DSpace/dspace-angular.git

# change directory
cd dspace-angular/

# Check out the pull request
git fetch origin pull/1922/head:pull1922

git checkout pull1922

# install the local dependencies
yarn install
```

2) Run the following command to run a subset of the tests:

```
yarn test --watch --include='src/app/core/data/base/**/*.spec.ts'
```

This will display a Chrome browser. Verify that all the tests pass. Refresh the page a number of times (perhaps 20 times), and verify that the tests pass each time.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
