### PR TITLE
Fixes "some item edit pages are accessible by anonymous users"

### DIFF
--- a/src/app/item-page/edit-item-page/edit-item-page.routing.module.ts
+++ b/src/app/item-page/edit-item-page/edit-item-page.routing.module.ts
@@ -38,6 +38,8 @@ import { ItemPageBitstreamsGuard } from './item-page-bitstreams.guard';
 import { ItemPageRelationshipsGuard } from './item-page-relationships.guard';
 import { ItemPageVersionHistoryGuard } from './item-page-version-history.guard';
 import { ItemPageCollectionMapperGuard } from './item-page-collection-mapper.guard';
+import { ItemPageCurateGuard } from './item-page-curate.guard';
+import { ItemPageAccessControlGuard } from './item-page-access-control.guard';
 import { ThemedDsoEditMetadataComponent } from '../../dso-shared/dso-edit-metadata/themed-dso-edit-metadata.component';
 import { ItemPageRegisterDoiGuard } from './item-page-register-doi.guard';
 import { ItemCurateComponent } from './item-curate/item-curate.component';
@@ -87,7 +89,8 @@ import { ItemAccessControlComponent } from './item-access-control/item-access-co
               {
                 path: 'curate',
                 component: ItemCurateComponent,
-                data: { title: 'item.edit.tabs.curate.title', showBreadcrumbs: true }
+                data: { title: 'item.edit.tabs.curate.title', showBreadcrumbs: true },
+                canActivate: [ItemPageCurateGuard]
               },
               {
                 path: 'relationships',
@@ -116,7 +119,8 @@ import { ItemAccessControlComponent } from './item-access-control/item-access-co
               {
                 path: 'access-control',
                 component: ItemAccessControlComponent,
-                data: { title: 'item.edit.tabs.access-control.title', showBreadcrumbs: true }
+                data: { title: 'item.edit.tabs.access-control.title', showBreadcrumbs: true },
+                canActivate: [ItemPageAccessControlGuard]
               },
               {
                 path: 'mapper',
@@ -202,11 +206,13 @@ import { ItemAccessControlComponent } from './item-access-control/item-access-co
     ItemPageWithdrawGuard,
     ItemPageAdministratorGuard,
     ItemPageMetadataGuard,
+    ItemPageCurateGuard,
     ItemPageStatusGuard,
     ItemPageBitstreamsGuard,
     ItemPageRelationshipsGuard,
     ItemPageVersionHistoryGuard,
     ItemPageCollectionMapperGuard,
+    ItemPageAccessControlGuard,
     ItemPageRegisterDoiGuard,
   ]
 })

--- a/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
@@ -23,7 +23,7 @@ export class ItemPageAccessControlGuard extends DsoPageSingleFeatureGuard<Item> 
   }
 
   /**
-   * Check manage mappings authorization rights
+   * Check administrator authorization rights
    */
   getFeatureID(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureID> {
     return observableOf(FeatureID.AdministratorOf);

--- a/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { ItemPageResolver } from '../item-page.resolver';
+import { Item } from '../../core/shared/item.model';
+import { DsoPageSingleFeatureGuard } from '../../core/data/feature-authorization/feature-authorization-guard/dso-page-single-feature.guard';
+import { Observable, of as observableOf } from 'rxjs';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { AuthService } from '../../core/auth/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * Guard for preventing unauthorized access to certain {@link Item} pages requiring manage mappings rights
+ */
+export class ItemPageAccessControlGuard extends DsoPageSingleFeatureGuard<Item> {
+  constructor(protected resolver: ItemPageResolver,
+              protected authorizationService: AuthorizationDataService,
+              protected router: Router,
+              protected authService: AuthService) {
+    super(resolver, authorizationService, router, authService);
+  }
+
+  /**
+   * Check manage mappings authorization rights
+   */
+  getFeatureID(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureID> {
+    return observableOf(FeatureID.AdministratorOf);
+  }
+}

--- a/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-access-control.guard.ts
@@ -12,7 +12,7 @@ import { AuthService } from '../../core/auth/auth.service';
   providedIn: 'root'
 })
 /**
- * Guard for preventing unauthorized access to certain {@link Item} pages requiring manage mappings rights
+ * Guard for preventing unauthorized access to certain {@link Item} pages requiring administrator rights
  */
 export class ItemPageAccessControlGuard extends DsoPageSingleFeatureGuard<Item> {
   constructor(protected resolver: ItemPageResolver,

--- a/src/app/item-page/edit-item-page/item-page-curate.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-curate.guard.ts
@@ -12,7 +12,7 @@ import { AuthService } from '../../core/auth/auth.service';
   providedIn: 'root'
 })
 /**
- * Guard for preventing unauthorized access to certain {@link Item} pages requiring edit metadata rights
+ * Guard for preventing unauthorized access to certain {@link Item} pages requiring administrator rights
  */
 export class ItemPageCurateGuard extends DsoPageSingleFeatureGuard<Item> {
   constructor(protected resolver: ItemPageResolver,

--- a/src/app/item-page/edit-item-page/item-page-curate.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-curate.guard.ts
@@ -23,7 +23,7 @@ export class ItemPageCurateGuard extends DsoPageSingleFeatureGuard<Item> {
   }
 
   /**
-   * Check edit curate authorization rights
+   * Check administrator authorization rights
    */
   getFeatureID(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureID> {
     return observableOf(FeatureID.AdministratorOf);

--- a/src/app/item-page/edit-item-page/item-page-curate.guard.ts
+++ b/src/app/item-page/edit-item-page/item-page-curate.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { ItemPageResolver } from '../item-page.resolver';
+import { Item } from '../../core/shared/item.model';
+import { DsoPageSingleFeatureGuard } from '../../core/data/feature-authorization/feature-authorization-guard/dso-page-single-feature.guard';
+import { Observable, of as observableOf } from 'rxjs';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { AuthService } from '../../core/auth/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * Guard for preventing unauthorized access to certain {@link Item} pages requiring edit metadata rights
+ */
+export class ItemPageCurateGuard extends DsoPageSingleFeatureGuard<Item> {
+  constructor(protected resolver: ItemPageResolver,
+              protected authorizationService: AuthorizationDataService,
+              protected router: Router,
+              protected authService: AuthService) {
+    super(resolver, authorizationService, router, authService);
+  }
+
+  /**
+   * Check edit curate authorization rights
+   */
+  getFeatureID(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureID> {
+    return observableOf(FeatureID.AdministratorOf);
+  }
+}


### PR DESCRIPTION
## References
Fixes #2609 

## Description
Users without the necessary authorizations (and especially anonymous users) should not have access to administrator pages.
Instead, they should be redirected to the login page, or be shown a 403 page.

## Instructions for Reviewers
Admin:

  - When accessing "/edit/access-control" as the administrator, we navigate successfully.

  - When accessing "/edit/curate" as the administrator, we navigate successfully.

Anonymous users:

  - If in the url the page the name "/edit/access-control"

  - The page automatically redirects to the login page

  - If in the url the page the name "/edit/curate"

  - The page automatically redirects to the login page

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
