### PR TITLE
Fix for "cannot read properties of undefined" error for Withdrawn Items

### DIFF
--- a/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
+++ b/src/app/core/breadcrumbs/dso-breadcrumbs.service.ts
@@ -39,7 +39,7 @@ export class DSOBreadcrumbsService implements BreadcrumbsProviderService<ChildHA
     return this.linkService.resolveLink(key, followLink(propertyName))[propertyName].pipe(
       find((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => parentRD.hasSucceeded || parentRD.statusCode === 204),
       switchMap((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => {
-        if (hasValue(parentRD.payload)) {
+        if (hasValue(parentRD) && hasValue(parentRD.payload)) {
           const parent = parentRD.payload;
           return this.getBreadcrumbs(parent, getDSORoute(parent));
         }


### PR DESCRIPTION
## References
* Fixed #2090

## Description
Fixes issue where withdrawn item page won't load in SSR.  The issues was with the breadcrumbs loading for a withdrawn item.

## Instructions for Reviewers
See steps to reproduce in #2090 