### PR TITLE
Check cssRules before css variables are read from stylesheet

### DIFF
--- a/src/app/shared/sass-helper/css-variable.service.ts
+++ b/src/app/shared/sass-helper/css-variable.service.ts
@@ -35,8 +35,6 @@ export class CSSVariableService {
     return styleSheet.hasOwnProperty('cssRules') && styleSheet.cssRules;
   };
 
-
-
   /*
    Determine if the given rule is a CSSStyleRule
    See: https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants

--- a/src/app/shared/sass-helper/css-variable.service.ts
+++ b/src/app/shared/sass-helper/css-variable.service.ts
@@ -26,6 +26,17 @@ export class CSSVariableService {
     return styleSheet.href.indexOf(window.location.origin) === 0;
   };
 
+  /**
+   * Checks whether the specific stylesheet object has the property cssRules
+   * @param styleSheet The stylesheet
+   */
+  hasCssRules = (styleSheet) => {
+    // Injected styles might have no css rules value
+    return styleSheet.hasOwnProperty('cssRules') && styleSheet.cssRules;
+  };
+
+
+
   /*
    Determine if the given rule is a CSSStyleRule
    See: https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants
@@ -93,8 +104,10 @@ export class CSSVariableService {
     if (isNotEmpty(document.styleSheets)) {
       // styleSheets is array-like, so we convert it to an array.
       // Filter out any stylesheets not on this domain
+      // Filter out any stylesheets that have no cssRules property
       return [...document.styleSheets]
         .filter(this.isSameDomain)
+        .filter(this.hasCssRules)
         .reduce(
           (finalArr, sheet) =>
             finalArr.concat(


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/2450

## Description
Checks all stylesheets stylesheet that are being readed from document, whether the cssRules property exists. If not, than the stylesheet is not processed.

## Instructions for Reviewers
- the stylesheet without cssRules can be applied by some browser-plugins, see the issue for more details. It might also be possible to inject them manually.


List of changes in this PR:
- added filter to filter the document.stylesheets being processed later in code
- added check for the cssRules property `cssRules`. Without the `hasOwnProperty('cssRules')` method check the page will remain blank.

**Include guidance for how to test or review your PR.** 
- See the issue for details how to reproduce the bug with specific browser addons that inject stylesheets into the DOM.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
