### PR TITLE
Add Caching of SSR public pages. Update default Cache-Control HTTP header

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -39,11 +39,16 @@ cache:
     maxBufferSize: 100
     timePerMethod:
       PATCH: 3 # time in seconds
-  # In-memory cache of server-side rendered content
+  # In-memory cache of server-side rendered pages. This cache stores the most recently accessed public pages.
+  # Pages are automatically added/dropped from this cache based on how recently they have been used.
   serverSide:
-    # Maximum number of pages (rendered via SSR) to cache. Set to zero to disable server side caching.
+    # Maximum number of pages to cache. Set to zero (0) to disable server side caching. Default is 100, which means
+    # the 100 most recently accessed public pages will be cached. As all pages are cached in server memory,
+    # increasing this value will increase memory needs. Individual cached pages are usually small (<100KB),
+    # so max=100 should only require a maximum of 9-10MB of memory. Restarting the app clears this page cache.
     max: 100
-    # Amount of time after which cached pages are considered stale (in ms)
+    # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
+    # copy is automatically refreshed on the next request.
     timeToLive: 900000 # 15 minutes
 
 # Authentication settings

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -32,12 +32,19 @@ cache:
   # NOTE: how long should objects be cached for by default
   msToLive:
     default: 900000 # 15 minutes
+  # Cache-Control HTTP Header
   control: max-age=60 # revalidate browser
   autoSync:
     defaultTime: 0
     maxBufferSize: 100
     timePerMethod:
       PATCH: 3 # time in seconds
+  # In-memory cache of server-side rendered content
+  serverSide:
+    # Maximum number of pages (rendered via SSR) to cache. Set to zero to disable server side caching.
+    max: 100
+    # Amount of time after which cached pages are considered stale (in ms)
+    timeToLive: 900000 # 15 minutes
 
 # Authentication settings
 auth:

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -32,8 +32,12 @@ cache:
   # NOTE: how long should objects be cached for by default
   msToLive:
     default: 900000 # 15 minutes
-  # Cache-Control HTTP Header
-  control: max-age=60 # revalidate browser
+  # Default 'Cache-Control' HTTP Header to set for all static content (including compiled *.js files)
+  # Defaults to max-age=604,800 seconds (one week). This lets a user's browser know that it can cache these
+  # files for one week, after which they will be "stale" and need to be redownloaded.
+  # NOTE: When updates are made to compiled *.js files, it will automatically bypass this browser cache, because
+  # all compiled *.js files include a unique hash in their name which updates when content is modified.
+  control: max-age=604800 # revalidate browser
   autoSync:
     defaultTime: 0
     maxBufferSize: 100

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -49,6 +49,8 @@ cache:
   # NOTE: To control the cache size, use the "max" setting. Keep in mind, individual cached pages are usually small (<100KB).
   # Enabling *both* caches will mean that a page may be cached twice, once in each cache (but may expire at different times via timeToLive).
   serverSide:
+    # Set to true to see all cache hits/misses/refreshes in your console logs. Useful for debugging SSR caching issues.
+    debug: false
     # When enabled (i.e. max > 0), known bots will be sent pages from a server side cache specific for bots.
     # (Keep in mind, bot detection cannot be guarranteed. It is possible some bots will bypass this cache.)
     botCache:
@@ -62,6 +64,11 @@ cache:
       # NOTE: For the bot cache, this setting may impact how quickly search engine bots will index new content on your site.
       # For example, setting this to one week may mean that search engine bots may not find all new content for one week.
       timeToLive: 86400000 # 1 day
+      # When set to true, after timeToLive expires, the next request will receive the *cached* page & then re-render the page
+      # behind the scenes to update the cache. This ensures users primarily interact with the cache, but may receive stale pages (older than timeToLive).
+      # When set to false, after timeToLive expires, the next request will wait on SSR to complete & receive a fresh page (which is then saved to cache).
+      # This ensures stale pages (older than timeToLive) are never returned from the cache, but some users will wait on SSR.
+      allowStale: true
     # When enabled (i.e. max > 0), all anonymous users will be sent pages from a server side cache.
     # This allows anonymous users to interact more quickly with the site, but also means they may see slightly
     # outdated content (based on timeToLive)
@@ -74,6 +81,11 @@ cache:
       # copy is automatically refreshed on the next request.
       # NOTE: For the anonymous cache, it is recommended to keep this value low to avoid anonymous users seeing outdated content.
       timeToLive: 10000 # 10 seconds
+      # When set to true, after timeToLive expires, the next request will receive the *cached* page & then re-render the page
+      # behind the scenes to update the cache. This ensures users primarily interact with the cache, but may receive stale pages (older than timeToLive).
+      # When set to false, after timeToLive expires, the next request will wait on SSR to complete & receive a fresh page (which is then saved to cache).
+      # This ensures stale pages (older than timeToLive) are never returned from the cache, but some users will wait on SSR.
+      allowStale: true
 
 # Authentication settings
 auth:

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -43,17 +43,37 @@ cache:
     maxBufferSize: 100
     timePerMethod:
       PATCH: 3 # time in seconds
