### PR TITLE
Fix multiple api calls on route change

### DIFF
--- a/src/app/core/data/root-data.service.ts
+++ b/src/app/core/data/root-data.service.ts
@@ -25,7 +25,7 @@ export class RootDataService extends BaseDataService<Root> {
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
   ) {
-    super('', requestService, rdbService, objectCache, halService, 60 * 1000);
+    super('', requestService, rdbService, objectCache, halService, 6 * 60 * 60 * 1000);
   }
 
   /**

--- a/src/app/core/data/root-data.service.ts
+++ b/src/app/core/data/root-data.service.ts
@@ -7,12 +7,11 @@ import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { Observable, of as observableOf } from 'rxjs';
 import { RemoteData } from './remote-data';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
-import { DspaceRestService } from '../dspace-rest/dspace-rest.service';
-import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
 import { catchError, map } from 'rxjs/operators';
 import { BaseDataService } from './base/base-data.service';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { dataService } from './base/data-service.decorator';
+import { getFirstCompletedRemoteData } from '../shared/operators';
 
 /**
  * A service to retrieve the {@link Root} object from the REST API.
@@ -25,21 +24,21 @@ export class RootDataService extends BaseDataService<Root> {
     protected rdbService: RemoteDataBuildService,
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
-    protected restService: DspaceRestService,
   ) {
-    super('', requestService, rdbService, objectCache, halService, 6 * 60 * 60 * 1000);
+    super('', requestService, rdbService, objectCache, halService, 60 * 1000);
   }
 
   /**
    * Check if root endpoint is available
    */
   checkServerAvailability(): Observable<boolean> {
-    return this.restService.get(this.halService.getRootHref()).pipe(
+    return this.findRoot().pipe(
       catchError((err ) => {
         console.error(err);
         return observableOf(false);
       }),
-      map((res: RawRestResponse) => res.statusCode === 200)
+      getFirstCompletedRemoteData(),
+      map((rootRd: RemoteData<Root>) => rootRd.statusCode === 200)
     );
   }
 
@@ -60,6 +59,6 @@ export class RootDataService extends BaseDataService<Root> {
    * Set to sale the root endpoint cache hit
    */
   invalidateRootCache() {
-    this.requestService.setStaleByHrefSubstring(this.halService.getRootHref());
+    this.requestService.setStaleByHref(this.halService.getRootHref());
   }
 }

--- a/src/app/core/server-check/server-check.guard.spec.ts
+++ b/src/app/core/server-check/server-check.guard.spec.ts
@@ -63,16 +63,18 @@ describe('ServerCheckGuard', () => {
   });
 
   describe(`listenForRouteChanges`, () => {
-    it(`should invalidate the root cache on every NavigationStart event`, () => {
+    it(`should invalidate the root cache when the method is first called, and then on every NavigationStart event`, () => {
         testScheduler.run(() => {
           guard.listenForRouteChanges();
+          expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(1);
+
           eventSubject.next(new NavigationStart(1,''));
           eventSubject.next(new NavigationEnd(1,'', ''));
           eventSubject.next(new NavigationStart(2,''));
           eventSubject.next(new NavigationEnd(2,'', ''));
           eventSubject.next(new NavigationStart(3,''));
         });
-        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(3);
+        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/app/core/server-check/server-check.guard.spec.ts
+++ b/src/app/core/server-check/server-check.guard.spec.ts
@@ -1,68 +1,78 @@
 import { ServerCheckGuard } from './server-check.guard';
-import { Router } from '@angular/router';
+import { Router, NavigationStart, UrlTree, NavigationEnd, RouterEvent } from '@angular/router';
 
-import { of } from 'rxjs';
-import { take } from 'rxjs/operators';
-
-import { getPageInternalServerErrorRoute } from '../../app-routing-paths';
+import { of, ReplaySubject } from 'rxjs';
 import { RootDataService } from '../data/root-data.service';
+import { TestScheduler } from 'rxjs/testing';
 import SpyObj = jasmine.SpyObj;
 
 describe('ServerCheckGuard', () => {
   let guard: ServerCheckGuard;
-  let router: SpyObj<Router>;
+  let router: Router;
+  const eventSubject = new ReplaySubject<RouterEvent>(1);
   let rootDataServiceStub: SpyObj<RootDataService>;
-
-  rootDataServiceStub = jasmine.createSpyObj('RootDataService', {
-    checkServerAvailability: jasmine.createSpy('checkServerAvailability'),
-    invalidateRootCache: jasmine.createSpy('invalidateRootCache')
-  });
-  router = jasmine.createSpyObj('Router', {
-    navigateByUrl: jasmine.createSpy('navigateByUrl')
-  });
+  let testScheduler: TestScheduler;
+  let redirectUrlTree: UrlTree;
 
   beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+    rootDataServiceStub = jasmine.createSpyObj('RootDataService', {
+      checkServerAvailability: jasmine.createSpy('checkServerAvailability'),
+      invalidateRootCache: jasmine.createSpy('invalidateRootCache')
+    });
+    redirectUrlTree = new UrlTree();
+    router = {
+      events: eventSubject.asObservable(),
+      navigateByUrl: jasmine.createSpy('navigateByUrl'),
+      parseUrl: jasmine.createSpy('parseUrl').and.returnValue(redirectUrlTree)
+    } as any;
     guard = new ServerCheckGuard(router, rootDataServiceStub);
-  });
-
-  afterEach(() => {
-    router.navigateByUrl.calls.reset();
-    rootDataServiceStub.invalidateRootCache.calls.reset();
   });
 
   it('should be created', () => {
     expect(guard).toBeTruthy();
   });
 
-  describe('when root endpoint has succeeded', () => {
+  describe('when root endpoint request has succeeded', () => {
     beforeEach(() => {
       rootDataServiceStub.checkServerAvailability.and.returnValue(of(true));
     });
 
-    it('should not redirect to error page', () => {
-      guard.canActivateChild({} as any, {} as any).pipe(
-        take(1)
-      ).subscribe((canActivate: boolean) => {
-        expect(canActivate).toEqual(true);
-        expect(rootDataServiceStub.invalidateRootCache).not.toHaveBeenCalled();
-        expect(router.navigateByUrl).not.toHaveBeenCalled();
+    it('should return true', () => {
+      testScheduler.run(({ expectObservable }) => {
+        const result$ = guard.canActivateChild({} as any, {} as any);
+        expectObservable(result$).toBe('(a|)', { a: true });
       });
     });
   });
 
-  describe('when root endpoint has not succeeded', () => {
+  describe('when root endpoint request has not succeeded', () => {
     beforeEach(() => {
       rootDataServiceStub.checkServerAvailability.and.returnValue(of(false));
     });
 
-    it('should redirect to error page', () => {
-      guard.canActivateChild({} as any, {} as any).pipe(
-        take(1)
-      ).subscribe((canActivate: boolean) => {
-        expect(canActivate).toEqual(false);
-        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalled();
-        expect(router.navigateByUrl).toHaveBeenCalledWith(getPageInternalServerErrorRoute());
+    it('should return a UrlTree with the route to the 500 error page', () => {
+      testScheduler.run(({ expectObservable }) => {
+        const result$ = guard.canActivateChild({} as any, {} as any);
+        expectObservable(result$).toBe('(b|)', { b: redirectUrlTree });
       });
+      expect(router.parseUrl).toHaveBeenCalledWith('/500');
+    });
+  });
+
+  describe(`listenForRouteChanges`, () => {
+    it(`should invalidate the root cache on every NavigationStart event`, () => {
+        testScheduler.run(() => {
+          guard.listenForRouteChanges();
+          eventSubject.next(new NavigationStart(1,''));
+          eventSubject.next(new NavigationEnd(1,'', ''));
+          eventSubject.next(new NavigationStart(2,''));
+          eventSubject.next(new NavigationEnd(2,'', ''));
+          eventSubject.next(new NavigationStart(3,''));
+        });
+        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/app/core/server-check/server-check.guard.spec.ts
+++ b/src/app/core/server-check/server-check.guard.spec.ts
@@ -20,7 +20,8 @@ describe('ServerCheckGuard', () => {
     });
     rootDataServiceStub = jasmine.createSpyObj('RootDataService', {
       checkServerAvailability: jasmine.createSpy('checkServerAvailability'),
-      invalidateRootCache: jasmine.createSpy('invalidateRootCache')
+      invalidateRootCache: jasmine.createSpy('invalidateRootCache'),
+      findRoot: jasmine.createSpy('findRoot')
     });
     redirectUrlTree = new UrlTree();
     router = {
@@ -63,18 +64,23 @@ describe('ServerCheckGuard', () => {
   });
 
   describe(`listenForRouteChanges`, () => {
-    it(`should invalidate the root cache when the method is first called, and then on every NavigationStart event`, () => {
+    it(`should retrieve the root endpoint, without using the cache, when the method is first called`, () => {
         testScheduler.run(() => {
           guard.listenForRouteChanges();
-          expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(1);
+          expect(rootDataServiceStub.findRoot).toHaveBeenCalledWith(false);
+        });
+    });
 
+    it(`should invalidate the root cache on every NavigationStart event`, () => {
+        testScheduler.run(() => {
+          guard.listenForRouteChanges();
           eventSubject.next(new NavigationStart(1,''));
           eventSubject.next(new NavigationEnd(1,'', ''));
           eventSubject.next(new NavigationStart(2,''));
           eventSubject.next(new NavigationEnd(2,'', ''));
           eventSubject.next(new NavigationStart(3,''));
         });
-        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(4);
+        expect(rootDataServiceStub.invalidateRootCache).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/app/core/server-check/server-check.guard.ts
+++ b/src/app/core/server-check/server-check.guard.ts
@@ -52,6 +52,10 @@ export class ServerCheckGuard implements CanActivateChild {
    * operation, the cached version is used.
    */
   listenForRouteChanges(): void {
+    // we'll always be too late for the first NavigationStart event with the router subscribe below,
+    // so this statement is for the very first route operation
+    this.rootDataService.invalidateRootCache();
+
     this.router.events.pipe(
       filter(event => event instanceof NavigationStart),
     ).subscribe(() => {

--- a/src/app/core/server-check/server-check.guard.ts
+++ b/src/app/core/server-check/server-check.guard.ts
@@ -53,8 +53,10 @@ export class ServerCheckGuard implements CanActivateChild {
    */
   listenForRouteChanges(): void {
     // we'll always be too late for the first NavigationStart event with the router subscribe below,
-    // so this statement is for the very first route operation
-    this.rootDataService.invalidateRootCache();
+    // so this statement is for the very first route operation. A `find` without using the cache,
+    // rather than an invalidateRootCache, because invalidating as the app is bootstrapping can
+    // break other features
+    this.rootDataService.findRoot(false);
 
     this.router.events.pipe(
       filter(event => event instanceof NavigationStart),

--- a/src/app/core/server-check/server-check.guard.ts
+++ b/src/app/core/server-check/server-check.guard.ts
@@ -1,8 +1,15 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivateChild,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+  NavigationStart
+} from '@angular/router';
 
 import { Observable } from 'rxjs';
-import { take, tap } from 'rxjs/operators';
+import { take, map, filter } from 'rxjs/operators';
 
 import { RootDataService } from '../data/root-data.service';
 import { getPageInternalServerErrorRoute } from '../../app-routing-paths';
@@ -23,17 +30,32 @@ export class ServerCheckGuard implements CanActivateChild {
    */
   canActivateChild(
     route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean> {
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
 
     return this.rootDataService.checkServerAvailability().pipe(
       take(1),
-      tap((isAvailable: boolean) => {
+      map((isAvailable: boolean) => {
         if (!isAvailable) {
-          this.rootDataService.invalidateRootCache();
-          this.router.navigateByUrl(getPageInternalServerErrorRoute());
+          return this.router.parseUrl(getPageInternalServerErrorRoute());
+        } else {
+          return true;
         }
       })
     );
+  }
 
+  /**
+   * Listen to all router events. Every time a new navigation starts, invalidate the cache
+   * for the root endpoint. That way we retrieve it once per routing operation to ensure the
+   * backend is not down. But if the guard is called multiple times during the same routing
+   * operation, the cached version is used.
+   */
+  listenForRouteChanges(): void {
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationStart),
+    ).subscribe(() => {
+      this.rootDataService.invalidateRootCache();
+    });
   }
 }

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -32,6 +32,7 @@ import { logStartupMessage } from '../../../startup-message';
 import { MenuService } from '../../app/shared/menu/menu.service';
 import { RootDataService } from '../../app/core/data/root-data.service';
 import { firstValueFrom, Subscription } from 'rxjs';
+import { ServerCheckGuard } from '../../app/core/server-check/server-check.guard';
 
 /**
  * Performs client-side initialization.
@@ -56,7 +57,8 @@ export class BrowserInitService extends InitService {
     protected authService: AuthService,
     protected themeService: ThemeService,
     protected menuService: MenuService,
-    private rootDataService: RootDataService
+    private rootDataService: RootDataService,
+    protected serverCheckGuard: ServerCheckGuard,
   ) {
     super(
       store,
@@ -170,6 +172,15 @@ export class BrowserInitService extends InitService {
     firstValueFrom(this.authenticationReady$()).then(() => {
         this.sub.unsubscribe();
       });
+  }
+
+  /**
+   * Start route-listening subscriptions
+   * @protected
+   */
+  protected initRouteListeners(): void {
+    super.initRouteListeners();
+    this.serverCheckGuard.listenForRouteChanges();
   }
 
 }


### PR DESCRIPTION
## References
* Fixes #2482 

## Description
The issue was caused by the fact that the guard made a new request to the api every time something subscribed to the result of its canActivateChild method. That happened more then once per route change

The solution was to use the cached /api response, and invalidate that cache on every NavigationStart event. That way, the first subscriber triggers the re-request, and all the others use the cached version.

## Instructions for Reviewers
Open the network tab in the browser's dev tools, and check that there's one a single /api request every time you change the route

Also verify that if the backend becomes unavailable, that you're redirected to the 500 error page the next time you change the route

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
