### PR TITLE
Fix Docker arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 ADD . /app/
 EXPOSE 4000
 
+# Ensure Python and other build tools are available
+# These are needed to install some node modules, especially on linux/arm64
+RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
+
 # We run yarn install with an increased network timeout (5min) to avoid "ESOCKETTIMEDOUT" errors from hub.docker.com
 # See, for example https://github.com/yarnpkg/yarn/issues/5540
 RUN yarn install --network-timeout 300000


### PR DESCRIPTION
## Description
After merging #2000 , the Docker build for arm64 platforms started failing because Python is not found. See https://github.com/DSpace/dspace-angular/actions/runs/3706259487.  

I don't believe this issue is directly related to #2000 (as least I'm not seeing the direct relation), but may be the result of a recently update to the base `node:18-alpine` image for arm64.

This small PR fixes the issue. I've tested this in my own CI builds and verified that the Docker arm64 image now builds successfully. 
