### PR TITLE
Buttons have same name but different actions.

### DIFF
--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
@@ -2,18 +2,21 @@
 
   <button class="btn btn-primary workflow-view mt-1 mb-3" data-test="view-btn"
     ngbTooltip="{{'submission.workspace.generic.view-help' | translate}}"
+    [attr.aria-label]="'submission.workspace.generic.view-help' | translate"
     [routerLink]="[getWorkspaceItemViewRoute(object)]">
     <i class="fa fa-info-circle"></i> {{"submission.workspace.generic.view" | translate}}
   </button>
 
   <a class="btn btn-primary mt-1 mb-3" id="{{'edit_' + object.id}}"
     ngbTooltip="{{'submission.workflow.generic.edit-help' | translate}}"
+    [attr.aria-label]="'submission.workflow.generic.edit-help' | translate"
     [routerLink]="['/workspaceitems/' + object.id + '/edit']" role="button">
     <i class="fa fa-edit"></i> {{'submission.workflow.generic.edit' | translate}}
   </a>
 
   <button type="button" id="{{'delete_' + object.id}}" class="btn btn-danger mt-1 mb-3"
     ngbTooltip="{{'submission.workflow.generic.delete-help' | translate}}"
+    [attr.aria-label]="'submission.workflow.generic.delete-help' | translate"
     (click)="$event.preventDefault();confirmDiscard(content)">
     <span *ngIf="(processingDelete$ | async)"><i class='fas fa-circle-notch fa-spin'></i>
       {{'submission.workflow.tasks.generic.processing' | translate}}</span>

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4635,7 +4635,7 @@
 
   "submission.workflow.generic.delete": "Delete",
 
-  "submission.workflow.generic.delete-help": "Select this option if you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  "submission.workflow.generic.delete-help": "Select this option to discard this item. You will then be asked to confirm it.",
 
   "submission.workflow.generic.edit": "Edit",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4635,7 +4635,7 @@
 
   "submission.workflow.generic.delete": "Delete",
 
-  "submission.workflow.generic.delete-help": "If you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
+  "submission.workflow.generic.delete-help": "Select this option if you would to discard this item, select \"Delete\".  You will then be asked to confirm it.",
 
   "submission.workflow.generic.edit": "Edit",
 


### PR DESCRIPTION
## References
Hello @tdonohue i have already with the 3rd task for this issue. I will be attentive to any comments.
* Fixes #1186 (ID 470750)

## Description
I added an `aria-label` for edit, delete and view buttons in my dspace section.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* `aria-label` added in edit, view and delete button inside of `workspaceitem-actions.component.html` file.
* i chanfed the text for: `submission.workflow.generic.delete-help` in en.json5

1. login as administrator.
2. go to my dspace section
3. open the browser console. You will see that the three buttons has aria-label according to the tooltip.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
