### PR TITLE
Fix `setStaleByHrefSubstring` not emitting true when all requests are stale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "7.6.0-next",
+  "version": "7.6.0",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",


### PR DESCRIPTION
## References
- Maintenance PR  #2404

## Description
In https://github.com/DSpace/dspace-angular/pull/961 `removeByHrefSubstring()`  was renamed to`setStaleByHrefSubstring()`, but its [return statement](https://github.com/DSpace/dspace-angular/blob/884aa0743096b4bfe946679aa48ad3f5727575df/src/app/core/data/request.service.ts#L316-L319) was never updated. It will still only emit if the requests are removed from the store entirely, which will no longer happen now. This means it will never emit.

This PR updates it so it emits after all requests are set to stale instead.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).