### PR TITLE
Fix several "potentially unsafe external link" warnings

### DIFF
--- a/src/app/shared/context-help-wrapper/context-help-wrapper.component.html
+++ b/src/app/shared/context-help-wrapper/context-help-wrapper.component.html
@@ -2,7 +2,7 @@
     <div class="preserve-line-breaks ds-context-help-content">
         <ng-container *ngFor="let elem of (parsedContent$ | async)">
             <ng-container *ngIf="elem.href">
-                <a href="{{elem.href}}" target="_blank">{{elem.text}}</a>
+                <a href="{{elem.href}}" target="_blank" rel="noopener noreferrer">{{elem.text}}</a>
             </ng-container>
             <ng-container *ngIf="elem.href === undefined">
                 {{ elem }}

--- a/src/app/submission/sections/sherpa-policies/publication-information/publication-information.component.html
+++ b/src/app/submission/sections/sherpa-policies/publication-information/publication-information.component.html
@@ -23,7 +23,7 @@
         </div>
         <div class="col-4">
             <p class="m-1">
-                <a href="{{journal.url}}" target="_blank">
+                <a href="{{journal.url}}" target="_blank" rel="noopener noreferrer">
                     {{journal.url}}
                 </a>
             </p>
@@ -35,7 +35,7 @@
         </div>
         <div class="col-4" *ngFor="let publisher of journal.publishers">
             <p class="m-1">
-                <a href="{{publisher.uri}}" target="_blank">
+                <a href="{{publisher.uri}}" target="_blank" rel="noopener noreferrer">
                     {{publisher.name}}
                 </a>
             </p>

--- a/src/app/submission/sections/sherpa-policies/publisher-policy/publisher-policy.component.html
+++ b/src/app/submission/sections/sherpa-policies/publisher-policy/publisher-policy.component.html
@@ -8,7 +8,7 @@
             </p>
             <ul>
                 <li *ngFor="let url of policy.urls | keyvalue">
-                    <a href="{{url.key}}" target="_blank">{{url.value}}</a>
+                    <a href="{{url.key}}" target="_blank" rel="noopener noreferrer">{{url.value}}</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## References
* Fixes several warnings from GitHub's security scanner regarding "potentially unsafe external links".  See https://codeql.github.com/codeql-query-help/javascript/js-unsafe-external-link/

## Description
Simply adds `rel="noopener noreferrer"` to several external links which generated this warning

## Instructions for Reviewers
* Review the code
* If desired, verify these links still work (they should be fine though, as we use `rel="noopener noreferrer"` elsewhere on many other links)