### PR TITLE
Fix #2197 authority key lookup

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
@@ -53,7 +53,7 @@ export abstract class DsDynamicVocabularyComponent extends DynamicFormControlCom
    */
   getInitValueFromModel(): Observable<FormFieldMetadataValueObject> {
     let initValue$: Observable<FormFieldMetadataValueObject>;
-    if (isNotEmpty(this.model.value) && (this.model.value instanceof FormFieldMetadataValueObject)) {
+    if (isNotEmpty(this.model.value) && (this.model.value instanceof FormFieldMetadataValueObject) && !this.model.value.hasAuthorityToGenerate()) {
       let initEntry$: Observable<VocabularyEntry>;
       if (this.model.value.hasAuthority()) {
         initEntry$ = this.vocabularyService.getVocabularyEntryByID(this.model.value.authority, this.model.vocabularyOptions);

--- a/src/app/shared/form/builder/models/form-field-metadata-value.model.ts
+++ b/src/app/shared/form/builder/models/form-field-metadata-value.model.ts
@@ -11,6 +11,10 @@ export interface OtherInformation {
  * A class representing a specific input-form field's value
  */
 export class FormFieldMetadataValueObject implements MetadataValueInterface {
+
+  static readonly AUTHORITY_SPLIT: string = '::';
+  static readonly AUTHORITY_GENERATE: string = 'will be generated' + FormFieldMetadataValueObject.AUTHORITY_SPLIT;
+
   metadata?: string;
   value: any;
   display: string;
@@ -56,6 +60,13 @@ export class FormFieldMetadataValueObject implements MetadataValueInterface {
    */
   hasAuthority(): boolean {
     return isNotEmpty(this.authority);
+  }
+
+  /**
+   * Returns true if this object has an authority value that needs to be generated
+   */
+  hasAuthorityToGenerate(): boolean {
+    return isNotEmpty(this.authority) && this.authority.startsWith(FormFieldMetadataValueObject.AUTHORITY_GENERATE);
   }
 
   /**


### PR DESCRIPTION
Avoid an authority key lookup in DsDynamicVocabularyComponent when it starts with "will be generated::"

## References
Fixes #2197

## Description
During initialization for DsDynamicVocabularyComponent, avoid an authority key lookup when it starts with "will be generated::".

## Instructions for Reviewers
List of changes in this PR:
* Added FormFieldMetadataValueObject.hasAuthorityToGenerate() method to check if the authority key still needs to be generated
* In DsDynamicVocabularyComponent.getInitValueFromModel(), skip the Solr authority lookup if the key still needs to be generated. This lets the logic fall through to the default else that creates initValue$ from the existing FormFieldMetadataValueObject

When ORCID authority is enabled, you can now lookup an author, save the submission for later, and when you reopen the submission, the correct author value (last name and first name) should be shown, and there will no longer be a Solr exception with the "will be generated::" lookup. Note that a complete fix for the Solr lookup exceptions requires DSpace/DSpace#8490 to be resolved as well.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [X] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
