### PR TITLE
Input type list doesn't work correctly if multiple value-pairs have the same pair value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "7.6.0-next",
+  "version": "7.6.0",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",


### PR DESCRIPTION
## References
* Fixes #2433

## Description
When you have 2 fields with input-type `list` which use value pairs which contains a same value for one of their `<pair>`s, you cannot select that value in the second field.

## Instructions for Reviewers
**List of changes in this PR:**
* In `DsDynamicListComponent` I updated the checkboxes/radio buttons id attribute and prefixed it with the metadata fiel

**Guidance for how to test & review this PR:**
1. Create a submission form with 2 fields with input-type `list`
2. Link both fields to a `<value-pairs>` which contains this `<pair>`:
   ```xml
   <pair>
      <displayed-value>Other</displayed-value>
      <stored-value>other</stored-value>
   </pair>
   ```
3. In the submission form try selecting the `Other` value from the second field, it should select the correct field and not the one from the first field

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
