### PR TITLE
Update section-identifiers.component.html

### DIFF
--- a/src/app/submission/sections/identifiers/section-identifiers.component.html
+++ b/src/app/submission/sections/identifiers/section-identifiers.component.html
@@ -2,6 +2,7 @@
 Template for the identifiers submission section component
 @author Kim Shepherd
 -->
+<ds-themed-loading *ngIf="!getSectionStatus()" message="{{'loading.default' | translate}}" [showMessage]="true"></ds-themed-loading>
 <!-- Main identifier data -->
 <ng-container *ngVar="(getIdentifierData() | async) as identifierData">
   <ng-container *ngIf="identifierData && identifierData.identifiers">


### PR DESCRIPTION
Add default loading component display while section is loading

## Description
Improves UX by adding missing loading spinner while identifiers section is loading

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Add missing "ds-themed-loading" component to template

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
