### PR TITLE
Fixed pagination issues on item mapper

### DIFF
--- a/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.ts
+++ b/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.ts
@@ -144,7 +144,9 @@ export class CollectionItemMapperComponent implements OnInit {
           this.shouldUpdate$.next(false);
         }
         return this.itemDataService.findListByHref(collectionRD.payload._links.mappedItems.href, Object.assign(options, {
-          sort: this.defaultSortOptions
+          currentPage: options.pagination.currentPage,
+          elementsPerPage: options.pagination.pageSize,
+          sort: this.defaultSortOptions,
         }),!shouldUpdate, false, followLink('owningCollection')).pipe(
           getAllSucceededRemoteData()
         );


### PR DESCRIPTION
## References
* Fixes #2613

## Description
Fixed the Item Mapper not paginating the items correctly. Because the page config was improperly configured the request to the backend did not include the page size & the cuurrent page. This lead to all items being displayed in the Item Mapper & the different pages always displaying the same result.

## Instructions for Reviewers
List of changes in this 
* Ensured the pagination options were correctly passed to the backend in `CollectionItemMapperComponent`.

**Guidance for how to test or review this PR:**
- Add a total of 11 items to a certain collection
- Create a new collection and go to `Edit Collection > Item Mapper`
- Map those 11 items to this new collection and check that the pagination in `Browse mapped items` is fixed

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).