### PR TITLE
Support for freetext values in submission for vocabulary controlled `onebox` and `tag` types

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
@@ -89,6 +89,18 @@ export class DsDynamicTagComponent extends DsDynamicVocabularyComponent implemen
         }
       }),
       map((list: PaginatedList<VocabularyEntry>) => list.page),
+      // Add user input as last item of the list
+      map((list: VocabularyEntry[]) => {
+        if (list && list.length > 0) {
+          if (isNotEmpty(this.currentValue)) {
+            let vocEntry = new VocabularyEntry();
+            vocEntry.display = this.currentValue;
+            vocEntry.value = this.currentValue;
+            list.push(vocEntry);
+        }
+        }
+        return list;
+      }),
       tap(() => this.changeSearchingStatus(false)),
       merge(this.hideSearchingWhenUnsubscribed));
 

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
@@ -10,6 +10,9 @@
         <button class="btn btn-outline-secondary" type="button" (click)="reset()">
           {{'vocabulary-treeview.search.form.reset' | translate}}
         </button>
+        <button class="btn btn-outline-primary" type="button" (click)="add()" [disabled]="this.vocabularyOptions.closed">
+          {{'vocabulary-treeview.search.form.add' | translate}}
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -293,6 +293,15 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
     }
   }
 
+  add() {
+    const userVocabularyEntry = {
+      value: this.searchText,
+      display: this.searchText,
+    } as VocabularyEntryDetail;
+    this.select.emit(userVocabularyEntry);
+  }
+
+
   /**
    * Unsubscribe from all subscriptions
    */

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5240,4 +5240,6 @@
 
   "access-control-option-end-date-note": "Select the date until which the related access condition is applied",
 
+  "vocabulary-treeview.search.form.add": "Add",
+
 }


### PR DESCRIPTION
## References
* Fixes #2435
* Requires DSpace/DSpace#9181

## Description
This PR adds support for adding custom input in submission fields that are controlled by a vocabulary

## Instructions for Reviewers
List of changes in this PR:
* Altered the `VocabularyTreeviewComponent` class and html template to show an "Add" (i18n message) button. This button is disabled if the vocabulary is closed, or if no text is given.
* Altered the `DynamicTagComponent` class so that custom user input is supported. If results are present from the vocabulary autofill, the custom user input is appended to the bottom of the list, this is done since a value from the vocabulary is preferred.

An in-depth "how-to-test" guide is included in the back end PR as these PR's can not be tested separately  

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
