### PR TITLE
Remove unnecessary subscriptions

### DIFF
--- a/src/app/header/context-help-toggle/context-help-toggle.component.ts
+++ b/src/app/header/context-help-toggle/context-help-toggle.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ContextHelpService } from '../../shared/context-help.service';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 /**
@@ -12,22 +12,15 @@ import { map } from 'rxjs/operators';
   templateUrl: './context-help-toggle.component.html',
   styleUrls: ['./context-help-toggle.component.scss']
 })
-export class ContextHelpToggleComponent implements OnInit, OnDestroy {
+export class ContextHelpToggleComponent implements OnInit {
   buttonVisible$: Observable<boolean>;
 
   constructor(
     private contextHelpService: ContextHelpService,
   ) { }
 
-  private subs: Subscription[];
-
   ngOnInit(): void {
     this.buttonVisible$ = this.contextHelpService.tooltipCount$().pipe(map(x => x > 0));
-    this.subs = [this.buttonVisible$.subscribe()];
-  }
-
-  ngOnDestroy() {
-    this.subs.forEach(sub => sub.unsubscribe());
   }
 
   onClick() {

--- a/src/app/shared/context-help-wrapper/context-help-wrapper.component.ts
+++ b/src/app/shared/context-help-wrapper/context-help-wrapper.component.ts
@@ -61,8 +61,7 @@ export class ContextHelpWrapperComponent implements OnInit, OnDestroy {
 
   parsedContent$: Observable<ParsedContent>;
 
-  private subs: {always: Subscription[], tooltipBound: Subscription[]}
-    = {always: [], tooltipBound: []};
+  private subs: Subscription[] = [];
 
   constructor(
     private translateService: TranslateService,
@@ -78,14 +77,13 @@ export class ContextHelpWrapperComponent implements OnInit, OnDestroy {
         dontParseLinks ? [text] : this.parseLinks(text))
     );
     this.shouldShowIcon$ = this.contextHelpService.shouldShowIcons$();
-    this.subs.always = [this.parsedContent$.subscribe(), this.shouldShowIcon$.subscribe()];
   }
 
   @ViewChild('tooltip', { static: false }) set setTooltip(tooltip: NgbTooltip) {
     this.tooltip = tooltip;
-    this.clearSubs('tooltipBound');
+    this.clearSubs();
     if (this.tooltip !== undefined) {
-      this.subs.tooltipBound = [
+      this.subs = [
         this.contextHelpService.getContextHelp$(this.id)
           .pipe(hasValueOperator())
           .subscribe((ch: ContextHelp) => {
@@ -159,13 +157,8 @@ export class ContextHelpWrapperComponent implements OnInit, OnDestroy {
     });
   }
 
-  private clearSubs(filter: null | 'tooltipBound' = null) {
-    if (filter === null) {
-      [].concat(...Object.values(this.subs)).forEach(sub => sub.unsubscribe());
-      this.subs = {always: [], tooltipBound: []};
-    } else {
-      this.subs[filter].forEach(sub => sub.unsubscribe());
-      this.subs[filter] = [];
-    }
+  private clearSubs() {
+    this.subs.forEach(sub => sub.unsubscribe());
+    this.subs = [];
   }
 }


### PR DESCRIPTION
## References
Follow-up on #2030: This PR just contains a minor fix to remove some unnecessary subscriptions. This is just an improvement to code quality, it does not fix any bugs or add new features.

## Description
There were some unnecessary subscriptions in `ContextHelpWrapperComponent` and `ContextHelpToggleComponent` to observables which were only being used in their respective templates. These subscriptions have been removed.

## Instructions for Reviewers
No behavior is changed; it should suffice to take a glance at the diff.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
