### PR TITLE
[DURACOM-160] Hide "Send feedback" link when CanSendFeedback is false

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -75,7 +75,7 @@
           <a class="text-white"
              routerLink="info/end-user-agreement">{{ 'footer.link.end-user-agreement' | translate}}</a>
         </li>
-        <li>
+        <li *ngIf="showSendFeedback$ | async">
           <a class="text-white"
              routerLink="info/feedback">{{ 'footer.link.feedback' | translate}}</a>
         </li>

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -15,6 +15,8 @@ import { FooterComponent } from './footer.component';
 
 import { TranslateLoaderMock } from '../shared/mocks/translate-loader.mock';
 import { storeModuleConfig } from '../app.reducer';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { AuthorizationDataServiceStub } from '../shared/testing/authorization-service.stub';
 
 let comp: FooterComponent;
 let fixture: ComponentFixture<FooterComponent>;
@@ -34,7 +36,8 @@ describe('Footer component', () => {
       })],
       declarations: [FooterComponent], // declare the test component
       providers: [
-        FooterComponent
+        FooterComponent,
+        { provide: AuthorizationDataService, useClass: AuthorizationDataServiceStub },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -2,6 +2,9 @@ import { Component, Optional } from '@angular/core';
 import { hasValue } from '../shared/empty.util';
 import { KlaroService } from '../shared/cookies/klaro.service';
 import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../core/data/feature-authorization/feature-id';
 
 @Component({
   selector: 'ds-footer',
@@ -17,8 +20,13 @@ export class FooterComponent {
   showTopFooter = false;
   showPrivacyPolicy = environment.info.enablePrivacyStatement;
   showEndUserAgreement = environment.info.enableEndUserAgreement;
+  showSendFeedback$: Observable<boolean>;
 
-  constructor(@Optional() private cookies: KlaroService) {
+  constructor(
+    @Optional() private cookies: KlaroService,
+    private authorizationService: AuthorizationDataService,
+  ) {
+    this.showSendFeedback$ = this.authorizationService.isAuthorized(FeatureID.CanSendFeedback);
   }
 
   showCookieSettings() {


### PR DESCRIPTION
## References
* Fixes #2323 

## Description
This fix hides "Send feedback" link when feedback feature is disabled (CanSendFeedback feature ID)

## Instructions for Reviewers
Set `feedback.recipient=` in `local.cfg` to disable feedback feature

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
