### PR TITLE
fix(i18n): curation-task.task.registerdoi.label

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -1712,7 +1712,8 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Virenscan",
 
-
+  // "curation-task.task.registerdoi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "DOI registrieren",
 
   // "curation.form.task-select.label": "Task:",
   "curation.form.task-select.label": "Aufgabe:",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1392,7 +1392,7 @@
 
   "curation-task.task.vscan.label": "Virus Scan",
 
-  "curation-task.task.register-doi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Register DOI",
 
   "curation.form.task-select.label": "Task:",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -2080,8 +2080,8 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Búsqueda de virus",
 
-  // "curation-task.task.register-doi.label": "Register DOI",
-  "curation-task.task.register-doi.label": "Registro DOI",
+  // "curation-task.task.registerdoi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Registro DOI",
 
 
 

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -2228,9 +2228,9 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Virus ellenőrzés",
 
-  // "curation-task.task.register-doi.label": "Register DOI",
+  // "curation-task.task.registerdoi.label": "Register DOI",
   // TODO New key - Add a translation
-  "curation-task.task.register-doi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Register DOI",
 
 
 

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -2160,9 +2160,9 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Scansione antivirus",
 
-  // "curation-task.task.register-doi.label": "Register DOI",
+  // "curation-task.task.registerdoi.label": "Register DOI",
   // TODO New key - Add a translation
-  "curation-task.task.register-doi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Register DOI",
 
 
 

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -2054,8 +2054,8 @@
   // "curation-task.task.vscan.label": "Virus Scan",
   "curation-task.task.vscan.label": "Scan de vírus",
 
-  // "curation-task.task.register-doi.label": "Register DOI",
-  "curation-task.task.register-doi.label": "Registo DOI",
+  // "curation-task.task.registerdoi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Registo DOI",
 
   // "curation.form.task-select.label": "Task:",
   "curation.form.task-select.label": "Tarefa:",

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -671,7 +671,7 @@
   "curation-task.task.citationpage.label": "Tạo trang trích dẫn",
   "curation-task.task.noop.label": "NOOP",
   "curation-task.task.profileformats.label": "Định dạng tệp tin",
-  "curation-task.task.register-doi.label": "Đăng ký DOI",
+  "curation-task.task.registerdoi.label": "Đăng ký DOI",
   "curation-task.task.requiredmetadata.label": "Kiểm tra các trường dữ liệu bắt buộc",
   "curation-task.task.translate.label": "Bộ dịch của Microsoft",
   "curation-task.task.vscan.label": "Quét Virus",


### PR DESCRIPTION
## References
* Fixes #2398

## Description
changed curation-task.task.register-doi.label back to curation-task.task.registerdoi.label and added German translation

## Instructions for Reviewers
Renamed the translation string identifier in all json5 files it was already present and added a German translation.

List of changes in this PR:
* curation-task.task.register-doi.label -> curation-task.task.registerdoi.label

**Include guidance for how to test or review your PR.** 
* Log in as admin
* Go to curation tasks
* Open Task dropdown
* Last entry should show 'Register DOI' instead of curation-task.task.registerdoi.label

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
