### PR TITLE
Add the ability to expand / collapse via keyboard

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -23,7 +23,7 @@
            (blur)="onBlur($event)"
            (click)="$event.stopPropagation(); openDropdown(sdRef);"
            (focus)="onFocus($event)"
-           (keypress)="$event.preventDefault()">
+           (keydown)="selectOnKeyDown($event, sdRef)">
   </div>
 
   <div ngbDropdownMenu

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
@@ -99,6 +99,23 @@ export class DsDynamicScrollableDropdownComponent extends DsDynamicVocabularyCom
   }
 
   /**
+   * KeyDown handler to allow toggling the dropdown via keyboard
+   * @param event KeyboardEvent
+   * @param sdRef The reference of the NgbDropdown.
+   */
+  selectOnKeyDown(event: KeyboardEvent, sdRef: NgbDropdown) {
+    const keyName = event.key;
+
+    if (keyName === ' ' || keyName === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      sdRef.toggle();
+    } else if (keyName === 'ArrowDown' || keyName === 'ArrowUp') {
+      this.openDropdown(sdRef);
+    }
+  }
+
+  /**
    * Loads any new entries
    */
   onScroll() {


### PR DESCRIPTION
## Description

At the moment, the dynamic scrollable dropdown component is not usable by keyboard alone. There's no way to expand the dropdown without resorting to the mouse. This violates [success criterion 2.1.1](https://www.w3.org/TR/WCAG21/#keyboard) of the Web Content Accessibility Guidelines (WCAG) 2.1. 

This creates a barrier for any keyboard only users looking to complete any submission form that uses the dropdown component.

## Instructions for Reviewers

List of changes in this PR:
1. Add a keydown event to the template.
2. Add a corresponding keydown event handler to the component

With these changes, you can now interact with the component by: 

1. Tab to a dropdown in a submission form (e.g. dc.type)
2. With the dropdown focused, push space or enter to toggle the dropdown. Alternatively, you can use the up or down arrow keys to expand the dropdown. 

Ideally, this component should mimic the keyboard interactions of a native select element, whereby subsequent presses of the arrow keys should allow the user to select a value from the dropdown. I wasn't able to get this to work, however this at least enables basic keyboard interaction. 

In my opinion, the best solution in the long run would be to use a native select element for this component, rather than relying on the [ng-bootstrap](https://ng-bootstrap.github.io/#/home) library. Using a native element will provide support out of the box for keyboard interaction as well as for screen readers. 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
