### PR TITLE
Add DataCite to i18n list of sources

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3836,6 +3836,8 @@
 
   "submission.import-external.source.crossref": "CrossRef",
 
+  "submission.import-external.source.datacite": "DataCite",
+
   "submission.import-external.source.scielo": "SciELO",
 
   "submission.import-external.source.scopus": "Scopus",


### PR DESCRIPTION
## References
* Required by https://github.com/DSpace/DSpace/pull/8593

## Description
Tiny PR to add the missing i18n key for the new DataCite import source added in https://github.com/DSpace/DSpace/pull/8593

As I used this tiny PR to test the backend PR, I know it works.  **I'll merge it immediately after GitHub CI passes.**