### PR TITLE
Utility gap-* classes for flexbox

### DIFF
--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -268,6 +268,30 @@ ul.dso-edit-menu-dropdown > li .nav-item.nav-link {
   vertical-align: middle;
 }
 
+/* Flexbox gap */
+
+.gap-0 { gap: 0; }
+.gap-1 { gap: calc(#{$spacer} * .25); }
+.gap-2 { gap: calc(#{$spacer} * .5); }
+.gap-3 { gap: #{$spacer}; }
+.gap-4 { gap: calc(#{$spacer} * 1.5); }
+.gap-5 { gap: calc(#{$spacer} * 3); }
+
+.gapx-0 { column-gap: 0; }
+.gapx-1 { column-gap: calc(#{$spacer} * .25); }
+.gapx-2 { column-gap: calc(#{$spacer} * .5); }
+.gapx-3 { column-gap: #{$spacer}; }
+.gapx-4 { column-gap: calc(#{$spacer} * 1.5); }
+.gapx-5 { column-gap: calc(#{$spacer} * 3); }
+
+.gapy-0 { row-gap: 0; }
+.gapy-1 { row-gap: calc(#{$spacer} * .25); }
+.gapy-2 { row-gap: calc(#{$spacer} * .5); }
+.gapy-3 { row-gap: #{$spacer}; }
+.gapy-4 { row-gap: calc(#{$spacer} * 1.5); }
+.gapy-5 { row-gap: calc(#{$spacer} * 3); }
+
+
 .pt-0\.5 {
   padding-top: 0.125rem !important;
 }

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -5,7 +5,7 @@
         <img src="assets/images/dspace-logo.svg" [attr.alt]="'menu.header.image.logo' | translate"/>
       </a>
     </div>
-    <div class="navbar-buttons d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
+    <div class="navbar-buttons d-flex flex-grow-1 ml-auto justify-content-end align-items-center gapx-1">
       <ds-themed-search-navbar></ds-themed-search-navbar>
       <ds-themed-lang-switch></ds-themed-lang-switch>
       <ds-context-help-toggle></ds-context-help-toggle>

--- a/src/themes/dspace/app/header/header.component.scss
+++ b/src/themes/dspace/app/header/header.component.scss
@@ -24,9 +24,3 @@
     color: var(--ds-header-icon-color-hover);
   }
 }
-
-.navbar-buttons {
-  display: flex;
-  gap: calc(var(--bs-spacer) / 3);
-  align-items: center;
-}

--- a/src/themes/dspace/app/navbar/navbar.component.html
+++ b/src/themes/dspace/app/navbar/navbar.component.html
@@ -15,7 +15,7 @@
         </li>
       </ul>
     </div>
-    <div class="navbar-buttons">
+    <div class="navbar-buttons d-flex align-items-center gapx-1">
       <ds-themed-search-navbar class="navbar-collapsed"></ds-themed-search-navbar>
       <ds-themed-lang-switch class="navbar-collapsed"></ds-themed-lang-switch>
       <ds-context-help-toggle class="navbar-collapsed"></ds-context-help-toggle>

--- a/src/themes/dspace/app/navbar/navbar.component.scss
+++ b/src/themes/dspace/app/navbar/navbar.component.scss
@@ -59,9 +59,3 @@ a.navbar-brand img {
     }
   }
 }
-
-.navbar-buttons {
-  display: flex;
-  gap: calc(var(--bs-spacer) / 3);
-  align-items: center;
-}


### PR DESCRIPTION
## Description
This PR adds some Bootstrap-style utility classes to handle horizontal and vertical gaps between flexbox elements.

A `gap-*` class adds a space between elements of the same size of `m-*` and `p-*` Bootstrap classes, while `gapx-*` and `gapy-*` classes allow to set horizontal and vertical gaps.

These classes will allow to handle spacing between many elents of the DSpace UI in a simpler way (currently the spacing is managed by manually adding margins to each element).

For example, in `dso-edit-menu.component.html`:

```html
<div class="dso-edit-menu d-flex"> <!-- add class "gap-1" -->
    <div *ngFor="let section of (sections | async)" class="ml-1"> <!-- remove class "ml-1" -->
        <ng-container
                *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;"></ng-container>
    </div>
</div>

```

## Instructions for Reviewers
Create a flex container and add gap-* classes to test them, e.g.

```html
<div class="d-flex gap-3">
  <div class="p-2 border border-primary">Flex item 1</div>
  <div class="p-2 border border-primary">Flex item 2</div>
  <div class="p-2 border border-primary">Flex item 3</div>
</div>
```


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
