### PR TITLE
Fix user authorization issues with admin sidebar

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -100,6 +100,7 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
         }
       }
     });
+    this.menuVisible = this.menuService.isMenuVisibleWithVisibleSections(this.menuID);
   }
 
   @HostListener('focusin')

--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -29,5 +29,7 @@ export enum FeatureID {
   CanViewUsageStatistics = 'canViewUsageStatistics',
   CanSendFeedback = 'canSendFeedback',
   CanClaimItem = 'canClaimItem',
-  CanSynchronizeWithORCID = 'canSynchronizeWithORCID'
+  CanSynchronizeWithORCID = 'canSynchronizeWithORCID',
+  CanSubmit = 'canSubmit',
+  CanEditItem = 'canEditItem',
 }

--- a/src/app/menu.resolver.spec.ts
+++ b/src/app/menu.resolver.spec.ts
@@ -19,6 +19,7 @@ import { cold } from 'jasmine-marbles';
 import createSpy = jasmine.createSpy;
 import { createSuccessfulRemoteDataObject$ } from './shared/remote-data.utils';
 import { createPaginatedList } from './shared/testing/utils.test';
+import { Feature } from './core/shared/feature.model';
 
 const BOOLEAN = { t: true, f: false };
 const MENU_STATE = {
@@ -142,29 +143,7 @@ describe('MenuResolver', () => {
   });
 
   describe('createAdminMenu$', () => {
-    it('should retrieve the menu by ID return an Observable that emits true as soon as it is created', () => {
-      (menuService as any).getMenu.and.returnValue(cold('--u--m', {
-        u: undefined,
-        m: MENU_STATE,
-      }));
-
-      expect(resolver.createAdminMenu$()).toBeObservable(cold('-----(t|)', BOOLEAN));
-      expect(menuService.getMenu).toHaveBeenCalledOnceWith(MenuID.ADMIN);
-    });
-
-    describe('for regular user', () => {
-      beforeEach(() => {
-        authorizationService.isAuthorized = createSpy('isAuthorized').and.callFake(() => {
-          return observableOf(false);
-        });
-      });
-
-      beforeEach((done) => {
-        resolver.createAdminMenu$().subscribe((_) => {
-          done();
-        });
-      });
-
+    const dontShowAdminSections = () => {
       it('should not show site admin section', () => {
         expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
           id: 'admin_search', visible: false,
@@ -180,19 +159,6 @@ describe('MenuResolver', () => {
         }));
         expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
           id: 'workflow', visible: false,
-        }));
-      });
-
-      it('should not show edit_community', () => {
-        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
-          id: 'edit_community', visible: false,
-        }));
-
-      });
-
-      it('should not show edit_collection', () => {
-        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
-          id: 'edit_collection', visible: false,
         }));
       });
 
@@ -222,6 +188,122 @@ describe('MenuResolver', () => {
           id: 'export', visible: true,
         }));
       });
