### PR TITLE
Fixed menu not updating when a new sub section is added after rendering has already completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "7.6.0-next",
+  "version": "7.6.0",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",

--- a/src/app/shared/menu/menu.component.spec.ts
+++ b/src/app/shared/menu/menu.component.spec.ts
@@ -1,12 +1,12 @@
+// eslint-disable-next-line max-classes-per-file
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { ChangeDetectionStrategy, Injector, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ChangeDetectionStrategy, Injector, NO_ERRORS_SCHEMA, Component } from '@angular/core';
 import { MenuService } from './menu.service';
 import { MenuComponent } from './menu.component';
-import { MenuServiceStub } from '../testing/menu-service.stub';
-import { of as observableOf } from 'rxjs';
-import { Router, ActivatedRoute } from '@angular/router';
+import { of as observableOf, BehaviorSubject } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MenuSection } from './menu-section.model';
 import { MenuID } from './menu-id.model';
@@ -15,14 +15,39 @@ import { AuthorizationDataService } from '../../core/data/feature-authorization/
 import { createSuccessfulRemoteDataObject } from '../remote-data.utils';
 import { ThemeService } from '../theme-support/theme.service';
 import { getMockThemeService } from '../mocks/theme-service.mock';
+import { MenuItemType } from './menu-item-type.model';
+import { LinkMenuItemModel } from './menu-item/models/link.model';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { StoreModule, Store } from '@ngrx/store';
+import { authReducer } from '../../core/auth/auth.reducer';
+import { storeModuleConfig, AppState } from '../../app.reducer';
+import { rendersSectionForMenu } from './menu-section.decorator';
+
+const mockMenuID = 'mock-menuID' as MenuID;
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '',
+  template: '',
+})
+@rendersSectionForMenu(mockMenuID, true)
+class TestExpandableMenuComponent {
+}
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '',
+  template: '',
+})
+@rendersSectionForMenu(mockMenuID, false)
+class TestMenuComponent {
+}
 
 describe('MenuComponent', () => {
   let comp: MenuComponent;
   let fixture: ComponentFixture<MenuComponent>;
   let menuService: MenuService;
-  let router: any;
-
-  const mockMenuID = 'mock-menuID' as MenuID;
+  let store: MockStore;
 
   const mockStatisticSection = { 'id': 'statistics_site', 'active': true, 'visible': true, 'index': 2, 'type': 'statistics', 'model': { 'type': 1, 'text': 'menu.section.statistics', 'link': 'statistics' } };
 
@@ -48,21 +73,55 @@ describe('MenuComponent', () => {
     children: []
   };
 
+  const initialState = {
+    menus: {
+      [mockMenuID]: {
+        collapsed: true,
+        id: mockMenuID,
+        previewCollapsed: true,
+        sectionToSubsectionIndex: {
+          section1: [],
+        },
+        sections: {
+          section1: {
+            id: 'section1',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'test',
+              link: '/test',
+            } as LinkMenuItemModel,
+          },
+        },
+        visible: true,
+      },
+    },
+  };
+
   beforeEach(waitForAsync(() => {
 
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(false)
     });
 
-    TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), NoopAnimationsModule, RouterTestingModule],
+    void TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        NoopAnimationsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(authReducer, storeModuleConfig),
+      ],
       declarations: [MenuComponent],
       providers: [
         Injector,
         { provide: ThemeService, useValue: getMockThemeService() },
-        { provide: MenuService, useClass: MenuServiceStub },
+        MenuService,
+        provideMockStore({ initialState }),
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: ActivatedRoute, useValue: routeStub },
+        TestExpandableMenuComponent,
+        TestMenuComponent,
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).overrideComponent(MenuComponent, {
@@ -74,11 +133,60 @@ describe('MenuComponent', () => {
     fixture = TestBed.createComponent(MenuComponent);
     comp = fixture.componentInstance; // SearchPageComponent test instance
     comp.menuID = mockMenuID;
-    menuService = (comp as any).menuService;
-    router = TestBed.inject(Router);
+    menuService = TestBed.inject(MenuService);
+    store = TestBed.inject(Store) as MockStore<AppState>;
     spyOn(comp as any, 'getSectionDataInjector').and.returnValue(MenuSection);
-    spyOn(comp as any, 'getSectionComponent').and.returnValue(observableOf({}));
     fixture.detectChanges();
+  });
+
+  describe('ngOnInit', () => {
+    it('should trigger the section observable again when a new sub section has been added', () => {
+      spyOn(comp.sectionMap$, 'next').and.callThrough();
+      const hasSubSections = new BehaviorSubject(false);
+      spyOn(menuService, 'hasSubSections').and.returnValue(hasSubSections.asObservable());
+      spyOn(store, 'dispatch').and.callThrough();
+
+      store.setState({
+        menus: {
+          [mockMenuID]: {
+            collapsed: true,
+            id: mockMenuID,
+            previewCollapsed: true,
+            sectionToSubsectionIndex: {
+              section1: ['test'],
+            },
+            sections: {
+              section1: {
+                id: 'section1',
+                active: false,
+                visible: true,
+                model: {
+                  type: MenuItemType.LINK,
+                  text: 'test',
+                  link: '/test',
+                } as LinkMenuItemModel,
+              },
+              test: {
+                id: 'test',
+                parentID: 'section1',
+                active: false,
+                visible: true,
+                model: {
+                  type: MenuItemType.LINK,
+                  text: 'test',
+                  link: '/test',
+                } as LinkMenuItemModel,
+              }
+            },
+            visible: true,
+          },
+        },
+      });
+      expect(menuService.hasSubSections).toHaveBeenCalled();
+      hasSubSections.next(true);
+
+      expect(comp.sectionMap$.next).toHaveBeenCalled();
+    });
   });
 
   describe('toggle', () => {

--- a/src/app/shared/menu/menu.component.ts
+++ b/src/app/shared/menu/menu.component.ts
@@ -102,7 +102,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         switchMap((section: MenuSection) => this.getSectionComponent(section).pipe(
           map((component: GenericConstructor<MenuSectionComponent>) => ({ section, component }))
         )),
-        distinctUntilChanged((x, y) => x.section.id === y.section.id)
+        distinctUntilChanged((x, y) => x.section.id === y.section.id && x.component.prototype === y.component.prototype),
       ).subscribe(({ section, component }) => {
         const nextMap = this.sectionMap$.getValue();
         nextMap.set(section.id, {


### PR DESCRIPTION
## References
* Fixes #2601

## Description
When a subsection is added to a menu section that has no subsections, the subsections won't appear if the component has already been rendered. To fix this we now not only check if new sections were added/removed, but also if the component that should be used to render that specific section has changed. This way the components will render again when we add a subsection to a section, because then the top level id still won't have changed, but the component that the top level sections  should use to render will have.

## Instructions for Reviewers
List of changes in this PR:
* The `distinctUntilChanged(compareArraysUsingIds)` check from `MenuComponent` has been moved to `MenuService#getMenuTopSections`
* In `MenuComponent` the `distinctUntilChanged` that is responsible for setting the value of `sectionMap$` now also checks it the component that should be renderd has changed.

**Guidance for how to test/review this PR:**
1. Add the following code to your `HomeNewsComponent`:
  ```ts
  ngOnInit(): void {
    this.menuService.addSection(MenuID.PUBLIC, Object.assign({
      id: 'test',
      parentID: 'browse_global_communities_and_collections',
      active: false,
      visible: true,
      model: {
        type: MenuItemType.LINK,
        text: 'test',
        link: '/test',
      } as LinkMenuItemModel,
    }, {
      shouldPersistOnRouteChange: true,
    }));
  }
  ```
2. Go to a random page (except for home, for example `/statistics`) and refresh the page
3. The `Communities & Collections` should have no subsection yet
4. Navigate to the home page using the breadcrumbs
5. The subsection is now visible underneath `Communities & Collections`

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).