### PR TITLE
avoiding error when user unselect a filter option

### DIFF
--- a/src/app/shared/search/search-labels/search-label/search-label.component.ts
+++ b/src/app/shared/search/search-labels/search-label/search-label.component.ts
@@ -7,6 +7,7 @@ import { SearchService } from '../../../../core/shared/search/search.service';
 import { currentPath } from '../../../utils/route.utils';
 import { PaginationService } from '../../../../core/pagination/pagination.service';
 import { SearchConfigurationService } from '../../../../core/shared/search/search-configuration.service';
+import { stripOperatorFromFilterValue } from '../../search.utils';
 
 @Component({
   selector: 'ds-search-label',
@@ -83,7 +84,8 @@ export class SearchLabelComponent implements OnInit {
   normalizeFilterValue(value: string) {
     // const pattern = /,[^,]*$/g;
     const pattern = /,authority*$/g;
-    return value.replace(pattern, '');
+    value = value.replace(pattern, '');
+    return stripOperatorFromFilterValue(value);
   }
 
   private getFilterName(): string {

--- a/src/app/shared/search/search-labels/search-labels.component.ts
+++ b/src/app/shared/search/search-labels/search-labels.component.ts
@@ -4,7 +4,6 @@ import { Observable } from 'rxjs';
 import { Params, Router } from '@angular/router';
 import { SearchConfigurationService } from '../../../core/shared/search/search-configuration.service';
 import { map } from 'rxjs/operators';
-import { stripOperatorFromFilterValue } from '../search.utils';
 
 @Component({
   selector: 'ds-search-labels',
@@ -37,7 +36,7 @@ export class SearchLabelsComponent {
         const labels = {};
         Object.keys(params)
           .forEach((key) => {
-            labels[key] = [...params[key].map((value) => stripOperatorFromFilterValue(value))];
+            labels[key] = [...params[key].map((value) => value)];
           });
         return labels;
       })


### PR DESCRIPTION
Hello @tdonohue i have good news. I've fixed **Removing a filter generates an invalid query**. I will be attentive to any comments. 😄 

## References
* Fixes #1998

## Description
When user unselect a filter tag option, the query is executed succesfully.

## Instructions for Reviewers

List of changes in this PR:
* i moved stripOperatorFromFilterValue from `search-labels` component to `search-label`.

1. go to search section.
2. apply two subject queries.
3. unselect any of them
4. you will see that the query is executed succesfully

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
