### PR TITLE
Fix issue where a colon in a uuid would get misinterpreted as a route param

### DIFF
--- a/src/app/shared/menu/menu.service.spec.ts
+++ b/src/app/shared/menu/menu.service.spec.ts
@@ -567,4 +567,41 @@ describe('MenuService', () => {
     });
   });
 
+  describe(`resolveSubstitutions`, () => {
+    let linkPrefix;
+    let link;
+    let uuid;
+
+    beforeEach(() => {
+      linkPrefix = 'statistics_collection_';
+      link = `${linkPrefix}:id`;
+      uuid = 'f7cc3ca4-3c2c-464d-8af8-add9f84f711c';
+    });
+
+    it(`shouldn't do anything when there are no params`, () => {
+      let result = (service as any).resolveSubstitutions(link, undefined);
+      expect(result).toEqual(link);
+      result = (service as any).resolveSubstitutions(link, null);
+      expect(result).toEqual(link);
+      result = (service as any).resolveSubstitutions(link, {});
+      expect(result).toEqual(link);
+    });
+
+    it(`should replace link params that are also route params`, () => {
+      const result = (service as any).resolveSubstitutions(link,{ 'id': uuid });
+      expect(result).toEqual(linkPrefix + uuid);
+    });
+
+    it(`should not replace link params that aren't route params`, () => {
+      const result = (service as any).resolveSubstitutions(link,{ 'something': 'else' });
+      expect(result).toEqual(link);
+    });
+
+    it(`should gracefully deal with routes that contain the name of the route param`, () => {
+      const selfReferentialParam = `:id:something`;
+      const result = (service as any).resolveSubstitutions(link,{ 'id': selfReferentialParam });
+      expect(result).toEqual(linkPrefix + selfReferentialParam);
+    });
+  });
+
 });

--- a/src/app/shared/menu/menu.service.ts
+++ b/src/app/shared/menu/menu.service.ts
@@ -17,7 +17,7 @@ import {
   ToggleActiveMenuSectionAction,
   ToggleMenuAction,
 } from './menu.actions';
-import { hasNoValue, hasValue, hasValueOperator, isNotEmpty } from '../empty.util';
+import { hasNoValue, hasValue, hasValueOperator, isNotEmpty, isEmpty } from '../empty.util';
 import { MenuState } from './menu-state.model';
 import { MenuSections } from './menu-sections.model';
 import { MenuSection } from './menu-section.model';
@@ -409,20 +409,14 @@ export class MenuService {
   }
 
   protected resolveSubstitutions(object, params) {
-
     let resolved;
-    if (typeof object === 'string') {
+    if (isEmpty(params)) {
       resolved = object;
-      let match: RegExpMatchArray;
-      do {
-        match = resolved.match(/:(\w+)/);
-        if (match) {
-          const substitute = params[match[1]];
-          if (hasValue(substitute)) {
-            resolved = resolved.replace(match[0], `${substitute}`);
-          }
-        }
-      } while (match);
+    } else if (typeof object === 'string') {
+      resolved = object;
+      Object.entries(params).forEach(([key, value]: [string, string]) =>
+        resolved = resolved.replaceAll(`:${key}`, value)
+      );
     } else if (Array.isArray(object)) {
       resolved = [];
       object.forEach((entry, index) => {


### PR DESCRIPTION
## References
* Replaces https://github.com/DSpace/dspace-angular/pull/2283

## Description
Some logic meant to copy route params to menu link params didn't work properly if the menu link contained a param, but the route didn't have a matching one

## Instructions for Reviewers
- Verify that the DSO routes containing a colon work properly now (they should redirect to the login page if you're logged out, or to 404 if you're logged in). e.g.
    - `/collections/sample:path`
    - `/communities/ab:cd`
- Verify what happens if you use the name of the route param in the route. e.g.
    - `/items/:id:foo`
- Verify that regular DSO routes still work
- Verify that context sensitive statistics links in the header menu still work (which is the reason the method causing the issue was written in the first place)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
