### PR TITLE
Update of mirador configuration and webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ package-lock.json
 /nbproject/
 
 junit.xml
+
+/src/mirador-viewer/config.local.js

--- a/src/mirador-viewer/config.default.js
+++ b/src/mirador-viewer/config.default.js
@@ -2,7 +2,7 @@ import Mirador from 'mirador/dist/es/src/index';
 
 // You can modify this default Mirador configuration file. However,
 // you should consider creating a copy of this file named
-// 'index.local.js'. If that file exists it will be used to build
+// 'config.local.js'. If that file exists it will be used to build
 // your local Mirador instance. This allows you to keep local
 // Mirador configuration separate from this default distribution
 // copy.

--- a/src/mirador-viewer/config.default.js
+++ b/src/mirador-viewer/config.default.js
@@ -1,4 +1,17 @@
 import Mirador from 'mirador/dist/es/src/index';
+
+// You can modify this default Mirador configuration file. However,
+// you should consider creating a copy of this file named
+// 'index.local.js'. If that file exists it will be used to build
+// your local Mirador instance. This allows you to keep local
+// Mirador configuration separate from this default distribution
+// copy.
+
+// For an example of all Mirador configuration options, see
+// https://github.com/ProjectMirador/mirador/blob/master/src/config/settings.js
+
+// You can add or remove plugins. When adding new plugins be sure to also
+// import them into the project via your package.json dependencies.
 import miradorShareDialogPlugin from 'mirador-share-plugin/es/MiradorShareDialog';
 import miradorSharePlugin from 'mirador-share-plugin/es/miradorSharePlugin';
 import miradorDownloadPlugin from 'mirador-dl-plugin/es/miradorDownloadPlugin';

--- a/webpack/webpack.mirador.config.ts
+++ b/webpack/webpack.mirador.config.ts
@@ -1,10 +1,13 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
+// @ts-ignore
+const fs = require('fs');
 
 module.exports = {
   mode: 'production',
   entry: {
-    mirador: './src/mirador-viewer/index.js'
+    mirador: fs.existsSync('./src/mirador-viewer/config.local.js')? './src/mirador-viewer/config.local.js' :
+      './src/mirador-viewer/config.default.js'
   },
   output: {
     path: path.resolve(__dirname, '..' , 'dist/iiif/mirador'),


### PR DESCRIPTION
## Description
Users can easily update the mirador configuration for their site today, but we haven't done a good job of explaining and supporting this. 

This makes a few small changes that should help. 

- By default the mirador webpack build now looks for a file in the `src/mirador-viewer` directory named `config.default.js` and uses this for out-of-the-box mirador configuration.
- Users can edit this file directly, but they have the option of creating a copy named `config.local.js`. If present, this file is used to build mirador. This allows the site to maintain a local configuration file that's distinct from the distribution copy.

These changes don't affect our current instructions for building the Mirador viewer, but later we might want to add a callout in the documentation that highlights these configuration options.

## Instructions for Reviewers

List of changes in this PR:

* Updated `webpack/webpack.mirador.config.ts` to check for a local config file
* Renamed `src/mirador-viewer/index.js` to `src/mirador-viewer/config-default.js`
* Added a few comments to `config-default.js`

To test this you can simply create a `config.local.js` and change the value of some property. After running `yarn run build:mirador` you can verify that the local configuration file was used by looking for the changed property value, found near the end of `dist/iiif/mirador/mirador.js`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