+    };
+
+    const dontShowNewSection = () => {
+      it('should not show the "New" section', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new_community', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new_collection', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new_item', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new', visible: false,
+        }));
+      });
+    };
+
+    const dontShowEditSection = () => {
+      it('should not show the "Edit" section', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit_community', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit_collection', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit_item', visible: false,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit', visible: false,
+        }));
+      });
+    };
+
+    it('should retrieve the menu by ID return an Observable that emits true as soon as it is created', () => {
+      (menuService as any).getMenu.and.returnValue(cold('--u--m', {
+        u: undefined,
+        m: MENU_STATE,
+      }));
+
+      expect(resolver.createAdminMenu$()).toBeObservable(cold('-----(t|)', BOOLEAN));
+      expect(menuService.getMenu).toHaveBeenCalledOnceWith(MenuID.ADMIN);
+    });
+
+    describe('for regular user', () => {
+      beforeEach(() => {
+        authorizationService.isAuthorized = createSpy('isAuthorized').and.callFake((featureID) => {
+          return observableOf(false);
+        });
+      });
+
+      beforeEach((done) => {
+        resolver.createAdminMenu$().subscribe((_) => {
+          done();
+        });
+      });
+
+      dontShowAdminSections();
+      dontShowNewSection();
+      dontShowEditSection();
+    });
+
+    describe('regular user who can submit', () => {
+      beforeEach(() => {
+        authorizationService.isAuthorized = createSpy('isAuthorized')
+          .and.callFake((featureID: FeatureID) => {
+            return observableOf(featureID === FeatureID.CanSubmit);
+          });
+      });
+
+      beforeEach((done) => {
+        resolver.createAdminMenu$().subscribe((_) => {
+          done();
+        });
+      });
+
+      it('should show "New Item" section', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new_item', visible: true,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new', visible: true,
+        }));
+      });
+
+      dontShowAdminSections();
+      dontShowEditSection();
+    });
+
+    describe('regular user who can edit items', () => {
+      beforeEach(() => {
+        authorizationService.isAuthorized = createSpy('isAuthorized')
+          .and.callFake((featureID: FeatureID) => {
+            return observableOf(featureID === FeatureID.CanEditItem);
+          });
+      });
+
+      beforeEach((done) => {
+        resolver.createAdminMenu$().subscribe((_) => {
+          done();
+        });
+      });
+
+      it('should show "Edit Item" section', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit_item', visible: true,
+        }));
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'edit', visible: true,
+        }));
+      });
+
+      dontShowAdminSections();
+      dontShowNewSection();
     });
 
     describe('for site admin', () => {

--- a/src/app/menu.resolver.spec.ts
+++ b/src/app/menu.resolver.spec.ts
@@ -319,6 +319,12 @@ describe('MenuResolver', () => {
         });
       });
 
