### PR TITLE
ul and li replaced to role list and listitem

### DIFF
--- a/src/app/shared/form/chips/chips.component.html
+++ b/src/app/shared/form/chips/chips.component.html
@@ -1,5 +1,5 @@
 <div [className]="'float-left w-100 ' + wrapperClass">
-  <ul class="nav nav-pills d-flex flex-column flex-sm-row" [sortablejs]="chips.getChips()" [sortablejsOptions]="options">
+  <div role="list" class="nav nav-pills d-flex flex-column flex-sm-row" [sortablejs]="chips.getChips()" [sortablejsOptions]="options">
     <ng-container *ngFor="let c of chips.getChips(); let i = index">
       <ng-template #tipContent>
         <p class="text-left p-0 m-0" *ngFor="let tip of tipText">
@@ -7,7 +7,7 @@
         </p>
       </ng-template>
 
-      <li class="nav-item mr-2 mb-1"
+      <div role="listitem" class="nav-item mr-2 mb-1"
           #t="ngbTooltip"
           triggers="manual"
           [ngbTooltip]="tipContent"
@@ -40,10 +40,10 @@
             <p class="chip-label text-truncate d-table-cell">{{c.display}}</p><i class="fas fa-times ml-2" (click)="removeChips($event, i)" [title]="'chips.remove' | translate"></i>
           </span>
         </a>
-      </li>
+      </div>
     </ng-container>
     <div [class.chips-sort-ignore]="(isDragging | async)" class="flex-grow-1">
       <ng-content ></ng-content>
     </div>
-  </ul>
+  </div>
 </div>

--- a/src/app/shared/form/chips/chips.component.spec.ts
+++ b/src/app/shared/form/chips/chips.component.spec.ts
@@ -122,7 +122,7 @@ describe('ChipsComponent test suite', () => {
     }));
 
     it('should save chips item index when drag and drop start', fakeAsync(() => {
-      const de = chipsFixture.debugElement.query(By.css('li.nav-item'));
+      const de = chipsFixture.debugElement.query(By.css('div.nav-item'));
 
       de.triggerEventHandler('dragstart', null);
 
@@ -131,7 +131,7 @@ describe('ChipsComponent test suite', () => {
 
     it('should update chips item order when drag and drop end', fakeAsync(() => {
       spyOn(chipsComp.chips, 'updateOrder');
-      const de = chipsFixture.debugElement.query(By.css('li.nav-item'));
+      const de = chipsFixture.debugElement.query(By.css('div.nav-item'));
 
       de.triggerEventHandler('dragend', null);
 
@@ -158,7 +158,7 @@ describe('ChipsComponent test suite', () => {
     });
 
     it('should show icon for every field that has a configured icon', () => {
-      const de = chipsFixture.debugElement.query(By.css('li.nav-item'));
+      const de = chipsFixture.debugElement.query(By.css('div.nav-item'));
       const icons = de.queryAll(By.css('i.fas'));
 
       expect(icons.length).toBe(4);
@@ -166,7 +166,7 @@ describe('ChipsComponent test suite', () => {
     });
 
     it('should show tooltip on mouse over an icon', () => {
-      const de = chipsFixture.debugElement.query(By.css('li.nav-item'));
+      const de = chipsFixture.debugElement.query(By.css('div.nav-item'));
       const icons = de.queryAll(By.css('i.fas'));
 
       icons[0].triggerEventHandler('mouseover', null);


### PR DESCRIPTION
Hello @tdonohue this is mi pull request. i will be attentive to any comment. 👍  (sorry for a lot of pull request, i was struggling with the github sync hehe).

## References
* Fixes #1187 with ID 469537

## Description
This pull request solves ID 469537. Now ds-chips component has role list and listitem

## Instructions for Reviewers
1. Login as administrator
2. Create new item.
3. add keywords for dc.subject
4. see the div with _role="list"_, you can see inside of this div there are elements with _role="listitem"_.

List of changes in this PR:
* Instead of using _ul_ and _li_ they were replaced to _div role="list"_ and _div role="listitem"_ respectivelly to keep the input inside the container.
* Test changed from li.nav-item to div.nav-item

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
