### PR TITLE
Improve style of tag input type in submission form

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.html
@@ -9,7 +9,7 @@
             [wrapperClass]="'border-bottom border-light'">
 
   <input *ngIf="!model.hasAuthority"
-         class="border-0 form-control-plaintext tag-input flex-grow-1 mt-1 mb-1"
+         class="border rounded form-control-plaintext tag-input flex-grow-1 mt-1 mb-1"
          type="text"
          role="textbox"
          [class.pl-3]="chips.hasItems()"
@@ -23,7 +23,7 @@
 
   <div *ngIf="model.hasAuthority" class="position-relative right-addon">
     <i *ngIf="searching" class="fas fa-circle-notch fa-spin fa-2x fa-fw text-primary position-absolute mt-1 p-0" aria-hidden="true"></i>
-    <input class="border-0 form-control-plaintext tag-input flex-grow-1 mt-1 mb-1"
+    <input class="border rounded form-control-plaintext tag-input flex-grow-1 mt-1 mb-1"
            type="text"
            [attr.aria-labelledby]="'label_' + model.id"
            [(ngModel)]="currentValue"


### PR DESCRIPTION
## Description
Improve the style of the `tag` input type in the submission form by adding a subtle rounded border similar to other input fields. Without some style to differentiate the input field it is not clear where the text field is unless you are an experienced user who already knows.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Use the `border` and `rounded` [Bootstrap border helper classes](https://getbootstrap.com/docs/4.6/utilities/borders/) on tag input elements

Video before:

https://github.com/DSpace/dspace-angular/assets/191754/4f01ccd4-15ed-4fd6-aa66-65665ae06e68

Video after:


https://github.com/DSpace/dspace-angular/assets/191754/1eb491cc-bf9c-44b8-a925-05dac1fb557b



**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

Test the DSpace 7 submission form with a `tag` input type, for example the "Subject Keywords" field in the default submission form. Make sure that the submission form works as expected and that the only change is the new style.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).