### PR TITLE
Fix e2e tests by running in production mode & using a user-agent for statistics

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -177,6 +177,8 @@ function generateViewEvent(uuid: string, dsoType: string): void {
                 [XSRF_REQUEST_HEADER] : csrfToken,
                 // use a known public IP address to avoid being seen as a "bot"
                 'X-Forwarded-For': '1.1.1.1',
+                // Use a user-agent of a Firefox browser on Windows. This again avoids being seen as a "bot"
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0',
             },
             //form: true, // indicates the body should be form urlencoded
             body: { targetId: uuid, targetType: dsoType },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:headless": "ng test --source-map=true --watch=false --configuration test --browsers=ChromeHeadless --code-coverage",
     "lint": "ng lint",
     "lint-fix": "ng lint --fix=true",
-    "e2e": "ng e2e",
+    "e2e": "cross-env NODE_ENV=production ng e2e",
     "clean:dev:config": "rimraf src/assets/config.json",
     "clean:coverage": "rimraf coverage",
     "clean:dist": "rimraf dist",


### PR DESCRIPTION
## References
* Fixes a bug in e2e tests which was an accidental side effect of https://github.com/DSpace/dspace-angular/pull/2464
* Adds a `user-agent` to e2e tests which generate statistics, as that's now required after https://github.com/DSpace/DSpace/pull/9157 was merged on backend

## Description
Fixes broken `homepage-statistics.cy.ts` tests based on a few recent changes:
* e2e tests need to run in Production mode for i18n text to always load.  This impacted tests more when running them locally via `yarn e2e`.  See first commit in this PR
* e2e test utility for generating usage statistics MUST have a `user-agent` which makes it look like a browser.  This is required because https://github.com/DSpace/DSpace/pull/9157 updated our user-agent list to include `HeadlessChrome`, thus ignoring all statistics from headless Chrome, which is the browser we use in GitHub CI. See second commit in this PR

## Instructions for Reviewers
* Assuming all GitHub CI tests succeed, we should merge this immediately.  This `homepage-statistics.cy.ts` test is failing consistently because it cannot generate usage statistics required for its tests. 