### PR TITLE
Fix jasmine Matchers functions not properly indexing in IntelliJ

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,5 +46,8 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true
-  }
+  },
+  "exclude": [
+    "cypress.config.ts"
+  ]
 }


### PR DESCRIPTION
## Description
Since the upgrade of the e2e tests to Cypress 12 in PR #2127, the [jasmine Matchers](https://github.com/JamieMason/Jasmine-Matchers#-api) all throw errors like the ones in the screenshots below (I currently use IntelliJ 2023.1.2 - IU-231.9011.34).

<img width="75%" alt="jasmine Matchers.toBe() throwing error TS2339" src="https://github.com/DSpace/dspace-angular/assets/43750381/01dfbc53-8bb2-40d2-a770-e803ec20bd2a">
<img width="75%" alt="jasmine Matchers.toEqual() throwing error TS2551" src="https://github.com/DSpace/dspace-angular/assets/43750381/ab969034-8954-4b6a-ad6f-ee0f9a96758f">

## Instructions for Reviewers
To fix this issue the `cypress.config.ts` just needs to be excluded in the `tsconfig.json` file.

**Guidance for how to test your PR:**
- Check if you have the same issue on the latest version of the code
- If you do check that this fixes the issue
- Check that the cypress tests don't have such errors

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).