### PR TITLE
Enable early release of backport-action to test korthout/backport-action#372

### DIFF
--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -27,7 +27,7 @@ jobs:
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@341-default-mainline
         with:
           # Trigger based on a "port to [branch]" label on PR
           # (This label must specify the branch name to port to)
@@ -39,6 +39,9 @@ jobs:
           # Copy all labels from original PR to (newly created) port PR
           # NOTE: The labels matching 'label_pattern' are automatically excluded
           copy_labels_pattern: '.*'
+          # The --mainline (parent-number) to use when cherry-picking. Value of '1' allows
+          # merge commits to be cherry picked. See https://git-scm.com/docs/git-cherry-pick
+          default_mainline: 1
           # Use a personal access token (PAT) to create PR as 'dspace-bot' user.
           # A PAT is required in order for the new PR to trigger its own actions (for CI checks)
           github_token: ${{ secrets.PR_PORT_TOKEN }}


### PR DESCRIPTION
## Description
This is a temporary update to the `backport-action` used to port PRs between `main` and `dspace-7_x`.

It is being added to test korthout/backport-action#372 .  If it works properly, this should allow the `backport-action` to also work for PRs which **have merge commits**.  

Will test shortly with https://github.com/DSpace/dspace-angular/pull/2408 -- this is an example of a small PR which has a merge commit as the second commit: https://github.com/DSpace/dspace-angular/pull/2408/commits

This PR is just to document *why* I'm pushing these changes to our `backport-action`.  I'll merge it immediately to allow us to test this new behavior.