### PR TITLE
Enable Vietnamese language pack

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -214,6 +214,9 @@ languages:
   - code: tr
     label: Türkçe
     active: true
+  - code: vi
+    label: Tiếng Việt
+    active: true
   - code: kk
     label: Қазақ
     active: true

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -229,6 +229,7 @@ export class DefaultAppConfig implements AppConfig {
     { code: 'fi', label: 'Suomi', active: true },
     { code: 'sv', label: 'Svenska', active: true },
     { code: 'tr', label: 'Türkçe', active: true },
+    { code: 'vi', label: 'Tiếng Việt', active: true },
     { code: 'kk', label: 'Қазақ', active: true },
     { code: 'bn', label: 'বাংলা', active: true },
     { code: 'hi', label: 'हिंदी', active: true},


### PR DESCRIPTION
## References
Follow up to #2210 (Thanks again @Zerosoul1990!)

## Description

This small PR just updates our default configuration to enable Vietnamese in the list of supported languages.

I used the changes in this PR to test #2210, so once this passes our GitHub CI, I'm going to merge it immediately.