-  # In-memory cache of server-side rendered pages. This cache stores the most recently accessed public pages.
-  # Pages are automatically added/dropped from this cache based on how recently they have been used.
+  # In-memory cache(s) of server-side rendered pages. These caches will store the most recently accessed public pages.
+  # Pages are automatically added/dropped from these caches based on how recently they have been used.
+  # Restarting the app clears all page caches.
+  # NOTE: To control the cache size, use the "max" setting. Keep in mind, individual cached pages are usually small (<100KB).
+  # Enabling *both* caches will mean that a page may be cached twice, once in each cache (but may expire at different times via timeToLive).
   serverSide:
-    # Maximum number of pages to cache. Set to zero (0) to disable server side caching. Default is 100, which means
-    # the 100 most recently accessed public pages will be cached. As all pages are cached in server memory,
-    # increasing this value will increase memory needs. Individual cached pages are usually small (<100KB),
-    # so max=100 should only require a maximum of 9-10MB of memory. Restarting the app clears this page cache.
-    max: 100
-    # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
-    # copy is automatically refreshed on the next request.
-    timeToLive: 900000 # 15 minutes
+    # When enabled (i.e. max > 0), known bots will be sent pages from a server side cache specific for bots.
+    # (Keep in mind, bot detection cannot be guarranteed. It is possible some bots will bypass this cache.)
+    botCache:
+      # Maximum number of pages to cache for known bots. Set to zero (0) to disable server side caching for bots.
+      # Default is 1000, which means the 1000 most recently accessed public pages will be cached.
+      # As all pages are cached in server memory, increasing this value will increase memory needs.
+      # Individual cached pages are usually small (<100KB), so max=1000 should only require ~100MB of memory.
+      max: 1000
+      # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
+      # copy is automatically refreshed on the next request.
+      # NOTE: For the bot cache, this setting may impact how quickly search engine bots will index new content on your site.
+      # For example, setting this to one week may mean that search engine bots may not find all new content for one week.
+      timeToLive: 86400000 # 1 day
+    # When enabled (i.e. max > 0), all anonymous users will be sent pages from a server side cache.
+    # This allows anonymous users to interact more quickly with the site, but also means they may see slightly
+    # outdated content (based on timeToLive)
+    anonymousCache:
+      # Maximum number of pages to cache. Default is zero (0) which means anonymous user cache is disabled.
+      # As all pages are cached in server memory, increasing this value will increase memory needs.
+      # Individual cached pages are usually small (<100KB), so a value of max=1000 would only require ~100MB of memory. 
+      max: 0
+      # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
+      # copy is automatically refreshed on the next request.
+      # NOTE: For the anonymous cache, it is recommended to keep this value low to avoid anonymous users seeing outdated content.
+      timeToLive: 10000 # 10 seconds
 
 # Authentication settings
 auth:

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "jwt-decode": "^3.1.2",
     "klaro": "^0.7.18",
     "lodash": "^4.17.21",
+    "lru-cache": "^7.14.1",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.1",
     "mirador": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "fast-json-patch": "^3.0.0-1",
     "filesize": "^6.1.0",
     "http-proxy-middleware": "^1.0.5",
+    "isbot": "^3.6.5",
     "js-cookie": "2.2.1",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.2",

--- a/server.ts
+++ b/server.ts
@@ -324,7 +324,7 @@ function initCache() {
     botCache = new LRU( {
       max: environment.cache.serverSide.botCache.max,
       ttl: environment.cache.serverSide.botCache.timeToLive || 24 * 60 * 60 * 1000, // 1 day
-      allowStale: environment.cache.serverSide.botCache.allowStale || true // if object is stale, return stale value before deleting
+      allowStale: environment.cache.serverSide.botCache.allowStale ?? true // if object is stale, return stale value before deleting
     });
   }
 
