### PR TITLE
pageSize applied in Recent Submissions

### DIFF
--- a/src/app/collection-page/collection-page.component.ts
+++ b/src/app/collection-page/collection-page.component.ts
@@ -77,7 +77,7 @@ export class CollectionPageComponent implements OnInit {
       currentPage: 1,
       pageSize: this.appConfig.browseBy.pageSize,
     });
-    
+
     this.sortConfig = new SortOptions('dc.date.accessioned', SortDirection.DESC);
   }
 

--- a/src/app/collection-page/collection-page.component.ts
+++ b/src/app/collection-page/collection-page.component.ts
@@ -77,7 +77,8 @@ export class CollectionPageComponent implements OnInit {
       currentPage: 1,
       pageSize: this.appConfig.browseBy.pageSize,
     });
-
+    
+    this.sortConfig = new SortOptions('dc.date.accessioned', SortDirection.DESC);
   }
 
   ngOnInit(): void {

--- a/src/app/collection-page/collection-page.component.ts
+++ b/src/app/collection-page/collection-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, Inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, combineLatest as observableCombineLatest, Observable, Subject } from 'rxjs';
 import { filter, map, mergeMap, startWith, switchMap, take } from 'rxjs/operators';
@@ -29,6 +29,7 @@ import { FeatureID } from '../core/data/feature-authorization/feature-id';
 import { getCollectionPageRoute } from './collection-page-routing-paths';
 import { redirectOn4xx } from '../core/shared/authorized.operators';
 import { BROWSE_LINKS_TO_FOLLOW } from '../core/browse/browse.service';
+import { APP_CONFIG, AppConfig } from '../../../src/config/app-config.interface';
 
 @Component({
   selector: 'ds-collection-page',
@@ -69,12 +70,13 @@ export class CollectionPageComponent implements OnInit {
     private authService: AuthService,
     private paginationService: PaginationService,
     private authorizationDataService: AuthorizationDataService,
+    @Inject(APP_CONFIG) public appConfig: AppConfig,
   ) {
-    this.paginationConfig = new PaginationComponentOptions();
-    this.paginationConfig.id = 'cp';
-    this.paginationConfig.pageSize = 5;
-    this.paginationConfig.currentPage = 1;
-    this.sortConfig = new SortOptions('dc.date.accessioned', SortDirection.DESC);
+    this.paginationConfig = Object.assign(new PaginationComponentOptions(), {
+      id: 'cp',
+      currentPage: 1,
+      pageSize: this.appConfig.browseBy.pageSize,
+    });
 
   }
 


### PR DESCRIPTION
Hello @tdonohue i have already finished with this issue. I hope it is worth for DSpace. ✋

## References
* Fixes #2044

## Description
Pagination Size in Browser Recent Submission is related to the configuration yml file.

## Instructions for Reviewers
1. Configure browseBy: pageSize with the desired number.
2. Go to any collection with items
3. in Recent Submission tab the items will be paginated according to the number

List of changes in this PR:
* pageSize instead of static number (5) is dinamically configured: `pageSize: this.appConfig.browseBy.pageSize`

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
