### PR TITLE
German translation for "browse.startsWith"

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -949,7 +949,7 @@
 
   // "browse.previous.button": "Previous",
   "browse.previous.button": "Zurück",
-  
+
   // "browse.startsWith": ", starting with {{ startsWith }}",
   "browse.startsWith": ", beginnend mit {{ startsWith }}",
 

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -949,6 +949,9 @@
 
   // "browse.previous.button": "Previous",
   "browse.previous.button": "Zurück",
+  
+  // "browse.startsWith": ", starting with {{ startsWith }}",
+  "browse.startsWith": ", beginnend mit {{ startsWith }}",
 
   // "browse.startsWith.choose_start": "(Choose start)",
   "browse.startsWith.choose_start": "(Startpunkt wählen)",


### PR DESCRIPTION
Added missing German translation for "browse.startsWith".

## References
* Not necessary on these minor changes

## Description
Added missing German translation for "browse.startsWith".

## Instructions for Reviewers


List of changes in this PR:
* Only added missing German translation for "browse.startsWith".

Should be covered by automatic tests?

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
