### PR TITLE
[CST-5729] fix issue with signposting endpoint url replace

### DIFF
--- a/src/app/core/data/signposting-data.service.ts
+++ b/src/app/core/data/signposting-data.service.ts
@@ -25,7 +25,8 @@ export class SignpostingDataService {
    * @param uuid
    */
   getLinks(uuid: string): Observable<SignpostingLink[]> {
-    const baseUrl = this.halService.getRootHref().replace('/api', '');
+    const regex = /\/api$/gm;
+    const baseUrl = this.halService.getRootHref().replace(regex, '');
 
     return this.restService.get(`${baseUrl}/signposting/links/${uuid}`).pipe(
       catchError((err) => {

--- a/src/app/core/data/signposting-data.service.ts
+++ b/src/app/core/data/signposting-data.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 
 import { catchError, map } from 'rxjs/operators';
 import { Observable, of as observableOf } from 'rxjs';
 
 import { DspaceRestService } from '../dspace-rest/dspace-rest.service';
-import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
 import { SignpostingLink } from './signposting-links.model';
+import { APP_CONFIG, AppConfig } from '../../../config/app-config.interface';
 
 /**
  * Service responsible for handling requests related to the Signposting endpoint
@@ -16,7 +16,7 @@ import { SignpostingLink } from './signposting-links.model';
 })
 export class SignpostingDataService {
 
-  constructor(private restService: DspaceRestService, protected halService: HALEndpointService) {
+  constructor(@Inject(APP_CONFIG) protected appConfig: AppConfig, private restService: DspaceRestService) {
   }
 
   /**
@@ -25,8 +25,7 @@ export class SignpostingDataService {
    * @param uuid
    */
   getLinks(uuid: string): Observable<SignpostingLink[]> {
-    const regex = /\/api$/gm;
-    const baseUrl = this.halService.getRootHref().replace(regex, '');
+    const baseUrl = `${this.appConfig.rest.baseUrl}`;
 
     return this.restService.get(`${baseUrl}/signposting/links/${uuid}`).pipe(
       catchError((err) => {


### PR DESCRIPTION
## References
* Relates to https://github.com/DSpace/dspace-angular/pull/2248

## Description
Fix a bug with a wrong string replace within the signposting data service.
Because the demo rest server url is `https://api7.dspace.org/server/api` the [replace done to remove `/api`](https://github.com/DSpace/dspace-angular/blob/main/src/app/core/data/signposting-data.service.ts#L28) just removed the first occurrence of it and this led to make a request with a wrong url. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
