### PR TITLE
Enable line breaks in deposit license during submission.

### DIFF
--- a/src/app/submission/sections/license/section-license.component.html
+++ b/src/app/submission/sections/license/section-license.component.html
@@ -1,4 +1,4 @@
-<span class="mb-5" [innerHTML]="licenseText$ | async"></span>
+<span class="mb-5 preserve-line-breaks" [innerHTML]="licenseText$ | async"></span>
 <br> <br>
 <ds-form *ngIf="formModel" #formRef="formComponent"
          [formId]="formId"


### PR DESCRIPTION
## Description
The submission page packs the deposit license into a rectangle regardless of whitespace in the original.  This patch preserves whitespace in the license text.

## Instructions for Reviewers
List of changes in this PR:
* `preserve-line-breaks` class added to the license text element.

To test:  write a default license with line breaks in it and see if they show up when you start a submission.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).