### PR TITLE
[Port dspace-7_x] Replace mentions of demo7.dspace.org and api7.dspace.org with new demo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ DSPACE_UI_SSL => DSPACE_SSL
 
 The same settings can also be overwritten by setting system environment variables instead, E.g.:
 ```bash
-export DSPACE_HOST=api7.dspace.org
-export DSPACE_UI_PORT=4200
+export DSPACE_HOST=demo.dspace.org
+export DSPACE_UI_PORT=4000
 ```
 
 The priority works as follows: **environment variable** overrides **variable in `.env` file** overrides external config set by `DSPACE_APP_CONFIG_PATH` overrides **`config.(prod or dev).yml`**
@@ -288,7 +288,7 @@ E2E tests (aka integration tests) use [Cypress.io](https://www.cypress.io/). Con
 The test files can be found in the `./cypress/integration/` folder.
 
 Before you can run e2e tests, two things are REQUIRED:
-1. You MUST be running the DSpace backend (i.e. REST API) locally. The e2e tests will *NOT* succeed if run against our demo REST API (https://api7.dspace.org/server/), as that server is uncontrolled and may have content added/removed at any time.
+1. You MUST be running the DSpace backend (i.e. REST API) locally. The e2e tests will *NOT* succeed if run against our demo/sandbox REST API (https://demo.dspace.org/server/ or https://sandbox.dspace.org/server/), as those sites may have content added/removed at any time.
     * After starting up your backend on localhost, make sure either your `config.prod.yml` or `config.dev.yml` has its `rest` settings defined to use that localhost backend.
 	* If you'd prefer, you may instead use environment variables as described at [Configuring](#configuring). For example:
        ```

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -22,7 +22,7 @@ ui:
 # 'synced' with the 'dspace.server.url' setting in your backend's local.cfg.
 rest:
   ssl: true
-  host: api7.dspace.org
+  host: sandbox.dspace.org
   port: 443
   # NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
   nameSpace: /server

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -22,7 +22,7 @@ ui:
 # 'synced' with the 'dspace.server.url' setting in your backend's local.cfg.
 rest:
   ssl: true
-  host: sandbox.dspace.org
+  host: demo.dspace.org
   port: 443
   # NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
   nameSpace: /server

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 rest:
   ssl: true
-  host: api7.dspace.org
+  host: sandbox.dspace.org
   port: 443
   nameSpace: /server

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 rest:
   ssl: true
-  host: sandbox.dspace.org
+  host: demo.dspace.org
   port: 443
   nameSpace: /server

--- a/docker/README.md
+++ b/docker/README.md
@@ -101,8 +101,8 @@ and the backend at http://localhost:8080/server/
 
 ## Run DSpace Angular dist build with DSpace Demo site backend
 
-This allows you to run the Angular UI in *production* mode, pointing it at the demo backend
-(https://api7.dspace.org/server/).
+This allows you to run the Angular UI in *production* mode, pointing it at the demo or sandbox backend
+(https://demo.dspace.org/server/ or https://sandbox.dspace.org/server/).
 
 ```
 docker-compose -f docker/docker-compose-dist.yml pull

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -24,7 +24,7 @@ services:
       # This is because Server Side Rendering (SSR) currently requires a public URL,
       # see this bug: https://github.com/DSpace/dspace-angular/issues/1485
       DSPACE_REST_SSL: 'true'
-      DSPACE_REST_HOST: api7.dspace.org
+      DSPACE_REST_HOST: sandbox.dspace.org
       DSPACE_REST_PORT: 443
       DSPACE_REST_NAMESPACE: /server
     image: dspace/dspace-angular:dspace-7_x-dist

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -24,7 +24,7 @@ services:
       # This is because Server Side Rendering (SSR) currently requires a public URL,
       # see this bug: https://github.com/DSpace/dspace-angular/issues/1485
       DSPACE_REST_SSL: 'true'
-      DSPACE_REST_HOST: sandbox.dspace.org
+      DSPACE_REST_HOST: demo.dspace.org
       DSPACE_REST_PORT: 443
       DSPACE_REST_NAMESPACE: /server
     image: dspace/dspace-angular:dspace-7_x-dist

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -48,7 +48,7 @@ dspace-angular connects to your DSpace installation by using its REST endpoint. 
 ```yaml
 rest:
   ssl: true
-  host: api7.dspace.org
+  host: demo.dspace.org
   port: 443
   nameSpace: /server
 }
@@ -57,7 +57,7 @@ rest:
 Alternately you can set the following environment variables. If any of these are set, it will override all configuration files:
 ```
   DSPACE_REST_SSL=true
-  DSPACE_REST_HOST=api7.dspace.org
+  DSPACE_REST_HOST=demo.dspace.org
   DSPACE_REST_PORT=443
   DSPACE_REST_NAMESPACE=/server
 ```

--- a/src/app/core/services/browser-hard-redirect.service.ts
+++ b/src/app/core/services/browser-hard-redirect.service.ts
@@ -38,8 +38,8 @@ export class BrowserHardRedirectService extends HardRedirectService {
   /**
    * Get the origin of the current URL
    * i.e. <scheme> "://" <hostname> [ ":" <port> ]
-   * e.g. if the URL is https://demo7.dspace.org/search?query=test,
-   * the origin would be https://demo7.dspace.org
+   * e.g. if the URL is https://demo.dspace.org/search?query=test,
+   * the origin would be https://demo.dspace.org
    */
   getCurrentOrigin(): string {
     return this.location.origin;

--- a/src/app/core/services/hard-redirect.service.ts
+++ b/src/app/core/services/hard-redirect.service.ts
@@ -25,8 +25,8 @@ export abstract class HardRedirectService {
   /**
    * Get the origin of the current URL
    * i.e. <scheme> "://" <hostname> [ ":" <port> ]
-   * e.g. if the URL is https://demo7.dspace.org/search?query=test,
-   * the origin would be https://demo7.dspace.org
+   * e.g. if the URL is https://demo.dspace.org/search?query=test,
+   * the origin would be https://demo.dspace.org
    */
   abstract getCurrentOrigin(): string;
 }

--- a/src/app/core/services/server-hard-redirect.service.ts
+++ b/src/app/core/services/server-hard-redirect.service.ts
@@ -69,8 +69,8 @@ export class ServerHardRedirectService extends HardRedirectService {
   /**
    * Get the origin of the current URL
    * i.e. <scheme> "://" <hostname> [ ":" <port> ]
-   * e.g. if the URL is https://demo7.dspace.org/search?query=test,
-   * the origin would be https://demo7.dspace.org
+   * e.g. if the URL is https://demo.dspace.org/search?query=test,
+   * the origin would be https://demo.dspace.org
    */
   getCurrentOrigin(): string {
     return this.req.protocol + '://' + this.req.headers.host;


### PR DESCRIPTION
## Description
Port of #2452 to `dspace-7_x`.

This includes the same commits EXCEPT that it adds a single change:
* Configuration on `dspace-7_x` is updated to use the new https://demo.dspace.org/server/ demo backend by default (as demo.dspace.org auto-updates based on the `dspace-7_x` branch)



## Instructions for Reviewers

**THIS SHOULD NOT BE MERGED UNTIL THE NEW https://demo.dspace.org/ IS LAUNCHED** (later this week)

The updated configurations in this PR require the new demo REST API Backend at https://demo.dspace.org/server/ _to exist_ before they will function properly.  I'll merge this once that site has been fully deployed.