### PR TITLE
Revert 2454 "Check cssRules before css variables are read from stylesheet"

### DIFF
--- a/src/app/shared/sass-helper/css-variable.service.ts
+++ b/src/app/shared/sass-helper/css-variable.service.ts
@@ -26,15 +26,6 @@ export class CSSVariableService {
     return styleSheet.href.indexOf(window.location.origin) === 0;
   };
 
-  /**
-   * Checks whether the specific stylesheet object has the property cssRules
-   * @param styleSheet The stylesheet
-   */
-  hasCssRules = (styleSheet) => {
-    // Injected styles might have no css rules value
-    return styleSheet.hasOwnProperty('cssRules') && styleSheet.cssRules;
-  };
-
   /*
    Determine if the given rule is a CSSStyleRule
    See: https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants
@@ -102,10 +93,8 @@ export class CSSVariableService {
     if (isNotEmpty(document.styleSheets)) {
       // styleSheets is array-like, so we convert it to an array.
       // Filter out any stylesheets not on this domain
-      // Filter out any stylesheets that have no cssRules property
       return [...document.styleSheets]
         .filter(this.isSameDomain)
-        .filter(this.hasCssRules)
         .reduce(
           (finalArr, sheet) =>
             finalArr.concat(


### PR DESCRIPTION
This reverts #2454 (i.e. commit fa79c358c09cb52ed142ef122e08b77de880685d)

## Description
Fixes #2557  (which was an accidental side effect of the changes in #2454)

## Instructions for Reviewers
See details in #2557.  This bug is appearing on all demo sites and locally. 