### PR TITLE
Fix "Edit -> Collection" by restoring ngOnInit() method which was accidentally removed

### DIFF
--- a/src/app/collection-page/collection-form/collection-form.component.ts
+++ b/src/app/collection-page/collection-form/collection-form.component.ts
@@ -67,6 +67,14 @@ export class CollectionFormComponent extends ComColFormComponent<Collection> imp
   }
 
   /**
+   * Initialize form for "New -> Collection"
+   */
+  ngOnInit() {
+    this.initializeForm();
+  }
+
+  /**
+   * Initialize form for "Edit -> Collection"
    * Detect changes to the dso and initialize the form,
    * if the dso changes, exists and it is not the first change
    */


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8911

## Description
Restores the `ngOnInit()` method to `collection-form.component.ts` which was accidentally removed in #2308 

## Instructions for Reviewers
* Verify https://github.com/DSpace/DSpace/issues/8911 no longer reproducible
    * Login as an Admin
    * Go to "New -> Collection".  Select a Community to add the Collection in
    * Verify the Collection form loads now, and verify that it allows you to create a Collection.