### PR TITLE
DS-8668: adds check for HTTP 413 status code when importing an SAF file

### DIFF
--- a/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
+++ b/src/app/admin/admin-import-batch-page/batch-import-page.component.ts
@@ -97,9 +97,15 @@ export class BatchImportPageComponent {
             this.router.navigateByUrl(getProcessDetailRoute(rd.payload.processId));
           }
         } else {
-          const title = this.translate.get('process.new.notification.error.title');
-          const content = this.translate.get('process.new.notification.error.content');
-          this.notificationsService.error(title, content);
+          if (rd.statusCode === 413) {
+            const title = this.translate.get('process.new.notification.error.title');
+            const content = this.translate.get('process.new.notification.error.max-upload.content');
+            this.notificationsService.error(title, content);
+          } else {
+            const title = this.translate.get('process.new.notification.error.title');
+            const content = this.translate.get('process.new.notification.error.content');
+            this.notificationsService.error(title, content);
+          }
         }
       });
     }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3255,7 +3255,7 @@
 
   "process.new.notification.error.content": "An error occurred while creating this process",
 
-  "process.new.notification.error.max-upload.content": "One or more files exceeds the maximum upload size",
+  "process.new.notification.error.max-upload.content": "The file exceeds the maximum upload size",
 
   "process.new.header": "Create a new process",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3255,6 +3255,8 @@
 
   "process.new.notification.error.content": "An error occurred while creating this process",
 
+  "process.new.notification.error.max-upload.content": "One or more files exceeds the maximum upload size",
+
   "process.new.header": "Create a new process",
 
   "process.new.title": "Create a new process",


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8668
* Companion PR: https://github.com/DSpace/DSpace/pull/8735

## Description
This PR adds a check for an HTTP 413 response from the backend when importing an SAF file and displays a different message to the user.

## Instructions for Reviewers
1. Go to /admin/batch-import
2. Upload an SAF file larger than 512 MB

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [X] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
