### PR TITLE
DS-2175: send "forgot password" email when user registration fails

### DIFF
--- a/src/app/register-page/create-profile/create-profile.component.spec.ts
+++ b/src/app/register-page/create-profile/create-profile.component.spec.ts
@@ -26,6 +26,7 @@ import {
   createSuccessfulRemoteDataObject$
 } from '../../shared/remote-data.utils';
 import { CoreState } from '../../core/core-state.model';
+import { EpersonRegistrationService } from 'src/app/core/data/eperson-registration.service';
 
 describe('CreateProfileComponent', () => {
   let comp: CreateProfileComponent;
@@ -37,6 +38,7 @@ describe('CreateProfileComponent', () => {
   let notificationsService;
   let store: Store<CoreState>;
   let endUserAgreementService: EndUserAgreementService;
+  let epersonRegistrationService: EpersonRegistrationService;
 
   const registration = Object.assign(new Registration(), {email: 'test@email.org', token: 'test-token'});
 
@@ -127,6 +129,10 @@ describe('CreateProfileComponent', () => {
       removeCookieAccepted: {}
     });
 
+    epersonRegistrationService = jasmine.createSpyObj('epersonRegistrationService', {
+      registerEmail: createSuccessfulRemoteDataObject$({})
+    });
+
     TestBed.configureTestingModule({
       imports: [CommonModule, RouterTestingModule.withRoutes([]), TranslateModule.forRoot(), ReactiveFormsModule],
       declarations: [CreateProfileComponent],
@@ -138,6 +144,7 @@ describe('CreateProfileComponent', () => {
         {provide: FormBuilder, useValue: new FormBuilder()},
         {provide: NotificationsService, useValue: notificationsService},
         {provide: EndUserAgreementService, useValue: endUserAgreementService},
+        {provide: EpersonRegistrationService, useValue: epersonRegistrationService},
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -235,8 +242,6 @@ describe('CreateProfileComponent', () => {
 
       expect(ePersonDataService.createEPersonForToken).toHaveBeenCalledWith(eperson, 'test-token');
       expect(store.dispatch).not.toHaveBeenCalled();
-      expect(router.navigate).not.toHaveBeenCalled();
-      expect(notificationsService.error).toHaveBeenCalled();
     });
 
     it('should submit not create an eperson when the user info form is invalid', () => {


### PR DESCRIPTION
## References
* Fixes #2175 

## Description
This PR removes the error message after a failed user registration and attempts to send a "forgot password" email instead.

## Instructions for Reviewers

1. Create a user with an email address
2. Finish the registration process
3. Create another user with the same email address
4. You should receive a "forgot password" alert in the browser and an email instead of an error message

### Notes
- This PR uses the given translation for the "forgot password" alert. A separate one could be created for this specific case if necessary.
- All of the potential failures when creating an EPerson send the same DSpaceBadRequestException, including when an EPerson with the same email address already exists – https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java#L159-L185. I could create a separate PR in the REST API that throws a different exception and HTTP Status Code for duplicate entity if that's warranted.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [X] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
