### PR TITLE
Minor header button improvements

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
@@ -12,8 +12,7 @@ import { Router } from '@angular/router';
  * Represents a non-expandable section in the admin sidebar
  */
 @Component({
-  /* eslint-disable @angular-eslint/component-selector */
-  selector: 'li[ds-admin-sidebar-section]',
+  selector: 'ds-admin-sidebar-section',
   templateUrl: './admin-sidebar-section.component.html',
   styleUrls: ['./admin-sidebar-section.component.scss'],
 

--- a/src/app/admin/admin-sidebar/admin-sidebar.component.html
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.html
@@ -26,10 +26,10 @@
               </div>
             </li>
 
-            <ng-container *ngFor="let section of (sections | async)">
+            <li *ngFor="let section of (sections | async)">
                 <ng-container
                         *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
-            </ng-container>
+            </li>
         </ul>
     </div>
     <div class="navbar-nav">

--- a/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.ts
+++ b/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.ts
@@ -15,8 +15,7 @@ import { Router } from '@angular/router';
  * Represents a expandable section in the sidebar
  */
 @Component({
-  /* eslint-disable @angular-eslint/component-selector */
-  selector: 'li[ds-expandable-admin-sidebar-section]',
+  selector: 'ds-expandable-admin-sidebar-section',
   templateUrl: './expandable-admin-sidebar-section.component.html',
   styleUrls: ['./expandable-admin-sidebar-section.component.scss'],
   animations: [rotate, slide, bgColor]

--- a/src/app/header/context-help-toggle/context-help-toggle.component.ts
+++ b/src/app/header/context-help-toggle/context-help-toggle.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ElementRef } from '@angular/core';
 import { ContextHelpService } from '../../shared/context-help.service';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 /**
@@ -15,12 +15,23 @@ import { map } from 'rxjs/operators';
 export class ContextHelpToggleComponent implements OnInit {
   buttonVisible$: Observable<boolean>;
 
+  subscriptions: Subscription[] = [];
+
   constructor(
-    private contextHelpService: ContextHelpService,
-  ) { }
+    protected elRef: ElementRef,
+    protected contextHelpService: ContextHelpService,
+  ) {
+  }
 
   ngOnInit(): void {
     this.buttonVisible$ = this.contextHelpService.tooltipCount$().pipe(map(x => x > 0));
+    this.subscriptions.push(this.buttonVisible$.subscribe((showContextHelpToggle: boolean) => {
+      if (showContextHelpToggle) {
+        this.elRef.nativeElement.classList.remove('d-none');
+      } else {
+        this.elRef.nativeElement.classList.add('d-none');
+      }
+    }));
   }
 
   onClick() {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -7,7 +7,7 @@
 
       <nav role="navigation" [attr.aria-label]="'nav.user.description' | translate" class="navbar navbar-light navbar-expand-md flex-shrink-0 px-0">
         <ds-themed-search-navbar></ds-themed-search-navbar>
-        <ds-lang-switch></ds-lang-switch>
+        <ds-themed-lang-switch></ds-themed-lang-switch>
         <ds-context-help-toggle></ds-context-help-toggle>
         <ds-themed-auth-nav-menu></ds-themed-auth-nav-menu>
         <ds-impersonate-navbar></ds-impersonate-navbar>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -11,8 +11,8 @@
         <ds-context-help-toggle></ds-context-help-toggle>
         <ds-themed-auth-nav-menu></ds-themed-auth-nav-menu>
         <ds-impersonate-navbar></ds-impersonate-navbar>
-        <div class="pl-2">
-          <button class="navbar-toggler" type="button" (click)="toggleNavbar()"
+        <div *ngIf="isXsOrSm$ | async" class="pl-2">
+          <button class="navbar-toggler px-0" type="button" (click)="toggleNavbar()"
                   aria-controls="collapsingNav"
                   aria-expanded="false" [attr.aria-label]="'nav.toggle' | translate">
             <span class="navbar-toggler-icon fas fa-bars fa-fw" aria-hidden="true"></span>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -20,3 +20,7 @@
   }
 }
 
+.navbar {
+  display: flex;
+  gap: 0.25rem;
+}

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -22,5 +22,6 @@
 
 .navbar {
   display: flex;
-  gap: 0.25rem;
+  gap: calc(var(--bs-spacer) / 3);
+  align-items: center;
 }

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -10,6 +10,8 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MenuService } from '../shared/menu/menu.service';
 import { MenuServiceStub } from '../shared/testing/menu-service.stub';
+import { HostWindowService } from '../shared/host-window.service';
+import { HostWindowServiceStub } from '../shared/testing/host-window-service.stub';
 
 let comp: HeaderComponent;
 let fixture: ComponentFixture<HeaderComponent>;
@@ -26,6 +28,7 @@ describe('HeaderComponent', () => {
         ReactiveFormsModule],
       declarations: [HeaderComponent],
       providers: [
+        { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
         { provide: MenuService, useValue: menuService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -40,7 +43,7 @@ describe('HeaderComponent', () => {
     fixture = TestBed.createComponent(HeaderComponent);
 
     comp = fixture.componentInstance;
-
+    fixture.detectChanges();
   });
 
   describe('when the toggle button is clicked', () => {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { MenuService } from '../shared/menu/menu.service';
 import { MenuID } from '../shared/menu/menu-id.model';
+import { HostWindowService } from '../shared/host-window.service';
 
 /**
  * Represents the header with the logo and simple navigation
@@ -11,18 +12,23 @@ import { MenuID } from '../shared/menu/menu-id.model';
   styleUrls: ['header.component.scss'],
   templateUrl: 'header.component.html',
 })
-export class HeaderComponent {
+export class HeaderComponent implements OnInit {
   /**
    * Whether user is authenticated.
    * @type {Observable<string>}
    */
   public isAuthenticated: Observable<boolean>;
-  public showAuth = false;
+  public isXsOrSm$: Observable<boolean>;
   menuID = MenuID.PUBLIC;
 
   constructor(
-    private menuService: MenuService
+    protected menuService: MenuService,
+    protected windowService: HostWindowService,
   ) {
+  }
+
+  ngOnInit(): void {
+    this.isXsOrSm$ = this.windowService.isXsOrSm();
   }
 
   public toggleNavbar(): void {

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -14,9 +14,9 @@
     </a>
     <ul @slide *ngIf="(active | async)" (click)="deactivateSection($event)"
         class="m-0 shadow-none border-top-0 dropdown-menu show">
-        <ng-container *ngFor="let subSection of (subSections$ | async)">
+        <li *ngFor="let subSection of (subSections$ | async)">
             <ng-container
                     *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
-        </ng-container>
+        </li>
     </ul>
 </div>

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -4,7 +4,6 @@ import { MenuService } from '../../shared/menu/menu.service';
 import { slide } from '../../shared/animations/slide';
 import { first } from 'rxjs/operators';
 import { HostWindowService } from '../../shared/host-window.service';
-import { rendersSectionForMenu } from '../../shared/menu/menu-section.decorator';
 import { MenuID } from '../../shared/menu/menu-id.model';
 
 /**
@@ -16,7 +15,6 @@ import { MenuID } from '../../shared/menu/menu-id.model';
   styleUrls: ['./expandable-navbar-section.component.scss'],
   animations: [slide]
 })
-@rendersSectionForMenu(MenuID.PUBLIC, true)
 export class ExpandableNavbarSectionComponent extends NavbarSectionComponent implements OnInit {
   /**
    * This section resides in the Public Navbar

--- a/src/app/navbar/expandable-navbar-section/themed-expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/themed-expandable-navbar-section.component.ts
@@ -8,8 +8,7 @@ import { MenuID } from '../../shared/menu/menu-id.model';
  * Themed wrapper for ExpandableNavbarSectionComponent
  */
 @Component({
-  /* eslint-disable @angular-eslint/component-selector */
-  selector: 'li[ds-themed-expandable-navbar-section]',
+  selector: 'ds-themed-expandable-navbar-section',
   styleUrls: [],
   templateUrl: '../../shared/theme-support/themed.component.html',
 })

--- a/src/app/navbar/navbar-section/navbar-section.component.ts
+++ b/src/app/navbar/navbar-section/navbar-section.component.ts
@@ -8,8 +8,7 @@ import { MenuID } from '../../shared/menu/menu-id.model';
  * Represents a non-expandable section in the navbar
  */
 @Component({
-  /* eslint-disable @angular-eslint/component-selector */
-  selector: 'li[ds-navbar-section]',
+  selector: 'ds-navbar-section',
   templateUrl: './navbar-section.component.html',
   styleUrls: ['./navbar-section.component.scss']
 })

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -8,9 +8,9 @@
                     <li *ngIf="(isXsOrSm$ | async) && (isAuthenticated$ | async)">
                         <ds-user-menu [inExpandableNavbar]="true"></ds-user-menu>
                     </li>
-                    <ng-container *ngFor="let section of (sections | async)">
+                    <li *ngFor="let section of (sections | async)">
                         <ng-container *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;"></ng-container>
-                    </ng-container>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -1,9 +1,9 @@
 <div id="search-navbar-container" [title]="'nav.search' | translate" (dsClickOutside)="collapse()">
   <div class="d-inline-block position-relative">
-    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on">
+    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
       <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
              formControlName="query" type="text" placeholder="{{searchExpanded ? ('nav.search' | translate) : ''}}"
-             class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-right p-1" [attr.data-test]="'header-search-box' | dsBrowserOnly">
+             class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-right pl-1" [attr.data-test]="'header-search-box' | dsBrowserOnly">
       <button class="submit-icon btn btn-link btn-link-inline" [attr.aria-label]="'nav.search.button' | translate" type="button" (click)="searchExpanded ? onSubmit(searchForm.value) : expand()" [attr.data-test]="'header-search-icon' | dsBrowserOnly">
         <em class="fas fa-search fa-lg fa-fw"></em>
       </button>

--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -3,7 +3,10 @@
     <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
       <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
              formControlName="query" type="text" placeholder="{{searchExpanded ? ('nav.search' | translate) : ''}}"
-             class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-right pl-1" [attr.data-test]="'header-search-box' | dsBrowserOnly">
+             class="bg-transparent position-absolute form-control dropdown-menu-right pl-1 pr-4"
+             [class.display]="searchExpanded ? 'inline-block' : 'none'"
+             [tabIndex]="searchExpanded ? 0 : -1"
+             [attr.data-test]="'header-search-box' | dsBrowserOnly">
       <button class="submit-icon btn btn-link btn-link-inline" [attr.aria-label]="'nav.search.button' | translate" type="button" (click)="searchExpanded ? onSubmit(searchForm.value) : expand()" [attr.data-test]="'header-search-icon' | dsBrowserOnly">
         <em class="fas fa-search fa-lg fa-fw"></em>
       </button>

--- a/src/app/search-navbar/search-navbar.component.scss
+++ b/src/app/search-navbar/search-navbar.component.scss
@@ -12,6 +12,7 @@ input[type="text"] {
   cursor: pointer;
   position: sticky;
   top: 0;
+  border: 0 !important;
 
   color: var(--ds-header-icon-color);
   &:hover, &:focus {

--- a/src/app/shared/animations/slide.ts
+++ b/src/app/shared/animations/slide.ts
@@ -55,7 +55,7 @@ export const slideSidebarPadding = trigger('slideSidebarPadding', [
 
 export const expandSearchInput = trigger('toggleAnimation', [
   state('collapsed', style({
-    width: '30px',
+    width: '0',
     opacity: '0'
   })),
   state('expanded', style({

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
@@ -2,7 +2,7 @@
   <li *ngIf="!(isAuthenticated | async) && !(isXsOrSm$ | async) && (showAuth | async)" class="nav-item"
       (click)="$event.stopPropagation();">
     <div ngbDropdown #loginDrop display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
-      <a href="javascript:void(0);" class="dropdownLogin px-1" [attr.aria-label]="'nav.login' |translate"
+      <a href="javascript:void(0);" class="dropdownLogin px-0.5" [attr.aria-label]="'nav.login' |translate"
          (click)="$event.preventDefault()" [attr.data-test]="'login-menu' | dsBrowserOnly"
          ngbDropdownToggle>{{ 'nav.login' | translate }}</a>
       <div class="loginDropdownMenu" [ngClass]="{'pl-3 pr-3': (loading | async)}" ngbDropdownMenu
@@ -13,7 +13,7 @@
     </div>
   </li>
   <li *ngIf="!(isAuthenticated | async) && (isXsOrSm$ | async)" class="nav-item">
-    <a routerLink="/login" routerLinkActive="active" class="loginLink px-1">
+    <a routerLink="/login" routerLinkActive="active" class="loginLink px-0.5">
       {{ 'nav.login' | translate }}<span class="sr-only">(current)</span>
     </a>
   </li>

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-expandable-menu-section/dso-edit-menu-expandable-section.component.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-expandable-menu-section/dso-edit-menu-expandable-section.component.ts
@@ -13,7 +13,6 @@ import { hasValue } from '../../../empty.util';
  * Represents an expandable section in the dso edit menus
  */
 @Component({
-  /* tslint:disable:component-selector */
   selector: 'ds-dso-edit-menu-expandable-section',
   templateUrl: './dso-edit-menu-expandable-section.component.html',
   styleUrls: ['./dso-edit-menu-expandable-section.component.scss'],

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.ts
@@ -10,7 +10,6 @@ import { MenuSection } from '../../../menu/menu-section.model';
  * Represents a non-expandable section in the dso edit menus
  */
 @Component({
-  /* tslint:disable:component-selector */
   selector: 'ds-dso-edit-menu-section',
   templateUrl: './dso-edit-menu-section.component.html',
   styleUrls: ['./dso-edit-menu-section.component.scss']

--- a/src/app/shared/impersonate-navbar/impersonate-navbar.component.html
+++ b/src/app/shared/impersonate-navbar/impersonate-navbar.component.html
@@ -1,4 +1,4 @@
-<ul class="navbar-nav" *ngIf="(isAuthenticated$ | async) && isImpersonating">
+<ul class="navbar-nav" *ngIf="isImpersonating$ | async">
   <li class="nav-item">
     <button class="btn btn-sm btn-dark" ngbTooltip="{{'nav.stop-impersonating' | translate}}" (click)="stopImpersonating()">
       <i class="fa fa-user-secret"></i>

--- a/src/app/shared/impersonate-navbar/impersonate-navbar.component.spec.ts
+++ b/src/app/shared/impersonate-navbar/impersonate-navbar.component.spec.ts
@@ -14,6 +14,7 @@ import { authReducer } from '../../core/auth/auth.reducer';
 import { AuthTokenInfo } from '../../core/auth/models/auth-token-info.model';
 import { EPersonMock } from '../testing/eperson.mock';
 import { AppState, storeModuleConfig } from '../../app.reducer';
+import { of as observableOf } from 'rxjs';
 
 describe('ImpersonateNavbarComponent', () => {
   let component: ImpersonateNavbarComponent;
@@ -65,7 +66,7 @@ describe('ImpersonateNavbarComponent', () => {
 
   describe('when the user is impersonating another user', () => {
     beforeEach(() => {
-      component.isImpersonating = true;
+      component.isImpersonating$ = observableOf(true);
       fixture.detectChanges();
     });
 

--- a/src/app/shared/lang-switch/lang-switch.component.html
+++ b/src/app/shared/lang-switch/lang-switch.component.html
@@ -1,7 +1,7 @@
 <div ngbDropdown class="navbar-nav" *ngIf="moreThanOneLanguage" display="dynamic" placement="bottom-right">
   <a href="javascript:void(0);" role="button"
      [attr.aria-label]="'nav.language' |translate"
-     [title]="'nav.language' | translate" class="px-1"
+     [title]="'nav.language' | translate"
      (click)="$event.preventDefault()" data-toggle="dropdown" ngbDropdownToggle
      tabindex="0">
     <i class="fas fa-globe-asia fa-lg fa-fw"></i>

--- a/src/app/shared/lang-switch/lang-switch.component.ts
+++ b/src/app/shared/lang-switch/lang-switch.component.ts
@@ -1,7 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-
+import { Component, OnInit, ElementRef } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-
 import { LangConfig } from '../../../config/lang-config.interface';
 import { environment } from '../../../environments/environment';
 import { LocaleService } from '../../core/locale/locale.service';
@@ -25,6 +23,7 @@ export class LangSwitchComponent implements OnInit {
   moreThanOneLanguage: boolean;
 
   constructor(
+    public el: ElementRef,
     public translate: TranslateService,
     private localeService: LocaleService
   ) {
@@ -33,6 +32,9 @@ export class LangSwitchComponent implements OnInit {
   ngOnInit(): void {
     this.activeLangs = environment.languages.filter((MyLangConfig) => MyLangConfig.active === true);
     this.moreThanOneLanguage = (this.activeLangs.length > 1);
+    if (!this.moreThanOneLanguage) {
+      this.el.nativeElement.style.display = 'none';
+    }
   }
 
   /**

--- a/src/app/shared/lang-switch/lang-switch.component.ts
+++ b/src/app/shared/lang-switch/lang-switch.component.ts
@@ -33,7 +33,7 @@ export class LangSwitchComponent implements OnInit {
     this.activeLangs = environment.languages.filter((MyLangConfig) => MyLangConfig.active === true);
     this.moreThanOneLanguage = (this.activeLangs.length > 1);
     if (!this.moreThanOneLanguage) {
-      this.el.nativeElement.style.display = 'none';
+      this.el.nativeElement.parentElement.classList.add('d-none');
     }
   }
 

--- a/src/app/shared/lang-switch/themed-lang-switch.component.ts
+++ b/src/app/shared/lang-switch/themed-lang-switch.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { ThemedComponent } from '../theme-support/themed.component';
+import { LangSwitchComponent } from './lang-switch.component';
+
+/**
+ * Themed wrapper for {@link LangSwitchComponent}
+ */
+@Component({
+  selector: 'ds-themed-lang-switch',
+  styleUrls: [],
+  templateUrl: '../theme-support/themed.component.html',
+})
+export class ThemedLangSwitchComponent extends ThemedComponent<LangSwitchComponent> {
+
+  protected getComponentName(): string {
+    return 'LangSwitchComponent';
+  }
+
+  protected importThemedComponent(themeName: string): Promise<any> {
+    return import(`../../../themes/${themeName}/app/shared/lang-switch/lang-switch.component`);
+  }
+
+  protected importUnthemedComponent(): Promise<any> {
+    return import(`./lang-switch.component`);
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -284,6 +284,7 @@ import {
 } from '../item-page/simple/field-components/specific-field/title/themed-item-page-field.component';
 import { BitstreamListItemComponent } from './object-list/bitstream-list-item/bitstream-list-item.component';
 import { NgxPaginationModule } from 'ngx-pagination';
+import { ThemedLangSwitchComponent } from './lang-switch/themed-lang-switch.component';
 
 const MODULES = [
   CommonModule,
@@ -335,6 +336,7 @@ const COMPONENTS = [
   DsSelectComponent,
   ErrorComponent,
   LangSwitchComponent,
+  ThemedLangSwitchComponent,
   LoadingComponent,
   ThemedLoadingComponent,
   LogInComponent,

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -267,3 +267,29 @@ ul.dso-edit-menu-dropdown > li .nav-item.nav-link {
 .table td {
   vertical-align: middle;
 }
+
+.pt-0\.5 {
+  padding-top: 0.125rem !important;
+}
+
+.pr-0\.5 {
+  padding-right: 0.125rem !important;
+}
+
+.pb-0\.5 {
+  padding-bottom: 0.125rem !important;
+}
+
+.pl-0\.5 {
+  padding-left: 0.125rem !important;
+}
+
+.px-0\.5 {
+  padding-left: 0.125rem !important;
+  padding-right: 0.125rem !important;
+}
+
+.py-0\.5 {
+  padding-top: 0.125rem !important;
+  padding-bottom: 0.125rem !important;
+}

--- a/src/themes/custom/app/shared/lang-switch/lang-switch.component.ts
+++ b/src/themes/custom/app/shared/lang-switch/lang-switch.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { LangSwitchComponent as BaseComponent } from '../../../../../app/shared/lang-switch/lang-switch.component';
+
+@Component({
+  selector: 'ds-lang-switch',
+  // styleUrls: ['./lang-switch.component.scss'],
+  styleUrls: ['../../../../../app/shared/lang-switch/lang-switch.component.scss'],
+  // templateUrl: './lang-switch.component.html',
+  templateUrl: '../../../../../app/shared/lang-switch/lang-switch.component.html',
+})
+export class LangSwitchComponent extends BaseComponent {
+}

--- a/src/themes/custom/eager-theme.module.ts
+++ b/src/themes/custom/eager-theme.module.ts
@@ -54,6 +54,7 @@ import {
   ItemSearchResultListElementComponent
 } from './app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component';
 import { TopLevelCommunityListComponent } from './app/home-page/top-level-community-list/top-level-community-list.component';
+import { LangSwitchComponent } from './app/shared/lang-switch/lang-switch.component';
 
 
 /**
@@ -91,6 +92,7 @@ const DECLARATIONS = [
   EditCollectionSelectorComponent,
   EditCommunitySelectorComponent,
   EditItemSelectorComponent,
+  LangSwitchComponent,
 ];
 
 @NgModule({

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -7,7 +7,7 @@
     </div>
     <div class="d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
       <ds-themed-search-navbar></ds-themed-search-navbar>
-      <ds-lang-switch></ds-lang-switch>
+      <ds-themed-lang-switch></ds-themed-lang-switch>
       <ds-context-help-toggle></ds-context-help-toggle>
       <ds-themed-auth-nav-menu></ds-themed-auth-nav-menu>
       <ds-impersonate-navbar></ds-impersonate-navbar>

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -5,7 +5,7 @@
         <img src="assets/images/dspace-logo.svg" [attr.alt]="'menu.header.image.logo' | translate"/>
       </a>
     </div>
-    <div class="d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
+    <div class="navbar-buttons d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
       <ds-themed-search-navbar></ds-themed-search-navbar>
       <ds-themed-lang-switch></ds-themed-lang-switch>
       <ds-context-help-toggle></ds-context-help-toggle>

--- a/src/themes/dspace/app/header/header.component.scss
+++ b/src/themes/dspace/app/header/header.component.scss
@@ -24,3 +24,9 @@
     color: var(--ds-header-icon-color-hover);
   }
 }
+
+.navbar-buttons {
+  display: flex;
+  gap: calc(var(--bs-spacer) / 3);
+  align-items: center;
+}

--- a/src/themes/dspace/app/navbar/navbar.component.html
+++ b/src/themes/dspace/app/navbar/navbar.component.html
@@ -10,9 +10,9 @@
         <li *ngIf="(isXsOrSm$ | async) && (isAuthenticated$ | async)">
             <ds-user-menu [inExpandableNavbar]="true"></ds-user-menu>
         </li>
-        <ng-container *ngFor="let section of (sections | async)">
+        <li *ngFor="let section of (sections | async)">
           <ng-container *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;"></ng-container>
-        </ng-container>
+        </li>
       </ul>
     </div>
     <div class="navbar-buttons">

--- a/src/themes/dspace/app/navbar/navbar.component.html
+++ b/src/themes/dspace/app/navbar/navbar.component.html
@@ -15,10 +15,12 @@
         </ng-container>
       </ul>
     </div>
-    <ds-search-navbar class="navbar-collapsed"></ds-search-navbar>
-    <ds-themed-lang-switch class="navbar-collapsed"></ds-themed-lang-switch>
-    <ds-context-help-toggle class="navbar-collapsed"></ds-context-help-toggle>
-    <ds-themed-auth-nav-menu class="navbar-collapsed"></ds-themed-auth-nav-menu>
-    <ds-impersonate-navbar class="navbar-collapsed"></ds-impersonate-navbar>
+    <div class="navbar-buttons">
+      <ds-themed-search-navbar class="navbar-collapsed"></ds-themed-search-navbar>
+      <ds-themed-lang-switch class="navbar-collapsed"></ds-themed-lang-switch>
+      <ds-context-help-toggle class="navbar-collapsed"></ds-context-help-toggle>
+      <ds-themed-auth-nav-menu class="navbar-collapsed"></ds-themed-auth-nav-menu>
+      <ds-impersonate-navbar class="navbar-collapsed"></ds-impersonate-navbar>
+    </div>
   </div>
 </nav>

--- a/src/themes/dspace/app/navbar/navbar.component.html
+++ b/src/themes/dspace/app/navbar/navbar.component.html
@@ -16,7 +16,7 @@
       </ul>
     </div>
     <ds-search-navbar class="navbar-collapsed"></ds-search-navbar>
-    <ds-lang-switch class="navbar-collapsed"></ds-lang-switch>
+    <ds-themed-lang-switch class="navbar-collapsed"></ds-themed-lang-switch>
     <ds-context-help-toggle class="navbar-collapsed"></ds-context-help-toggle>
     <ds-themed-auth-nav-menu class="navbar-collapsed"></ds-themed-auth-nav-menu>
     <ds-impersonate-navbar class="navbar-collapsed"></ds-impersonate-navbar>

--- a/src/themes/dspace/app/navbar/navbar.component.scss
+++ b/src/themes/dspace/app/navbar/navbar.component.scss
@@ -54,3 +54,9 @@ a.navbar-brand img {
     color: var(--ds-navbar-link-color-hover);
   }
 }
+
+.navbar-buttons {
+  display: flex;
+  gap: calc(var(--bs-spacer) / 3);
+  align-items: center;
+}


### PR DESCRIPTION
## References
- Partially resolves larger ticket #1174
  - one of these was probably for the `ExpandableNavbarSectionComponent`: 468407, 468408, 468409, 468410
  - Issue ID: 468472

## Description
Minor header improvements for header icons spacing (by refactoring the code to use flex gap) & improved search navbar bar accessibility.

<img width="20%" alt="image" src="https://github.com/DSpace/dspace-angular/assets/43750381/a2d9e950-1530-4470-8544-136e1174f56f">

## Instructions for Reviewers
List of changes in this PR:
* Fixed a html issue: the `ExpandableNavbarSectionComponent` has a `<ul>` containing non-`<li>` elements ([here](https://github.com/DSpace/dspace-angular/blob/7caacdb20aa465bb0b60d5789831bb910faa6b60/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html#L15))
* Added flex gap to the navbar button container
* Removed the individual paddings on all the buttons
* Improved the search navbar by preventing it to focus on the input when it's not expanded (Deque issue ID: 468472)
* Themed the `LangSwitchComponent` for testing purposes in order to check that when the language button is hidden that there is no double padding being applied & that it works for themed components as well

**Include guidance for how to test or review your PR:**
* Test this by just looking at the header icons in both mobile & desktop mode
* Test it with the `dspace` theme & the base theme (done by commenting out the `dspace` theme in `src/config/default-app-config.ts`)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