+      it('should show new_process', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
+          id: 'new_process', visible: true,
+        }))
+      });
+
       it('should contain site admin section', () => {
         expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
           id: 'admin_search', visible: true,

--- a/src/app/menu.resolver.spec.ts
+++ b/src/app/menu.resolver.spec.ts
@@ -19,7 +19,6 @@ import { cold } from 'jasmine-marbles';
 import createSpy = jasmine.createSpy;
 import { createSuccessfulRemoteDataObject$ } from './shared/remote-data.utils';
 import { createPaginatedList } from './shared/testing/utils.test';
-import { Feature } from './core/shared/feature.model';
 
 const BOOLEAN = { t: true, f: false };
 const MENU_STATE = {

--- a/src/app/menu.resolver.spec.ts
+++ b/src/app/menu.resolver.spec.ts
@@ -322,7 +322,7 @@ describe('MenuResolver', () => {
       it('should show new_process', () => {
         expect(menuService.addSection).toHaveBeenCalledWith(MenuID.ADMIN, jasmine.objectContaining({
           id: 'new_process', visible: true,
-        }))
+        }));
       });
 
       it('should contain site admin section', () => {

--- a/src/app/menu.resolver.ts
+++ b/src/app/menu.resolver.ts
@@ -167,10 +167,11 @@ export class MenuResolver implements Resolve<boolean> {
     combineLatest([
       this.authorizationService.isAuthorized(FeatureID.IsCollectionAdmin),
       this.authorizationService.isAuthorized(FeatureID.IsCommunityAdmin),
-      this.authorizationService.isAuthorized(FeatureID.AdministratorOf)
-    ]).subscribe(([isCollectionAdmin, isCommunityAdmin, isSiteAdmin]) => {
-      const menuList = [
-        /* News */
+      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
+      this.authorizationService.isAuthorized(FeatureID.CanSubmit),
+      this.authorizationService.isAuthorized(FeatureID.CanEditItem),
+    ]).subscribe(([isCollectionAdmin, isCommunityAdmin, isSiteAdmin, canSubmit, canEditItem]) => {
+      const newSubMenuList = [
         {
           id: 'new_community',
           parentID: 'new',
@@ -201,7 +202,7 @@ export class MenuResolver implements Resolve<boolean> {
           id: 'new_item',
           parentID: 'new',
           active: false,
-          visible: true,
+          visible: canSubmit,
           model: {
             type: MenuItemType.ONCLICK,
             text: 'menu.section.new_item',
@@ -221,30 +222,8 @@ export class MenuResolver implements Resolve<boolean> {
             link: '/processes/new'
           } as LinkMenuItemModel,
         },
-        {
-          id: 'new',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.TEXT,
-            text: 'menu.section.new'
-          } as TextMenuItemModel,
-          icon: 'plus',
-          index: 0
-        },
-        // TODO: enable this menu item once the feature has been implemented
-        // {
-        //   id: 'new_item_version',
-        //   parentID: 'new',
-        //   active: false,
-        //   visible: true,
-        //   model: {
-        //     type: MenuItemType.LINK,
-        //     text: 'menu.section.new_item_version',
-        //     link: ''
-        //   } as LinkMenuItemModel,
-        // },
-
+      ];
+      const editSubMenuList = [
         /* Edit */
         {
           id: 'edit_community',
@@ -276,7 +255,7 @@ export class MenuResolver implements Resolve<boolean> {
           id: 'edit_item',
           parentID: 'edit',
           active: false,
-          visible: true,
+          visible: canEditItem,
           model: {
             type: MenuItemType.ONCLICK,
             text: 'menu.section.edit_item',
@@ -285,17 +264,47 @@ export class MenuResolver implements Resolve<boolean> {
             }
           } as OnClickMenuItemModel,
         },
-        {
-          id: 'edit',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.TEXT,
-            text: 'menu.section.edit'
-          } as TextMenuItemModel,
-          icon: 'pencil-alt',
-          index: 1
-        },
+      ];
+      const newSubMenu = {
+        id: 'new',
+        active: false,
+        visible: newSubMenuList.map(subMenu => subMenu.visible).reduce((x,y) => x || y),
+        model: {
+          type: MenuItemType.TEXT,
+          text: 'menu.section.new'
+        } as TextMenuItemModel,
+        icon: 'plus',
+        index: 0
+      }
+      const editSubMenu = {
+        id: 'edit',
+        active: false,
+        visible: editSubMenuList.map(subMenu => subMenu.visible).reduce((x,y) => x || y),
+        model: {
+          type: MenuItemType.TEXT,
+          text: 'menu.section.edit'
+        } as TextMenuItemModel,
+        icon: 'pencil-alt',
+        index: 1
+      }
+
+      const menuList = [
+        ...newSubMenuList,
+        newSubMenu,
+        ...editSubMenuList,
+        editSubMenu,
+        // TODO: enable this menu item once the feature has been implemented
+        // {
+        //   id: 'new_item_version',
+        //   parentID: 'new',
+        //   active: false,
+        //   visible: true,
+        //   model: {
+        //     type: MenuItemType.LINK,
+        //     text: 'menu.section.new_item_version',
+        //     link: ''
+        //   } as LinkMenuItemModel,
+        // },
 
         /* Statistics */
         // TODO: enable this menu item once the feature has been implemented

--- a/src/app/menu.resolver.ts
+++ b/src/app/menu.resolver.ts
@@ -172,17 +172,6 @@ export class MenuResolver implements Resolve<boolean> {
       const menuList = [
         /* News */
         {
-          id: 'new',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.TEXT,
-            text: 'menu.section.new'
-          } as TextMenuItemModel,
-          icon: 'plus',
-          index: 0
-        },
-        {
           id: 'new_community',
           parentID: 'new',
           active: false,
@@ -232,6 +221,17 @@ export class MenuResolver implements Resolve<boolean> {
             link: '/processes/new'
           } as LinkMenuItemModel,
         },
+        {
+          id: 'new',
+          active: false,
+          visible: true,
+          model: {
+            type: MenuItemType.TEXT,
+            text: 'menu.section.new'
+          } as TextMenuItemModel,
+          icon: 'plus',
+          index: 0
+        },
         // TODO: enable this menu item once the feature has been implemented
         // {
         //   id: 'new_item_version',
@@ -246,17 +246,6 @@ export class MenuResolver implements Resolve<boolean> {
         // },
 
         /* Edit */
-        {
-          id: 'edit',
-          active: false,
-          visible: true,
-          model: {
-            type: MenuItemType.TEXT,
-            text: 'menu.section.edit'
-          } as TextMenuItemModel,
-          icon: 'pencil-alt',
-          index: 1
-        },
         {
           id: 'edit_community',
           parentID: 'edit',
@@ -295,6 +284,17 @@ export class MenuResolver implements Resolve<boolean> {
               this.modalService.open(ThemedEditItemSelectorComponent);
             }
           } as OnClickMenuItemModel,
+        },
+        {
+          id: 'edit',
+          active: false,
+          visible: true,
+          model: {
+            type: MenuItemType.TEXT,
+            text: 'menu.section.edit'
+          } as TextMenuItemModel,
+          icon: 'pencil-alt',
+          index: 1
         },
 
         /* Statistics */

--- a/src/app/menu.resolver.ts
+++ b/src/app/menu.resolver.ts
@@ -215,7 +215,7 @@ export class MenuResolver implements Resolve<boolean> {
           id: 'new_process',
           parentID: 'new',
           active: false,
-          visible: isCollectionAdmin,
+          visible: isSiteAdmin,
           model: {
             type: MenuItemType.LINK,
             text: 'menu.section.new_process',
@@ -268,7 +268,7 @@ export class MenuResolver implements Resolve<boolean> {
       const newSubMenu = {
         id: 'new',
         active: false,
-        visible: newSubMenuList.map(subMenu => subMenu.visible).reduce((x,y) => x || y),
+        visible: newSubMenuList.some(subMenu => subMenu.visible),
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.new'
@@ -279,7 +279,7 @@ export class MenuResolver implements Resolve<boolean> {
       const editSubMenu = {
         id: 'edit',
         active: false,
-        visible: editSubMenuList.map(subMenu => subMenu.visible).reduce((x,y) => x || y),
+        visible: editSubMenuList.some(subMenu => subMenu.visible),
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.edit'

--- a/src/app/menu.resolver.ts
+++ b/src/app/menu.resolver.ts
@@ -275,7 +275,7 @@ export class MenuResolver implements Resolve<boolean> {
         } as TextMenuItemModel,
         icon: 'plus',
         index: 0
-      }
+      };
       const editSubMenu = {
         id: 'edit',
         active: false,
@@ -286,7 +286,7 @@ export class MenuResolver implements Resolve<boolean> {
         } as TextMenuItemModel,
         icon: 'pencil-alt',
         index: 1
-      }
+      };
 
       const menuList = [
         ...newSubMenuList,

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -61,7 +61,7 @@ export class RootComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.sidebarVisible = this.menuService.isMenuVisible(MenuID.ADMIN);
+    this.sidebarVisible = this.menuService.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
 
     this.collapsedSidebarWidth = this.cssService.getVariable('collapsedSidebarWidth');
     this.totalSidebarWidth = this.cssService.getVariable('totalSidebarWidth');

--- a/src/app/shared/menu/menu.service.spec.ts
+++ b/src/app/shared/menu/menu.service.spec.ts
@@ -245,7 +245,7 @@ describe('MenuService', () => {
 
   describe('isMenuVisibleWithVisibleSections', () => {
     it('should return false when the menu is empty', () => {
-      const fakeMenu = {
+      const testMenu = {
         id: MenuID.ADMIN,
         collapsed: false,
         visible: true,
@@ -253,7 +253,7 @@ describe('MenuService', () => {
         previewCollapsed: false,
         sectionToSubsectionIndex: {}
       } as any;
-      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+      spyOn(service, 'getMenu').and.returnValue(observableOf(testMenu));
 
       const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
       const expected = cold('(b|)', {
@@ -269,8 +269,8 @@ describe('MenuService', () => {
         section_3: {id: 's3', visible: false},
         section_4: {id: 's1_1', visible: true, parentID: 's1'},
         section_5: {id: 's2_1', visible: true, parentID: 's2'},
-      }
-      const fakeMenu = {
+      };
+      const testMenu = {
         id: MenuID.ADMIN,
         collapsed: false,
         visible: true,
@@ -281,7 +281,7 @@ describe('MenuService', () => {
           'section_2': ['section_5'],
         }
       } as any;
-      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+      spyOn(service, 'getMenu').and.returnValue(observableOf(testMenu));
 
       const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
       const expected = cold('(b|)', {
@@ -298,8 +298,8 @@ describe('MenuService', () => {
         section_3: {id: 's3', visible: false},
         section_4: {id: 's1_1', visible: true, parentID: 's1'},
         section_5: {id: 's2_1', visible: true, parentID: 's2'},
-      }
-      const fakeMenu = {
+      };
+      const testMenu = {
         id: MenuID.ADMIN,
         collapsed: false,
         visible: true,
@@ -310,7 +310,7 @@ describe('MenuService', () => {
           'section_2': ['section_5'],
         }
       } as any;
-      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+      spyOn(service, 'getMenu').and.returnValue(observableOf(testMenu));
 
       const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
       const expected = cold('(b|)', {

--- a/src/app/shared/menu/menu.service.spec.ts
+++ b/src/app/shared/menu/menu.service.spec.ts
@@ -243,6 +243,84 @@ describe('MenuService', () => {
     });
   });
 
+  describe('isMenuVisibleWithVisibleSections', () => {
+    it('should return false when the menu is empty', () => {
+      const fakeMenu = {
+        id: MenuID.ADMIN,
+        collapsed: false,
+        visible: true,
+        sections: {},
+        previewCollapsed: false,
+        sectionToSubsectionIndex: {}
+      } as any;
+      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+
+      const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
+      const expected = cold('(b|)', {
+        b: false
+      });
+
+      expect(result).toBeObservable(expected);
+    });
+    it('should return false when no top-level sections are visible', () => {
+      const noTopLevelVisibleSections = {
+        section: {id: 's1', visible: false},
+        section_2: {id: 's2', visible: false},
+        section_3: {id: 's3', visible: false},
+        section_4: {id: 's1_1', visible: true, parentID: 's1'},
+        section_5: {id: 's2_1', visible: true, parentID: 's2'},
+      }
+      const fakeMenu = {
+        id: MenuID.ADMIN,
+        collapsed: false,
+        visible: true,
+        sections: noTopLevelVisibleSections,
+        previewCollapsed: false,
+        sectionToSubsectionIndex: {
+          'section': ['section_4'],
+          'section_2': ['section_5'],
+        }
+      } as any;
+      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+
+      const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
+      const expected = cold('(b|)', {
+        b: false
+      });
+
+      expect(result).toBeObservable(expected);
+    });
+
+    it('should return true when any top-level section is visible', () => {
+      const noTopLevelVisibleSections = {
+        section: {id: 's1', visible: false},
+        section_2: {id: 's2', visible: true},
+        section_3: {id: 's3', visible: false},
+        section_4: {id: 's1_1', visible: true, parentID: 's1'},
+        section_5: {id: 's2_1', visible: true, parentID: 's2'},
+      }
+      const fakeMenu = {
+        id: MenuID.ADMIN,
+        collapsed: false,
+        visible: true,
+        sections: noTopLevelVisibleSections,
+        previewCollapsed: false,
+        sectionToSubsectionIndex: {
+          'section': ['section_4'],
+          'section_2': ['section_5'],
+        }
+      } as any;
+      spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));
+
+      const result = service.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
+      const expected = cold('(b|)', {
+        b: true
+      });
+
+      expect(result).toBeObservable(expected);
+    });
+  });
+
   describe('isMenuVisible', () => {
     beforeEach(() => {
       spyOn(service, 'getMenu').and.returnValue(observableOf(fakeMenu));

--- a/src/app/shared/menu/menu.service.ts
+++ b/src/app/shared/menu/menu.service.ts
@@ -182,7 +182,7 @@ export class MenuService {
   }
 
   /**
-   * Check if a given menu is visible and has visible sections
+   * Check if a given menu is visible and has visible top-level (!) sections
    * @param {MenuID} menuID The ID of the menu that is to be checked
    * @returns {Observable<boolean>} Emits true if the given menu is
    *   visible and has visible sections, emits false when it's hidden
@@ -205,14 +205,16 @@ export class MenuService {
   }
 
   /**
-   * Check if a menu has at least one section that is visible.
+   * Check if a menu has at least one top-level (!) section that is visible.
    * @param {MenuID} menuID The ID of the menu that is to be checked
    * @returns {Observable<boolean>} Emits true if the given menu has visible sections, emits false otherwise
    */ 
   menuHasVisibleSections(menuID: MenuID): Observable<boolean> {
     return this.getMenu(menuID).pipe(
       map((state: MenuState) => hasValue(state)
-        ? Object.values(state.sections).map(section => section.visible).reduce((x,y) => x || y, false)
+        ? Object.values(state.sections)
+          .map(section => section.visible && section.parentID === undefined)
+          .reduce((x,y) => x || y, false)
         : undefined)
     );
   }

--- a/src/app/shared/menu/menu.service.ts
+++ b/src/app/shared/menu/menu.service.ts
@@ -213,8 +213,7 @@ export class MenuService {
     return this.getMenu(menuID).pipe(
       map((state: MenuState) => hasValue(state)
         ? Object.values(state.sections)
-          .map(section => section.visible && section.parentID === undefined)
-          .reduce((x,y) => x || y, false)
+          .some(section => section.visible && section.parentID === undefined)
         : undefined)
     );
   }

--- a/src/app/shared/menu/menu.service.ts
+++ b/src/app/shared/menu/menu.service.ts
@@ -182,6 +182,18 @@ export class MenuService {
   }
 
   /**
+   * Check if a given menu is visible and has visible sections
+   * @param {MenuID} menuID The ID of the menu that is to be checked
+   * @returns {Observable<boolean>} Emits true if the given menu is
+   *   visible and has visible sections, emits false when it's hidden
+   */
+  isMenuVisibleWithVisibleSections(menuID: MenuID): Observable<boolean> {
+    return observableCombineLatest([this.isMenuVisible(menuID), this.menuHasVisibleSections(menuID)]).pipe(
+      map(([menuVisible, visibleSections]) => menuVisible && visibleSections)
+    );
+  }
+
+  /**
    * Check if a given menu is visible
    * @param {MenuID} menuID The ID of the menu that is to be checked
    * @returns {Observable<boolean>} Emits true if the given menu is visible, emits falls when it's hidden
@@ -189,6 +201,19 @@ export class MenuService {
   isMenuVisible(menuID: MenuID): Observable<boolean> {
     return this.getMenu(menuID).pipe(
       map((state: MenuState) => hasValue(state) ? state.visible : undefined)
+    );
+  }
+
+  /**
+   * Check if a menu has at least one section that is visible.
+   * @param {MenuID} menuID The ID of the menu that is to be checked
+   * @returns {Observable<boolean>} Emits true if the given menu has visible sections, emits false otherwise
+   */ 
+  menuHasVisibleSections(menuID: MenuID): Observable<boolean> {
+    return this.getMenu(menuID).pipe(
+      map((state: MenuState) => hasValue(state)
+        ? Object.values(state.sections).map(section => section.visible).reduce((x,y) => x || y, false)
+        : undefined)
     );
   }
 

--- a/src/app/shared/menu/menu.service.ts
+++ b/src/app/shared/menu/menu.service.ts
@@ -208,7 +208,7 @@ export class MenuService {
    * Check if a menu has at least one top-level (!) section that is visible.
    * @param {MenuID} menuID The ID of the menu that is to be checked
    * @returns {Observable<boolean>} Emits true if the given menu has visible sections, emits false otherwise
-   */ 
+   */
   menuHasVisibleSections(menuID: MenuID): Observable<boolean> {
     return this.getMenu(menuID).pipe(
       map((state: MenuState) => hasValue(state)

--- a/src/app/shared/testing/menu-service.stub.ts
+++ b/src/app/shared/testing/menu-service.stub.ts
@@ -66,6 +66,10 @@ export class MenuServiceStub {
     return observableOf(true);
   }
 
+  isMenuVisibleWithVisibleSections(id: MenuID): Observable<boolean> {
+    return observableOf(true);
+  }
+
   isMenuCollapsed(id: MenuID): Observable<boolean> {
     return observableOf(false);
   }


### PR DESCRIPTION
## References
* Fixes [#1643](https://github.com/DSpace/dspace-angular/issues/1643)
* Lays groundwork for [#1331](https://github.com/DSpace/dspace-angular/issues/1331)
* [Related backend PR](https://github.com/DSpace/DSpace/pull/8607)

## Description
* Frontend: hides admin sidebar sections for users who lack relevant permissions.
* Backend: adds authorization features to support the frontend changes.

## Instructions for Reviewers
List of changes in this PR:
* The menu resolver now checks the new `canSubmit` and `canEditItem` authorizations to determine whether to add the corresponding sections to the admin sidebar for a logged-in user.
* If this results in the user having no permissions at all, the admin sidebar is omitted altogether.

### To test

1. Make some users:
    1. one with no permissions at all
    2. one with write permissions on a single item (or admin permissions on a collection containing an item, or ...)
    3. one with add permissions on a collection (or admin on a community containing a collection, or ...)
2. Log in as those users. 
3. Then see whether you can see the admin sidebar and whether it contains the "New->Item" and/or "Edit->Item" sections.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
