### PR TITLE
[CST-6171] Preserve original Bootstrap colors

### DIFF
--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -17,26 +17,31 @@ $enable-responsive-font-sizes: true;
 
 /** Bootstrap Variables **/
 /* Colors */
-$gray-700: #495057 !default;  // Bootstrap $gray-700
-$gray-100: #f8f9fa !default;  //           $gray-100
+$ds-gray-800: #343a40 !default;
+$ds-gray-700: #495057 !default;
+$ds-gray-400: #ced4da !default;
+$ds-gray-300: #dee2e6 !default;
+$ds-gray-200: #e9ecef !default;
+$ds-gray-100: #f8f9fa !default;
+$ds-white:    #fff !default;
 
 /* Reassign color vars to semantic color scheme */
-$blue:   #2B4E72 !default;
-$green:  #94BA65 !default;
-$cyan:   #006666 !default;
-$yellow: #ec9433 !default;
-$red:    #CF4444 !default;
-$dark:   darken($blue, 17%) !default;
+$ds-blue:   #2B4E72 !default;
+$ds-green:  #94BA65 !default;
+$ds-cyan:   #006666 !default;
+$ds-yellow: #ec9433 !default;
+$ds-red:    #CF4444 !default;
+$ds-dark:   darken($ds-blue, 17%) !default;
 
 $theme-colors: (
-        primary: $blue,
-        secondary: $gray-700,
-        success: $green,
-        info: $cyan,
-        warning: $yellow,
-        danger: $red,
-        light: $gray-100,
-        dark: $dark
+        primary: $ds-blue,
+        secondary: $ds-gray-700,
+        success: $ds-green,
+        info: $ds-cyan,
+        warning: $ds-yellow,
+        danger: $ds-red,
+        light: $ds-gray-100,
+        dark: $ds-dark
 ) !default;
 /* Fonts */
 $link-color: map-get($theme-colors, info) !default;

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -19,15 +19,15 @@
   --ds-footer-z-index: 0;
   --ds-sidebar-z-index: 20;
 
-  --ds-header-bg: #{$white};
+  --ds-header-bg: #{$ds-white};
   --ds-header-logo-height: 50px;
   --ds-header-logo-height-xs: 50px;
-  --ds-header-icon-color: #{$cyan};
-  --ds-header-icon-color-hover: #{darken($white, 15%)};
-  --ds-header-navbar-border-top-color: #{$white};
-  --ds-header-navbar-border-bottom-color: #{$gray-400};
-  --ds-navbar-link-color: #{$cyan};
-  --ds-navbar-link-color-hover: #{darken($cyan, 15%)};
+  --ds-header-icon-color: #{$ds-cyan};
+  --ds-header-icon-color-hover: #{darken($ds-white, 15%)};
+  --ds-header-navbar-border-top-color: #{$ds-white};
+  --ds-header-navbar-border-bottom-color: #{$ds-gray-400};
+  --ds-navbar-link-color: #{$ds-cyan};
+  --ds-navbar-link-color-hover: #{darken($ds-cyan, 15%)};
 
   $admin-sidebar-bg: darken(#2B4E72, 17%);
   $admin-sidebar-active-bg: darken($admin-sidebar-bg, 3%);
@@ -46,9 +46,9 @@
   --ds-edit-item-language-field-width: 43px;
 
   --ds-thumbnail-max-width: 125px;
-  --ds-thumbnail-placeholder-background: #{$gray-100};
-  --ds-thumbnail-placeholder-border: 1px solid #{$gray-300};
-  --ds-thumbnail-placeholder-color: #{lighten($gray-800, 7%)};
+  --ds-thumbnail-placeholder-background: #{$ds-gray-100};
+  --ds-thumbnail-placeholder-border: 1px solid #{$ds-gray-300};
+  --ds-thumbnail-placeholder-color: #{lighten($ds-gray-800, 7%)};
 
   --ds-dso-selector-list-max-height: 475px;
   --ds-dso-selector-current-background-color: #eeeeee;
@@ -64,24 +64,24 @@
   --ds-sidebar-items-width: #{$sidebar-items-width};
   --ds-total-sidebar-width: #{$total-sidebar-width};
 
-  --ds-top-footer-bg: #{$gray-200};
+  --ds-top-footer-bg: #{$ds-gray-200};
   --ds-footer-bg: #{theme-color('primary')};
   --ds-footer-border: 1px solid var(--bs-gray-400);
   --ds-footer-padding: 0;
   --ds-footer-padding-bottom: 0;
   --ds-footer-logo-height: 50px;
 
-  $home-news-link-color: $cyan;
+  $home-news-link-color: $ds-cyan;
   --ds-home-news-link-color: #{$home-news-link-color};
   --ds-home-news-link-hover-color: #{darken($home-news-link-color, 15%)};
-  --ds-home-news-background-color: #{$gray-200};
+  --ds-home-news-background-color: #{$ds-gray-200};
 
-  --ds-breadcrumb-bg: #{$gray-200} !important;
-  --ds-breadcrumb-link-color: #{$cyan};
-  --ds-breadcrumb-link-active-color: #{darken($cyan, 30%)};
+  --ds-breadcrumb-bg: #{$ds-gray-200} !important;
+  --ds-breadcrumb-link-color: #{$ds-cyan};
+  --ds-breadcrumb-link-active-color: #{darken($ds-cyan, 30%)};
   --ds-breadcrumb-max-length: 200px;
 
-  --ds-slider-color: #{$green};
+  --ds-slider-color: #{$ds-green};
   --ds-slider-handle-width: 18px;
 
   --ds-search-form-scope-max-width: 150px;

--- a/src/themes/dspace/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_css_variable_overrides.scss
@@ -4,8 +4,8 @@
   --ds-header-logo-height: 40px;
   --ds-banner-text-background: rgba(0, 0, 0, 0.45);
   --ds-banner-background-gradient-width: 300px;
-  --ds-home-news-link-color: #{$green};
-  --ds-home-news-link-hover-color: #{darken($green, 15%)};
-  --ds-header-navbar-border-bottom-color: #{$green};
+  --ds-home-news-link-color: #{$ds-green};
+  --ds-home-news-link-hover-color: #{darken($ds-green, 15%)};
+  --ds-header-navbar-border-bottom-color: #{$ds-green};
 }
 

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -10,32 +10,35 @@ $font-family-sans-serif: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI"
 $navbar-dark-color: #FFFFFF;
 
 /* Reassign color vars to semantic color scheme */
