### PR TITLE
Fix "Submission input type date doesn't work properly once a value has been set"

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.spec.ts
@@ -1,7 +1,7 @@
 // Load the implementations that should be tested
-import { ChangeDetectorRef, Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, inject, TestBed, waitForAsync, } from '@angular/core/testing';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { ChangeDetectorRef, Component, CUSTOM_ELEMENTS_SCHEMA, Renderer2 } from '@angular/core';
+import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync, } from '@angular/core/testing';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { DynamicFormLayoutService, DynamicFormValidationService } from '@ng-dynamic-forms/core';
@@ -13,6 +13,7 @@ import {
   mockDynamicFormLayoutService,
   mockDynamicFormValidationService
 } from '../../../../../testing/dynamic-form-mock-services';
+import { By } from '@angular/platform-browser';
 
 
 export const DATE_TEST_GROUP = new UntypedFormGroup({
@@ -39,6 +40,11 @@ describe('DsDatePickerComponent test suite', () => {
   let dateFixture: ComponentFixture<DsDatePickerComponent>;
   let html;
 
+  const renderer2: Renderer2 = {
+    selectRootElement: jasmine.createSpy('selectRootElement'),
+    querySelector: jasmine.createSpy('querySelector'),
+  } as unknown as Renderer2;
+
   // waitForAsync beforeEach
   beforeEach(waitForAsync(() => {
 
@@ -54,7 +60,8 @@ describe('DsDatePickerComponent test suite', () => {
         ChangeDetectorRef,
         DsDatePickerComponent,
         { provide: DynamicFormLayoutService, useValue: mockDynamicFormLayoutService },
-        { provide: DynamicFormValidationService, useValue: mockDynamicFormValidationService }
+        { provide: DynamicFormValidationService, useValue: mockDynamicFormValidationService },
+        { provide: Renderer2, useValue: renderer2 },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
@@ -233,6 +240,102 @@ describe('DsDatePickerComponent test suite', () => {
         expect(dateComp.disabledMonth).toBeFalsy();
         expect(dateComp.disabledDay).toBeFalsy();
       });
+
+      it('should move focus on month field when on year field and tab pressed', fakeAsync(() => {
+        const event = {
+          field: 'day',
+          value: null
+        };
+        const event1 = {
+          field: 'month',
+          value: null
+        };
+        dateComp.onChange(event);
+        dateComp.onChange(event1);
+
+        const yearElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_year`));
+        const monthElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_month`));
+
+        yearElement.nativeElement.focus();
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(yearElement.nativeElement);
+
+        dateFixture.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'tab' }));
+        dateFixture.detectChanges();
+
+        tick(200);
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(monthElement.nativeElement);
+      }));
+
+      it('should move focus on day field when on month field and tab pressed', fakeAsync(() => {
+        const event = {
+          field: 'day',
+          value: null
+        };
+        dateComp.onChange(event);
+
+        const monthElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_month`));
+        const dayElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_day`));
+
+        monthElement.nativeElement.focus();
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(monthElement.nativeElement);
+
+        dateFixture.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'tab' }));
+        dateFixture.detectChanges();
+
+        tick(200);
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(dayElement.nativeElement);
+      }));
+
+      it('should move focus on month field when on day field and shift tab pressed', fakeAsync(() => {
+        const event = {
+          field: 'day',
+          value: null
+        };
+        dateComp.onChange(event);
+
+        const monthElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_month`));
+        const dayElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_day`));
+
+        dayElement.nativeElement.focus();
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(dayElement.nativeElement);
+
+        dateFixture.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'shift.tab' }));
+        dateFixture.detectChanges();
+
+        tick(200);
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(monthElement.nativeElement);
+      }));
+
+      it('should move focus on year field when on month field and shift tab pressed', fakeAsync(() => {
+        const yearElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_year`));
+        const monthElement = dateFixture.debugElement.query(By.css(`#${dateComp.model.id}_month`));
+
+        monthElement.nativeElement.focus();
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(monthElement.nativeElement);
+
+        dateFixture.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'shift.tab' }));
+        dateFixture.detectChanges();
+
+        tick(200);
+        dateFixture.detectChanges();
+
+        expect(document.activeElement).toBe(yearElement.nativeElement);
+      }));
+
     });
   });
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
+import { Component, EventEmitter, HostListener, Inject, Input, OnInit, Output, Renderer2 } from '@angular/core';
 import { DynamicDsDatePickerModel } from './date-picker.model';
 import { hasValue } from '../../../../../empty.util';
 import {
@@ -7,6 +7,11 @@ import {
   DynamicFormLayoutService,
   DynamicFormValidationService
 } from '@ng-dynamic-forms/core';
+import { DOCUMENT } from '@angular/common';
+import isEqual from 'lodash/isEqual';
+
+
+export type DatePickerFieldType = '_year' | '_month' | '_day';
 
 export const DS_DATE_PICKER_SEPARATOR = '-';
 
@@ -50,8 +55,12 @@ export class DsDatePickerComponent extends DynamicFormControlComponent implement
   disabledMonth = true;
   disabledDay = true;
 
+  private readonly fields: DatePickerFieldType[] = ['_year', '_month', '_day'];
+
   constructor(protected layoutService: DynamicFormLayoutService,
-              protected validationService: DynamicFormValidationService
+              protected validationService: DynamicFormValidationService,
+              private renderer: Renderer2,
+              @Inject(DOCUMENT) private _document: Document
   ) {
     super(layoutService, validationService);
   }
@@ -164,6 +173,67 @@ export class DsDatePickerComponent extends DynamicFormControlComponent implement
 
     this.model.value = value;
     this.change.emit(value);
+  }
+
+  /**
+   * Listen to keydown Tab event.
+   * Get the active element and blur it, in order to focus the next input field.
+   */
+  @HostListener('keydown.tab', ['$event'])
+  onTabKeydown(event: KeyboardEvent) {
+    event.preventDefault();
+    const activeElement: Element = this._document.activeElement;
+    (activeElement as any).blur();
+    const index = this.selectedFieldIndex(activeElement);
+    if (index < 0) {
+      return;
+    }
+    let fieldToFocusOn = index + 1;
+    if (fieldToFocusOn < this.fields.length) {
+      this.focusInput(this.fields[fieldToFocusOn]);
+    }
+  }
+
+  @HostListener('keydown.shift.tab', ['$event'])
+  onShiftTabKeyDown(event: KeyboardEvent) {
+    event.preventDefault();
+    const activeElement: Element = this._document.activeElement;
+    (activeElement as any).blur();
+    const index = this.selectedFieldIndex(activeElement);
+    let fieldToFocusOn = index - 1;
+    if (fieldToFocusOn >= 0) {
+      this.focusInput(this.fields[fieldToFocusOn]);
+    }
+  }
+
+  private selectedFieldIndex(activeElement: Element): number {
+    return this.fields.findIndex(field => isEqual(activeElement.id, this.model.id.concat(field)));
+  }
+
+  /**
+   * Focus the input field for the given type
+   * based on the model id.
+   * Used to focus the next input field
+   * in case of a disabled field.
+   * @param type DatePickerFieldType
+   */
+  focusInput(type: DatePickerFieldType) {
+    const field = this._document.getElementById(this.model.id.concat(type));
+    if (field) {
+
+      if (hasValue(this.year) && isEqual(type, '_year')) {
+        this.disabledMonth = true;
+        this.disabledDay = true;
+      }
+      if (hasValue(this.year) && isEqual(type, '_month')) {
+        this.disabledMonth = false;
+      } else if (hasValue(this.month) && isEqual(type, '_day')) {
+        this.disabledDay = false;
+      }
+      setTimeout(() => {
+        this.renderer.selectRootElement(field).focus();
+      }, 100);
+    }
   }
 
   onFocus(event) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
