### PR TITLE
[Port dspace-7_x] Fixed MathJax code being displayed twice by `dsMarkdown` pipe

### DIFF
--- a/src/app/shared/utils/markdown.pipe.ts
+++ b/src/app/shared/utils/markdown.pipe.ts
@@ -67,7 +67,9 @@ export class MarkdownPipe implements PipeTransform {
         // sanitize-html doesn't let through SVG by default, so we extend its allowlists to cover MathJax SVG
         allowedTags: [
           ...sanitizeHtml.defaults.allowedTags,
-          'mjx-container', 'svg', 'g', 'path', 'rect', 'text'
+          'mjx-container', 'svg', 'g', 'path', 'rect', 'text',
+          // Also let the mjx-assistive-mml tag (and it's children) through (for screen readers)
+          'mjx-assistive-mml', 'math', 'mrow', 'mi',
         ],
         allowedAttributes: {
           ...sanitizeHtml.defaults.allowedAttributes,
@@ -88,7 +90,16 @@ export class MarkdownPipe implements PipeTransform {
           ],
           text: [
             'transform', 'font-size'
-          ]
+          ],
+          'mjx-assistive-mml': [
+            'unselectable', 'display', 'style',
+          ],
+          math: [
+            'xmlns',
+          ],
+          mrow: [
+            'data-mjx-texclass',
+          ],
         },
         parser: {
           lowerCaseAttributeNames: false,


### PR DESCRIPTION
- Port of #2397 to `dspace-7_x`.