### PR TITLE
adding space in es.json5 for pagination.showing.label

### DIFF
--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -4238,7 +4238,7 @@
   "pagination.showing.detail": "{{ range }} de {{ total }}",
 
   // "pagination.showing.label": "Now showing ",
-  "pagination.showing.label": "Mostrando",
+  "pagination.showing.label": "Mostrando ",
 
   // "pagination.sort-direction": "Sort Options",
   "pagination.sort-direction": "Opciones de clasificación",


### PR DESCRIPTION
Hi @tdonohue here is my proposal to solve this problem.

## References
* Fixes #2059 

## Description
The file `es.json5` just needed to add an space for the label `pagination.showing.label`

## Instructions for Reviewers
1. Login as adminsitrator.
2. Visit: /mydspace?configuration=workflow
3. change the language to spanish
4. You will notice that there is a space between the text "mostrando" (showing) and the number

List of changes in this PR:
* es.json5 file

## Checklist

- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
