### PR TITLE
DS-1905: fixes route function to match default value of websvc.opensearch.svccontext

### DIFF
--- a/src/app/shared/rss-feed/rss.component.spec.ts
+++ b/src/app/shared/rss-feed/rss.component.spec.ts
@@ -96,17 +96,17 @@ describe('RssComponent', () => {
     });
 
     it('should formulate the correct url given params in url', () => {
-        const route = comp.formulateRoute(uuid, 'opensearch', options, query);
+        const route = comp.formulateRoute(uuid, 'opensearch/search', options, query);
         expect(route).toBe('/opensearch/search?format=atom&scope=2cfcf65e-0a51-4bcb-8592-b8db7b064790&sort=dc.title&sort_direction=DESC&query=test');
     });
 
     it('should skip uuid if its null', () => {
-        const route = comp.formulateRoute(null, 'opensearch', options, query);
+        const route = comp.formulateRoute(null, 'opensearch/search', options, query);
         expect(route).toBe('/opensearch/search?format=atom&sort=dc.title&sort_direction=DESC&query=test');
     });
 
     it('should default to query * if none provided', () => {
-        const route = comp.formulateRoute(null, 'opensearch', options, null);
+        const route = comp.formulateRoute(null, 'opensearch/search', options, null);
         expect(route).toBe('/opensearch/search?format=atom&sort=dc.title&sort_direction=DESC&query=*');
     });
 });

--- a/src/app/shared/rss-feed/rss.component.spec.ts
+++ b/src/app/shared/rss-feed/rss.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { SortDirection, SortOptions } from '../../core/cache/models/sort-options.model';
 import { ConfigurationDataService } from '../../core/data/configuration-data.service';
 import { RemoteData } from '../../core/data/remote-data';
 import { GroupDataService } from '../../core/eperson/group-data.service';
@@ -23,7 +22,6 @@ import { RouterMock } from '../mocks/router.mock';
 
 describe('RssComponent', () => {
     let comp: RSSComponent;
-    let options: SortOptions;
     let fixture: ComponentFixture<RSSComponent>;
     let uuid: string;
     let query: string;
@@ -63,7 +61,6 @@ describe('RssComponent', () => {
               pageSize: 10,
               currentPage: 1
             }),
-            sort: new SortOptions('dc.title', SortDirection.ASC),
           }));
         groupDataService = jasmine.createSpyObj('groupsDataService', {
             findListByHref: createSuccessfulRemoteDataObject$(createPaginatedList([])),
@@ -88,7 +85,6 @@ describe('RssComponent', () => {
       }));
 
     beforeEach(() => {
-        options = new SortOptions('dc.title', SortDirection.DESC);
         uuid = '2cfcf65e-0a51-4bcb-8592-b8db7b064790';
         query = 'test';
         fixture = TestBed.createComponent(RSSComponent);
@@ -96,18 +92,18 @@ describe('RssComponent', () => {
     });
 
     it('should formulate the correct url given params in url', () => {
-        const route = comp.formulateRoute(uuid, 'opensearch/search', options, query);
-        expect(route).toBe('/opensearch/search?format=atom&scope=2cfcf65e-0a51-4bcb-8592-b8db7b064790&sort=dc.title&sort_direction=DESC&query=test');
+        const route = comp.formulateRoute(uuid, 'opensearch/search', query);
+        expect(route).toBe('/opensearch/search?format=atom&scope=2cfcf65e-0a51-4bcb-8592-b8db7b064790&query=test');
     });
 
     it('should skip uuid if its null', () => {
-        const route = comp.formulateRoute(null, 'opensearch/search', options, query);
-        expect(route).toBe('/opensearch/search?format=atom&sort=dc.title&sort_direction=DESC&query=test');
+        const route = comp.formulateRoute(null, 'opensearch/search', query);
+        expect(route).toBe('/opensearch/search?format=atom&query=test');
     });
 
     it('should default to query * if none provided', () => {
-        const route = comp.formulateRoute(null, 'opensearch/search', options, null);
-        expect(route).toBe('/opensearch/search?format=atom&sort=dc.title&sort_direction=DESC&query=*');
+        const route = comp.formulateRoute(null, 'opensearch/search', null);
+        expect(route).toBe('/opensearch/search?format=atom&query=*');
     });
 });
 

--- a/src/app/shared/rss-feed/rss.component.ts
+++ b/src/app/shared/rss-feed/rss.component.ts
@@ -114,7 +114,7 @@ export class RSSComponent implements OnInit, OnDestroy  {
    * @returns The combine URL to opensearch
    */
   formulateRoute(uuid: string, opensearch: string, sort: SortOptions, query: string): string {
-    let route = 'search?format=atom';
+    let route = '?format=atom';
     if (uuid) {
       route += `&scope=${uuid}`;
     }
@@ -126,7 +126,7 @@ export class RSSComponent implements OnInit, OnDestroy  {
     } else {
       route += `&query=*`;
     }
-    route = '/' + opensearch + '/' + route;
+    route = '/' + opensearch + route;
     return route;
   }
 

--- a/src/app/shared/rss-feed/rss.component.ts
+++ b/src/app/shared/rss-feed/rss.component.ts
@@ -12,7 +12,6 @@ import { ConfigurationDataService } from '../../core/data/configuration-data.ser
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { environment } from '../../../../src/environments/environment';
 import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
-import { SortOptions } from '../../core/cache/models/sort-options.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { Router } from '@angular/router';
 import { map, switchMap } from 'rxjs/operators';
@@ -39,7 +38,6 @@ export class RSSComponent implements OnInit, OnDestroy  {
 
   uuid: string;
   configuration$: Observable<string>;
-  sortOption$: Observable<SortOptions>;
 
   subs: Subscription[] = [];
 
@@ -93,7 +91,7 @@ export class RSSComponent implements OnInit, OnDestroy  {
         return null;
       }
       this.uuid = this.groupDataService.getUUIDFromString(this.router.url);
-      const route = environment.rest.baseUrl + this.formulateRoute(this.uuid, openSearchUri, searchOptions.sort, searchOptions.query);
+      const route = environment.rest.baseUrl + this.formulateRoute(this.uuid, openSearchUri, searchOptions.query);
       this.addLinks(route);
       this.linkHeadService.addTag({
         href: environment.rest.baseUrl + '/' + openSearchUri + '/service',
@@ -109,17 +107,13 @@ export class RSSComponent implements OnInit, OnDestroy  {
    * Function created a route given the different params available to opensearch
    * @param uuid The uuid if a scope is present
    * @param opensearch openSearch uri
-   * @param sort The sort options for the opensearch request
    * @param query The query string that was provided in the search
    * @returns The combine URL to opensearch
    */
-  formulateRoute(uuid: string, opensearch: string, sort: SortOptions, query: string): string {
+  formulateRoute(uuid: string, opensearch: string, query: string): string {
     let route = '?format=atom';
     if (uuid) {
       route += `&scope=${uuid}`;
-    }
-    if (sort && sort.direction && sort.field && sort.field !== 'id') {
-      route += `&sort=${sort.field}&sort_direction=${sort.direction}`;
     }
     if (query) {
       route += `&query=${query}`;


### PR DESCRIPTION
## References
* Fixes #1905 

## Description
This small PR fixes the path issues in the RSS link. 

## Instructions for Reviewers
See #1905 for testing instructions.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [X] My PR doesn't introduce circular dependencies
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
