### PR TITLE
ItemStatus component should handle missing config gracefully

### DIFF
--- a/src/app/item-page/edit-item-page/item-status/item-status.component.ts
+++ b/src/app/item-page/edit-item-page/item-status/item-status.component.ts
@@ -9,9 +9,9 @@ import { RemoteData } from '../../../core/data/remote-data';
 import { getItemEditRoute, getItemPageRoute } from '../../item-page-routing-paths';
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
-import { hasValue } from '../../../shared/empty.util';
+import { hasValue, isNotEmpty } from '../../../shared/empty.util';
 import {
-  getAllSucceededRemoteDataPayload, getFirstSucceededRemoteData, getRemoteDataPayload,
+  getAllSucceededRemoteDataPayload, getFirstCompletedRemoteData, getFirstSucceededRemoteData, getRemoteDataPayload,
 } from '../../../core/shared/operators';
 import { IdentifierDataService } from '../../../core/data/identifier-data.service';
 import { Identifier } from '../../../shared/object-list/identifier-data/identifier.model';
@@ -105,12 +105,13 @@ export class ItemStatusComponent implements OnInit {
 
       // Observable for configuration determining whether the Register DOI feature is enabled
       let registerConfigEnabled$: Observable<boolean> = this.configurationService.findByPropertyName('identifiers.item-status.register-doi').pipe(
-        getFirstSucceededRemoteData(),
-        getRemoteDataPayload(),
-        map((enabled: ConfigurationProperty) => {
-          if (enabled !== undefined && enabled.values) {
-            return true;
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<ConfigurationProperty>) => {
+          // If the config property is exposed via rest and has a value set, return it
+          if (rd.hasSucceeded && hasValue(rd.payload) && isNotEmpty(rd.payload.values)) {
+            return rd.payload.values[0] === 'true';
           }
+          // Otherwise, return false
           return false;
         })
       );


### PR DESCRIPTION
If the "register identifier" config is missing, simply return enabled=false rather than break the rest of the page features from loading. This is a tiny fix that would be great to squeeze into 7.6

## Description
The item status page looks for the `identifiers.item-status.register-doi` config property to determine whether the Register DOI feature should be included. If this property is not exposed by REST or the request fails in some other way, the remaining features would not load because the pipe would wait forever for a successful response.

This fix checks for first _completed_ REST response and then evaluates it properly, with any errors being handled gracefully and resulting in the Register DOI button being excluded from the feature list.

## Instructions for Reviewers
**before** applying this patch
1. Ensure `identifiers.item-status.register-doi` is exposed in rest.cfg and exists in identifiers.cfg, but is false
2. As an administrator, visit an item status page and note the buttons display normally
3. Comment out the config property from rest.cfg or identifiers.cfg and restart tomcat
4. As an administrator, visit an item status page and note the buttons do not finish loading, they are all disabled
5. Apply the PR and repeat the first 4 steps, now step 4 should result in a normal, successful item status page
6. You can also change the config property to true in identifiers.cfg to ensure that it does display the button as expected (note, it will only be enabled if that item is eligible for a DOI as per usual, but it should at least display a disabled button)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
