### PR TITLE
 Fixed: Clear metadata if value has not set. Reference issue no #1612

### DIFF
--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-form.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-form.ts
@@ -404,11 +404,16 @@ export class DsoEditMetadataForm {
           if (hasValue(value.change)) {
             if (value.change === DsoEditMetadataChangeType.UPDATE) {
               // Only changes to value or language are considered "replace" operations. Changes to place are considered "move", which is processed below.
-              if (value.originalValue.value !== value.newValue.value || value.originalValue.language !== value.newValue.language) {
-                replaceOperations.push(new MetadataPatchReplaceOperation(field, value.originalValue.place, {
-                  value: value.newValue.value,
-                  language: value.newValue.language,
-                }));
+              // If the changed values has zero length, change will be considered as a "remove" operation.
+              if (!value.newValue.value || !value.newValue.value.trim()) {
+                removeOperations.push(new MetadataPatchRemoveOperation(field, value.originalValue.place));
+              } else {
+                if (value.originalValue.value !== value.newValue.value || value.originalValue.language !== value.newValue.language) {
+                  replaceOperations.push(new MetadataPatchReplaceOperation(field, value.originalValue.place, {
+                    value: value.newValue.value,
+                    language: value.newValue.language,
+                  }));
+                }
               }
             } else if (value.change === DsoEditMetadataChangeType.REMOVE) {
               removeOperations.push(new MetadataPatchRemoveOperation(field, value.originalValue.place));


### PR DESCRIPTION
## References
* Fixes #1612 

## Description
If any metadata value field is left empty then the change will considered as a 'remove' operation.

## Instructions for Reviewers

List of changes in this PR:
* An if-else statement has been added to check whether the _metadata value_ in the upcoming change is having length 0 or not.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
