### PR TITLE
aria-selected added to Item Edit "Status" Tab. Fixed ID: 470076

### DIFF
--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -4,7 +4,7 @@
             <h2 class="border-bottom">{{'item.edit.head' | translate}}</h2>
             <div class="pt-2">
                 <ul class="nav nav-tabs justify-content-start">
-                    <li *ngFor="let page of pages" class="nav-item">
+                    <li *ngFor="let page of pages" class="nav-item" [attr.aria-selected]="page.page === currentPage">
                         <a *ngIf="(page.enabled | async)"
                            class="nav-link"
                            [ngClass]="{'active' : page.page === currentPage}"

--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -3,8 +3,8 @@
         <div class="col-12">
             <h2 class="border-bottom">{{'item.edit.head' | translate}}</h2>
             <div class="pt-2">
-                <ul class="nav nav-tabs justify-content-start">
-                    <li *ngFor="let page of pages" class="nav-item" [attr.aria-selected]="page.page === currentPage">
+                <ul class="nav nav-tabs justify-content-start" role="tablist">
+                    <li *ngFor="let page of pages" class="nav-item" [attr.aria-selected]="page.page === currentPage" role="tab">
                         <a *ngIf="(page.enabled | async)"
                            class="nav-link"
                            [ngClass]="{'active' : page.page === currentPage}"


### PR DESCRIPTION
Hi @tdonohue ✋, I am submitting this pull request as a solution to activity ID 470076 in issue 1190. Regarding "Selected state of the element is missing or incorrect."

## References
* Fixes first issue noted in #1190

## Description
in each of the tabs of the page that opens when editing an item, an aria-selected has been added, if the tab is active, it will have the value of "true", if not, it will have the value of "false".

## Instructions for Reviewers

List of changes in this PR:
* _[attr.aria-selected]="page.page === currentPage"_ added in _edit-item-page.component.html_

To test my PR:
1. Login as adminsitrator
2. Edit any item
3. check the value of aria-selected of each li tag in the displayed tab.
![image](https://user-images.githubusercontent.com/51240376/215604630-7b70465c-484d-456e-a369-bbb1547c6940.png)


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
