### PR TITLE
Test cases of date.util.spec.ts fixed

### DIFF
--- a/src/app/shared/date.util.spec.ts
+++ b/src/app/shared/date.util.spec.ts
@@ -22,7 +22,7 @@ describe('Date Utils', () => {
         });
         it('should convert NgbDateStruct to YYYY-MM-DDThh:mm:ssZ string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            const date = new Date(2022, 5, 3);
+            const date = new Date(Date.UTC(2022, 5, 3))
             expect(dateToISOFormat(dateToNgbDateStruct(date))).toEqual('2022-06-03T00:00:00Z');
         });
     });
@@ -30,22 +30,22 @@ describe('Date Utils', () => {
     describe('dateToString', () => {
         it('should convert Date to YYYY-MM-DD string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            expect(dateToString(new Date(2022, 5, 3))).toEqual('2022-06-03');
+            expect(dateToString(new Date(Date.UTC(2022, 5, 3)))).toEqual('2022-06-03');
         });
         it('should convert Date with time to YYYY-MM-DD string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            expect(dateToString(new Date(2022, 5, 3, 3, 24, 0))).toEqual('2022-06-03');
+            expect(dateToString(new Date(Date.UTC(2022, 5, 3, 3, 24, 0)))).toEqual('2022-06-03');
         });
         it('should convert Month only to YYYY-MM-DD string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            expect(dateToString(new Date(2022, 5))).toEqual('2022-06-01');
+            expect(dateToString(new Date(Date.UTC(2022, 5)))).toEqual('2022-06-01');
         });
         it('should convert ISO Date to YYYY-MM-DD string', () => {
             expect(dateToString(new Date('2022-06-03T03:24:00Z'))).toEqual('2022-06-03');
         });
         it('should convert NgbDateStruct to YYYY-MM-DD string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            const date = new Date(2022, 5, 3);
+            const date = new Date(Date.UTC(2022, 5, 3));
             expect(dateToString(dateToNgbDateStruct(date))).toEqual('2022-06-03');
         });
     });

--- a/src/app/shared/date.util.spec.ts
+++ b/src/app/shared/date.util.spec.ts
@@ -22,7 +22,7 @@ describe('Date Utils', () => {
         });
         it('should convert NgbDateStruct to YYYY-MM-DDThh:mm:ssZ string', () => {
             // NOTE: month is zero indexed which is why it increases by one
-            const date = new Date(Date.UTC(2022, 5, 3))
+            const date = new Date(Date.UTC(2022, 5, 3));
             expect(dateToISOFormat(dateToNgbDateStruct(date))).toEqual('2022-06-03T00:00:00Z');
         });
     });


### PR DESCRIPTION
## References
* Fixes #1941 

## Description
Some unit tests were failing when the timezone of the OS had a positive UTC/GMT offset. This has been fixed by using UTC date format as input for the tested methods:

```javascript
// const date = new Date(2022, 5, 3);
const date = new Date(Date.UTC(2022, 5, 3));
```

## Instructions for Reviewers
If you live in a region where the UTC/GMT offset is negative, then change the time zone of your OS so that the UTC/GMT offset is positive (e.g. Europe Central Time, GMT+0100). You can check the offset on your browser's console: 

```javascript
console.log(new Date())
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
