### PR TITLE
Minor CSS fixes

### DIFF
--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -8,7 +8,7 @@
           <button class="mr-auto btn btn-success addEPerson-button"
                   (click)="isEPersonFormShown = true">
             <i class="fas fa-plus"></i>
-            <span class="d-none d-sm-inline">{{labelPrefix + 'button.add' | translate}}</span>
+            <span class="d-none d-sm-inline ml-1">{{labelPrefix + 'button.add' | translate}}</span>
           </button>
         </div>
       </div>
@@ -30,7 +30,7 @@
           <div class="flex-grow-1 mr-3 ml-3">
             <div class="form-group input-group">
               <input type="text" name="query" id="query" formControlName="query"
-                    class="form-control" attr.aria-label="{{labelPrefix + 'search.placeholder' | translate}}"
+                    class="form-control" [attr.aria-label]="labelPrefix + 'search.placeholder' | translate"
                      [placeholder]="(labelPrefix + 'search.placeholder' | translate)">
               <span class="input-group-append">
                 <button type="submit" class="search-button btn btn-primary">
@@ -72,13 +72,13 @@
                 <td>{{epersonDto.eperson.email}}</td>
                 <td>
                   <div class="btn-group edit-field">
-                    <button class="delete-button" (click)="toggleEditEPerson(epersonDto.eperson)"
+                    <button (click)="toggleEditEPerson(epersonDto.eperson)"
                             class="btn btn-outline-primary btn-sm access-control-editEPersonButton"
                             title="{{labelPrefix + 'table.edit.buttons.edit' | translate: {name: epersonDto.eperson.name} }}">
                       <i class="fas fa-edit fa-fw"></i>
                     </button>
                     <button [disabled]="!epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
-                            class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                            class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                             title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: epersonDto.eperson.name} }}">
                       <i class="fas fa-trash-alt fa-fw"></i>
                     </button>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,7 +1,7 @@
 import { Router } from '@angular/router';
 import { Observable, of as observableOf } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
