### PR TITLE
Implement basic 301 Redirect for DSpace 6.x URLs when SSR is used.

### DIFF
--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -6,8 +6,7 @@
  * http://www.dspace.org/license/
  */
 /* eslint-disable max-classes-per-file */
-import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
-import { Router } from '@angular/router';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { hasValue } from '../../shared/empty.util';
@@ -21,8 +20,7 @@ import { getFirstCompletedRemoteData } from '../shared/operators';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { IdentifiableDataService } from './base/identifiable-data.service';
 import { getDSORoute } from '../../app-routing-paths';
-import { RESPONSE } from '@nguniversal/express-engine/tokens';
-import { isPlatformServer } from '@angular/common';
+import { HardRedirectService } from '../services/hard-redirect.service';
 
 const ID_ENDPOINT = 'pid';
 const UUID_ENDPOINT = 'dso';
@@ -76,9 +74,7 @@ export class DsoRedirectService {
     protected rdbService: RemoteDataBuildService,
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
-    private router: Router,
-    @Optional() @Inject(RESPONSE) private response: any,
-    @Inject(PLATFORM_ID) private platformId: any
+    private hardRedirectService: HardRedirectService
   ) {
     this.dataService = new DsoByIdOrUUIDDataService(requestService, rdbService, objectCache, halService);
   }
@@ -87,9 +83,6 @@ export class DsoRedirectService {
    * Redirect to a DSpaceObject's path using the given identifier type and ID.
    * This is used to redirect paths like "/handle/[prefix]/[suffix]" to the object's path (e.g. /items/[uuid]).
    * See LookupGuard for more examples.
-   *
-   * If this is called server side (via SSR), it performs a 301 Redirect.
-   * If this is called client side (via CSR), it simply uses the Angular router to do the redirect.
    *
    * @param id              the identifier of the object to retrieve
    * @param identifierType  the type of the given identifier (defaults to UUID)
@@ -104,12 +97,8 @@ export class DsoRedirectService {
           if (hasValue(dso.uuid)) {
             let newRoute = getDSORoute(dso);
             if (hasValue(newRoute)) {
-              // If running via SSR, perform a "301 Moved Permanently" redirect for SEO purposes.
-              if (isPlatformServer(this.platformId)) {
-                this.response.redirect(301, newRoute);
-              } else {
-                this.router.navigate([newRoute]);
-              }
+              // Use a "301 Moved Permanently" redirect for SEO purposes
+              this.hardRedirectService.redirect(newRoute, 301);
             }
           }
         }

--- a/src/app/core/services/hard-redirect.service.ts
+++ b/src/app/core/services/hard-redirect.service.ts
@@ -11,8 +11,10 @@ export abstract class HardRedirectService {
    *
    * @param url
    *    the page to redirect to
+   * @param statusCode
+   *    optional HTTP status code to use for redirect (default = 302, which is a temporary redirect)
    */
-  abstract redirect(url: string);
+  abstract redirect(url: string, statusCode?: number);
 
   /**
    * Get the current route, with query params included

--- a/src/app/core/services/server-hard-redirect.service.spec.ts
+++ b/src/app/core/services/server-hard-redirect.service.spec.ts
@@ -22,16 +22,29 @@ describe('ServerHardRedirectService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('when performing a redirect', () => {
-
+  describe('when performing a default redirect', () => {
     const redirect = 'test redirect';
 
     beforeEach(() => {
       service.redirect(redirect);
     });
 
-    it('should update the response object', () => {
+    it('should perform a 302 redirect', () => {
       expect(mockResponse.redirect).toHaveBeenCalledWith(302, redirect);
+      expect(mockResponse.end).toHaveBeenCalled();
+    });
+  });
+
+  describe('when performing a 301 redirect', () => {
+    const redirect = 'test 301 redirect';
+    const redirectStatusCode = 301;
+
+    beforeEach(() => {
+      service.redirect(redirect, redirectStatusCode);
+    });
+
+    it('should redirect with passed in status code', () => {
+      expect(mockResponse.redirect).toHaveBeenCalledWith(redirectStatusCode, redirect);
       expect(mockResponse.end).toHaveBeenCalled();
     });
   });

--- a/src/app/core/services/server-hard-redirect.service.ts
+++ b/src/app/core/services/server-hard-redirect.service.ts
@@ -17,10 +17,14 @@ export class ServerHardRedirectService extends HardRedirectService {
   }
 
   /**
-   * Perform a hard redirect to URL
+   * Perform a hard redirect to a given location.
+   *
    * @param url
+   *    the page to redirect to
+   * @param statusCode
+   *    optional HTTP status code to use for redirect (default = 302, which is a temporary redirect)
    */
-  redirect(url: string) {
+  redirect(url: string, statusCode?: number) {
 
     if (url === this.req.url) {
       return;
@@ -38,8 +42,8 @@ export class ServerHardRedirectService extends HardRedirectService {
         process.exit(1);
       }
     } else {
-      // attempt to use the already set status
-      let status = this.res.statusCode || 0;
+      // attempt to use passed in statusCode or the already set status (in request)
+      let status = statusCode || this.res.statusCode || 0;
       if (status < 300 || status >= 400) {
         // temporary redirect
         status = 302;


### PR DESCRIPTION
## References
* Fixes #2265 

## Description
Minor changes to the `dso-redirect.service.ts` to ensure it returns a `301 Moved Permanently` redirect when running during server side rendering (SSR).  This required changes to the existing HardRedirectService to support 301 redirects.

Added specs for all changes as well.

## Instructions for Reviewers
* Attempt to reproduce bug in #2265 using `/handle/[prefix]/[suffix]` paths to an existing Community, Collection or Item.
* Verify that a 301 redirect now occurs.
