### PR TITLE
Issue 2535 hide add more button submission if no disabled sections 7.x

### DIFF
--- a/src/app/submission/form/section-add/submission-form-section-add.component.html
+++ b/src/app/submission/form/section-add/submission-form-section-add.component.html
@@ -3,13 +3,14 @@
      placement="bottom-right"
      class="d-inline-block"
      [ngClass]="{'w-100': windowService.isXs()}">
+  <ng-container *ngIf="hasSections$ | async">
   <button class="btn btn-outline-primary dropdown-toggle"
           id="sectionControls"
-          [disabled]="!(hasSections$ | async)"
           [ngClass]="{'w-100': (windowService.isXs() | async)}"
           ngbDropdownToggle>
           {{ 'submission.sections.general.add-more' | translate }} <i class="fa fa-plus" aria-hidden="true"></i>
   </button>
+  </ng-container>
   <div ngbDropdownMenu
        class="sections-dropdown-menu"
        aria-labelledby="sectionControls"


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/2535

## Description
Hides the disabled [+Add More] button in top right corner of submission causing confusion

## Instructions for Reviewers
With **no** disabled steps (default):

- Go to submission in default submission form, eg https://demo.dspace.org/workspaceitems/33406/edit
- There is a no more disabled [+Add More] button in top right corner of submission causing confusion

With disabled steps:
- Set `mandatory="false"` in `item-submission.xml`: `<step-definition id="traditionalpagetwo" mandatory="false">` on the default second describe step
- Verify in submission of default submission form that the [+Add More] button in top right corner is now present again & contains a dropdown containing the second described step (if clicked adds that step to the submission)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
