### PR TITLE
src/app: fix path to deny-request-copy component

### DIFF
--- a/src/app/request-copy/deny-request-copy/themed-deny-request-copy.component.ts
+++ b/src/app/request-copy/deny-request-copy/themed-deny-request-copy.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ThemedComponent } from 'src/app/shared/theme-support/themed.component';
 
-import { DenyRequestCopyComponent } from 'src/themes/custom/app/request-copy/deny-request-copy/deny-request-copy.component';
+import { DenyRequestCopyComponent } from './deny-request-copy.component';
 
 /**
  * Themed wrapper for deny-request-copy.component


### PR DESCRIPTION
## References
* Fixes #https://github.com/DSpace/dspace-angular/issues/2351

## Description
The themed-deny-request-copy.component erroneously includes the custom theme's deny-request-copy component instead of its own.

This is the `main` port of DSpace `dspace-7_x` pull request. See: #2354 