@@ -89,9 +89,8 @@ export class DsDatePickerComponent extends DynamicFormControlComponent implement
       }
     }
 
-    this.maxYear = this.initialYear + 100;
-
-  }
+    this.maxYear = now.getUTCFullYear() + 100;
+    }
 
   onBlur(event) {
     this.blur.emit();

--- a/src/app/shared/form/number-picker/number-picker.component.ts
+++ b/src/app/shared/form/number-picker/number-picker.component.ts
@@ -103,13 +103,12 @@ export class NumberPickerComponent implements OnInit, ControlValueAccessor {
 
       if (i >= this.min && i <= this.max) {
         this.value = i;
-        this.emitChange();
       } else if (event.target.value === null || event.target.value === '') {
         this.value = null;
-        this.emitChange();
       } else {
         this.value = undefined;
       }
+      this.emitChange();
     } catch (e) {
       this.value = undefined;
     }


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/2588

## Description
There have been changes on `DsDatePickerComponent` and `NumberPickerComponent` affecting the `maxYear` value, because the issue was caused by the restriction set by `maxYear`  value on `DsDatePickerComponent`. `update()` method in `NumberPickerComponent` is fixed in order to emit the changes when the value is greater than the maxValue. This change triggers the form validations. 

## Instructions for Reviewers
List of changes in this PR:
* First, `maxYear` variable should not get its value by `initialYear` ( because for eg. in our case the initialYear's value is 23), but it should consider `now.getUTCFullYear()` and start from the actual year (+ 100 , existing part).
 But in case it is entered a greater value than `now.getUTCFullYear() + 100` , the behavior with leaving the input empty will be triggered again.
* So, in order to trigger the validations of the form, the `update()` method of `NumberPickerComponent` is fixed in order to emit the changes when the value is greater than the `maxValue` (it emits `undefined` in this case). This way the user will make sure to enter a valid value.

**steps to reproduce the bug**  are the same as described on https://github.com/DSpace/dspace-angular/issues/2588
**Result:**
https://github.com/DSpace/dspace-angular/assets/126179045/97984ce5-cdc7-42e9-9719-bcaa8a7db7f1


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
