### PR TITLE
Fix background-color overwrite issue

### DIFF
--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -28,6 +28,8 @@ $yellow: #ec9433 !default;
 $red:    #CF4444 !default;
 $dark:   darken($blue, 17%) !default;
 
+
+
 $theme-colors: (
         primary: $blue,
         secondary: $gray-700,
@@ -49,3 +51,10 @@ $navbar-light-toggler-icon-bg: url("data:image/svg+xml;charset=utf8,<svg+viewBox
 $enable-shadows: true !default;
 
 $yiq-contrasted-threshold:  165 !default;
+
+$primary-bg: #{lighten(map-get($theme-colors, primary), 30%)} !default;
+$secondary-bg: #{lighten(map-get($theme-colors, secondary), 30%)} !default;
+$success-bg: #{lighten(map-get($theme-colors, success), 30%)} !default;
+$info-bg: #{lighten(map-get($theme-colors, info), 30%)} !default;
+$warning-bg: #{lighten(map-get($theme-colors, warning), 30%)} !default;
+$danger-bg: #{lighten(map-get($theme-colors, danger), 30%)} !default;

--- a/src/styles/_bootstrap_variables_mapping.scss
+++ b/src/styles/_bootstrap_variables_mapping.scss
@@ -29,17 +29,17 @@
   --bs-teal: #{$teal};
   --bs-cyan: #{$cyan};
   --bs-primary: #{$primary};
-  --bs-primary-bg: #{lighten($primary, 30%)};
+  --bs-primary-bg: #{$primary-bg};
   --bs-secondary: #{$secondary};
-  --bs-secondary-bg: #{lighten($secondary, 30%)};
+  --bs-secondary-bg: #{$secondary-bg};
   --bs-success: #{$success};
-  --bs-success-bg: #{lighten($success, 30%)};
+  --bs-success-bg: #{$success-bg};
   --bs-info: #{$info};
-  --bs-info-bg: #{lighten($info, 30%)};
+  --bs-info-bg: #{$info-bg};
   --bs-warning: #{$warning};
-  --bs-warning-bg: #{lighten($warning, 30%)};
+  --bs-warning-bg: #{$warning-bg};
   --bs-danger: #{$danger};
-  --bs-danger-bg: #{lighten($danger, 30%)};
+  --bs-danger-bg: #{$danger-bg};
   --bs-light: #{$light};
   --bs-dark: #{$dark};
 


### PR DESCRIPTION
## References
* Fixes #2335

## Description
This PR makes it possible to overwrite bootstrap-based background color variables with SASS variables. It removes new variable definitions from `_bootstrap_variables_mapping.scss`. 

## Instructions for Reviewers
Overwrite the `$[primary/secondary/success/info/warning/danger]-bg variables in a theme in the `/styles/_theme_sass_variable_overrides.scss` file. Make sure to enable this theme for testing.
Check if the overwritten values are used on the edit-metadata page. 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR passes all specs/tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
