### PR TITLE
Enable Polish language by default

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -145,6 +145,9 @@ languages:
   - code: nl
     label: Nederlands
     active: true
+  - code: pl
+    label: Polski
+    active: true
   - code: pt-PT
     label: Português
     active: true
@@ -174,9 +177,6 @@ languages:
     active: true
   - code: uk
     label: Yкраї́нська
-    active: true
-  - code: pl
-    label: Polski
     active: true
 
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -197,6 +197,7 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'lv', label: 'Latviešu', active: true },
     { code: 'hu', label: 'Magyar', active: true },
     { code: 'nl', label: 'Nederlands', active: true },
+    { code: 'pl', label: 'Polski', active: true },
     { code: 'pt-PT', label: 'Português', active: true },
     { code: 'pt-BR', label: 'Português do Brasil', active: true },
     { code: 'fi', label: 'Suomi', active: true },


### PR DESCRIPTION
## References
* Follow up to #2001 which provides the actual Polish translations (thanks again @michdyk !)

## Description
This small PR just updates our default configuration to enable Polish in the list of supported languages.

I used the changes in this PR to test #2001, so once this passes our GitHub CI, I'm going to merge it immediately.