### PR TITLE
Fix to Mobile navbar hamburger menu doesn't work in Firefox/Safari #2372

### DIFF
--- a/src/themes/dspace/app/navbar/navbar.component.scss
+++ b/src/themes/dspace/app/navbar/navbar.component.scss
@@ -7,7 +7,7 @@ nav.navbar {
 /** Mobile menu styling **/
 @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
   .navbar {
-    width: 100%;
+    width: 100vw;
     background-color: var(--bs-white);
     position: absolute;
     overflow: hidden;


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #`2372`

## Description
I change the property of width to solve the bug, I think maybe firefox isn't calculated properly on the parent, so 100% it doesn't work.

![image](https://github.com/DSpace/dspace-angular/assets/132490359/c682bfca-8576-42e9-8741-6d4a25c4ed80)

## Instructions for Reviewers
Steps to reproduce the behavior:

1. Open https://demo7.dspace.org/
2. Resize the screen anywhere below a width of 768px
- The header navbar will be replaced by a menu toggled by a "hamburger button"
- In Chrome, this button still toggles the menu as expected
- In Firefox & Safari, the menu never appears

## Expected behavior
The mobile navbar menu should work in all broswers.

![image](https://github.com/DSpace/dspace-angular/assets/132490359/c9975725-81db-4c13-aec9-7947cfb35fa7)


List of changes in this PR:
* I only modified the nabvar.component.scss on dspace theme, since if the default theme.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
