### PR TITLE
Fix i18n labels and alignment in vocabulary-treeview

### DIFF
--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
@@ -1,4 +1,4 @@
-<ds-alert *ngIf="description | async" [content]="description | async" [type]="'alert-info'"></ds-alert>
+<ds-alert [content]="'vocabulary-treeview.info' | translate" [type]="'alert-info'"></ds-alert>
 <div class="treeview-header row">
   <div class="col-12">
     <div class="input-group">

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
@@ -23,7 +23,7 @@
     <!-- Leaf node -->
     <cdk-tree-node *cdkTreeNodeDef="let node" cdkTreeNodePadding class="d-flex">
         <button type="button" class="btn btn-default" cdkTreeNodeToggle>
-          <span class="fas fa-angle-right invisible" aria-hidden="true"></span>
+          <span class="fas fa-fw fa-angle-right invisible" aria-hidden="true"></span>
         </button>
           <label *ngIf="multiSelect" class="d-flex align-items-center m-0 p-0 form-check"
                  [class.text-success]="node.isSelected"
@@ -55,7 +55,7 @@
         <button type="button" class="btn btn-default" cdkTreeNodeToggle
                 [attr.aria-label]="'toggle ' + node.name"
                 (click)="loadChildren(node)">
-          <span class="fas {{treeControl.isExpanded(node) ? 'fa-angle-down' : 'fa-angle-right'}}"
+          <span class="fas fa-fw {{treeControl.isExpanded(node) ? 'fa-angle-down' : 'fa-angle-right'}}"
                 aria-hidden="true"></span>
         </button>
 

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -1,7 +1,6 @@
 import { FlatTreeControl } from '@angular/cdk/tree';
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
 
-import { map } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
@@ -16,7 +15,6 @@ import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vo
 import { VocabularyTreeFlattener } from './vocabulary-tree-flattener';
 import { VocabularyTreeFlatDataSource } from './vocabulary-tree-flat-data-source';
 import { CoreState } from '../../../core/core-state.model';
-import { lowerCase } from 'lodash/string';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
 
@@ -49,11 +47,6 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * Whether to allow selecting multiple values with checkboxes
    */
   @Input() multiSelect = false;
-
-  /**
-   * Contain a descriptive message for this vocabulary retrieved from i18n files
-   */
-  description: Observable<string>;
 
   /**
    * A map containing the current node showed by the tree
@@ -214,12 +207,6 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
       this.vocabularyTreeviewService.getData().subscribe((data) => {
         this.dataSource.data = data;
       })
-    );
-
-    this.translate.get(`search.filters.filter.${this.vocabularyOptions.name}.head`).pipe(
-      map((type) => lowerCase(type)),
-    ).subscribe(
-      (type) => this.description = this.translate.get('vocabulary-treeview.info', { type })
     );
 
     this.loading = this.vocabularyTreeviewService.isLoading();


### PR DESCRIPTION
## Description

### i18n labels

The `vocabulary-treeview` uses the `description` variable to show an i18n label:

    this.translate.get(`search.filters.filter.${this.vocabularyOptions.name}.head`).pipe(
      map((type) => lowerCase(type)),
    ).subscribe(
      (type) => this.description = this.translate.get('vocabulary-treeview.info', { type })
    );

The label used to contain a `type` parameter, but it doesn't contain it anymore.
Therefore this code can be safely removed and the label can be used directly in the HTML template.

### Alignment

The tree view uses `fa-angle-right` and `fa-angle-down` FA icons, which have different widths. When an item is expanded it is no longer aligned with other items:
![Schermata del 2023-10-13 10-53-01](https://github.com/DSpace/dspace-angular/assets/87638927/4a47e10e-9b0b-4c7b-897f-669ab07058be)

I added the `fa-fw` class to give the icons a fixed width:
![Schermata del 2023-10-13 10-59-36](https://github.com/DSpace/dspace-angular/assets/87638927/d3a4a7e5-258d-4cf1-adb5-597e19083095)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
