### PR TITLE
Show error message from the password validation response

### DIFF
--- a/src/app/profile-page/profile-page.component.ts
+++ b/src/app/profile-page/profile-page.component.ts
@@ -161,7 +161,7 @@ export class ProfilePageComponent implements OnInit {
         } else {
           this.notificationsService.error(
             this.translate.instant(this.PASSWORD_NOTIFICATIONS_PREFIX + 'error.title'),
-            this.translate.instant(this.PASSWORD_NOTIFICATIONS_PREFIX + 'error.change-failed')
+            this.getPasswordErrorMessage(response)
           );
         }
       });
@@ -197,6 +197,20 @@ export class ProfilePageComponent implements OnInit {
    */
   isResearcherProfileEnabled(): Observable<boolean> {
     return this.isResearcherProfileEnabled$.asObservable();
+  }
+
+  /**
+   * Returns an error message from a password validation request with a specific reason or
+   * a default message without specific reason.
+   * @param response from the validation password patch request.
+   */
+  getPasswordErrorMessage(response) {
+    if (response.hasFailed && isNotEmpty(response.errorMessage)) {
+      // Response has a specific error message. Show this message in the error notification.
+      return this.translate.instant(response.errorMessage);
+    }
+    // Show default error message notification.
+    return this.translate.instant(this.PASSWORD_NOTIFICATIONS_PREFIX + 'error.change-failed');
   }
 
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/dspace-angular/issues/2379

## Description
When the user is changing the password the more specific validation error message is popped up instead of unclear, the default message. The error message is loaded from the response error message.

## Instructions for Reviewers
Updated `profile-page.component.ts`: The validation patch response is processed in the way that the error message from the response is added into notification message.


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

Try to change the password for some user.
1. Fill in a correct password.
2. Fill in a new password into password input fields which is less than 8 characters. Click to Save and the more specific error message will be popped up.
3. Fill in a new password into password input fields which is more than 8 characters and provide a wrong original password. Click to Save and the more specific error message will be popped up.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
