### PR TITLE
The number of people and groups on access control page are now configurable

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -213,6 +213,18 @@ collection:
   edit:
     undoTimeout: 10000 # 10 seconds
 
+accesscontrol:
+  epeople:
+    # Number of entries in the epeople list in the access controll page.
+    # Rounded to the nearest size in the list of selectable sizes on the
+    # settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+    pageSize: 5
+  groups:
+    # Number of entries in the group list in the access controll page.
+    # Rounded to the nearest size in the list of selectable sizes on the
+    # settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+    pageSize: 5
+
 # Theme Config
 themes:
   # Add additional themes here. In the case where multiple themes match a route, the first one

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -48,7 +48,7 @@
         <ds-themed-loading *ngIf="searching$ | async"></ds-themed-loading>
         <ds-pagination
           *ngIf="(pageInfoState$ | async)?.totalElements > 0 && !(searching$ | async)"
-          [paginationOptions]="config"
+          [paginationOptions]="paginationConfig"
           [pageInfoState]="pageInfoState$"
           [collectionSize]="(pageInfoState$ | async)?.totalElements"
           [hideGear]="true"

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -27,6 +27,8 @@ import { RequestService } from '../../core/data/request.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
 import { FindListOptions } from '../../core/data/find-list-options.model';
+import { APP_CONFIG } from 'src/config/app-config.interface';
+import { environment } from 'src/environments/environment';
 
 describe('EPeopleRegistryComponent', () => {
   let component: EPeopleRegistryComponent;
@@ -138,7 +140,8 @@ describe('EPeopleRegistryComponent', () => {
         { provide: FormBuilderService, useValue: builderService },
         { provide: Router, useValue: new RouterStub() },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: APP_CONFIG, useValue: environment }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, Inject } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -21,6 +21,7 @@ import { RequestService } from '../../core/data/request.service';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { NoContent } from '../../core/shared/NoContent.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
+import { AppConfig, APP_CONFIG } from 'src/config/app-config.interface';
 
 @Component({
   selector: 'ds-epeople-registry',
@@ -57,11 +58,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
   /**
    * Pagination config used to display the list of epeople
    */
-  config: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
-    id: 'elp',
-    pageSize: 5,
-    currentPage: 1
-  });
+  paginationConfig: PaginationComponentOptions;
 
   /**
    * Whether or not to show the EPerson form
@@ -93,13 +90,19 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               private router: Router,
               private modalService: NgbModal,
               private paginationService: PaginationService,
-              public requestService: RequestService) {
+              public requestService: RequestService,
+              @Inject(APP_CONFIG) protected appConfig: AppConfig) {
     this.currentSearchQuery = '';
     this.currentSearchScope = 'metadata';
     this.searchForm = this.formBuilder.group(({
       scope: 'metadata',
       query: '',
     }));
+    this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
+      id: 'elp',
+      pageSize: this.appConfig.accesscontrol.epeople.pageSize,
+      currentPage: 1
+    });
   }
 
   ngOnInit() {
@@ -152,7 +155,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
     if (hasValue(this.findListOptionsSub)) {
       this.findListOptionsSub.unsubscribe();
     }
-    this.findListOptionsSub = this.paginationService.getCurrentPagination(this.config.id, this.config).pipe(
+    this.findListOptionsSub = this.paginationService.getCurrentPagination(this.paginationConfig.id, this.paginationConfig).pipe(
       switchMap((findListOptions) => {
           const query: string = data.query;
           const scope: string = data.scope;
@@ -161,14 +164,14 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               queryParamsHandling: 'merge'
             });
             this.currentSearchQuery = query;
-            this.paginationService.resetPage(this.config.id);
+            this.paginationService.resetPage(this.paginationConfig.id);
           }
           if (scope != null && this.currentSearchScope !== scope) {
             this.router.navigate([this.epersonService.getEPeoplePageRouterLink()], {
               queryParamsHandling: 'merge'
             });
             this.currentSearchScope = scope;
-            this.paginationService.resetPage(this.config.id);
+            this.paginationService.resetPage(this.paginationConfig.id);
 
           }
           return this.epersonService.searchByScope(this.currentSearchScope, this.currentSearchQuery, {
@@ -253,7 +256,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   ngOnDestroy(): void {
     this.cleanupSubscribes();
-    this.paginationService.clearPagination(this.config.id);
+    this.paginationService.clearPagination(this.paginationConfig.id);
   }
 
 

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -36,7 +36,7 @@
       <ds-themed-loading *ngIf="loading$ | async"></ds-themed-loading>
       <ds-pagination
         *ngIf="(pageInfoState$ | async)?.totalElements > 0 && !(loading$ | async)"
-        [paginationOptions]="config"
+        [paginationOptions]="paginationConfig"
         [pageInfoState]="pageInfoState$"
         [collectionSize]="(pageInfoState$ | async)?.totalElements"
         [hideGear]="true"

--- a/src/app/access-control/group-registry/groups-registry.component.spec.ts
+++ b/src/app/access-control/group-registry/groups-registry.component.spec.ts
@@ -32,6 +32,8 @@ import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
 import { FeatureID } from '../../core/data/feature-authorization/feature-id';
 import { NoContent } from '../../core/shared/NoContent.model';
+import { environment } from 'src/environments/environment';
+import { APP_CONFIG } from 'src/config/app-config.interface';
 
 describe('GroupRegistryComponent', () => {
   let component: GroupsRegistryComponent;
@@ -179,7 +181,8 @@ describe('GroupRegistryComponent', () => {
         { provide: Router, useValue: new RouterMock() },
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: PaginationService, useValue: paginationService },
-        { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) }
+        { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
+        { provide: APP_CONFIG, useValue: environment }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/config/access-control-config.interface.ts
+++ b/src/config/access-control-config.interface.ts
@@ -1,0 +1,26 @@
+import { Config } from './config.interface';
+
+/**
+ * Config that determines the access control screen
+ */
+export interface AccessControlConfig extends Config {
+
+  epeople: {
+    /**
+     * Number of entries in the epeople list in the access controll page.
+     * Rounded to the nearest size in the list of selectable sizes on the settings
+     * menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+     */
+    pageSize: number;
+  };
+
+  groups: {
+    /**
+     * Number of entries in the group list in the access controll page.
+     * Rounded to the nearest size in the list of selectable sizes on the settings
+     * menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+     */
+    pageSize: number;
+  }
+
+}

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -20,6 +20,7 @@ import { InfoConfig } from './info-config.interface';
 import { CommunityListConfig } from './community-list-config.interface';
 import { HomeConfig } from './homepage-config.interface';
 import { MarkdownConfig } from './markdown-config.interface';
+import { AccessControlConfig } from './access-control-config.interface';
 
 interface AppConfig extends Config {
   ui: UIServerConfig;
@@ -38,6 +39,7 @@ interface AppConfig extends Config {
   homePage: HomeConfig;
   item: ItemConfig;
   collection: CollectionPageConfig;
+  accesscontrol: AccessControlConfig;
   themes: ThemeConfig[];
   mediaViewer: MediaViewerConfig;
   bundle: BundleConfig;

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -20,6 +20,7 @@ import { InfoConfig } from './info-config.interface';
 import { CommunityListConfig } from './community-list-config.interface';
 import { HomeConfig } from './homepage-config.interface';
 import { MarkdownConfig } from './markdown-config.interface';
+import { AccessControlConfig } from './access-control-config.interface';
 
 export class DefaultAppConfig implements AppConfig {
   production = false;
@@ -252,6 +253,21 @@ export class DefaultAppConfig implements AppConfig {
   collection: CollectionPageConfig = {
     edit: {
       undoTimeout: 10000 // 10 seconds
+    }
+  };
+
+  accesscontrol: AccessControlConfig = {
+    epeople: {
+      // Number of entries in the epeople list in the access controll page.
+      // Rounded to the nearest size in the list of selectable sizes on the
+      // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+      pageSize: 5
+    },
+    groups: {
+      // Number of entries in the groups list in the access controll page.
+      // Rounded to the nearest size in the list of selectable sizes on the
+      // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+      pageSize: 5
     }
   };
 

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -236,6 +236,20 @@ export const environment: BuildConfig = {
       undoTimeout: 10000 // 10 seconds
     }
   },
+  accesscontrol: {
+    epeople: {
+      // Number of entries in the epeople list in the access controll page.
+      // Rounded to the nearest size in the list of selectable sizes on the
+      // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+      pageSize: 5
+    },
+    groups: {
+      // Number of entries in the group list in the access controll page.
+      // Rounded to the nearest size in the list of selectable sizes on the
+      // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
+      pageSize: 5
+    }
+  },
   themes: [
     {
       name: 'full-item-page-theme',


### PR DESCRIPTION
## References

* Fixes #1764 

## Description

The size of the groups and epeople list on access control page can be configured.

The new configs are under a new accesscontrol property in config.yml
* accesscontrol > epeople > pageSize
* accesscontrol > groups > pageSize

The default value is 5 for both.

## Instructions for Reviewers

List of changes in this PR:

* New configuration property have been created: accesscontrol
* New configuration properties have been created: epeople and groups under "accesscontrol" property
* New configuration property created under both: pageSize
* The hard-coded number 5 have been replaced by the value of pageSize

The value of pageSize must match the pagination pages sizes of the browseby like https://github.com/DSpace/dspace-angular/pull/1771#pullrequestreview-1093428318

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
