### PR TITLE
Fix statistics option position in header on different DSO pages

### DIFF
--- a/src/app/collection-page/collection-page-routing.module.ts
+++ b/src/app/collection-page/collection-page-routing.module.ts
@@ -72,6 +72,7 @@ import { MenuItemType } from '../shared/menu/menu-item-type.model';
               id: 'statistics_collection_:id',
               active: true,
               visible: true,
+              index: 2,
               model: {
                 type: MenuItemType.LINK,
                 text: 'menu.section.statistics',

--- a/src/app/community-page/community-page-routing.module.ts
+++ b/src/app/community-page/community-page-routing.module.ts
@@ -55,6 +55,7 @@ import { MenuItemType } from '../shared/menu/menu-item-type.model';
               id: 'statistics_community_:id',
               active: true,
               visible: true,
+              index: 2,
               model: {
                 type: MenuItemType.LINK,
                 text: 'menu.section.statistics',

--- a/src/app/item-page/item-page-routing.module.ts
+++ b/src/app/item-page/item-page-routing.module.ts
@@ -67,6 +67,7 @@ import { OrcidPageGuard } from './orcid-page/orcid-page.guard';
               id: 'statistics_item_:id',
               active: true,
               visible: true,
+              index: 2,
               model: {
                 type: MenuItemType.LINK,
                 text: 'menu.section.statistics',

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -3513,6 +3513,9 @@
 
   // "menu.section.export_metadata": "Metadata",
   "menu.section.export_metadata": "Métadonnées",
+  
+  // "menu.section.export_batch": "Batch Export (ZIP)",
+  "menu.section.export_batch": "Exporter en lot (ZIP)",
 
   // "menu.section.icon.access_control": "Access Control menu section",
   "menu.section.icon.access_control": "Section du menu relative au contrôle d'accès",
@@ -4020,6 +4023,32 @@
 
   // "process.overview.new": "New",
   "process.overview.new": "Nouveau",
+  
+   // "process.overview.table.actions": "Actions",
+   "process.overview.table.actions": "Actions",
+  
+  // "process.overview.delete": "Delete {{count}} processes",
+  "process.overview.delete": "Supprimer {{count}} processus",
+
+  // "process.overview.delete.processing": "{{count}} process(es) are being deleted. Please wait for the deletion to fully complete. Note that this can take a while.",
+  "process.overview.delete.processing": "{{count}} processus sont en train d'être supprimés. Patientez jusqu'à ce que la suppression soit terminée. Notez que cela peut prendre un certain temps.",
+
+  // "process.overview.delete.body": "Are you sure you want to delete {{count}} process(es)?",
+  "process.overview.delete.body": "Êtes-vous certain-e de vouloir supprimer {{count}} processus?",
+
+  // "process.overview.delete.header": "Delete processes",
+  "process.overview.delete.header": "Supprimer les processus",
+
+  // "process.bulk.delete.error.head": "Error on deleteing process",
+  "process.bulk.delete.error.head": "Erreur lors de la suppression de processus",
+
+  // "process.bulk.delete.error.body": "The process with ID {{processId}} could not be deleted. The remaining processes will continue being deleted. ",
+  "process.bulk.delete.error.body": "Le processus numéro {{processId}} n'a pu être supprimé. Les processus restants continueront à être supprimés. ",
+
+  // "process.bulk.delete.success": "{{count}} process(es) have been succesfully deleted",
+  "process.bulk.delete.success": "{{count}} processus ont été supprimés.",
+
+ 
 
   // "profile.breadcrumbs": "Update Profile",
   "profile.breadcrumbs": "Mise à jour profil",
@@ -5022,6 +5051,30 @@
 
   // "submission.import-external.source.arxiv": "arXiv",
   "submission.import-external.source.arxiv": "arXiv",
+  
+   // "submission.import-external.source.ads": "NASA/ADS",
+  "submission.import-external.source.ads": "NASA/ADS",
+
+  // "submission.import-external.source.cinii": "CiNii",
+  "submission.import-external.source.cinii": "CiNii",
+
+  // "submission.import-external.source.crossref": "CrossRef",
+  "submission.import-external.source.crossref": "CrossRef (DOI)",
+
+  // "submission.import-external.source.scielo": "SciELO",
+  "submission.import-external.source.scielo": "SciELO",
+
+  // "submission.import-external.source.scopus": "Scopus",
+  "submission.import-external.source.scopus": "Scopus",
+
+  // "submission.import-external.source.vufind": "VuFind",
+  "submission.import-external.source.vufind": "VuFind",
+
+  // "submission.import-external.source.wos": "Web Of Science",
+  "submission.import-external.source.wos": "Web Of Science",
+
+  // "submission.import-external.source.orcidWorks": "ORCID",
+   "submission.import-external.source.orcidWorks": "ORCID",
 
   // "submission.import-external.source.loading": "Loading ...",
   "submission.import-external.source.loading": "En cours de chargement ...",
@@ -5043,6 +5096,9 @@
 
   // "submission.import-external.source.pubmed": "Pubmed",
   "submission.import-external.source.pubmed": "Pubmed",
+  
+  // "submission.import-external.source.pubmedeu": "Pubmed Europe",
+  "submission.import-external.source.pubmedeu": "Pubmed Europe",
 
   // "submission.import-external.source.lcname": "Library of Congress Names",
   "submission.import-external.source.lcname": "Autorités de noms de la Bibliothèque du Congrès",
@@ -5680,6 +5736,95 @@
   // "submission.sections.accesses.form.until-placeholder": "Until",
   "submission.sections.accesses.form.until-placeholder": "Jusqu'au",
 
+  
+  // "submission.sections.license.granted-label": "I confirm the license above",
+  "submission.sections.license.granted-label": "J'approuve la licence ci-dessus",
+  
+  // "submission.sections.license.required": "You must accept the license",
+  "submission.sections.license.required": "Vous devez accepter la licence",
+  
+  // "submission.sections.license.notgranted":  "You must accept the license",
+  "submission.sections.license.notgranted":  "Vous devez accepter la licence",
+ 
+  // "submission.sections.sherpa.publication.information": "Publication information",
+  "submission.sections.sherpa.publication.information": "Information sur la publication",
+
+  // "submission.sections.sherpa.publication.information.title": "Title",
+  "submission.sections.sherpa.publication.information.title": "Titre",
+
+  // "submission.sections.sherpa.publication.information.issns": "ISSNs",
+  "submission.sections.sherpa.publication.information.issns": "ISSNs",
+
+  // "submission.sections.sherpa.publication.information.url": "URL",
+   "submission.sections.sherpa.publication.information.url": "URL",
+
+  // "submission.sections.sherpa.publication.information.publishers": "Publisher",
+  "submission.sections.sherpa.publication.information.publishers": "Éditeur",
+
+  // "submission.sections.sherpa.publication.information.romeoPub": "Romeo Pub",
+  "submission.sections.sherpa.publication.information.romeoPub": "Romeo Pub",
+
+  // "submission.sections.sherpa.publication.information.zetoPub": "Zeto Pub",
+  "submission.sections.sherpa.publication.information.zetoPub": "Zeto Pub",
+
+  // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
+  "submission.sections.sherpa.publisher.policy": "Politique de l'éditeur",
+
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "L'information ci-dessous provient de Sherpa Romeo. Elle vous permet de savoir quelle version vous êtes autorisé-e à déposer et si une restriction de diffusion (embargo) doit être appliquée. Si vous avez des questions, contactez votre administrateur-trice en utilisant le formulaire en pied de page.",
+
+  // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
+  "submission.sections.sherpa.publisher.policy.openaccess": "Les voies de libre accès autorisées par la politique de cette revue sont listées ci-dessous par version d'article. Cliquez sur l'une des voies pour plus de détails.",
+
+  // "submission.sections.sherpa.publisher.policy.more.information": "For more information, please see the following links:",
+  "submission.sections.sherpa.publisher.policy.more.information": "Pour plus d'information, cliquez sur le lien suivant :",
+
+  // "submission.sections.sherpa.publisher.policy.version": "Version",
+  "submission.sections.sherpa.publisher.policy.version": "Version",
+
+  // "submission.sections.sherpa.publisher.policy.embargo": "Embargo",
+  "submission.sections.sherpa.publisher.policy.embargo": "Embargo",
+
+  // "submission.sections.sherpa.publisher.policy.noembargo": "No Embargo",
+  "submission.sections.sherpa.publisher.policy.noembargo": "Aucun embargo",
+
+  // "submission.sections.sherpa.publisher.policy.nolocation": "None",
+  "submission.sections.sherpa.publisher.policy.nolocation": "Aucun",
+
+  // "submission.sections.sherpa.publisher.policy.license": "License",
+  "submission.sections.sherpa.publisher.policy.license": "Licence",
+
+  // "submission.sections.sherpa.publisher.policy.prerequisites": "Prerequisites",
+  "submission.sections.sherpa.publisher.policy.prerequisites": "Prérequis",
+
+  // "submission.sections.sherpa.publisher.policy.location": "Location",
+  "submission.sections.sherpa.publisher.policy.location": "Lieu",
+
+  // "submission.sections.sherpa.publisher.policy.conditions": "Conditions",
+  "submission.sections.sherpa.publisher.policy.conditions": "Conditions",
+
+  // "submission.sections.sherpa.publisher.policy.refresh": "Refresh",
+  "submission.sections.sherpa.publisher.policy.refresh": "Rafraîchir",
+
+  // "submission.sections.sherpa.record.information": "Record Information",
+  "submission.sections.sherpa.record.information": "Information",
+
+  // "submission.sections.sherpa.record.information.id": "ID",
+  "submission.sections.sherpa.record.information.id": "ID",
+
+  // "submission.sections.sherpa.record.information.date.created": "Date Created",
+  "submission.sections.sherpa.record.information.date.created": "Date de création",
+
+  // "submission.sections.sherpa.record.information.date.modified": "Last Modified",
+  "submission.sections.sherpa.record.information.date.modified": "Dernière modification",
+
+  // "submission.sections.sherpa.record.information.uri": "URI",
+  "submission.sections.sherpa.record.information.uri": "URI",
+
+  // "submission.sections.sherpa.error.message": "There was an error retrieving sherpa informations",
+  "submission.sections.sherpa.error.message": "Une erreur s'est produite lors de la recherche d'infomation dans Sherpa.",
+  
+  
   // "submission.submit.breadcrumbs": "New submission",
   "submission.submit.breadcrumbs": "Nouvelle soumission",
 
@@ -5763,6 +5908,12 @@
 
   // "submission.workflow.tasks.pool.show-detail": "Show detail",
   "submission.workflow.tasks.pool.show-detail": "Afficher le détail",
+  
+  // "submission.workspace.generic.view": "View",
+  "submission.workspace.generic.view": "Voir",
+
+  // "submission.workspace.generic.view-help": "Select this option to view the item's metadata.",
+  "submission.workspace.generic.view-help": "Sélectionner cette option pour voir les métadonnées de l'item.",
 
   // "thumbnail.default.alt": "Thumbnail Image",
   "thumbnail.default.alt": "Vignette d'image",
@@ -5903,8 +6054,14 @@
   // "workflow-item.send-back.button.confirm": "Send back",
   "workflow-item.send-back.button.confirm": "Renvoyer",
 
-  // "workflow-item.view.breadcrumbs": "Workflow View",
+   // "workflow-item.view.breadcrumbs": "Workflow View",
   "workflow-item.view.breadcrumbs": "Vue d'ensemble du Workflow",
+
+  // "workspace-item.view.breadcrumbs": "Workspace View",
+  "workspace-item.view.breadcrumbs": "Vue du tableau de suivi",
+
+  // "workspace-item.view.title": "Workspace View",
+  "workspace-item.view.title": "Vue du tableau de suivi",
 
   // "idle-modal.header": "Session will expire soon",
   "idle-modal.header": "La session expirera bientôt",


### PR DESCRIPTION
## Description
This fixes the issue that the "Statistics" option in the header switches places.

## Instructions for Reviewers

List of changes in this PR:
* Added the index parameter to the different required routing modules

How to test this PR:

1. Set up a base DSpace instance ( this happens on https://demo7.dspace.org/home for example)
2. Browse along Community / Collection / Item pages -> notice that the "Statistics" link in the header changes place
3. Set up a DSpace instance with the changes of this PR and verify this behaviour has been fixed

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [x] My PR doesn't introduce circular dependencies
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
