### PR TITLE
Fixed MathJax code being displayed twice by `dsMarkdown` pipe

### DIFF
--- a/src/app/shared/utils/markdown.pipe.ts
+++ b/src/app/shared/utils/markdown.pipe.ts
@@ -67,7 +67,9 @@ export class MarkdownPipe implements PipeTransform {
         // sanitize-html doesn't let through SVG by default, so we extend its allowlists to cover MathJax SVG
         allowedTags: [
           ...sanitizeHtml.defaults.allowedTags,
-          'mjx-container', 'svg', 'g', 'path', 'rect', 'text'
+          'mjx-container', 'svg', 'g', 'path', 'rect', 'text',
+          // Also let the mjx-assistive-mml tag (and it's children) through (for screen readers)
+          'mjx-assistive-mml', 'math', 'mrow', 'mi',
         ],
         allowedAttributes: {
           ...sanitizeHtml.defaults.allowedAttributes,
@@ -88,7 +90,16 @@ export class MarkdownPipe implements PipeTransform {
           ],
           text: [
             'transform', 'font-size'
-          ]
+          ],
+          'mjx-assistive-mml': [
+            'unselectable', 'display', 'style',
+          ],
+          math: [
+            'xmlns',
+          ],
+          mrow: [
+            'data-mjx-texclass',
+          ],
         },
         parser: {
           lowerCaseAttributeNames: false,


### PR DESCRIPTION
## References
- Fixes #2170
- Maintenance PR  #2392

## Description
Fixed MathJax code being displayed twice, this is because a HTML tag `mjx-assistive-mml` is created for screen readers to be able to read the MathJax code. Because the `dsMarkdown` pipe sanitises the HTML it transformed this hidden HTML tag to text instead leading to the MathJax code being displayed twice.

## Instructions for Reviewers
List of changes in this PR:
* Added the `mjx-assistive-mml` HTML tag (and it's child HTML tags) to the `sanitizeHtml`'s `allowedTags` to ensure it won't be turned into text

**Guidance for how to test/review this PR:**
* Create a new item with the following content in `dc.description.abstract`:
   ```
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam rutrum mi ligula, eget luctus diam ultricies vitae ${\ell}$. Quisque elit libero, eleifend eu pretium a, gravida at felis. Proin sed imperdiet nibh. Integer sit amet eleifend ligula. Maecenas semper vestibulum lorem. Mauris ut tortor diam ${\color{Red}2\ell\geq\binom{d}{\lfloor\frac{d}{2} \rfloor}}$. Sed elementum erat dolor, id rhoncus augue dignissim et. Curabitur a ligula vestibulum sapien maximus ultricies dignissim at leo ${\color{Red}\textit{L}_T}$. Mauris vulputate magna at turpis eleifend, sit amet lacinia tellus malesuada. Nam nisi ex, ultrices sed posuere at, laoreet vel ligula. Aenean scelerisque in lacus sed tristique ${\color{Red}\mathcal{O}\left(\textit{L}_T\text{ log}\left(\textit{L}_T\ell \right) \right)}$. Pellentesque rhoncus viverra metus vitae scelerisque. Aliquam iaculis commodo erat, tincidunt auctor augue tincidunt sit amet. Suspendisse placerat velit ut magna vulputate semper. Praesent non aliquet tortor.
   ```
* Check that the MathJax code is only displayed once

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).