### PR TITLE
markdown removed in list

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "prop-types": "^15.7.2",
     "react-copy-to-clipboard": "^5.0.1",
     "reflect-metadata": "^0.1.13",
+    "remove-markdown": "^0.5.0",
     "rxjs": "^7.5.5",
     "sanitize-html": "^2.7.2",
     "sortablejs": "1.13.0",

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.html
@@ -38,7 +38,7 @@
 
           <ds-truncatable-part [id]="item.id" [minLines]="1" class="item-list-abstract">
             <span [ngClass]="{'text-muted': !item.firstMetadataValue('dc.description.abstract')}"
-              [innerHTML]="(item.firstMetadataValue('dc.description.abstract')) || ('mydspace.results.no-abstract' | translate)"></span>
+              [innerHTML]="(removeMarkdown(item.firstMetadataValue('dc.description.abstract'))) || ('mydspace.results.no-abstract' | translate)"></span>
           </ds-truncatable-part>
 
         </div>

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
@@ -1,4 +1,5 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
+import removeMarkdown from 'remove-markdown';
 
 import { Item } from '../../../../core/shared/item.model';
 import { fadeInOut } from '../../../animations/fade';
@@ -64,5 +65,7 @@ export class ItemListPreviewComponent implements OnInit {
     this.dsoTitle = this.dsoNameService.getHitHighlights(this.object, this.item);
   }
 
-
+  removeMarkdown(text: string) {
+    return removeMarkdown(text);
+  }
 }

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
@@ -39,7 +39,7 @@
       </span>
       <div *ngIf="dso.firstMetadataValue('dc.description.abstract')" class="item-list-abstract">
         <ds-truncatable-part [id]="dso.id" [minLines]="3"><span
-          [innerHTML]="firstMetadataValue('dc.description.abstract')"></span>
+          [innerHTML]="removeMarkdown(firstMetadataValue('dc.description.abstract'))"></span>
         </ds-truncatable-part>
       </div>
     </ds-truncatable>

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.ts
@@ -1,3 +1,4 @@
+import removeMarkdown from 'remove-markdown';
 import { Component } from '@angular/core';
 import { listableObjectComponent } from '../../../../../object-collection/shared/listable-object/listable-object.decorator';
 import { ViewMode } from '../../../../../../core/shared/view-mode.model';
@@ -31,5 +32,9 @@ export class ItemSearchResultListElementComponent extends SearchResultListElemen
     super.ngOnInit();
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;
     this.itemPageRoute = getItemPageRoute(this.dso);
+  }
+
+  removeMarkdown(text: string) {
+    return removeMarkdown(text);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9661,6 +9661,11 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
+remove-markdown@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.5.0.tgz#a596264bbd60b9ceab2e2ae86e5789eee91aee32"
+  integrity sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg==
+
 request-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"


### PR DESCRIPTION
Hello @tdonohue i've finished this task ✋ i will be attentive to any comments.

## References
* Fixes #2119 

## Description
Markdown is not applied in item lists.

## Instructions for Reviewers
1. Login
2. Create an item with an abstract using markdown.
3. go to recent items section in home page.
4. You can see that markdown is not applied.

List of changes in this PR:
* i've installed remove-markdown library which has **MIT License**.
* I removed markdown in description section of each item.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
