### PR TITLE
Minor fixes related to line breaks & Markdown in metadata fields

### DIFF
--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -1,16 +1,16 @@
 <ds-metadata-field-wrapper [label]="label | translate">
     <ng-container *ngFor="let mdValue of mdValues; let last=last;">
-      <ng-container *ngTemplateOutlet="(renderMarkdown ? markdown : simple); context: {value: mdValue.value, classes: 'dont-break-out preserve-line-breaks'}">
+      <ng-container *ngTemplateOutlet="(renderMarkdown ? markdown : simple); context: {value: mdValue.value}">
       </ng-container>
       <span class="separator" *ngIf="!last" [innerHTML]="separator"></span>
     </ng-container>
 </ds-metadata-field-wrapper>
 
-<ng-template #markdown let-value="value" let-classes="classes">
-  <span class="{{classes}}" [innerHTML]="value | dsMarkdown | async">
+<ng-template #markdown let-value="value">
+  <span class="dont-break-out" [innerHTML]="value | dsMarkdown | async">
   </span>
 </ng-template>
 
-<ng-template #simple let-value="value" let-classes="classes">
-  <span class="{{classes}}">{{value}}</span>
+<ng-template #simple let-value="value">
+  <span class="dont-break-out preserve-line-breaks">{{value}}</span>
 </ng-template>

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -12,7 +12,5 @@
 </ng-template>
 
 <ng-template #simple let-value="value" let-classes="classes">
-  <span class="{{classes}}">
-    {{value}}
-  </span>
+  <span class="{{classes}}">{{value}}</span>
 </ng-template>

--- a/src/app/item-page/simple/field-components/specific-field/generic/generic-item-page-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/generic/generic-item-page-field.component.ts
@@ -35,4 +35,10 @@ export class GenericItemPageFieldComponent extends ItemPageFieldComponent {
    */
   @Input() label: string;
 
+  /**
+   * Whether the {@link MarkdownPipe} should be used to render this metadata.
+   */
+  @Input() enableMarkdown = false;
+
+
 }

--- a/src/app/item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/item-page/simple/item-types/publication/publication.component.html
@@ -76,7 +76,7 @@
 
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.subject']"
-      [separator]="','"
+      [separator]="', '"
       [label]="'item.page.subject'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="object"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -61,7 +61,7 @@
 
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.subject']"
-      [separator]="','"
+      [separator]="', '"
       [label]="'item.page.subject'">
     </ds-generic-item-page-field>
     <ds-generic-item-page-field [item]="object"


### PR DESCRIPTION
## References
* https://github.com/DSpace/dspace-angular/pull/1851

## Description
This PR bundles a few minor fixes related to https://github.com/DSpace/dspace-angular/pull/1851

* Even spacing between comma-separated MDVs (e.g. subjects)
  <img width="539" alt="20221021-180851" src="https://user-images.githubusercontent.com/31547038/197240874-15bdf05b-0cae-4dfb-8d47-fa3ea11a3b7a.png">
  
  This was an older issue, caused by line breaks within the `<span>`, which Angular translates into unwanted spacing. Now we include a space in the separator itself: `', '`

* Made `enableMarkdown` an input of `ds-generic-item-page-field` so it's easier to enable Markdown for arbitrary Item page fields

* When the new `dsMarkdown` pipe is combined with the new `.preserve-line-breaks` CSS class, line breaks in Markdown are effectively doubled. Therefore, we shouldn't add this class when rendering Markdown.

## Instructions for Reviewers
Confirm that this PR solves the issues listed above and that the changes are sensible.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
