### PR TITLE
Fix to Value of dropdown changes automatically on item submission page

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -43,7 +43,7 @@
 
       <button class="dropdown-item disabled" *ngIf="optionsList && optionsList.length == 0">{{'form.no-results' | translate}}</button>
       <button class="dropdown-item collection-item text-truncate" *ngFor="let listEntry of optionsList"
-              (click)="onSelect(listEntry); sdRef.close()" (mousedown)="onSelect(listEntry); sdRef.close()"
+              (keydown.enter)="onSelect(listEntry); sdRef.close()" (mousedown)="onSelect(listEntry); sdRef.close()"
               title="{{ listEntry.display }}" role="option"
               [attr.id]="listEntry.display == (currentValue|async) ? ('combobox_' + id + '_selected') : null">
         {{inputFormatter(listEntry)}}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.spec.ts
@@ -159,14 +159,15 @@ describe('Dynamic Dynamic Scrollable Dropdown component', () => {
         let de: any = scrollableDropdownFixture.debugElement.query(By.css('input.form-control'));
         let btnEl = de.nativeElement;
 
-        btnEl.click();
+        const mousedownEvent = new MouseEvent('mousedown');
+
+        btnEl.dispatchEvent(mousedownEvent);
         scrollableDropdownFixture.detectChanges();
 
         de = scrollableDropdownFixture.debugElement.queryAll(By.css('button.dropdown-item'));
         btnEl = de[0].nativeElement;
 
-        btnEl.click();
-
+        btnEl.dispatchEvent(mousedownEvent);
         scrollableDropdownFixture.detectChanges();
 
         expect((scrollableDropdownComp.model as any).value).toEqual(selectedValue);


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes  #2145

## Description
On item submission page, the value of first dropdown automatically resets to the first value present in the dropdown on pressing "enter" in any of the textbox. _Now this has been fixed._

## Instructions for Reviewers

1. Go to Item submission page
2. Select book from “type” dropdown. (Select any value other than first value in dropdown)
3. Click on text box with label as "identifier" and then press enter.

List of changes in this PR:
* First, I change the event that triggers the OnSelect function, before it was onClick, now it is "keydown.enter". I made this change because the bug was in the click event, when the detect change was made to some other input (as explained in issue 2145), the click event was triggered on the dropdown by setting the first default value. But currently the "mousedown" event is handled, which seamlessly replaces the click event. Added the "keydown.enter" because trying to interact via the keyboard (and since the click event was not there) failed to fire the event.
* Second, in the test I had to change the click event to "mousedown", since this is now the event that triggers the onSelect function.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
