### PR TITLE
browse-by-metadata-page works correctly on numeric 'value' param

### DIFF
--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -109,7 +109,7 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
   /**
    * The authority key (may be undefined) associated with {@link #value}.
    */
-  authority: string;
+   authority: string;
 
   /**
    * The current startsWith option (fetched and updated from query-params)
@@ -122,19 +122,19 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
   fetchThumbnails: boolean;
 
   public constructor(protected route: ActivatedRoute,
-    protected browseService: BrowseService,
-    protected dsoService: DSpaceObjectDataService,
-    protected paginationService: PaginationService,
-    protected router: Router,
-    @Inject(APP_CONFIG) public appConfig: AppConfig) {
+                     protected browseService: BrowseService,
+                     protected dsoService: DSpaceObjectDataService,
+                     protected paginationService: PaginationService,
+                     protected router: Router,
+                     @Inject(APP_CONFIG) public appConfig: AppConfig) {
 
     this.fetchThumbnails = this.appConfig.browseBy.showThumbnails;
     this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
-      id: BBM_PAGINATION_ID,
-      currentPage: 1,
-      pageSize: this.appConfig.browseBy.pageSize,
-    });
-  }
+        id: BBM_PAGINATION_ID,
+        currentPage: 1,
+        pageSize: this.appConfig.browseBy.pageSize,
+        });
+    }
 
 
   ngOnInit(): void {
@@ -149,28 +149,28 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
           return [Object.assign({}, routeParams, queryParams),currentPage,currentSort];
         })
       ).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
-        this.browseId = params.id || this.defaultBrowseId;
-        this.authority = params.authority;
-
-        if (typeof params.value === 'string'){
-          this.value = params.value.trim();
-        }
-
-        this.value = +params.value || params.value || '';
-
-        if (typeof params.startsWith === 'string'){
-          this.startsWith = params.startsWith.trim();
-        }
-
-        if (isNotEmpty(this.value)) {
-          this.updatePageWithItems(
-            browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), this.value, this.authority);
-        } else {
-          this.updatePage(browseParamsToOptions(params, currentPage, currentSort, this.browseId, false));
-        }
-        this.updateParent(params.scope);
-        this.updateLogo();
-      }));
+          this.browseId = params.id || this.defaultBrowseId;
+          this.authority = params.authority;
+          
+          if (typeof params.value === 'string'){
+            this.value = params.value.trim();
+          }
+  
+          this.value = +params.value || params.value || '';
+  
+          if (typeof params.startsWith === 'string'){
+            this.startsWith = params.startsWith.trim();
+          }
+          
+          if (isNotEmpty(this.value)) {
+            this.updatePageWithItems(
+              browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), this.value, this.authority);
+          } else {
+            this.updatePage(browseParamsToOptions(params, currentPage, currentSort, this.browseId, false));
+          }
+          this.updateParent(params.scope);
+          this.updateLogo();
+        }));
     this.updateStartsWithTextOptions();
 
   }
@@ -222,8 +222,8 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
         true,
         true,
         ...linksToFollow() as FollowLinkConfig<DSpaceObject>[]).pipe(
-          getFirstSucceededRemoteData()
-        );
+        getFirstSucceededRemoteData()
+      );
     }
   }
 
@@ -287,9 +287,9 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
  * @returns BrowseEntrySearchOptions instance
  */
 export function getBrowseSearchOptions(defaultBrowseId: string,
-  paginationConfig: PaginationComponentOptions,
-  sortConfig: SortOptions,
-  fetchThumbnails?: boolean) {
+                                       paginationConfig: PaginationComponentOptions,
+                                       sortConfig: SortOptions,
+                                       fetchThumbnails?: boolean) {
   if (!hasValue(fetchThumbnails)) {
     fetchThumbnails = false;
   }
@@ -306,10 +306,10 @@ export function getBrowseSearchOptions(defaultBrowseId: string,
  * @param fetchThumbnail   Optional parameter for requesting thumbnail images
  */
 export function browseParamsToOptions(params: any,
-  paginationConfig: PaginationComponentOptions,
-  sortConfig: SortOptions,
-  metadata?: string,
-  fetchThumbnail?: boolean): BrowseEntrySearchOptions {
+                                      paginationConfig: PaginationComponentOptions,
+                                      sortConfig: SortOptions,
+                                      metadata?: string,
+                                      fetchThumbnail?: boolean): BrowseEntrySearchOptions {
   return new BrowseEntrySearchOptions(
     metadata,
     paginationConfig,

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -151,15 +151,15 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
       ).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
           this.browseId = params.id || this.defaultBrowseId;
           this.authority = params.authority;
-          
+
           if (typeof params.value === 'string'){
             this.value = params.value.trim();
           }
-  
+
           if (typeof params.startsWith === 'string'){
             this.startsWith = params.startsWith.trim();
           }
-          
+
           if (isNotEmpty(this.value)) {
             this.updatePageWithItems(
               browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), this.value, this.authority);

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -152,13 +152,13 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
         this.browseId = params.id || this.defaultBrowseId;
         this.authority = params.authority;
 
-        if(typeof params.value === "string"){
+        if (typeof params.value === 'string'){
           this.value = params.value.trim();
         }
 
         this.value = +params.value || params.value || '';
-        
-        if(typeof params.startsWith === "string"){
+
+        if (typeof params.startsWith === 'string'){
           this.startsWith = params.startsWith.trim();
         }
 

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -156,8 +156,6 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
             this.value = params.value.trim();
           }
   
-          this.value = +params.value || params.value || '';
-  
           if (typeof params.startsWith === 'string'){
             this.startsWith = params.startsWith.trim();
           }

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -109,7 +109,7 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
   /**
    * The authority key (may be undefined) associated with {@link #value}.
    */
-   authority: string;
+  authority: string;
 
   /**
    * The current startsWith option (fetched and updated from query-params)
@@ -122,19 +122,19 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
   fetchThumbnails: boolean;
 
   public constructor(protected route: ActivatedRoute,
-                     protected browseService: BrowseService,
-                     protected dsoService: DSpaceObjectDataService,
-                     protected paginationService: PaginationService,
-                     protected router: Router,
-                     @Inject(APP_CONFIG) public appConfig: AppConfig) {
+    protected browseService: BrowseService,
+    protected dsoService: DSpaceObjectDataService,
+    protected paginationService: PaginationService,
+    protected router: Router,
+    @Inject(APP_CONFIG) public appConfig: AppConfig) {
 
     this.fetchThumbnails = this.appConfig.browseBy.showThumbnails;
     this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
-        id: BBM_PAGINATION_ID,
-        currentPage: 1,
-        pageSize: this.appConfig.browseBy.pageSize,
-        });
-    }
+      id: BBM_PAGINATION_ID,
+      currentPage: 1,
+      pageSize: this.appConfig.browseBy.pageSize,
+    });
+  }
 
 
   ngOnInit(): void {
@@ -149,19 +149,28 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
           return [Object.assign({}, routeParams, queryParams),currentPage,currentSort];
         })
       ).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
-          this.browseId = params.id || this.defaultBrowseId;
-          this.authority = params.authority;
-          this.value = +params.value || params.value || '';
-          this.startsWith = +params.startsWith || params.startsWith;
-          if (isNotEmpty(this.value)) {
-            this.updatePageWithItems(
-              browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), this.value, this.authority);
-          } else {
-            this.updatePage(browseParamsToOptions(params, currentPage, currentSort, this.browseId, false));
-          }
-          this.updateParent(params.scope);
-          this.updateLogo();
-        }));
+        this.browseId = params.id || this.defaultBrowseId;
+        this.authority = params.authority;
+
+        if(typeof params.value === "string"){
+          this.value = params.value.trim();
+        }
+
+        this.value = +params.value || params.value || '';
+        
+        if(typeof params.startsWith === "string"){
+          this.startsWith = params.startsWith.trim();
+        }
+
+        if (isNotEmpty(this.value)) {
+          this.updatePageWithItems(
+            browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), this.value, this.authority);
+        } else {
+          this.updatePage(browseParamsToOptions(params, currentPage, currentSort, this.browseId, false));
+        }
+        this.updateParent(params.scope);
+        this.updateLogo();
+      }));
     this.updateStartsWithTextOptions();
 
   }
@@ -213,8 +222,8 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
         true,
         true,
         ...linksToFollow() as FollowLinkConfig<DSpaceObject>[]).pipe(
-        getFirstSucceededRemoteData()
-      );
+          getFirstSucceededRemoteData()
+        );
     }
   }
 
@@ -278,9 +287,9 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
  * @returns BrowseEntrySearchOptions instance
  */
 export function getBrowseSearchOptions(defaultBrowseId: string,
-                                       paginationConfig: PaginationComponentOptions,
-                                       sortConfig: SortOptions,
-                                       fetchThumbnails?: boolean) {
+  paginationConfig: PaginationComponentOptions,
+  sortConfig: SortOptions,
+  fetchThumbnails?: boolean) {
   if (!hasValue(fetchThumbnails)) {
     fetchThumbnails = false;
   }
@@ -297,15 +306,15 @@ export function getBrowseSearchOptions(defaultBrowseId: string,
  * @param fetchThumbnail   Optional parameter for requesting thumbnail images
  */
 export function browseParamsToOptions(params: any,
-                                      paginationConfig: PaginationComponentOptions,
-                                      sortConfig: SortOptions,
-                                      metadata?: string,
-                                      fetchThumbnail?: boolean): BrowseEntrySearchOptions {
+  paginationConfig: PaginationComponentOptions,
+  sortConfig: SortOptions,
+  metadata?: string,
+  fetchThumbnail?: boolean): BrowseEntrySearchOptions {
   return new BrowseEntrySearchOptions(
     metadata,
     paginationConfig,
     sortConfig,
-    +params.startsWith || params.startsWith,
+    params.startsWith,
     params.scope,
     fetchThumbnail
   );


### PR DESCRIPTION
Hello @tdonohue ✋. i already finished this issue. I will be attentive to any comments.
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #2128

## Description
Browse By Metadata page will work correctly on numeric 'value' param.

## Instructions for Reviewers
i just avoid the symbol "+" in "+startsWith" to prevent conversion from string to number.

1. login
2. select any section from "all of DSpace" that its index is according to a metadata value.
3. Search for an item that has leading "0". (like in the issue)
4. you should be able to find the item.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
