### PR TITLE
Shibboleth page update after authentication

### DIFF
--- a/src/app/core/auth/auth.actions.ts
+++ b/src/app/core/auth/auth.actions.ts
@@ -17,6 +17,7 @@ export const AuthActionTypes = {
   AUTHENTICATED_SUCCESS: type('dspace/auth/AUTHENTICATED_SUCCESS'),
   CHECK_AUTHENTICATION_TOKEN: type('dspace/auth/CHECK_AUTHENTICATION_TOKEN'),
   CHECK_AUTHENTICATION_TOKEN_COOKIE: type('dspace/auth/CHECK_AUTHENTICATION_TOKEN_COOKIE'),
+  SET_AUTH_COOKIE_STATUS: type('dspace/auth/SET_AUTH_COOKIE_STATUS'),
   RETRIEVE_AUTH_METHODS: type('dspace/auth/RETRIEVE_AUTH_METHODS'),
   RETRIEVE_AUTH_METHODS_SUCCESS: type('dspace/auth/RETRIEVE_AUTH_METHODS_SUCCESS'),
   RETRIEVE_AUTH_METHODS_ERROR: type('dspace/auth/RETRIEVE_AUTH_METHODS_ERROR'),
@@ -148,6 +149,19 @@ export class CheckAuthenticationTokenAction implements Action {
  */
 export class CheckAuthenticationTokenCookieAction implements Action {
   public type: string = AuthActionTypes.CHECK_AUTHENTICATION_TOKEN_COOKIE;
+}
+
+/**
+ * Sets the authentication cookie status to flag an external authentication response.
+ */
+export class SetAuthCookieStatus implements Action {
+  public type: string = AuthActionTypes.SET_AUTH_COOKIE_STATUS;
+
+  payload = false;
+
+  constructor(exists: boolean) {
+    this.payload = exists;
+  }
 }
 
 /**
@@ -425,6 +439,7 @@ export type AuthActions
   | AuthenticationSuccessAction
   | CheckAuthenticationTokenAction
   | CheckAuthenticationTokenCookieAction
+  | SetAuthCookieStatus
   | RedirectWhenAuthenticationIsRequiredAction
   | RedirectWhenTokenExpiredAction
   | AddAuthenticationMessageAction

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -221,7 +221,8 @@ describe('AuthEffects', () => {
 
         expect(authEffects.checkTokenCookie$).toBeObservable(expected);
         authEffects.checkTokenCookie$.subscribe(() => {
-          expect(authServiceStub.setExternalAuthStatus).toHaveBeenCalledWith(true);
+          expect(authServiceStub.setExternalAuthStatus).toHaveBeenCalled();
+          expect(authServiceStub.isExternalAuthentication).toBeTrue();
           expect((authEffects as any).authorizationsService.invalidateAuthorizationsRequestCache).toHaveBeenCalled();
         });
       });

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -214,12 +214,14 @@ describe('AuthEffects', () => {
               authenticated: true
             })
         );
+        spyOn((authEffects as any).authService, 'setExternalAuthStatus');
         actions = hot('--a-', { a: { type: AuthActionTypes.CHECK_AUTHENTICATION_TOKEN_COOKIE } });
 
         const expected = cold('--b-', { b: new RetrieveTokenAction() });
 
         expect(authEffects.checkTokenCookie$).toBeObservable(expected);
         authEffects.checkTokenCookie$.subscribe(() => {
+          expect(authServiceStub.setExternalAuthStatus).toHaveBeenCalledWith(true);
           expect((authEffects as any).authorizationsService.invalidateAuthorizationsRequestCache).toHaveBeenCalled();
         });
       });

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -153,6 +153,7 @@ export class AuthEffects {
       return this.authService.checkAuthenticationCookie().pipe(
         map((response: AuthStatus) => {
           if (response.authenticated) {
+            this.authService.setExternalAuthStatus(true);
             this.authorizationsService.invalidateAuthorizationsRequestCache();
             return new RetrieveTokenAction();
           } else {

--- a/src/app/core/auth/auth.reducer.spec.ts
+++ b/src/app/core/auth/auth.reducer.spec.ts
@@ -8,6 +8,7 @@ import {
   AuthenticationErrorAction,
   AuthenticationSuccessAction,
   CheckAuthenticationTokenAction,
+  SetAuthCookieStatus,
   CheckAuthenticationTokenCookieAction,
   LogOutAction,
   LogOutErrorAction,
@@ -214,6 +215,28 @@ describe('authReducer', () => {
       loaded: false,
       blocking: false,
       loading: true,
+      idle: false
+    };
+    expect(newState).toEqual(state);
+  });
+
+  it('should set the authentication cookie status in response to a SET_AUTH_COOKIE_STATUS action', () => {
+    initialState = {
+      authenticated: true,
+      loaded: false,
+      blocking: false,
+      loading: true,
+      externalAuth: false,
+      idle: false
+    };
+    const action = new SetAuthCookieStatus(true);
+    const newState = authReducer(initialState, action);
+    state = {
+      authenticated: true,
+      loaded: false,
+      blocking: false,
+      loading: true,
+      externalAuth: true,
       idle: false
     };
     expect(newState).toEqual(state);

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -10,7 +10,7 @@ import {
   RedirectWhenTokenExpiredAction,
   RefreshTokenSuccessAction,
   RetrieveAuthenticatedEpersonSuccessAction,
-  RetrieveAuthMethodsSuccessAction,
+  RetrieveAuthMethodsSuccessAction, SetAuthCookieStatus,
   SetRedirectUrlAction
 } from './auth.actions';
 // import models
@@ -59,6 +59,8 @@ export interface AuthState {
   // all authentication Methods enabled at the backend
   authMethods?: AuthMethod[];
 
+  externalAuth?: boolean,
+
   // true when the current user is idle
   idle: boolean;
 
@@ -73,6 +75,7 @@ const initialState: AuthState = {
   blocking: true,
   loading: false,
   authMethods: [],
+  externalAuth: false,
   idle: false
 };
 
@@ -102,6 +105,11 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
     case AuthActionTypes.CHECK_AUTHENTICATION_TOKEN_COOKIE:
       return Object.assign({}, state, {
         loading: true,
+      });
+
+    case AuthActionTypes.SET_AUTH_COOKIE_STATUS:
+      return Object.assign({}, state, {
+        externalAuth: (action as SetAuthCookieStatus).payload
       });
 
     case AuthActionTypes.AUTHENTICATED_ERROR:

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -156,10 +156,19 @@ export class AuthService {
     return this.store.pipe(select(isAuthenticatedLoaded));
   }
 
+  /**
+   * Used to set the external authentication status when authenticating via an
+   * external authentication system (e.g. Shibboleth).
+   * @param external
+   */
   public setExternalAuthStatus(external: boolean) {
     this.store.dispatch(new SetAuthCookieStatus(external));
   }
 
+  /**
+   * Returns true if an external authentication system (e.g. Shibboleth) is being used
+   * for authentication. Returns false otherwise.
+   */
   public isExternalAuthentication(): Observable<boolean> {
     return this.store.pipe(
       select(getExternalAuthCookieStatus));

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -25,7 +25,7 @@ import {
 import { CookieService } from '../services/cookie.service';
 import {
   getAuthenticatedUserId,
-  getAuthenticationToken,
+  getAuthenticationToken, getExternalAuthCookieStatus,
   getRedirectUrl,
   isAuthenticated,
   isAuthenticatedLoaded,
@@ -36,7 +36,7 @@ import { AppState } from '../../app.reducer';
 import {
   CheckAuthenticationTokenAction,
   RefreshTokenAction,
-  ResetAuthenticationMessagesAction,
+  ResetAuthenticationMessagesAction, SetAuthCookieStatus,
   SetRedirectUrlAction,
   SetUserAsIdleAction,
   UnsetUserAsIdleAction
@@ -154,6 +154,15 @@ export class AuthService {
    */
   public isAuthenticationLoaded(): Observable<boolean> {
     return this.store.pipe(select(isAuthenticatedLoaded));
+  }
+
+  public setExternalAuthStatus(external: boolean) {
+    this.store.dispatch(new SetAuthCookieStatus(external));
+  }
+
+  public isExternalAuthentication(): Observable<boolean> {
+    return this.store.pipe(
+      select(getExternalAuthCookieStatus));
   }
 
   /**

--- a/src/app/core/auth/selectors.ts
+++ b/src/app/core/auth/selectors.ts
@@ -181,7 +181,7 @@ export const isAuthenticated = createSelector(getAuthState, _isAuthenticated);
 export const isAuthenticatedLoaded = createSelector(getAuthState, _isAuthenticatedLoaded);
 
 /**
- * Returns the authentication cookie status. Expect to be ture when external authentication
+ * Returns the authentication cookie status. Expect to be true when external authentication
  * is used.
  * @function getExternalAuthCookieStatus
  * @param {AuthState} state

--- a/src/app/core/auth/selectors.ts
+++ b/src/app/core/auth/selectors.ts
@@ -116,6 +116,8 @@ const _getRedirectUrl = (state: AuthState) => state.redirectUrl;
 
 const _getAuthenticationMethods = (state: AuthState) => state.authMethods;
 
+const _getExternalAuthCookieStatus = (state: AuthState) => state.externalAuth;
+
 /**
  * Returns true if the user is idle.
  * @function _isIdle
@@ -177,6 +179,16 @@ export const isAuthenticated = createSelector(getAuthState, _isAuthenticated);
  * @return {boolean}
  */
 export const isAuthenticatedLoaded = createSelector(getAuthState, _isAuthenticatedLoaded);
+
+/**
+ * Returns the authentication cookie status. Expect to be ture when external authentication
+ * is used.
+ * @function getExternalAuthCookieStatus
+ * @param {AuthState} state
+ * @param {any} props
+ * @return {boolean}
+ */
+export const getExternalAuthCookieStatus = createSelector(getAuthState, _getExternalAuthCookieStatus);
 
 /**
  * Returns true if the authentication request is loading.

--- a/src/app/shared/testing/auth-service.stub.ts
+++ b/src/app/shared/testing/auth-service.stub.ts
@@ -17,6 +17,7 @@ export class AuthServiceStub {
   token: AuthTokenInfo = new AuthTokenInfo('token_test');
   impersonating: string;
   private _tokenExpired = false;
+  private _isExternalAuth = false;
   private redirectUrl;
 
   constructor() {
@@ -123,11 +124,11 @@ export class AuthServiceStub {
     return;
   }
   setExternalAuthStatus(externalCookie: boolean) {
-    return;
+    this._isExternalAuth = externalCookie;
   }
 
   isExternalAuthentication(): Observable<boolean> {
-    return;
+    return observableOf(this._isExternalAuth);
   }
 
   retrieveAuthMethodsFromAuthStatus(status: AuthStatus) {

--- a/src/app/shared/testing/auth-service.stub.ts
+++ b/src/app/shared/testing/auth-service.stub.ts
@@ -122,6 +122,13 @@ export class AuthServiceStub {
   checkAuthenticationCookie() {
     return;
   }
+  setExternalAuthStatus(externalCookie: boolean) {
+    return;
+  }
+
+  isExternalAuthentication(): Observable<boolean> {
+    return;
+  }
 
   retrieveAuthMethodsFromAuthStatus(status: AuthStatus) {
     return observableOf(authMethodsMock);

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -56,7 +56,7 @@ export class BrowserInitService extends InitService {
     protected authService: AuthService,
     protected themeService: ThemeService,
     protected menuService: MenuService,
-    private rootDatatService: RootDataService
+    private rootDataService: RootDataService
   ) {
     super(
       store,
@@ -153,7 +153,7 @@ export class BrowserInitService extends InitService {
         filter((externalAuth: boolean) => externalAuth)
       ).subscribe(() => {
         // Clear the transferState data.
-        this.rootDatatService.invalidateRootCache();
+        this.rootDataService.invalidateRootCache();
         this.authService.setExternalAuthStatus(false);
       }
     );

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -139,19 +139,18 @@ export class BrowserInitService extends InitService {
   }
 
   /**
-   * When authenticated during the external authentication flow invalidate
-   * the cache so the app is rehydrated with fresh data.
+   * During the external authentication flow invalidates the SSR transferState
+   * data in the cache. This allows the app to fetch fresh content.
    * @private
    */
   private externalAuthCheck() {
 
-    this.authenticationReady$().pipe(
-        switchMap(() => this.authService.isExternalAuthentication().pipe(
-          filter((externalAuth: boolean) => externalAuth)
-        ))
+    this.authService.isExternalAuthentication().pipe(
+        filter((externalAuth: boolean) => externalAuth)
       ).subscribe(() => {
-        this.authService.setExternalAuthStatus(false);
+        // Clear the transferState data.
         this.rootDatatService.invalidateRootCache();
+        this.authService.setExternalAuthStatus(false);
       }
     );
 

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -26,7 +26,7 @@ import { AuthService } from '../../app/core/auth/auth.service';
 import { ThemeService } from '../../app/shared/theme-support/theme.service';
 import { StoreAction, StoreActionTypes } from '../../app/store.actions';
 import { coreSelector } from '../../app/core/core.selectors';
-import { filter, find, map, switchMap } from 'rxjs/operators';
+import { filter, find, map } from 'rxjs/operators';
 import { isNotEmpty } from '../../app/shared/empty.util';
 import { logStartupMessage } from '../../../startup-message';
 import { MenuService } from '../../app/shared/menu/menu.service';

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -169,8 +169,7 @@ export class BrowserInitService extends InitService {
   private closeAuthCheckSubscription() {
     firstValueFrom(this.authenticationReady$()).then(() => {
         this.sub.unsubscribe();
-      }
-    )
+      });
   }
 
 }


### PR DESCRIPTION
## References
* Fixes #1665

## Description
After the final redirect from external Shibboleth authentication the page content is not updated with new, authorized content. This PR tracks when an authentication cookie was returned in the final external redirect. When external authentication is detected the cache is invalidated and the page  is initialized with fresh data.

## Instructions for Reviewers

List of changes in this PR:
* When the external authentication cookie is detected during initialization the store is updated with a value to indicate external authentication. This process is started by function in `init.service`.
* The `browser-init.service` checks for external authentication and invalidates the cache if found.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
