### PR TITLE
Enable Ukrainian by default

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -170,6 +170,9 @@ languages:
   - code: el
     label: Ελληνικά
     active: true
+  - code: uk
+    label: Yкраї́нська
+    active: true
 
 # Browse-By Pages
 browseBy:

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -204,7 +204,8 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'kk', label: 'Қазақ', active: true },
     { code: 'bn', label: 'বাংলা', active: true },
     { code: 'hi', label: 'हिंदी', active: true},
-    { code: 'el', label: 'Ελληνικά', active: true }
+    { code: 'el', label: 'Ελληνικά', active: true },
+    { code: 'uk', label: 'Yкраї́нська', active: true}
   ];
 
   // Browse-By Pages


### PR DESCRIPTION
## References
* Follow up to #1940 which provides the actual Ukrainian translations (thanks again @AndrukhivAndriy)

## Description
This small PR just updates our default configuration to enable Ukrainian in the list of supported languages.

I used the changes in this PR to test #1940, so once this passes our GitHub CI, I'm going to merge it immediately.