### PR TITLE
Fix item/coll/comm pages to return 404 when object not found

### DIFF
--- a/src/app/collection-page/collection-page.resolver.spec.ts
+++ b/src/app/collection-page/collection-page.resolver.spec.ts
@@ -1,22 +1,26 @@
 import { first } from 'rxjs/operators';
 import { CollectionPageResolver } from './collection-page.resolver';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
+import { Router } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
 
 describe('CollectionPageResolver', () => {
   describe('resolve', () => {
     let resolver: CollectionPageResolver;
     let collectionService: any;
     let store: any;
+    let router: any;
     const uuid = '1234-65487-12354-1235';
 
     beforeEach(() => {
+      router = TestBed.inject(Router);
       collectionService = {
         findById: (id: string) => createSuccessfulRemoteDataObject$({ id })
       };
       store = jasmine.createSpyObj('store', {
         dispatch: {},
       });
-      resolver = new CollectionPageResolver(collectionService, store);
+      resolver = new CollectionPageResolver(collectionService, store, router);
     });
 
     it('should resolve a collection with the correct id', (done) => {

--- a/src/app/community-page/community-page.resolver.spec.ts
+++ b/src/app/community-page/community-page.resolver.spec.ts
@@ -1,22 +1,26 @@
 import { first } from 'rxjs/operators';
 import { CommunityPageResolver } from './community-page.resolver';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
+import { Router } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
 
 describe('CommunityPageResolver', () => {
   describe('resolve', () => {
     let resolver: CommunityPageResolver;
     let communityService: any;
     let store: any;
+    let router: any;
     const uuid = '1234-65487-12354-1235';
 
     beforeEach(() => {
+      router = TestBed.inject(Router);
       communityService = {
         findById: (id: string) => createSuccessfulRemoteDataObject$({ id })
       };
       store = jasmine.createSpyObj('store', {
         dispatch: {},
       });
-      resolver = new CommunityPageResolver(communityService, store);
+      resolver = new CommunityPageResolver(communityService, store, router);
     });
 
     it('should resolve a community with the correct id', (done) => {

--- a/src/app/community-page/community-page.resolver.ts
+++ b/src/app/community-page/community-page.resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { RemoteData } from '../core/data/remote-data';
 import { Community } from '../core/shared/community.model';
@@ -8,6 +8,7 @@ import { followLink, FollowLinkConfig } from '../shared/utils/follow-link-config
 import { getFirstCompletedRemoteData } from '../core/shared/operators';
 import { ResolvedAction } from '../core/resolving/resolver.actions';
 import { Store } from '@ngrx/store';
+import { PAGE_NOT_FOUND_PATH } from '../app-routing-paths';
 
 /**
  * The self links defined in this list are expected to be requested somewhere in the near future
@@ -27,7 +28,8 @@ export const COMMUNITY_PAGE_LINKS_TO_FOLLOW: FollowLinkConfig<Community>[] = [
 export class CommunityPageResolver implements Resolve<RemoteData<Community>> {
   constructor(
     private communityService: CommunityDataService,
-    private store: Store<any>
+    private store: Store<any>,
+    protected router: Router
   ) {
   }
 
@@ -49,7 +51,12 @@ export class CommunityPageResolver implements Resolve<RemoteData<Community>> {
     );
 
     communityRD$.subscribe((communityRD: RemoteData<Community>) => {
-      this.store.dispatch(new ResolvedAction(state.url, communityRD.payload));
+      if (communityRD.hasSucceeded) {
+        this.store.dispatch(new ResolvedAction(state.url, communityRD.payload));
+      } else {
+        // Community not found
+        void this.router.navigate([PAGE_NOT_FOUND_PATH]);
+      }
     });
 
     return communityRD$;

--- a/src/app/item-page/item.resolver.ts
+++ b/src/app/item-page/item.resolver.ts
@@ -8,6 +8,7 @@ import { followLink, FollowLinkConfig } from '../shared/utils/follow-link-config
 import { getFirstCompletedRemoteData } from '../core/shared/operators';
 import { Store } from '@ngrx/store';
 import { ResolvedAction } from '../core/resolving/resolver.actions';
+import { PAGE_NOT_FOUND_PATH } from '../app-routing-paths';
 
 /**
  * The self links defined in this list are expected to be requested somewhere in the near future
@@ -52,7 +53,12 @@ export class ItemResolver implements Resolve<RemoteData<Item>> {
     );
 
     itemRD$.subscribe((itemRD: RemoteData<Item>) => {
-      this.store.dispatch(new ResolvedAction(state.url, itemRD.payload));
+      if (itemRD.hasSucceeded) {
+        this.store.dispatch(new ResolvedAction(state.url, itemRD.payload));
+      } else {
+        // Item not found
+        void this.router.navigate([PAGE_NOT_FOUND_PATH]);
+      }
     });
 
     return itemRD$;

--- a/src/app/item-page/version-page/version.resolver.ts
+++ b/src/app/item-page/version-page/version.resolver.ts
@@ -8,6 +8,7 @@ import { Store } from '@ngrx/store';
 import { ResolvedAction } from '../../core/resolving/resolver.actions';
 import { Version } from '../../core/shared/version.model';
 import { VersionDataService } from '../../core/data/version-data.service';
+import { PAGE_NOT_FOUND_PATH } from 'src/app/app-routing-paths';
 
 /**
  * The self links defined in this list are expected to be requested somewhere in the near future
@@ -46,7 +47,12 @@ export class VersionResolver implements Resolve<RemoteData<Version>> {
     );
 
     versionRD$.subscribe((versionRD: RemoteData<Version>) => {
-      this.store.dispatch(new ResolvedAction(state.url, versionRD.payload));
+      if (versionRD.hasSucceeded) {
+        this.store.dispatch(new ResolvedAction(state.url, versionRD.payload));
+      } else {
+        // Version not found
+        void this.router.navigate([PAGE_NOT_FOUND_PATH]);
+      }
     });
 
     return versionRD$;


### PR DESCRIPTION
## Description
Fixes an issue discovered on demo site where invalid `/items`, `/collections` and `/communities` URLs are not returning proper 404 responses.  Instead, they will redirect you to a login page.  For example:

https://demo7.dspace.org/communities/not-a-uuid
https://demo7.dspace.org/collections/not-a-uuid
https://demo7.dspace.org/items/not-a-uuid

This seems like improper behavior for often public-facing URLs.

The fix is to add a check to the Resolvers for these objects to verify that the object was *found* via the REST API before dispatching the `ResolvedAction` to the ngrx store.  If the object is *not* found, we now send the user to the 404 page, instead of allowing the object page to continue loading.

## Instructions for Reviewers
* Review code changes.
* When running in production mode (`yarn build:prod; yarn serve:ssr`), verify invalid Item/Collection/Community URLs now return 404 and display the 404 page.