### PR TITLE
Fixed mobile navbar not expanding & use same css variable for all header icons

### DIFF
--- a/src/app/header-nav-wrapper/header-navbar-wrapper.component.scss
+++ b/src/app/header-nav-wrapper/header-navbar-wrapper.component.scss
@@ -1,7 +1,4 @@
-@media screen and (max-width: map-get($grid-breakpoints, md)) {
-    :host.open {
-        background-color: var(--bs-white);
-        top: 0;
-        position: sticky;
-    }
+:host {
+  position: relative;
+  z-index: var(--ds-nav-z-index);
 }

--- a/src/app/header-nav-wrapper/themed-header-navbar-wrapper.component.scss
+++ b/src/app/header-nav-wrapper/themed-header-navbar-wrapper.component.scss
@@ -1,3 +1,0 @@
-:host {
-  z-index: var(--ds-nav-z-index);
-}

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -11,13 +11,12 @@
   line-height: 1.5;
 }
 
-.navbar ::ng-deep {
-  a {
-    color: var(--ds-header-icon-color);
+.navbar-toggler {
+  border: none;
+  color: var(--ds-header-icon-color);
 
-    &:hover, &:focus {
-      color: var(--ds-header-icon-color-hover);
-    }
+  &:hover, &:focus {
+    color: var(--ds-header-icon-color-hover);
   }
 }
 

--- a/src/app/search-navbar/search-navbar.component.scss
+++ b/src/app/search-navbar/search-navbar.component.scss
@@ -1,6 +1,7 @@
 input[type="text"] {
   margin-top: calc(-0.5 * var(--bs-font-size-base));
   background-color: #fff !important;
+  border-color: var(--ds-header-icon-color);
 
   &.collapsed {
     opacity: 0;

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
@@ -19,7 +19,7 @@
   </li>
   <li *ngIf="(isAuthenticated | async) && !(isXsOrSm$ | async) && (showAuth | async)" class="nav-item">
     <div ngbDropdown display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="javascript:void(0);" role="button" [attr.aria-label]="'nav.user-profile-menu-and-logout' |translate" (click)="$event.preventDefault()" [title]="'nav.user-profile-menu-and-logout' | translate" class="px-1" [attr.data-test]="'user-menu' | dsBrowserOnly" ngbDropdownToggle>
+      <a href="javascript:void(0);" role="button" [attr.aria-label]="'nav.user-profile-menu-and-logout' |translate" (click)="$event.preventDefault()" [title]="'nav.user-profile-menu-and-logout' | translate" class="dropdownLogout px-1" [attr.data-test]="'user-menu' | dsBrowserOnly" ngbDropdownToggle>
         <i class="fas fa-user-circle fa-lg fa-fw"></i></a>
       <div class="logoutDropdownMenu" ngbDropdownMenu [attr.aria-label]="'nav.user-profile-menu-and-logout' |translate">
         <ds-user-menu></ds-user-menu>
@@ -27,7 +27,7 @@
     </div>
   </li>
   <li *ngIf="(isAuthenticated | async) && (isXsOrSm$ | async)" class="nav-item">
-    <a id="logoutLink" role="button" [attr.aria-label]="'nav.logout' |translate" [title]="'nav.logout' | translate" routerLink="/logout" routerLinkActive="active" class="px-1">
+    <a role="button" [attr.aria-label]="'nav.logout' |translate" [title]="'nav.logout' | translate" routerLink="/logout" routerLinkActive="active" class="logoutLink px-1">
       <i class="fas fa-sign-out-alt fa-lg fa-fw"></i>
       <span class="sr-only">(current)</span>
     </a>

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.scss
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.scss
@@ -12,7 +12,7 @@
   background-color: transparent !important;
 }
 
-.dropdown-toggle {
+.loginLink, .dropdownLogin, .logoutLink, .dropdownLogout {
   color: var(--ds-header-icon-color);
 
   &:hover, &:focus {

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
@@ -358,7 +358,7 @@ describe('AuthNavMenuComponent', () => {
       });
 
       it('should render logout link', inject([Store], (store: Store<AppState>) => {
-        const logoutDropdownMenu = deNavMenuItem.query(By.css('a[id=logoutLink]'));
+        const logoutDropdownMenu = deNavMenuItem.query(By.css('a.logoutLink'));
         expect(logoutDropdownMenu.nativeElement).toBeDefined();
       }));
     });

--- a/src/themes/dspace/app/header-nav-wrapper/header-navbar-wrapper.component.ts
+++ b/src/themes/dspace/app/header-nav-wrapper/header-navbar-wrapper.component.ts
@@ -6,7 +6,7 @@ import { HeaderNavbarWrapperComponent as BaseComponent } from '../../../../app/h
  */
 @Component({
   selector: 'ds-header-navbar-wrapper',
-  styleUrls: ['header-navbar-wrapper.component.scss'],
+  styleUrls: ['../../../../app/header-nav-wrapper/header-navbar-wrapper.component.scss'],
   templateUrl: 'header-navbar-wrapper.component.html',
 })
 export class HeaderNavbarWrapperComponent extends BaseComponent {

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -6,7 +6,7 @@
       </a>
     </div>
     <div class="d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
-      <ds-search-navbar class="navbar-search"></ds-search-navbar>
+      <ds-themed-search-navbar></ds-themed-search-navbar>
       <ds-lang-switch></ds-lang-switch>
       <ds-context-help-toggle></ds-context-help-toggle>
       <ds-themed-auth-nav-menu></ds-themed-auth-nav-menu>

--- a/src/themes/dspace/app/header/header.component.scss
+++ b/src/themes/dspace/app/header/header.component.scss
@@ -15,5 +15,12 @@
 .navbar-toggler .navbar-toggler-icon {
   background-image: none !important;
   line-height: 1.5;
-  color: var(--bs-link-color);
+}
+
+.navbar-toggler {
+  color: var(--ds-header-icon-color);
+
+  &:hover, &:focus {
+    color: var(--ds-header-icon-color-hover);
+  }
 }

--- a/src/themes/dspace/app/navbar/navbar.component.scss
+++ b/src/themes/dspace/app/navbar/navbar.component.scss
@@ -2,7 +2,6 @@ nav.navbar {
   border-top: 1px var(--ds-header-navbar-border-top-color) solid;
   border-bottom: 5px var(--ds-header-navbar-border-bottom-color) solid;
   align-items: baseline;
-  color: var(--ds-header-icon-color);
 }
 
 /** Mobile menu styling **/


### PR DESCRIPTION
## Description
Currently the mobile navbar does not open on the home page and on other pages like the item page the navbar is not being shown correctly for both the `dspace` and the `custom` theme.
This PR also makes it easier to customise the color and the hover color from the header icons by using the same variable for all of them (using the css variables `--ds-header-icon-color` & `--ds-header-icon-color-hover`).

## Instructions for Reviewers
List of changes in this PR:
- `HeaderNavbarWrapperComponent`: applied the `--ds-nav-z-index` on the wrapper
- Applied the css variables `--ds-header-icon-color` & `--ds-header-icon-color-hover` on every header icon

**Guidance for how to test and review this PR:**
- Uncomment the `custom` theme in `src/themes/eager-themes.module.ts`
- For both the `dspace` and the `custom` theme check the following:
  - Add these lines to the theme's `_theme_css_variable_overrides.scss`:
     ```
     --ds-header-icon-color: red;
     --ds-header-icon-color-hover: orange;
     ```
  - Check that all the header icons are now red by default and orange when you hover/focus on them. Check this in both desktop mode and mobile mode and check this when you are logged in and also check it when you are logged out.
  - Check that the mobile navbar can be expanded

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