-$blue: #2b4e72 !default;
-$green: #92C642 !default;
-$cyan: #207698 !default;
-$yellow: #ec9433 !default;
-$red: #CF4444 !default;
-$dark: #43515f !default;
+$ds-blue: #2b4e72 !default;
+$ds-green: #92C642 !default;
+$ds-cyan: #207698 !default;
+$ds-yellow: #ec9433 !default;
+$ds-red: #CF4444 !default;
+$ds-dark: #43515f !default;
 
-$gray-800: #343a40 !default;
-$gray-700: #495057 !default;
-$gray-400: #ced4da !default;
-$gray-100: #f8f9fa !default;
+$ds-gray-800: #343a40 !default;
+$ds-gray-700: #495057 !default;
+$ds-gray-400: #ced4da !default;
+$ds-gray-300: #dee2e6 !default;
+$ds-gray-200: #e9ecef !default;
+$ds-gray-100: #f8f9fa !default;
+$ds-white:    #fff !default;
 
-$body-color: $gray-800 !default;                    // Bootstrap $gray-800
+$body-color: $ds-gray-800 !default;
 
-$table-accent-bg: $gray-100 !default;   // Bootstrap $gray-100
-$table-hover-bg: $gray-400 !default;   // Bootstrap $gray-400
+$table-accent-bg: $ds-gray-100 !default;
+$table-hover-bg: $ds-gray-400 !default;
 
 $yiq-contrasted-threshold:  170 !default;
 
 $theme-colors: (
-        primary: $dark,
-        secondary: $gray-700,
-        success: $green,
-        info: $cyan,
-        warning: $yellow,
-        danger: $red,
-        light: $gray-100,
-        dark: $dark
+        primary: $ds-dark,
+        secondary: $ds-gray-700,
+        success: $ds-green,
+        info: $ds-cyan,
+        warning: $ds-yellow,
+        danger: $ds-red,
+        light: $ds-gray-100,
+        dark: $ds-dark
 ) !default;


### PR DESCRIPTION
## References
* Additional fix for https://github.com/DSpace/dspace-angular/issues/1914#issuecomment-1286780667 (see comments)

## Description
This PR renames the colour SASS variables from `$colour` to `$ds-colour` so that the original Bootstrap variables are not overridden.
These variables are only referenced inside the theme files and this PR should not cause conflicts in most cases.
Bootstrap variable `$theme-colors` has not been renamed and it is still overridden.


## Instructions for Reviewers
These changes have been tested for both base and DSpace theme.


## Checklist
- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
