### PR TITLE
Fix some routes not using the correct baseHref

### DIFF
--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
@@ -25,7 +25,7 @@
   <div class="{{columnSizes.columns[3].buildClasses()}} row-element d-flex align-items-center">
     <div class="text-center w-100">
       <div class="btn-group relationship-action-buttons">
-        <a *ngIf="bitstreamDownloadUrl != null" [href]="bitstreamDownloadUrl"
+        <a *ngIf="bitstreamDownloadUrl != null" [routerLink]="bitstreamDownloadUrl"
                 class="btn btn-outline-primary btn-sm"
                 title="{{'item.edit.bitstreams.edit.buttons.download' | translate}}"
                 [attr.data-test]="'download-button' | dsBrowserOnly">

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.spec.ts
@@ -13,6 +13,7 @@ import { createSuccessfulRemoteDataObject$ } from '../../../../shared/remote-dat
 import { getBitstreamDownloadRoute } from '../../../../app-routing-paths';
 import { By } from '@angular/platform-browser';
 import { BrowserOnlyMockPipe } from '../../../../shared/testing/browser-only-mock.pipe';
+import { RouterTestingModule } from '@angular/router/testing';
 
 let comp: ItemEditBitstreamComponent;
 let fixture: ComponentFixture<ItemEditBitstreamComponent>;
@@ -72,7 +73,10 @@ describe('ItemEditBitstreamComponent', () => {
     );
 
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot(),
+      ],
       declarations: [
         ItemEditBitstreamComponent,
         VarDirective,

--- a/src/app/shared/cookies/klaro-configuration.ts
+++ b/src/app/shared/cookies/klaro-configuration.ts
@@ -22,7 +22,7 @@ export const GOOGLE_ANALYTICS_KLARO_KEY = 'google-analytics';
 export const klaroConfiguration: any = {
   storageName: ANONYMOUS_STORAGE_NAME_KLARO,
 
-  privacyPolicy: '/info/privacy',
+  privacyPolicy: './info/privacy',
 
   /*
   Setting 'hideLearnMore' to 'true' will hide the "learn more / customize" link in


### PR DESCRIPTION
## References
* Fixes #2446

## Description
Fixed 2 urls not working correctly when using a baseHref (`ui.nameSpace`)

## Instructions for Reviewers
List of changes in this PR:
* Used `[routerLink]` instead of `[href]` in order to let Angular automatically add the correct baseHref prefix on the edit item bitstreams page
* Fixed the privacy policy link on the cookie setting popup

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).