### PR TITLE
src/app: adjust item count style

### DIFF
--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -33,12 +33,15 @@
         <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}"
               aria-hidden="true"></span>
       </button>
-      <h5 class="align-middle pt-2">
-        <a [routerLink]="node.route" class="lead">
-          {{ dsoNameService.getName(node.payload) }}
-        </a>
-        <span *ngIf="node.payload.archivedItemsCount >= 0" class="archived-items-lead">[{{node.payload.archivedItemsCount}}]</span>
-      </h5>
+      <div class="d-flex flex-row">
+        <h5 class="align-middle pt-2">
+          <a [routerLink]="node.route" class="lead">
+            {{ dsoNameService.getName(node.payload) }}
+          </a>
+          <span class="pr-2">&nbsp;</span>
+          <span *ngIf="node.payload.archivedItemsCount >= 0" class="badge badge-pill badge-secondary align-top archived-items-lead">{{node.payload.archivedItemsCount}}</span>
+        </h5>
+      </div>
     </div>
     <ds-truncatable [id]="node.id">
       <div class="text-muted" cdkTreeNodePadding>

--- a/src/app/shared/object-list/collection-list-element/collection-list-element.component.html
+++ b/src/app/shared/object-list/collection-list-element/collection-list-element.component.html
@@ -1,10 +1,13 @@
-<a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null" [routerLink]="['/collections/' + object.id]" class="lead">
-  {{ dsoNameService.getName(object) }}
-</a>
-<span *ngIf="linkType == linkTypes.None" class="lead">
-  {{ dsoNameService.getName(object) }}
-</span>
-<span *ngIf="object.archivedItemsCount >= 0" class="lead archived-items-lead">[{{object.archivedItemsCount}}]</span>
+<div class="d-flex flex-row">
+  <a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null" [routerLink]="['/collections/' + object.id]" class="lead">
+    {{ dsoNameService.getName(object) }}
+  </a>
+  <span *ngIf="linkType == linkTypes.None" class="lead">
+    {{ dsoNameService.getName(object) }}
+  </span>
+  <span class="pr-2">&nbsp;</span>
+  <span *ngIf="object.archivedItemsCount >= 0" class="badge badge-pill badge-secondary align-self-center archived-items-lead">{{object.archivedItemsCount}}</span>
+</div>
 <div *ngIf="object.shortDescription" class="text-muted abstract-text">
     {{object.shortDescription}}
 </div>

--- a/src/app/shared/object-list/community-list-element/community-list-element.component.html
+++ b/src/app/shared/object-list/community-list-element/community-list-element.component.html
@@ -1,10 +1,13 @@
-<a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null" [routerLink]="['/communities/' + object.id]" class="lead">
-  {{ dsoNameService.getName(object) }}
-</a>
-<span *ngIf="linkType == linkTypes.None" class="lead">
-  {{ dsoNameService.getName(object) }}
-</span>
-<span *ngIf="object.archivedItemsCount >= 0" class="lead archived-items-lead">[{{object.archivedItemsCount}}]</span>
+<div class="d-flex flex-row">
+  <a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null" [routerLink]="['/communities/' + object.id]" class="lead">
+    {{ dsoNameService.getName(object) }}
+  </a>
+  <span *ngIf="linkType == linkTypes.None" class="lead">
+    {{ dsoNameService.getName(object) }}
+  </span>
+  <span class="pr-2">&nbsp;</span>
+  <span *ngIf="object.archivedItemsCount >= 0" class="badge badge-pill badge-secondary align-self-center archived-items-lead">{{object.archivedItemsCount}}</span>
+</div>
 <div *ngIf="object.shortDescription" class="text-muted abstract-text">
     {{object.shortDescription}}
 </div>


### PR DESCRIPTION
## References
* Related to #2250

## Description
Minor adjustment to community and collection item counts. Instead of using the Bootstrap `lead` class, which reduces weight but increases size, we should use the `font-weight-light` class. This reduces the weight alone.

See: https://getbootstrap.com/docs/4.6/utilities/text/#font-weight-and-italics

Before (in my custom theme, but the effect is the same in the default theme):

<p align="center">
  <img src="https://github.com/DSpace/DSpace/assets/191754/063bc17f-3fa0-4ad0-895f-6a3e7e4f4286" width="600">
</p>

After:

<p align="center">
  <img src="https://github.com/DSpace/DSpace/assets/191754/1f205a60-4d19-4f05-b5ed-a0e9c7dc7ec9" width="600">
</p>

## Instructions for Reviewers

List of changes in this PR:
* Change the CSS class used in the community and collection counts

Reviewers should build the frontend and make sure the style of the item counts looks OK.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).