### PR TITLE
View mode switch accessibility

### DIFF
--- a/src/app/shared/view-mode-switch/view-mode-switch.component.html
+++ b/src/app/shared/view-mode-switch/view-mode-switch.component.html
@@ -1,5 +1,5 @@
 <div class="btn-group" data-toggle="buttons">
-    <a *ngIf="isToShow(viewModeEnum.ListElement)"
+    <button *ngIf="isToShow(viewModeEnum.ListElement)"
        routerLink="."
        [queryParams]="{view: 'list'}"
        queryParamsHandling="merge"
@@ -8,9 +8,9 @@
        [class.active]="currentMode === viewModeEnum.ListElement"
        class="btn btn-secondary"
        [attr.data-test]="'list-view' | dsBrowserOnly">
-          <i class="fas fa-list" title="{{'search.view-switch.show-list' | translate}}"></i>
-    </a>
-    <a *ngIf="isToShow(viewModeEnum.GridElement)"
+       <span class="fas fa-list"></span><span class="sr-only">{{'search.view-switch.show-list' | translate}}</span>
+    </button>
+    <button *ngIf="isToShow(viewModeEnum.GridElement)"
        routerLink="."
        [queryParams]="{view: 'grid'}"
        queryParamsHandling="merge"
@@ -19,9 +19,9 @@
        [class.active]="currentMode === viewModeEnum.GridElement"
        class="btn btn-secondary"
        [attr.data-test]="'grid-view' | dsBrowserOnly">
-          <i class="fas fa-th-large" title="{{'search.view-switch.show-grid' | translate}}"></i>
-    </a>
-    <a *ngIf="isToShow(viewModeEnum.DetailedListElement)"
+       <span class="fas fa-th-large"></span><span class="sr-only">{{'search.view-switch.show-grid' | translate}}</span>
+    </button>
+    <button *ngIf="isToShow(viewModeEnum.DetailedListElement)"
        routerLink="."
        [queryParams]="{view: 'detailed'}"
        queryParamsHandling="merge"
@@ -30,6 +30,6 @@
        [class.active]="currentMode === viewModeEnum.DetailedListElement"
        class="btn btn-secondary"
        [attr.data-test]="'detail-view' | dsBrowserOnly">
-      <i class="far fa-square" title="{{'search.view-switch.show-detail' | translate}}"></i>
-    </a>
+      <span class="far fa-square"></span><span class="sr-only">{{'search.view-switch.show-detail' | translate}}</span>
+    </button>
 </div>

--- a/src/app/shared/view-mode-switch/view-mode-switch.component.spec.ts
+++ b/src/app/shared/view-mode-switch/view-mode-switch.component.spec.ts
@@ -61,7 +61,7 @@ describe('ViewModeSwitchComponent', () => {
       searchService.setViewMode(ViewMode.ListElement);
       tick();
       fixture.detectChanges();
-      const debugElements = fixture.debugElement.queryAll(By.css('a'));
+      const debugElements = fixture.debugElement.queryAll(By.css('button'));
       listButton = debugElements[0].nativeElement;
       gridButton = debugElements[1].nativeElement;
     }));
@@ -96,7 +96,7 @@ describe('ViewModeSwitchComponent', () => {
       searchService.setViewMode(ViewMode.ListElement);
       tick();
       fixture.detectChanges();
-      const debugElements = fixture.debugElement.queryAll(By.css('a'));
+      const debugElements = fixture.debugElement.queryAll(By.css('button'));
       listButton = debugElements[0].nativeElement;
       detailButton = debugElements[1].nativeElement;
     }));


### PR DESCRIPTION
## Description
Use more semantically appropriate elements for list controls and markup that better aligns with WCAG recommendations.

## Instructions for Reviewers
This issue originally brought to my attention because our accessibility auditing tools flag the links as having empty link content. While in practice they read fine to me in my testing using the NVDA screen reader, other assistive technology might not infer that the icon title should be used as the link text.

The crux of this change is to use more semantically appropriate elements for the view mode switch controls. The use of button elements is more appropriate as they don't imply a significant change of context the way that a link element does. The other change here is to explicitly include the name for the control in the button element itself, instead of as part of the title attribute on the icon inside of the link. This better aligns with the WCAG since the name of the control is more explicitly available for programmatic access. 

List of changes in this PR:
1. Use buttons instead of links for the controls
2. Move the name of the control outside of the icon title attribute and into the body of the button element
3. Use span for the icon elements as the idiomatic text element doesn't make semantic sense for an icon
4. Update tests

An alternative strategy for #2 would be to set the title element on the button itself, rather than on the icon. This would keep the tool tip that is lost from this change. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
