### PR TITLE
Fix RequestService test sometimes failing in CICD

### DIFF
--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -661,7 +661,9 @@ describe('RequestService', () => {
       spyOn(service, 'getByHref').and.returnValue(observableOf(staleRE));
       spyOn(store, 'dispatch');
       service.setStaleByHref(href).subscribe(() => {
-        expect(store.dispatch).toHaveBeenCalledWith(new RequestStaleAction(uuid));
+        const requestStaleAction = new RequestStaleAction(uuid);
+        requestStaleAction.lastUpdated = jasmine.any(Number) as any;
+        expect(store.dispatch).toHaveBeenCalledWith(requestStaleAction);
         done();
       });
     });


### PR DESCRIPTION
## Description
Because tests are executed slower on CICD it can sometimes take one second or more to execute the `RequestService#setStaleByHref(href)`, when the test arrives inside the subscribe, a create new `RequestStaleAction` with the current time is created (this can already be a few seconds after `RequestService#setStaleByHref(href)` was called). To prevent such errors we can just expect that `lastUpdated` will be a number instead of comparing the actual values. The purpose of that test is to check the type of `RequestUpdateAction` returned by the function and not the date when it was created, so this doesn't have any side effects. [This is an example of such a failure.](https://github.com/DSpace/dspace-angular/actions/runs/6580387915/job/17878258713)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
