### PR TITLE
[CST-7221] Opaque search bar

### DIFF
--- a/src/app/search-navbar/search-navbar.component.scss
+++ b/src/app/search-navbar/search-navbar.component.scss
@@ -1,9 +1,6 @@
 input[type="text"] {
   margin-top: calc(-0.5 * var(--bs-font-size-base));
-
-  &:focus {
-    background-color: rgba(255, 255, 255, 0.5) !important;
-  }
+  background-color: #fff !important;
 
   &.collapsed {
     opacity: 0;


### PR DESCRIPTION
## References
* Fixes #1393

## Description
Problem: the search box has a transparent background, and on medium screens it overlaps with main menu on medium screen
Solution: the search box background has been replaced with opaque white.

![image](https://user-images.githubusercontent.com/87638927/216938267-241003e9-efa0-42ea-9933-5ad6e3ca48f0.png)


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
