### PR TITLE
Possible fix for browse-by-date links

### DIFF
--- a/src/app/shared/starts-with/date/starts-with-date.component.ts
+++ b/src/app/shared/starts-with/date/starts-with-date.component.ts
@@ -131,7 +131,6 @@ export class StartsWithDateComponent extends StartsWithAbstractComponent {
     } else {
       this.startsWithYear = +startsWith;
     }
-    this.setStartsWithParam(false);
   }
 
   /**

--- a/src/app/shared/starts-with/starts-with-abstract.component.ts
+++ b/src/app/shared/starts-with/starts-with-abstract.component.ts
@@ -70,7 +70,6 @@ export abstract class StartsWithAbstractComponent implements OnInit, OnDestroy {
    */
   setStartsWith(startsWith: string) {
     this.startsWith = startsWith;
-    this.setStartsWithParam(false);
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #2214

## Description
Currently the browse-by-date component appears to be initialized multiple times via router updates. One of these updates seems unnecessary and removing it solves the problem with item links.

The removed line might actually needed in cases that I haven't found. But if it's truly redundant then removing might be a quick fix for #2214


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