@@ -335,7 +335,7 @@ function initCache() {
     anonymousCache = new LRU( {
       max: environment.cache.serverSide.anonymousCache.max,
       ttl: environment.cache.serverSide.anonymousCache.timeToLive || 10 * 1000, // 10 seconds
-      allowStale: environment.cache.serverSide.anonymousCache.allowStale || true // if object is stale, return stale value before deleting
+      allowStale: environment.cache.serverSide.anonymousCache.allowStale ?? true // if object is stale, return stale value before deleting
     });
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -93,12 +93,12 @@ export function app() {
   /*
    * If production mode is enabled in the environment file:
    * - Enable Angular's production mode
-   * - Enable caching of SSR rendered pages (if enabled in config.yml)
+   * - Initialize caching of SSR rendered pages (if enabled in config.yml)
    * - Enable compression for SSR reponses. See [compression](https://github.com/expressjs/compression)
    */
   if (environment.production) {
     enableProdMode();
-    enableCache();
+    initCache();
     server.use(compression({
       // only compress responses we've marked as SSR
       // otherwise, this middleware may compress files we've chosen not to compress via compression-webpack-plugin
@@ -310,9 +310,9 @@ function addCacheControl(req, res, next) {
 }
 
 /*
- * Enable server-side caching of pages rendered via SSR.
+ * Initialize server-side caching of pages rendered via SSR.
  */
-function enableCache() {
+function initCache() {
   if (cacheEnabled()) {
     // Initialize a new "least-recently-used" item cache (where least recently used items are removed first)
     // See https://www.npmjs.com/package/lru-cache

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,7 @@ import * as expressStaticGzip from 'express-static-gzip';
 /* eslint-enable import/no-namespace */
 
 import axios from 'axios';
+import LRU from 'lru-cache';
 import { createCertificate } from 'pem';
 import { createServer } from 'https';
 import { json } from 'body-parser';
@@ -54,6 +55,7 @@ import { APP_CONFIG, AppConfig } from './src/config/app-config.interface';
 import { extendEnvironmentWithAppConfig } from './src/config/config.util';
 import { logStartupMessage } from './startup-message';
 
+
 /*
  * Set path for the browser application's dist folder
  */
@@ -66,6 +68,9 @@ const indexHtml = existsSync(join(DIST_FOLDER, 'index.html')) ? 'index.html' : '
 const cookieParser = require('cookie-parser');
 
 const appConfig: AppConfig = buildAppConfig(join(DIST_FOLDER, 'assets/config.json'));
+
+// cache of SSR pages, only enabled in production mode
+let cache: LRU<string, any>;
 
 // extend environment with app config for server
 extendEnvironmentWithAppConfig(environment, appConfig);
@@ -87,10 +92,12 @@ export function app() {
   /*
    * If production mode is enabled in the environment file:
    * - Enable Angular's production mode
+   * - Enable caching of SSR rendered pages (if enabled in config.yml)
    * - Enable compression for SSR reponses. See [compression](https://github.com/expressjs/compression)
    */
   if (environment.production) {
     enableProdMode();
+    enableCache();
     server.use(compression({
       // only compress responses we've marked as SSR
       // otherwise, this middleware may compress files we've chosen not to compress via compression-webpack-plugin
@@ -186,7 +193,7 @@ export function app() {
    * Serve static resources (images, i18n messages, …)
    * Handle pre-compressed files with [express-static-gzip](https://github.com/tkoenig89/express-static-gzip)
    */
-  router.get('*.*', cacheControl, expressStaticGzip(DIST_FOLDER, {
+  router.get('*.*', addCacheControl, expressStaticGzip(DIST_FOLDER, {
     index: false,
     enableBrotli: true,
     orderPreference: ['br', 'gzip'],
@@ -202,8 +209,11 @@ export function app() {
    */
   server.get('/app/health', healthCheck);
 
-  // Register the ngApp callback function to handle incoming requests
-  router.get('*', ngApp);
+  /**
+   * Default sending all incoming requests to ngApp() function, after first checking for a cached
+   * copy of the page (see cacheCheck())
+   */
+  router.get('*', cacheCheck, ngApp);
 
   server.use(environment.ui.nameSpace, router);
 
@@ -215,60 +225,191 @@ export function app() {
  */
 function ngApp(req, res) {
   if (environment.universal.preboot) {
-    res.render(indexHtml, {
-      req,
-      res,
-      preboot: environment.universal.preboot,
-      async: environment.universal.async,
-      time: environment.universal.time,
-      baseUrl: environment.ui.nameSpace,
-      originUrl: environment.ui.baseUrl,
-      requestUrl: req.originalUrl,
-      providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }]
-    }, (err, data) => {
-      if (hasNoValue(err) && hasValue(data)) {
-        res.locals.ssr = true;  // mark response as SSR
-        res.send(data);
-      } else if (hasValue(err) && err.code === 'ERR_HTTP_HEADERS_SENT') {
-        // When this error occurs we can't fall back to CSR because the response has already been
-        // sent. These errors occur for various reasons in universal, not all of which are in our
-        // control to solve.
-        console.warn('Warning [ERR_HTTP_HEADERS_SENT]: Tried to set headers after they were sent to the client');
-      } else {
-        console.warn('Error in SSR, serving for direct CSR.');
-        if (hasValue(err)) {
-          console.warn('Error details : ', err);
-        }
-        res.render(indexHtml, {
-          req,
-          providers: [{
-            provide: APP_BASE_HREF,
-            useValue: req.baseUrl
-          }]
-        });
-      }
-    });
+    // Render the page to user via SSR (server side rendering)
+    serverSideRender(req, res);
   } else {
     // If preboot is disabled, just serve the client
-    console.log('Universal off, serving for direct CSR');
-    res.render(indexHtml, {
-      req,
-      providers: [{
-        provide: APP_BASE_HREF,
-        useValue: req.baseUrl
-      }]
+    console.log('Universal off, serving for direct client-side rendering (CSR)');
+    clientSideRender(req, res);
+  }
+}
+
+/**
+ * Render page content on server side using Angular SSR. By default this page content is
+ * returned to the user.
+ * @param req current request
+ * @param res current response
+ * @param sendToUser if true (default), send the rendered content to the user.
+ * If false, then only save this rendered content to the in-memory cache (to refresh cache).
+ */
+function serverSideRender(req, res, sendToUser: boolean = true) {
+  // Render the page via SSR (server side rendering)
+  res.render(indexHtml, {
+    req,
+    res,
+    preboot: environment.universal.preboot,
+    async: environment.universal.async,
+    time: environment.universal.time,
+    baseUrl: environment.ui.nameSpace,
+    originUrl: environment.ui.baseUrl,
+    requestUrl: req.originalUrl,
+    providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }]
+  }, (err, data) => {
+    if (hasNoValue(err) && hasValue(data)) {
+      res.locals.ssr = true;  // mark response as SSR (enables text compression)
+      // save server side rendered data to cache
+      saveToCache(getCacheKey(req), data);
+      if (sendToUser) {
+        // send rendered page to user
+        res.send(data);
+      }
+    } else if (hasValue(err) && err.code === 'ERR_HTTP_HEADERS_SENT') {
+      // When this error occurs we can't fall back to CSR because the response has already been
+      // sent. These errors occur for various reasons in universal, not all of which are in our
+      // control to solve.
+      console.warn('Warning [ERR_HTTP_HEADERS_SENT]: Tried to set headers after they were sent to the client');
+    } else {
+      console.warn('Error in server-side rendering (SSR)');
+      if (hasValue(err)) {
+        console.warn('Error details : ', err);
+      }
+      if (sendToUser) {
+        console.warn('Falling back to serving direct client-side rendering (CSR).');
+        clientSideRender(req, res);
+      }
+    }
+  });
+}
+
+/**
+ * Send back response to user to trigger direct client-side rendering (CSR)
+ * @param req current request
+ * @param res current response
+ */
+function clientSideRender(req, res) {
+  res.render(indexHtml, {
+    req,
+    providers: [{
+      provide: APP_BASE_HREF,
+      useValue: req.baseUrl
+    }]
+  });
+}
+
+
+/*
+ * Adds a Cache-Control HTTP header to the response.
+ * The cache control value can be configured in the config.*.yml file
+ * Defaults to max-age=604,800 seconds (1 week)
+ */
+function addCacheControl(req, res, next) {
+  // instruct browser to revalidate
+  res.header('Cache-Control', environment.cache.control || 'max-age=604800');
+  next();
+}
+
+/*
+ * Enable server-side caching of pages rendered via SSR.
+ */
+function enableCache() {
+  if (cacheEnabled()) {
+    // Initialize a new "least-recently-used" item cache.
+    // See https://www.npmjs.com/package/lru-cache
+    cache = new LRU( {
+      max: environment.cache.serverSide.max || 100,            // 100 items in cache maximum
+      ttl: environment.cache.serverSide.timeToLive || 15 * 60 * 1000, // 15 minute cache
+      allowStale: true // If object is found to be stale, return stale value before deleting
     });
   }
 }
 
-/*
- * Adds a cache control header to the response
- * The cache control value can be configured in the environments file and defaults to max-age=60
+/**
+ * Return whether server side caching is enabled in configuration.
  */
-function cacheControl(req, res, next) {
-  // instruct browser to revalidate
-  res.header('Cache-Control', environment.cache.control || 'max-age=60');
-  next();
+function cacheEnabled(): boolean {
+  // Caching is only enabled is SSR is enabled AND
+  // "serverSide.max" setting is greater than zero
+  return environment.universal.preboot && environment.cache.serverSide.max && (environment.cache.serverSide.max > 0);
+}
+
+/**
+ * Check if the currently requested page is in our server-side, in-memory cache.
+ * Caching is ONLY done for SSR requests. Pages are cached base on their path (e.g. /home or /search?query=test)
+ */
+function cacheCheck(req, res, next) {
+  let cacheHit = false;
+  let debug = false; // Enable to see cache hits & re-rendering logs
+
+  // Only check cache if cache enabled & SSR is enabled
+  if (cacheEnabled()) {
+    const key = getCacheKey(req);
+
+    // Check if this page is in our cache
+    let cachedCopy = cache.get(key);
+    if (cachedCopy) {
+      cacheHit = true;
+      res.locals.ssr = true;  // mark response as SSR (enables text compression)
+      if (debug) { console.log(`CACHE HIT FOR ${key}`); }
+      // return page from cache to user
+      res.send(cachedCopy);
+
+      // Check if cached copy is expired (in this sitution key will now be gone from cache)
+      if (!cache.has(key)) {
+        if (debug) { console.log(`CACHE EXPIRED FOR ${key} Re-rendering...`); }
+        // Update cached copy by rerendering server-side
+        // NOTE: Cached copy was already returned to user above. So, this re-render is just to prepare for next user.
+        serverSideRender(req, res, false);
+      }
+
+      // Tell Express to skip all other handlers for this path
+      // This ensures we don't try to re-render the page since we've already returned the cached copy
+      next('router');
+    }
+  }
+
+  // If nothing found in cache, just continue with next handler
+  // (This should send the request on to the handler that rerenders the page via SSR)
+  if (!cacheHit) {
+    next();
+  }
+}
+
+/**
+ * Create a cache key from the current request.
+ * The cache key is the URL path (NOTE: this key will also include any querystring params).
+ * E.g. "/home" or "/search?query=test"
+ * @param req current request
+ * @returns cache key to use for this page
+ */
+function getCacheKey(req): string {
+  // NOTE: this will return the URL path *without* any baseUrl
+  return req.url;
+}
+
+/**
+ * Save data to server side cache, if enabled. If caching is not enabled, this is a noop
+ * @param key page key
+ * @param data page data to save to cache
+ */
+function saveToCache(key: string, data: any) {
+  // Only cache if caching is enabled and this path is allowed to be cached
+  if (cacheEnabled() && canCachePage(key)) {
+    cache.set(key, data);
+  }
+}
+
+/**
+ * Whether this path is allowed to be cached. Only public paths can be cached as the cache is shared across all users.
+ * @param key page key (corresponds to path of page)
+ * @returns true if allowed to be cached, false otherwise.
+ */
+function canCachePage(key: string) {
+  // Only these publicly accessible pages can be cached.
+  // NOTE: Caching pages which require authentication is NOT ALLOWED. The same cache is used by all users & user-specific data must NEVER appear in cache.
+  const allowedPages = [/^\/$/, /^\/home$/, /^\/items\//, /^\/entities\//, /^\/collections\//, /^\/communities\//, /^\/search[\/?]?/, /\/browse\//, /^\/community-list$/];
+
+  // Check whether any of these regexs match with the passed in key
+  return allowedPages.some(regex => regex.test(key));
 }
 
 /*

--- a/server.ts
+++ b/server.ts
@@ -399,7 +399,12 @@ function saveToCache(req, data: any) {
   // NOTE: It's not safe to save page data to the cache when a user is authenticated. In that situation,
   // the page may include sensitive or user-specific materials. As the cache is shared across all users, it can only contain public info.
   if (cacheEnabled() && !isUserAuthenticated(req)) {
-    cache.set(getCacheKey(req), data);
+    const key = getCacheKey(req);
+    // Make sure this key is not already in our cache. If "has()" returns true,
+    // then it's in the cache already and *not* expired.
+    if (!cache.has(key)) {
+      cache.set(key, data);
+    }
   }
 }
 

--- a/server.ts
+++ b/server.ts
@@ -55,7 +55,6 @@ import { APP_CONFIG, AppConfig } from './src/config/app-config.interface';
 import { extendEnvironmentWithAppConfig } from './src/config/config.util';
 import { logStartupMessage } from './startup-message';
 import { TOKENITEM } from 'src/app/core/auth/models/auth-token-info.model';
-import { isAuthenticated } from 'src/app/core/auth/selectors';
 
 
 /*

--- a/src/config/cache-config.interface.ts
+++ b/src/config/cache-config.interface.ts
@@ -5,6 +5,14 @@ export interface CacheConfig extends Config {
   msToLive: {
     default: number;
   };
+  // Cache-Control HTTP Header
   control: string;
   autoSync: AutoSyncConfig;
+  // In-memory cache of server-side rendered content
+  serverSide: {
+    // Maximum number of pages (rendered via SSR) to cache.
+    max: number;
+    // Amount of time after which cached pages are considered stale (in ms)
+    timeToLive: number;
+  }
 }

--- a/src/config/cache-config.interface.ts
+++ b/src/config/cache-config.interface.ts
@@ -8,11 +8,22 @@ export interface CacheConfig extends Config {
   // Cache-Control HTTP Header
   control: string;
   autoSync: AutoSyncConfig;
-  // In-memory cache of server-side rendered content
+  // In-memory caches of server-side rendered (SSR) content. These caches can be used to limit the frequency
+  // of re-generating SSR pages to improve performance.
   serverSide: {
-    // Maximum number of pages (rendered via SSR) to cache.
-    max: number;
-    // Amount of time after which cached pages are considered stale (in ms)
-    timeToLive: number;
+    // Cache specific to known bots.  Allows you to serve cached contents to bots only.
+    botCache: {
+      // Maximum number of pages (rendered via SSR) to cache. Setting max=0 disables the cache.
+      max: number;
+      // Amount of time after which cached pages are considered stale (in ms)
+      timeToLive: number;
+    },
+    // Cache specific to anonymous users. Allows you to serve cached content to non-authenticated users.
+    anonymousCache: {
+      // Maximum number of pages (rendered via SSR) to cache. Setting max=0 disables the cache.
+      max: number;
+      // Amount of time after which cached pages are considered stale (in ms)
+      timeToLive: number;
+    }
   }
 }

--- a/src/config/cache-config.interface.ts
+++ b/src/config/cache-config.interface.ts
@@ -11,12 +11,16 @@ export interface CacheConfig extends Config {
   // In-memory caches of server-side rendered (SSR) content. These caches can be used to limit the frequency
   // of re-generating SSR pages to improve performance.
   serverSide: {
+    // Debug server-side caching.  Set to true to see cache hits/misses/refreshes in console logs.
+    debug: boolean,
     // Cache specific to known bots.  Allows you to serve cached contents to bots only.
     botCache: {
       // Maximum number of pages (rendered via SSR) to cache. Setting max=0 disables the cache.
       max: number;
       // Amount of time after which cached pages are considered stale (in ms)
       timeToLive: number;
+      // true = return page from cache after timeToLive expires. false = return a fresh page after timeToLive expires
+      allowStale: boolean;
     },
     // Cache specific to anonymous users. Allows you to serve cached content to non-authenticated users.
     anonymousCache: {
@@ -24,6 +28,8 @@ export interface CacheConfig extends Config {
       max: number;
       // Amount of time after which cached pages are considered stale (in ms)
       timeToLive: number;
+      // true = return page from cache after timeToLive expires. false = return a fresh page after timeToLive expires
+      allowStale: boolean;
     }
   }
 }

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -68,7 +68,7 @@ export class DefaultAppConfig implements AppConfig {
       default: 15 * 60 * 1000 // 15 minutes
     },
     // Cache-Control HTTP Header
-    control: 'max-age=60', // revalidate browser
+    control: 'max-age=604800', // revalidate browser
     autoSync: {
       defaultTime: 0,
       maxBufferSize: 100,

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -67,11 +67,19 @@ export class DefaultAppConfig implements AppConfig {
     msToLive: {
       default: 15 * 60 * 1000 // 15 minutes
     },
+    // Cache-Control HTTP Header
     control: 'max-age=60', // revalidate browser
     autoSync: {
       defaultTime: 0,
       maxBufferSize: 100,
       timePerMethod: { [RestRequestMethod.PATCH]: 3 } as any // time in seconds
+    },
+    // In-memory cache of server-side rendered content
+    serverSide: {
+      // Maximum number of pages (rendered via SSR) to cache. Set to zero to disable server side caching.
+      max: 100,
+      // Amount of time after which cached pages are considered stale (in ms)
+      timeToLive: 15 * 60 * 1000 // 15 minutes
     }
   };
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -76,6 +76,7 @@ export class DefaultAppConfig implements AppConfig {
     },
     // In-memory cache of server-side rendered content
     serverSide: {
+      debug: false,
       // Cache specific to known bots.  Allows you to serve cached contents to bots only.
       // Defaults to caching 1,000 pages. Each page expires after 1 day
       botCache: {
@@ -83,6 +84,7 @@ export class DefaultAppConfig implements AppConfig {
         max: 1000,
         // Amount of time after which cached pages are considered stale (in ms)
         timeToLive: 24 * 60 * 60 * 1000, // 1 day
+        allowStale: true,
       },
       // Cache specific to anonymous users. Allows you to serve cached content to non-authenticated users.
       // Defaults to caching 0 pages. But, when enabled, each page expires after 10 seconds (to minimize anonymous users seeing out-of-date content)
@@ -91,6 +93,7 @@ export class DefaultAppConfig implements AppConfig {
         max: 0, // disabled by default
         // Amount of time after which cached pages are considered stale (in ms)
         timeToLive: 10 * 1000, // 10 seconds
+        allowStale: true,
       }
     }
   };

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -76,10 +76,22 @@ export class DefaultAppConfig implements AppConfig {
     },
     // In-memory cache of server-side rendered content
     serverSide: {
-      // Maximum number of pages (rendered via SSR) to cache. Set to zero to disable server side caching.
-      max: 100,
-      // Amount of time after which cached pages are considered stale (in ms)
-      timeToLive: 15 * 60 * 1000 // 15 minutes
+      // Cache specific to known bots.  Allows you to serve cached contents to bots only.
+      // Defaults to caching 1,000 pages. Each page expires after 1 day
+      botCache: {
+        // Maximum number of pages (rendered via SSR) to cache. Setting max=0 disables the cache.
+        max: 1000,
+        // Amount of time after which cached pages are considered stale (in ms)
+        timeToLive: 24 * 60 * 60 * 1000, // 1 day
+      },
+      // Cache specific to anonymous users. Allows you to serve cached content to non-authenticated users.
+      // Defaults to caching 0 pages. But, when enabled, each page expires after 10 seconds (to minimize anonymous users seeing out-of-date content)
+      anonymousCache: {
+        // Maximum number of pages (rendered via SSR) to cache. Setting max=0 disables the cache.
+        max: 0, // disabled by default
+        // Amount of time after which cached pages are considered stale (in ms)
+        timeToLive: 10 * 1000, // 10 seconds
+      }
     }
   };
 

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -55,6 +55,11 @@ export const environment: BuildConfig = {
       defaultTime: 0,
       maxBufferSize: 100,
       timePerMethod: { [RestRequestMethod.PATCH]: 3 } as any // time in seconds
+    },
+    // In-memory cache of server-side rendered pages. Disabled in test environment (max=0)
+    serverSide: {
+      max: 0,
+      timeToLive: 15 * 60 * 1000, // 15 minutes
     }
   },
 

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -58,13 +58,16 @@ export const environment: BuildConfig = {
     },
     // In-memory cache of server-side rendered pages. Disabled in test environment (max=0)
     serverSide: {
+      debug: false,
       botCache: {
         max: 0,
         timeToLive: 24 * 60 * 60 * 1000, // 1 day
+        allowStale: true,
       },
       anonymousCache: {
         max: 0,
         timeToLive: 10 * 1000, // 10 seconds
+        allowStale: true,
       }
     }
   },

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -58,8 +58,14 @@ export const environment: BuildConfig = {
     },
     // In-memory cache of server-side rendered pages. Disabled in test environment (max=0)
     serverSide: {
-      max: 0,
-      timeToLive: 15 * 60 * 1000, // 15 minutes
+      botCache: {
+        max: 0,
+        timeToLive: 24 * 60 * 60 * 1000, // 1 day
+      },
+      anonymousCache: {
+        max: 0,
+        timeToLive: 10 * 1000, // 10 seconds
+      }
     }
   },
 

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <title>DSpace</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <meta http-equiv="cache-control" content="no-store">
 </head>
 
 <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6749,6 +6749,11 @@ isbinaryfile@^4.0.8:
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
   integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
 
+isbot@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/isbot/-/isbot-3.6.5.tgz#a749980d9dfba9ebcc03ee7b548d1f24dd8c9f1e"
+  integrity sha512-BchONELXt6yMad++BwGpa0oQxo/uD0keL7N15cYVf0A1oMIoNQ79OqeYdPMFWDrNhCqCbRuw9Y9F3QBjvAxZ5g==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7468,7 +7468,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.7.1:
+lru-cache@^7.14.1, lru-cache@^7.7.1:
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
   integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==


### PR DESCRIPTION
## References
* Relates to #1954 and #1921

## Description
This PR adds basic, in-memory page caching of all *public* server-side rendered pages.  As most SSR requests are for public (anonymous access) pages, this can significantly increase the speed of the site.  

(However, it has no impact on the speed of SSR for authenticated content -- as it's not possible to cache this access-restricted content since it is much more dynamic & may include user-specific, sensitive information.)

## Instructions for Reviewers
List of changes in this PR:
* Adds a new `serverSide` section to the `cache` settings in `config.yml`:
  ```
  # In-memory cache(s) of server-side rendered pages. These caches will store the most recently accessed public pages.
  # Pages are automatically added/dropped from these caches based on how recently they have been used.
  # Restarting the app clears all page caches.
  # NOTE: To control the cache size, use the "max" setting. Keep in mind, individual cached pages are usually small (<100KB).
  # Enabling *both* caches will mean that a page may be cached twice, once in each cache (but may expire at different times via timeToLive).
  serverSide:
    # Set to true to see all cache hits/misses/refreshes in your console logs. Useful for debugging SSR caching issues.
    debug: false
    # When enabled (i.e. max > 0), known bots will be sent pages from a server side cache specific for bots.
    # (Keep in mind, bot detection cannot be guarranteed. It is possible some bots will bypass this cache.)
    botCache:
      # Maximum number of pages to cache for known bots. Set to zero (0) to disable server side caching for bots.
      # Default is 1000, which means the 1000 most recently accessed public pages will be cached.
      # As all pages are cached in server memory, increasing this value will increase memory needs.
      # Individual cached pages are usually small (<100KB), so max=1000 should only require ~100MB of memory.
      max: 1000
      # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
      # copy is automatically refreshed on the next request.
      # NOTE: For the bot cache, this setting may impact how quickly search engine bots will index new content on your site.
      # For example, setting this to one week may mean that search engine bots may not find all new content for one week.
      timeToLive: 86400000 # 1 day
      # When set to true, after timeToLive expires, the next request will receive the *cached* page & then re-render the page
      # behind the scenes to update the cache. This ensures users primarily interact with the cache, but may receive stale pages (older than timeToLive).
      # When set to false, after timeToLive expires, the next request will wait on SSR to complete & receive a fresh page (which is then saved to cache).
      # This ensures stale pages (older than timeToLive) are never returned from the cache, but some users will wait on SSR.
      allowStale: true
    # When enabled (i.e. max > 0), all anonymous users will be sent pages from a server side cache.
    # This allows anonymous users to interact more quickly with the site, but also means they may see slightly
    # outdated content (based on timeToLive)
    anonymousCache:
      # Maximum number of pages to cache. Default is zero (0) which means anonymous user cache is disabled.
      # As all pages are cached in server memory, increasing this value will increase memory needs.
      # Individual cached pages are usually small (<100KB), so a value of max=1000 would only require ~100MB of memory. 
      max: 0
      # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
      # copy is automatically refreshed on the next request.
      # NOTE: For the anonymous cache, it is recommended to keep this value low to avoid anonymous users seeing outdated content.
      timeToLive: 10000 # 10 seconds
      # When set to true, after timeToLive expires, the next request will receive the *cached* page & then re-render the page
      # behind the scenes to update the cache. This ensures users primarily interact with the cache, but may receive stale pages (older than timeToLive).
      # When set to false, after timeToLive expires, the next request will wait on SSR to complete & receive a fresh page (which is then saved to cache).
      # This ensures stale pages (older than timeToLive) are never returned from the cache, but some users will wait on SSR.
      allowStale: true
    ```
* Updates the `Cache-Control` HTTP Header behavior to help a user's browser to more appropriately cache files:
  * For static files (including *.js), default is now `Cache-Control: max-age=604800`, which sets it to one week.  This lets a user's browser cache these files for a week without needing to re-request them frequently (previously this was set to one *minute*).
      * Because we have `outputHashing: "all"` enabled in our [Angular build](https://angular.io/cli/build) settings in `angular.json`, all our compiled JS files automatically include a unique hash in their name.  This hash updates every time the content of the JS file changes.  Because the filename changes when updated, this will bypass the `Cache-Control` settings whenever these JS files are changed.
  * However, `index.html` now includes a `<meta>` directive to tell browsers not to cache it.  This is necessary for `outputHashing` to work right, as the `index.html` is updated with the new names of any newly compiled JS files.

HOW TO TEST:
* HINT: For easier cache testing, enable the `serverSide.debug: true` flag in your `config.*.yml`.  When enabled, all cache hits, misses & refreshes are logged.
* Build/deploy this PR. By default, ONLY the "bot" cache is enabled.
* First, as a normal anonymous user, verify that SSR is triggered on every request. Reload the page a few times, and verify you are seeing responses over over a second (at best).  If you'd enabled the "debug" logging, you'll also see no cache hits.
* Now, test that the "bot" cache is working. You can test it by temporarily changing your browser's user-agent to match that of a known bot. For example in Chrome:
    * Open up Dev Tools. Click on the three dots in upper right.
    * Go to "More Tools" and select "Network Conditions"
    * Deselect "Use browser default" for "User Agent".  In the dropdown, select "Googlebot".   This browser tab will now act like a Googlebot.
* Access the homepage. Verify you see a 200 OK response initially.  This first access will also take longer, as the server-side cache has not been initialized. On my local machine this first access usually takes ~2-3 seconds to load:
    ```
    GET /home 200 2220.162 ms - -
    ```
* Click reload in your browser. Normally, this would trigger SSR again.  However, with this PR you'll be accessing the page from cache and it'll load in just a few milliseconds.  If you enabled debugging, you'll also see a cache hit for the "bot cache":
    ```
    CACHE HIT FOR /home in bot cache
    GET /home 304 3.711 ms - -
    ```
* Now remove your "user-agent" so that you are no longer a "bot".
* Change your "config.prod.yml" settings to enable the "anonymous" cache & restart the UI:
  ```
  cache:
    serverSide:
      anonymousCache:
        max: 1000
  ```
* As an anonymous user, verify the cache is working.  The first request should take a second or two (and trigger SSR). If you reload the same page, you'll see it loads in a few milliseconds. If you enabled debugging, you'll also see a cache hit for the "anonymous cache":
  ```
  CACHE HIT FOR /home in anonymous cache
  GET /home 200 6.759 ms - 
  ```
    * NOTE: After the page is cached, you can also access the same page from a different local browser.  In that scenario, you'll get the cached version, but a 200 OK response (as it's your first access of that page).  This is because the cached copy is shared among all anonymous users.
* Verify that the anonymous cache reloads frequently. Wait for at least 10 seconds, and reload your page. You should see this in the logs:
   ```
   CACHE HIT FOR /home in anonymous cache
   CACHE EXPIRED FOR /home in anonymous cache. Re-rendering...
   GET /home 200 6.759 ms - -
   ```
* Verify there is no obvious differences in behavior after the cached copy of the page loads. (There shouldn't be, as the cached copy is quickly replaced by the CSR version.)
* Test a few other pages.  Initial page access will take longer, and the next reload will be very quick.
* Login. Verify that the same caching never triggers while authenticated.  When clicking the reload in your browser, all pages will return a 200 OK response and all will show a slightly slower load time as they are triggering SSR.
