### PR TITLE
Use bitstream description in simple item view if present

### DIFF
--- a/src/app/item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/app/item-page/simple/field-components/file-section/file-section.component.html
@@ -2,7 +2,7 @@
   <ds-metadata-field-wrapper *ngIf="bitstreams?.length > 0" [label]="label | translate">
     <div class="file-section">
       <ds-themed-file-download-link *ngFor="let file of bitstreams; let last=last;" [bitstream]="file" [item]="item">
-        <span>{{file?.name}}</span>
+        <span>{{file?.firstMetadataValue("dc.description") ? file?.firstMetadataValue("dc.description") : file?.name}}</span>
         <span>({{(file?.sizeBytes) | dsFileSize }})</span>
         <span *ngIf="!last" innerHTML="{{separator}}"></span>
       </ds-themed-file-download-link>


### PR DESCRIPTION
## References
* Fixes #2103 

## Description
We should show the bitstream description instead of the file name in the simple item view if it is present. This is how DSpace XMLUI has behaved at least for many years. Here is the adjusted Angular simple item view:

<p align="center">
  <img width="600" src="https://user-images.githubusercontent.com/191754/219603616-1bc42a98-4252-4688-b7e5-fa9bde156b9a.png" />
</p>

_Note:_ I am new to Angular so I am not sure if this syntax is the preferred, though it does work. I referenced the full item page to find the description variable.

## Instructions for Reviewers

List of changes in this PR:
* Check the item view for a bitstream that has a description
* Check the item view for a bitstream that does not have a description

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).