@@ -42,6 +42,7 @@ describe('EPeopleRegistryComponent', () => {
   let paginationService;
 
   beforeEach(waitForAsync(() => {
+    jasmine.getEnv().allowRespy(true);
     mockEPeople = [EPersonMock, EPersonMock2];
     ePersonDataServiceStub = {
       activeEPerson: null,
@@ -98,7 +99,7 @@ describe('EPeopleRegistryComponent', () => {
       deleteEPerson(ePerson: EPerson): Observable<boolean> {
         this.allEpeople = this.allEpeople.filter((ePerson2: EPerson) => {
           return (ePerson2.uuid !== ePerson.uuid);
-        });
+            });
         return observableOf(true);
       },
       editEPerson(ePerson: EPerson) {
@@ -260,17 +261,16 @@ describe('EPeopleRegistryComponent', () => {
   describe('delete EPerson button when the isAuthorized returns false', () => {
     let ePeopleDeleteButton;
     beforeEach(() => {
-      authorizationService = jasmine.createSpyObj('authorizationService', {
-        isAuthorized: observableOf(false)
-      });
+      spyOn(authorizationService, 'isAuthorized').and.returnValue(observableOf(false));
+      component.initialisePage();
+      fixture.detectChanges();
     });
 
     it('should be disabled', () => {
       ePeopleDeleteButton = fixture.debugElement.queryAll(By.css('#epeople tr td div button.delete-button'));
-      ePeopleDeleteButton.forEach((deleteButton) => {
+      ePeopleDeleteButton.forEach((deleteButton: DebugElement) => {
         expect(deleteButton.nativeElement.disabled).toBe(true);
       });
-
     });
   });
 });

--- a/src/app/access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
+++ b/src/app/access-control/group-registry/group-form/subgroup-list/subgroups-list.component.html
@@ -65,7 +65,7 @@
                 <i class="fas fa-trash-alt fa-fw"></i>
               </button>
 
-              <p *ngIf="(isActiveGroup(group) | async)">{{ messagePrefix + '.table.edit.currentGroup' | translate }}</p>
+              <span *ngIf="(isActiveGroup(group) | async)">{{ messagePrefix + '.table.edit.currentGroup' | translate }}</span>
 
               <button *ngIf="!(isSubgroupOfGroup(group) | async) && !(isActiveGroup(group) | async)"
                       (click)="addSubgroupToGroup(group)"

--- a/src/app/access-control/group-registry/groups-registry.component.html
+++ b/src/app/access-control/group-registry/groups-registry.component.html
@@ -7,7 +7,7 @@
           <button class="mr-auto btn btn-success"
                   [routerLink]="['newGroup']">
             <i class="fas fa-plus"></i>
-            <span class="d-none d-sm-inline">{{messagePrefix + 'button.add' | translate}}</span>
+            <span class="d-none d-sm-inline ml-1">{{messagePrefix + 'button.add' | translate}}</span>
           </button>
         </div>
       </div>
@@ -17,7 +17,7 @@
         <div class="flex-grow-1 mr-3">
           <div class="form-group input-group">
             <input type="text" name="query" id="query" formControlName="query"
-                   class="form-control" attr.aria-label="{{messagePrefix + 'search.placeholder' | translate}}"
+                   class="form-control" [attr.aria-label]="messagePrefix + 'search.placeholder' | translate"
                    [placeholder]="(messagePrefix + 'search.placeholder' | translate)" >
             <span class="input-group-append">
               <button type="submit" class="search-button btn btn-primary">

--- a/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.html
+++ b/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.html
@@ -29,7 +29,7 @@
             <tbody>
             <tr *ngFor="let bitstreamFormat of (bitstreamFormats | async)?.payload?.page">
               <td>
-                <label>
+                <label class="mb-0">
                   <input type="checkbox"
                          [checked]="isSelected(bitstreamFormat) | async"
                          (change)="selectBitStreamFormat(bitstreamFormat, $event)"

--- a/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.html
+++ b/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.html
@@ -29,7 +29,7 @@
                         <tr *ngFor="let schema of (metadataSchemas | async)?.payload?.page"
                             [ngClass]="{'table-primary' : isActive(schema) | async}">
                             <td>
-                                <label>
+                                <label class="mb-0">
                                     <input type="checkbox"
                                            [checked]="isSelected(schema) | async"
                                            (change)="selectMetadataSchema(schema, $event)"

--- a/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.scss
+++ b/src/app/admin/admin-registries/metadata-registry/metadata-registry.component.scss
@@ -1,3 +1,7 @@
 .selectable-row:hover {
   cursor: pointer;
 }
+
+:host ::ng-deep #metadatadataschemagroup {
+  display: flex;
+}

--- a/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.html
+++ b/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.html
@@ -34,14 +34,14 @@
               <tr *ngFor="let field of fields?.page"
                   [ngClass]="{'table-primary' : isActive(field) | async}">
                 <td>
-                  <label>
+                  <label class="mb-0">
                     <input type="checkbox"
                            [checked]="isSelected(field) | async"
                            (change)="selectMetadataField(field, $event)">
                   </label>
                 </td>
                 <td class="selectable-row" (click)="editField(field)">{{field.id}}</td>
-                <td class="selectable-row" (click)="editField(field)">{{schema?.prefix}}.{{field.element}}<label *ngIf="field.qualifier">.</label>{{field.qualifier}}</td>
+                <td class="selectable-row" (click)="editField(field)">{{schema?.prefix}}.{{field.element}}<label *ngIf="field.qualifier" class="mb-0">.</label>{{field.qualifier}}</td>
                 <td class="selectable-row" (click)="editField(field)">{{field.scopeNote}}</td>
               </tr>
               </tbody>

--- a/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.scss
+++ b/src/app/admin/admin-registries/metadata-schema/metadata-schema.component.scss
@@ -1,3 +1,8 @@
 .selectable-row:hover {
   cursor: pointer;
 }
+
+:host ::ng-deep #metadatadatafieldgroup {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/src/app/shared/log-in/log-in.component.html
+++ b/src/app/shared/log-in/log-in.component.html
@@ -1,5 +1,5 @@
 <ds-themed-loading *ngIf="(loading | async) || (isAuthenticated | async)" class="m-5"></ds-themed-loading>
-<div *ngIf="!(loading | async) && !(isAuthenticated | async)" class="px-4 py-3 login-container">
+<div *ngIf="!(loading | async) && !(isAuthenticated | async)" class="px-4 py-3 mx-auto login-container">
   <ng-container *ngFor="let authMethod of (authMethods); let i = index">
     <div *ngIf="i === 1" class="text-center mt-2">
       <span class="align-middle">{{"login.form.or-divider" | translate}}</span>

--- a/src/app/shared/log-in/log-in.component.scss
+++ b/src/app/shared/log-in/log-in.component.scss
@@ -1,3 +1,8 @@
 .login-container {
   max-width: 350px;
 }
+
+a {
+  white-space: normal;
+  padding: .25rem .75rem;
+}

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -246,3 +246,8 @@ ul.dso-edit-menu-dropdown > li .nav-item.nav-link {
   padding: 0;
   display: inline;
 }
+
+.table th,
+.table td {
+  vertical-align: middle;
+}


### PR DESCRIPTION
## References
* Fixes #1952

## Description
Fixes minor CSS issues & a false powsitive test that I discovered while making the improvements

## Instructions for Reviewers
- Change language to Greek (Ελληνικά) and click on the login button in the header the text should not overflow and should look like this (it should also wrap the text on the `/login` page):

  <img src="https://user-images.githubusercontent.com/43750381/221372345-0ca804fc-a81a-4300-baf2-cff0dc0674d3.png" width="30%"/>
- When you set the language to Greek (Ελληνικά) the login container on `/login` is not centerd anymore

  <img src="https://user-images.githubusercontent.com/43750381/221372418-a64752d9-038a-4cb9-9956-3487719d97ae.png" width="50%"/>
- On the metadata registry the input fields aren't correclty alligned when only one field has an error (`/admin/registries/metadata` & `/admin/registries/metadata/dc`):

  <img src="https://user-images.githubusercontent.com/43750381/221372542-c10e59f5-c671-48ed-bc17-f90e5d1d4833.png" width="75%"/>
- The text & buttons in some `<table>`s were not correctly vertically aligned for example the edit eperson page:

  <img src="https://user-images.githubusercontent.com/43750381/221382214-a16a4cf6-534d-4497-8fd2-f06529d55222.png" width="47%"/> <img src="https://user-images.githubusercontent.com/43750381/221382139-ec815018-c720-4460-b7d7-171cf6ac19c1.png" width="47%"/>

List of changes in this PR:
* Various small CSS changes
* While making those css adjustments I found a problem in `EPeopleRegistryComponent`, the HTML `class=""` attribute was assigned twice for a button which meant that it was overwritten by default. Fixing this made it possible to find a broken test:
  * The `delete-button` class was put on the wrong button (it was put on the edit button when it should have been put on the delete button).
  * The page was not regenerated after altering the spy, which meant that the previous state was still being shown.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).