### PR TITLE
Minor cypress updates & stabilize e2e tests

### DIFF
--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -122,8 +122,6 @@ describe('New Submission page', () => {
 
         // Wait for upload to complete before proceeding
         cy.wait('@upload');
-        // Close the upload success notice
-        cy.get('[data-dismiss="alert"]').click({multiple: true});
 
         // Wait for deposit button to not be disabled & click it.
         cy.get('button#deposit').should('not.be.disabled').click();

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
-    "cypress": "^12.0.1",
+    "cypress": "12.9.0",
     "cypress-axe": "^1.1.0",
     "deep-freeze": "0.0.1",
     "eslint": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,10 +4270,10 @@ cypress-axe@^1.1.0:
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.4.0.tgz#e67482bfe9e740796bf77c7823f19781a8a2faff"
   integrity sha512-Ut7NKfzjyKm0BEbt2WxuKtLkIXmx6FD2j0RwdvO/Ykl7GmB/qRQkwbKLk3VP35+83hiIr8GKD04PDdrTK5BnyA==
 
-cypress@^12.0.1:
-  version "12.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.7.0.tgz#69900f82af76cf3ba0ddb9b59ec3b0d38222ab22"
-  integrity sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==
+cypress@12.9.0:
+  version "12.9.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.9.0.tgz#e6ab43cf329fd7c821ef7645517649d72ccf0a12"
+  integrity sha512-Ofe09LbHKgSqX89Iy1xen2WvpgbvNxDzsWx3mgU1mfILouELeXYGwIib3ItCwoRrRifoQwcBFmY54Vs0zw7QCg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description
Builds on the work down in #2127 .

This does the following:
* Attempts to stabilize a flakey test which is causing random e2e test failures in `submission.cy.ts`. This test appears to be failing roughly 50% of the time, even on my local machine.  
    * Removes the flakey check for a success notification popup after uploading a file in the submission process. This popup seems to be sometimes disappearing before it can be clicked close.  This check is unnecessary for the test & the test in question works more smoothly without it.
* Updates us to latest version of Cypress 12.  Just a minor update.
