### PR TITLE
ProcessDetailComponent test improvement

### DIFF
--- a/src/app/process-page/detail/process-detail.component.spec.ts
+++ b/src/app/process-page/detail/process-detail.component.spec.ts
@@ -147,7 +147,7 @@ describe('ProcessDetailComponent', () => {
       providers: [
         {
           provide: ActivatedRoute,
-          useValue: { data: observableOf({ process: createSuccessfulRemoteDataObject(process) }) }
+          useValue: { data: observableOf({ process: createSuccessfulRemoteDataObject(process) }), snapshot: { params: { id: 1 } } },
         },
         { provide: ProcessDataService, useValue: processService },
         { provide: BitstreamDataService, useValue: bitstreamDataService },
@@ -310,10 +310,11 @@ describe('ProcessDetailComponent', () => {
       });
 
       it('should call refresh method every 5 seconds, until process is completed', fakeAsync(() => {
-        spyOn(component, 'refresh');
-        spyOn(component, 'stopRefreshTimer');
+        spyOn(component, 'refresh').and.callThrough();
+        spyOn(component, 'stopRefreshTimer').and.callThrough();
 
-        process.processStatus = ProcessStatus.COMPLETED;
+        // start off with a running process in order for the refresh counter starts counting up
+        process.processStatus = ProcessStatus.RUNNING;
         // set findbyId to return a completed process
         (processService.findById as jasmine.Spy).and.returnValue(observableOf(createSuccessfulRemoteDataObject(process)));
 
@@ -335,6 +336,10 @@ describe('ProcessDetailComponent', () => {
 
         tick(1001); // 1 second + 1 ms by the setTimeout
         expect(component.refreshCounter$.value).toBe(0); // 1 - 1
+
+        // set the process to completed right before the counter checks the process
+        process.processStatus = ProcessStatus.COMPLETED;
+        (processService.findById as jasmine.Spy).and.returnValue(observableOf(createSuccessfulRemoteDataObject(process)));
 
         tick(1000); // 1 second
 


### PR DESCRIPTION
## References
* Improves test cases from #2228 

## Description
This PR adds some improvements and fixes to test cases of ProcessDetailComponent

## Instructions for Reviewers
The test that's being improved is a test responsible for the 5s refresh timer.

It's supposed to mimic a running process during this timer, but the process is set to COMPLETED from the start, so I've modified the test to set it to RUNNING from the start and only set it to COMPLETED 1 second before the timer ends, so that the end result can still be tested.

Because of this change, the test started failing because it expected `refresh()` and `stopRefreshTimer()` to execute their code, but they weren't. This is because they were being spied on using `spyOn(component, 'refresh')`, which stubs the entire method and stops it from executing altogether. Adding `.and.callThrough();` to this fixes the issue and the methods are now spied upon, but will still execute their code.

The test cases succeed again after this, confirming they're functional.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
