### PR TITLE
DS-8651-8879: "Browse by" incorrect usage of `_links` sent from server

### DIFF
--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -60,6 +60,10 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
       observableCombineLatest([this.route.params, this.route.queryParams, this.route.data,
         this.currentPagination$, this.currentSort$]).pipe(
         map(([routeParams, queryParams, data, currentPage, currentSort]) => {
+          // get direction from definition
+          if (data.browseDefinition && data.browseDefinition.defaultSortOrder) {
+            currentSort.direction = data.browseDefinition.defaultSortOrder;
+          }
           return [Object.assign({}, routeParams, queryParams, data), currentPage, currentSort];
         })
       ).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {

--- a/src/app/core/browse/browse.service.ts
+++ b/src/app/core/browse/browse.service.ts
@@ -78,7 +78,7 @@ export class BrowseService {
       getBrowseDefinitionLinks(options.metadataDefinition),
       hasValueOperator(),
       map((_links: any) => {
-        const entriesLink = _links.entries.href || _links.entries;
+        const entriesLink = _links.entries ? _links.entries.href : _links.entries;
         return entriesLink;
       }),
       hasValueOperator(),
@@ -121,7 +121,12 @@ export class BrowseService {
       getBrowseDefinitionLinks(options.metadataDefinition),
       hasValueOperator(),
       map((_links: any) => {
-        const itemsLink = _links.items.href || _links.items;
+        const itemsLink = _links.items ? _links.items.href : _links.items;
+
+        //Ensure "valueList" browses do not call "items" links without a valid "fieldValue"
+        if (_links.items && _links.items_fieldValueOnly === true && !filterValue){
+          return undefined;
+        }
         return itemsLink;
       }),
       hasValueOperator(),
@@ -170,6 +175,10 @@ export class BrowseService {
       hasValueOperator(),
       map((_links: any) => {
         const itemsLink = _links.items.href || _links.items;
+        //Ensure "valueList" browses do not call "items" links
+        if (_links.items && _links.items_fieldValueOnly === true){
+          return undefined;
+        }
         return itemsLink;
       }),
       hasValueOperator(),

--- a/src/app/core/data/browse-response-parsing.service.spec.ts
+++ b/src/app/core/data/browse-response-parsing.service.spec.ts
@@ -34,6 +34,7 @@ describe('BrowseResponseParsingService', () => {
     const mockValueList = {
         id: 'author',
         browseType: 'valueList',
+        _links: {},
         type: 'browse',
       };
 

--- a/src/app/core/data/browse-response-parsing.service.ts
+++ b/src/app/core/data/browse-response-parsing.service.ts
@@ -40,7 +40,12 @@ export class BrowseResponseParsingService extends DspaceRestResponseParsingServi
       } else {
         throw new Error('An error occurred while retrieving the browse definitions.');
       }
-      return serializer.deserialize(obj);
+      //DS-8879: set extra attribute as a condition for "items" link when browseType == "valueList":
+      const des_obj = serializer.deserialize(obj);
+      if (des_obj instanceof ValueListBrowseDefinition) {
+        des_obj._links.items_fieldValueOnly = true;
+      }
+      return des_obj;
     } else {
       throw new Error('An error occurred while retrieving the browse definitions.');
     }

--- a/src/app/core/shared/value-list-browse-definition.model.ts
+++ b/src/app/core/shared/value-list-browse-definition.model.ts
@@ -28,6 +28,7 @@ export class ValueListBrowseDefinition extends NonHierarchicalBrowseDefinition {
   _links: {
     self: HALLink;
     entries: HALLink;
+    items_fieldValueOnly: boolean;
   };
 
   getRenderType(): string {


### PR DESCRIPTION
## References

* Requires DSpace/DSpace#8871 (if a REST API PR is required to test this)

## Description
Accompanied with with DSpace/DSpace#8871, this PR fix DSpace/DSpace#8651 and DSpace/DSpace#8879

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
