### PR TITLE
Fix email validation regex to use email validation regex from HTML5 specs

### DIFF
--- a/src/app/register-email-form/register-email-form.component.spec.ts
+++ b/src/app/register-email-form/register-email-form.component.spec.ts
@@ -95,6 +95,10 @@ describe('RegisterEmailComponent', () => {
       comp.form.patchValue({email: 'valid@email.org'});
       expect(comp.form.invalid).toBeFalse();
     });
+    it('should be valid when uppercase letters are used', () => {
+      comp.form.patchValue({email: 'VALID@email.org'});
+      expect(comp.form.invalid).toBeFalse();
+    });
   });
   describe('register', () => {
     it('should send a registration to the service and on success display a message and return to home', () => {

--- a/src/app/register-email-form/register-email-form.component.ts
+++ b/src/app/register-email-form/register-email-form.component.ts
@@ -79,7 +79,9 @@ export class RegisterEmailFormComponent implements OnInit {
     this.form = this.formBuilder.group({
       email: new FormControl('', {
         validators: [Validators.required,
-          Validators.pattern('^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$')
+          // Regex pattern borrowed from HTML5 specs for a valid email address:
+          // https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+          Validators.pattern('^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$')
         ],
       })
     });


### PR DESCRIPTION
## References
* Fixes #1983 

## Description
Updates our regex validator for email addresses to use the documented regex in the HTML5 specs for a valid email: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address

This ensures that uppercase characters are now acceptable in emails, along with some other missing special characters which were not accepted by our previous regex.

## Instructions for Reviewers
* Verify code & new test for uppercase characters
* Manually test that uppercase characters no longer throw a validation error (making the input box red)
