### PR TITLE
resolve German translation inconsistency in scopenote

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -262,7 +262,7 @@
   "admin.registries.schema.fields.table.id": "ID",
 
   // "admin.registries.schema.fields.table.scopenote": "Scope Note",
-  "admin.registries.schema.fields.table.scopenote": "Gültigkeitsbereich",
+  "admin.registries.schema.fields.table.scopenote": "Geltungs- bzw. Gültigkeitsbereich",
 
   // "admin.registries.schema.form.create": "Create metadata field",
   "admin.registries.schema.form.create": "Metadatenfeld anlegen",
@@ -277,7 +277,7 @@
   "admin.registries.schema.form.qualifier": "Qualifizierer",
 
   // "admin.registries.schema.form.scopenote": "Scope Note",
-  "admin.registries.schema.form.scopenote": "Geltungsbereich",
+  "admin.registries.schema.form.scopenote": "Geltungs- bzw. Gültigkeitsbereich",
 
   // "admin.registries.schema.head": "Metadata Schema",
   "admin.registries.schema.head": "Metadatenschema",


### PR DESCRIPTION
## Description

This PR resolves a minor bug in `de.json5` in which two different translations of `scopenote` can be found. As it is not clear which translation is preferable I suggest a combined translation including both terms.
