### PR TITLE
Add missing export for ItemRequest module

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -176,6 +176,7 @@ import { VocabularyEntryDetailsDataService } from './submission/vocabularies/voc
 import { IdentifierData } from '../shared/object-list/identifier-data/identifier-data.model';
 import { Subscription } from '../shared/subscriptions/models/subscription.model';
 import { SupervisionOrderDataService } from './supervision-order/supervision-order-data.service';
+import { ItemRequest } from './shared/item-request.model';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
@@ -369,6 +370,7 @@ export const models =
     AccessStatusObject,
     IdentifierData,
     Subscription,
+    ItemRequest,
   ];
 
 @NgModule({


### PR DESCRIPTION
## References
Fixes #2195 

## Description
Somewhere along the way the ItemRequest module is no longer being exported.  This results in a blank page in the UI whenever you visit an ItemRequest page:
http://localhost:4000/request-a-copy/[token]

## Instructions for Reviewers
* Create a request for copy
    * Restrict a bitstream
    * Login as a user without privileges and submit a request for copy.
* As a user who can respond to the request, login and visit http://localhost:4000/request-a-copy/[token]
    * Verify on `main` that you see a blank page.
    * Verify that with this PR, the request a copy page loads & you can then either approve or reject the request.