### PR TITLE
Fix mouse cursor on language dropdown menu

### DIFF
--- a/src/app/shared/lang-switch/lang-switch.component.scss
+++ b/src/app/shared/lang-switch/lang-switch.component.scss
@@ -9,3 +9,7 @@
     color: var(--ds-header-icon-color-hover);
   }
 }
+
+.dropdown-item {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Description
The mouse cursor over items in the language selection menu is currently an arrow ↖. This PR replaces it with the more appropriate pointer 👆🏼.

![image](https://github.com/DSpace/dspace-angular/assets/87638927/88b48271-c2b1-48f7-bac8-86b7d1c0cd1d)


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
