### PR TITLE
Fix to Pagination position is retained between searches #2159

### DIFF
--- a/src/app/shared/search-form/search-form.component.spec.ts
+++ b/src/app/shared/search-form/search-form.component.spec.ts
@@ -28,6 +28,7 @@ describe('SearchFormComponent', () => {
   const searchService = new SearchServiceStub();
   const paginationService = new PaginationServiceStub();
   const searchConfigService = { paginationID: 'test-id' };
+  const firstPage = { 'spc.page': 1 };
   const dspaceObjectService = {
     findById: () => createSuccessfulRemoteDataObject$(undefined),
   };
@@ -104,16 +105,16 @@ describe('SearchFormComponent', () => {
     const scope = 'MCU';
     let searchQuery = {};
 
-    it('should navigate to the search page even when no parameters are provided', () => {
+    it('should navigate to the search first page even when no parameters are provided', () => {
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: searchQuery,
+        queryParams: { ...searchQuery, ...firstPage },
         queryParamsHandling: 'merge'
       });
     });
 
-    it('should navigate to the search page with parameters only query if only query is provided', () => {
+    it('should navigate to the search first page with parameters only query if only query is provided', () => {
       searchQuery = {
         query: query
       };
@@ -121,12 +122,12 @@ describe('SearchFormComponent', () => {
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: searchQuery,
+        queryParams: { ...searchQuery, ...firstPage },
         queryParamsHandling: 'merge'
       });
     });
 
-    it('should navigate to the search page with parameters only query if only scope is provided', () => {
+    it('should navigate to the search first page with parameters only query if only scope is provided', () => {
       searchQuery = {
         scope: scope
       };
@@ -134,7 +135,7 @@ describe('SearchFormComponent', () => {
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: searchQuery,
+        queryParams: {...searchQuery, ...firstPage},
         queryParamsHandling: 'merge'
       });
     });

--- a/src/app/shared/search-form/search-form.component.ts
+++ b/src/app/shared/search-form/search-form.component.ts
@@ -114,7 +114,14 @@ export class SearchFormComponent implements OnChanges {
    * @param data Updated parameters
    */
   updateSearch(data: any) {
-    const queryParams = Object.assign({}, data);
+    const goToFirstPage = { 'spc.page': 1 };
+
+    const queryParams = Object.assign(
+      {
+        ...goToFirstPage
+      },
+      data
+    );
 
     void this.router.navigate(this.getSearchLinkParts(), {
       queryParams: queryParams,


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes [`#2159`](https://github.com/DSpace/dspace-angular/issues/2159)
## Description
I made a little fix, now when search submit is trigger, it must return to first page. I think this is the correct behaviour for search components.

## Instructions for Reviewers
  1. Open https://demo7.dspace.org/search (in this case, the /search route)
  2. Go to the last results page
  3. Change the query to test → bound to have fewer results than everything
  4. "Your search returned no results"
  5. The pagination UI is not shown, the only way to find out you're on a page that doesn't exist is through the URL: it will still have e.g. spc.page=170

List of changes in this PR:
* First, I added firstPage Query Param to force navigating to first Page after submit
* Second, I changed test's of Search-Component-Form in order to expect the correct behaviour of the search.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
