### PR TITLE
[DURACOM-99] Tests fixed

### DIFF
--- a/src/app/core/locale/locale.service.spec.ts
+++ b/src/app/core/locale/locale.service.spec.ts
@@ -28,7 +28,7 @@ describe('LocaleService test suite', () => {
     isAuthenticationLoaded: jasmine.createSpy('isAuthenticationLoaded')
   });
 
-  const langList = ['en', 'it', 'de'];
+  const langList = ['en', 'xx', 'de'];
 
   beforeEach(waitForAsync(() => {
     return TestBed.configureTestingModule({
@@ -82,8 +82,8 @@ describe('LocaleService test suite', () => {
     });
 
     it('should return language from browser setting', () => {
-      spyOn(translateService, 'getBrowserLang').and.returnValue('it');
-      expect(service.getCurrentLanguageCode()).toBe('it');
+      spyOn(translateService, 'getBrowserLang').and.returnValue('xx');
+      expect(service.getCurrentLanguageCode()).toBe('xx');
     });
 
     it('should return default language from config', () => {
@@ -114,9 +114,9 @@ describe('LocaleService test suite', () => {
     });
 
     it('should set the given language', () => {
-      service.setCurrentLanguageCode('it');
-      expect(translateService.use).toHaveBeenCalledWith('it');
-      expect(service.saveLanguageCodeToCookie).toHaveBeenCalledWith('it');
+      service.setCurrentLanguageCode('xx');
+      expect(translateService.use).toHaveBeenCalledWith('xx');
+      expect(service.saveLanguageCodeToCookie).toHaveBeenCalledWith('xx');
     });
 
     it('should set the current language', () => {
@@ -135,7 +135,7 @@ describe('LocaleService test suite', () => {
 
   describe('', () => {
     it('should set quality to current language list', () => {
-      const langListWithQuality = ['en;q=1', 'it;q=0.9', 'de;q=0.8'];
+      const langListWithQuality = ['en;q=1', 'xx;q=0.9', 'de;q=0.8'];
       spyOn(service, 'setQuality').and.returnValue(langListWithQuality);
       service.setQuality(langList, LANG_ORIGIN.BROWSER, false);
       expect(service.setQuality).toHaveBeenCalledWith(langList, LANG_ORIGIN.BROWSER, false);


### PR DESCRIPTION
## References
* Fixes #1917 (unit tests only)

## Description
* Unit test were failing on machines with `it` locale

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
