### PR TITLE
fix for bitstreams are not visible to crawlers when caching is enabled

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -461,6 +461,8 @@ function saveToCache(req, page: any) {
     const key = getCacheKey(req);
     // Avoid caching "/reload/[random]" paths (these are hard refreshes after logout)
     if (key.startsWith('/reload')) { return; }
+    // Avoid caching not successful responses (status code different from 2XX status)
+    if (hasNotSucceeded(req.res.statusCode)) { return; }
 
     // Retrieve response headers to save, if any
     const headers = retrieveHeaders(req.res);
@@ -477,6 +479,15 @@ function saveToCache(req, page: any) {
       if (environment.cache.serverSide.debug) { console.log(`CACHE SAVE FOR ${key} in anonymous cache.`); }
     }
   }
+}
+
+/**
+ * Check if status code is different from 2XX
+ * @param statusCode
+ */
+function hasNotSucceeded(statusCode) {
+  const rgx = new RegExp(/20+/);
+  return !rgx.test(statusCode)
 }
 
 function retrieveHeaders(response) {

--- a/server.ts
+++ b/server.ts
@@ -486,7 +486,7 @@ function saveToCache(req, page: any) {
  * @param statusCode
  */
 function hasNotSucceeded(statusCode) {
-  const rgx = new RegExp(/20+/);
+  const rgx = new RegExp(/^20+/);
   return !rgx.test(statusCode)
 }
 


### PR DESCRIPTION
## References
* Fixes #2333

## Description
With this PR only successful page are saved into the SSR cache. In this way bitstream download page which return a 302 code is not saved 

## Instructions for Reviewers
check issue described into #2333 is fixed

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
