### PR TITLE
Replace all old docker "dspace-7_x" tags with "latest" on main

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -2,7 +2,7 @@
 # See https://github.com/DSpace/dspace-angular/tree/main/docker for usage details
 
 # Test build:
-# docker build -f Dockerfile.dist -t dspace/dspace-angular:dspace-7_x-dist .
+# docker build -f Dockerfile.dist -t dspace/dspace-angular:latest-dist .
 
 FROM node:18-alpine as build
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,14 +23,14 @@ the Docker compose scripts in this 'docker' folder.
 This Dockerfile is used to build a *development* DSpace 7 Angular UI image, published as 'dspace/dspace-angular'
 
 ```
-docker build -t dspace/dspace-angular:dspace-7_x .
+docker build -t dspace/dspace-angular:latest .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace-angular:dspace-7_x
+docker push dspace/dspace-angular:latest
 ```
 
 ### Dockerfile.dist
@@ -39,7 +39,7 @@ The `Dockerfile.dist` is used to generate a *production* build and runtime envir
 
 ```bash
 # build the latest image
-docker build -f Dockerfile.dist -t dspace/dspace-angular:dspace-7_x-dist .
+docker build -f Dockerfile.dist -t dspace/dspace-angular:latest-dist .
 ```
 
 A default/demo version of this image is built *automatically*.

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -16,7 +16,7 @@ version: "3.7"
 
 services:
   dspace-cli:
-    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-latest}"
     container_name: dspace-cli
     environment:
       # Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -35,7 +35,7 @@ services:
       solr__D__statistics__P__autoCommit: 'false'
     depends_on:
     - dspacedb
-    image: dspace/dspace:dspace-7_x-test
+    image: dspace/dspace:latest-test
     networks:
       dspacenet:
     ports:

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -27,7 +27,7 @@ services:
       DSPACE_REST_HOST: api7.dspace.org
       DSPACE_REST_PORT: 443
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:dspace-7_x-dist
+    image: dspace/dspace-angular:${DSPACE_VER:-latest}-dist
     build:
       context: ..
       dockerfile: Dockerfile.dist

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -39,7 +39,7 @@ services:
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests 
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: '172.23.0'
-    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-7_x-test}"
+    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     depends_on:
     - dspacedb
     networks:
@@ -82,7 +82,7 @@ services:
   # DSpace Solr container  
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
     - dspace

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:dspace-7_x
+    image: dspace/dspace-angular:${DSPACE_VER:-latest}
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## References
* Follow-up to #2359

## Description
Currently, our Docker scripts on `main` are still referencing the `dspace-7_x` tagged Docker images.  However in #8942, we updated `main` branch to generate Docker images with the `latest` tag.  (The `dspace-7_x` tag in DockerHub is to be used for the `dspace-7_x` branch in GitHub.)

In other words:
* `main` branch in GitHub should always use `latest` tag in DockerHub
* `dspace-7_x` branch in GitHub should always use `dspace-7_x` tag in DockerHub

This PR ensures that our Docker scripts on `main` are always referencing the tag `latest` from DockerHub.  (This ensures that `main` isn't accidentally using Docker images from our `dspace-7_x` brach)

(Corresponding PR was submitted to backend as well: https://github.com/DSpace/DSpace/pull/8974)

## Instructions for Reviewers
* Assuming Docker images build properly, then this is ready to merge.  I've tested it locally to ensure local builds from `main` now use `latest` images from DockerHub.