### PR TITLE
Delete EPerson from "Edit EPerson" form 

### DIFF
--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -287,14 +287,17 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
   /**
    * This method will set everything to stale, which will cause the lists on this page to update.
    */
-  reset() {
+  reset(): void {
     this.epersonService.getBrowseEndpoint().pipe(
-      take(1)
-    ).subscribe((href: string) => {
-      this.requestService.setStaleByHrefSubstring(href).pipe(take(1)).subscribe(() => {
-        this.epersonService.cancelEditEPerson();
-        this.isEPersonFormShown = false;
-      });
+      take(1),
+      switchMap((href: string) => {
+        return this.requestService.setStaleByHrefSubstring(href).pipe(
+          take(1),
+        );
+      })
+    ).subscribe(()=>{
+      this.epersonService.cancelEditEPerson();
+      this.isEPersonFormShown = false;
     });
   }
 }

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@ng-dynamic-forms/core';
 import { TranslateService } from '@ngx-translate/core';
 import { combineLatest as observableCombineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
-import { debounceTime, switchMap, take } from 'rxjs/operators';
+import { debounceTime, finalize, map, switchMap, take } from 'rxjs/operators';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
@@ -463,31 +463,43 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    * Deletes the EPerson from the Repository. The EPerson will be the only that this form is showing.
    * It'll either show a success or error message depending on whether the delete was successful or not.
    */
-  delete() {
-    this.epersonService.getActiveEPerson().pipe(take(1)).subscribe((eperson: EPerson) => {
-      const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = eperson;
-      modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-      modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-      modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-      modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-      modalRef.componentInstance.brandColor = 'danger';
-      modalRef.componentInstance.confirmIcon = 'fas fa-trash';
-      modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
-        if (confirm) {
-          if (hasValue(eperson.id)) {
-            this.epersonService.deleteEPerson(eperson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
-              if (restResponse.hasSucceeded) {
-                this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
-                this.submitForm.emit();
-              } else {
-                this.notificationsService.error('Error occured when trying to delete EPerson with id: ' + eperson.id + ' with code: ' + restResponse.statusCode + ' and message: ' + restResponse.errorMessage);
-              }
-              this.cancelForm.emit();
-            });
-          }
-        }
-      });
+  delete(): void {
+    this.epersonService.getActiveEPerson().pipe(
+      take(1),
+      switchMap((eperson: EPerson) => {
+        const modalRef = this.modalService.open(ConfirmationModalComponent);
+        modalRef.componentInstance.dso = eperson;
+        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+        modalRef.componentInstance.brandColor = 'danger';
+        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+
+        return modalRef.componentInstance.response.pipe(
+          take(1),
+          switchMap((confirm: boolean) => {
+            if (confirm && hasValue(eperson.id)) {
+              this.canDelete$ = observableOf(false);
+              return this.epersonService.deleteEPerson(eperson).pipe(
+                getFirstCompletedRemoteData(),
+                map((restResponse: RemoteData<NoContent>) => ({ restResponse, eperson }))
+              );
+            } else {
+              return observableOf(null);
+            }
+          }),
+          finalize(() => this.canDelete$ = observableOf(true))
+        );
+      })
+    ).subscribe(({ restResponse, eperson }: { restResponse: RemoteData<NoContent> | null, eperson: EPerson }) => {
+      if (restResponse?.hasSucceeded) {
+        this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
+        this.submitForm.emit();
+      } else {
+        this.notificationsService.error(`Error occurred when trying to delete EPerson with id: ${eperson?.id} with code: ${restResponse?.statusCode} and message: ${restResponse?.errorMessage}`);
+      }
+      this.cancelForm.emit();
     });
   }
 
@@ -523,7 +535,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    * Cancel the current edit when component is destroyed & unsub all subscriptions
    */
   ngOnDestroy(): void {
-    this.onCancel();
     this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
     this.paginationService.clearPagination(this.config.id);
     if (hasValue(this.emailValueChangeSubscribe)) {

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -495,7 +495,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     ).subscribe(({ restResponse, eperson }: { restResponse: RemoteData<NoContent> | null, eperson: EPerson }) => {
       if (restResponse?.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
-        this.submitForm.emit();
       } else {
         this.notificationsService.error(`Error occurred when trying to delete EPerson with id: ${eperson?.id} with code: ${restResponse?.statusCode} and message: ${restResponse?.errorMessage}`);
       }

--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -627,8 +627,11 @@ describe('RequestService', () => {
 
     it('should return an Observable that emits true as soon as the request is stale', fakeAsync(() => {
       dispatchSpy.and.callFake(() => { /* empty */ });   // don't actually set as stale
-      getByUUIDSpy.and.returnValue(cold('-----(a|)', {  // but fake the state in the cache
-        a: { state: RequestEntryState.SuccessStale },
+      getByUUIDSpy.and.returnValue(cold('a-b--c--d-', {  // but fake the state in the cache
+        a: { state: RequestEntryState.ResponsePending },
+        b: { state: RequestEntryState.Success },
+        c: { state: RequestEntryState.SuccessStale },
+        d: { state: RequestEntryState.Error },
       }));
 
       const done$ = service.setStaleByUUID('something');

--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -627,11 +627,8 @@ describe('RequestService', () => {
 
     it('should return an Observable that emits true as soon as the request is stale', fakeAsync(() => {
       dispatchSpy.and.callFake(() => { /* empty */ });   // don't actually set as stale
-      getByUUIDSpy.and.returnValue(cold('a-b--c--d-', {  // but fake the state in the cache
-        a: { state: RequestEntryState.ResponsePending },
-        b: { state: RequestEntryState.Success },
-        c: { state: RequestEntryState.SuccessStale },
-        d: { state: RequestEntryState.Error },
+      getByUUIDSpy.and.returnValue(cold('-----(a|)', {  // but fake the state in the cache
+        a: { state: RequestEntryState.SuccessStale },
       }));
 
       const done$ = service.setStaleByUUID('something');

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -328,10 +328,10 @@ export class RequestService {
     this.store.dispatch(new RequestStaleAction(uuid));
 
     return this.getByUUID(uuid).pipe(
+      take(1),
       map((request: RequestEntry) => isStale(request.state)),
       filter((stale: boolean) => stale),
-      take(1),
-    );
+      );
   }
 
   /**

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -328,9 +328,9 @@ export class RequestService {
     this.store.dispatch(new RequestStaleAction(uuid));
 
     return this.getByUUID(uuid).pipe(
-      take(1),
       map((request: RequestEntry) => isStale(request.state)),
       filter((stale: boolean) => stale),
+      take(1),
       );
   }
 


### PR DESCRIPTION
## References
* Fixes [#2291](https://github.com/DSpace/dspace-angular/issues/2291)

## Description
There has been a refactor of the methods participating in EPerson delete action, including avoiding nested subscriptions and removing unnecessary events.

## Instructions for Reviewers
List of changes in this PR:
* First, refactor the `delete() `method of `EPersonFormComponent`, in order to avoid nested subscriptions and manage of disabling the delete button when the delete of the entity is confirmed (since the request takes a whole and the button can be clicked again). After the delete has finished successfully, we only need to notify the user for the status of the deletion, there is no need to trigger a submit of the form. So the `this.submitForm.emit()` is removed.
* Second, the` reset() `method of `EPeopleRegistryComponent` is refactored for the same reason, to avoid nested subscriptions.
* Another change would include removing the call of `onCancel()` method on destroy of `EPersonFormComponent`. This method is called also when going back from the "edit" form to the list and the logic this method contains is also used when needed in other methods, so there is no need for an extra execution of the logic inside `onCancel()` method.

**Include guidance for how to test or review your PR.** 
Steps to reproduce the bug are the same as the ones mentioned in [#2291](https://github.com/DSpace/dspace-angular/issues/2291) .

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
