### PR TITLE
Correctly load choice ui form.other-information translation keys

### DIFF
--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -2489,10 +2489,6 @@
   // TODO New key - Add a translation
   "form.no-value": "No value entered",
 
-  // "form.other-information": {},
-  // TODO New key - Add a translation
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   // TODO New key - Add a translation
   "form.remove": "Remove",

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -2205,9 +2205,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "কোন মান প্রবেশ",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "অপসারণ",
 

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -2386,9 +2386,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "No s'ha introduït cap valor",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Eliminar",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2436,10 +2436,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Nebyla zadána hodnota",
 
-  // "form.other-information": {},
-  // TODO New key - Add a translation
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Smazat",
 

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -2077,9 +2077,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Kein Wert eingegeben",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Entfernen",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1737,6 +1737,18 @@
 
   "form.no-value": "No value entered",
 
+  "form.other-information.email": "Email",
+
+  "form.other-information.first-name": "First Name",
+
+  "form.other-information.insolr": "In Solr Index",
+
+  "form.other-information.institution": "Institution",
+
+  "form.other-information.last-name": "Last Name",
+
+  "form.other-information.orcid": "ORCID",
+
   "form.remove": "Remove",
 
   "form.save": "Save",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1737,8 +1737,6 @@
 
   "form.no-value": "No value entered",
 
-  "form.other-information": {},
-
   "form.remove": "Remove",
 
   "form.save": "Save",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -2565,9 +2565,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "No se introdujo ningún valor",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Eliminar",
 

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -1896,9 +1896,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Ei syötettyä arvoa",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Poista",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -2163,9 +2163,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Aucune valeur entrée",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Supprimer",
 

--- a/src/assets/i18n/gd.json5
+++ b/src/assets/i18n/gd.json5
@@ -2220,9 +2220,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Cha deach luach a chur a-steach",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Thoir às",
 

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -2769,9 +2769,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Nem adott meg értéket",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Törlés",
 

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -2489,10 +2489,6 @@
   // TODO New key - Add a translation
   "form.no-value": "No value entered",
 
-  // "form.other-information": {},
-  // TODO New key - Add a translation
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   // TODO New key - Add a translation
   "form.remove": "Remove",

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -2328,9 +2328,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Мәні енгізілмеді",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Өшіру",
 

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -2069,9 +2069,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Vērtība netika ievadīta",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Dzēst",
 

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -2267,9 +2267,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Geen waarde ingevoerd",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Verwijder",
 

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -2089,9 +2089,6 @@
   "form.group-collapse-help": "Kliknij tutaj, aby zwinąć",
   "form.group-expand": "Rozwiń",
   "form.group-expand-help": "Kliknij tutaj, aby rozwinąć",
-  "form.other-information": {
-
-  },
   "health.breadcrumbs": "Stan systemu",
   "health-page.heading": "Stan systemu",
   "health-page.info-tab": "Informacje",

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -2254,9 +2254,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Nenhum valor informado",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Apagar",
 

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -2102,9 +2102,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Nenhum valor informado",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Apagar",
 

--- a/src/assets/i18n/sv.json5
+++ b/src/assets/i18n/sv.json5
@@ -2232,9 +2232,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Inget värde har angivits",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Ta bort",
 

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -2489,10 +2489,6 @@
   // TODO New key - Add a translation
   "form.no-value": "No value entered",
 
-  // "form.other-information": {},
-  // TODO New key - Add a translation
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   // TODO New key - Add a translation
   "form.remove": "Remove",

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -1894,9 +1894,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Değer girilmez",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Kaldır",
 

--- a/src/assets/i18n/uk.json5
+++ b/src/assets/i18n/uk.json5
@@ -2011,9 +2011,6 @@
   // "form.no-value": "No value entered",
   "form.no-value": "Значення не введено",
 
-  // "form.other-information": {},
-  "form.other-information": {},
-
   // "form.remove": "Remove",
   "form.remove": "Видалити",
 


### PR DESCRIPTION
fixes https://github.com/DSpace/dspace-angular/issues/2219 by removing the json object for key form.other-information which avoids to load subordinated translation keys

## References
* Fixes #2219 

## Description
- removed json object in translation files which blocks loading subordinated translation files used by some components

## Instructions for Reviewers
- it's certainly easier and faster to proof that behaviour of json objects in the translation files on other keys
- e.g. use `"form": {},` or `"submission": {},` to check if the translation messages in the submission forms are not loaded.

List of changes in this PR:
* removed json object in translation files
* added missing `form.other-information` keys which are displayed in AuthorityValues on the Choice UI

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
