### PR TITLE
Setup the Docker GH Action for Matrix Building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ permissions:
 
 
 env:
+  REGISTRY_IMAGE: dspace/dspace-angular
   # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
   # For a new commit on default branch (main), use the literal tag 'latest' on Docker image.
   # For a new commit on other branches, use the branch name as the tag for Docker image.
@@ -30,21 +31,30 @@ env:
   # We manage the 'latest' tag ourselves to the 'main' branch (see settings above)
   TAGS_FLAVOR: |
     latest=false
-  # Architectures / Platforms for which we will build Docker images
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
-  PLATFORMS: linux/amd64${{ github.event_name != 'pull_request' && ', linux/arm64' || '' }}
-
 
 jobs:
-  ###############################################
-  # Build/Push the 'dspace/dspace-angular' image
-  ###############################################
+  #############################################################
+  # Build/Push the '${{ env.REGISTRY_IMAGE }}' image
+  #############################################################
   dspace-angular:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
     if: github.repository == 'dspace/dspace-angular'
-    runs-on: ubuntu-latest
 
+    strategy:
+        matrix:
+            isPr:
+                - ${{ github.event_name == 'pull_request' }}
+            # Architectures / Platforms for which we will build Docker images
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
+            arch: ['linux/amd64', 'linux/arm64']
+            os: [ubuntu-latest]
+            exclude:
+                - isPr: true
+                  os: ubuntu-latest
+                  arch: linux/arm64
+
+    runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
@@ -61,7 +71,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
+        if: ${{ ! matrix.isPr }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -73,7 +83,7 @@ jobs:
         id: meta_build
         uses: docker/metadata-action@v4
         with:
-          images: dspace/dspace-angular
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
@@ -84,22 +94,89 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.arch }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ ! matrix.isPr }}
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
 
+      - name: Export digest
+        if: ${{ ! matrix.isPr }}
+        run: |
+            mkdir -p /tmp/digests
+            digest="${{ steps.docker_build.outputs.digest }}"
+            touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - dspace-angular
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
   #############################################################
-  # Build/Push the 'dspace/dspace-angular' image ('-dist' tag)
+  # Build/Push the '${{ env.REGISTRY_IMAGE }}' image ('-dist' tag)
   #############################################################
   dspace-angular-dist:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
     if: github.repository == 'dspace/dspace-angular'
-    runs-on: ubuntu-latest
 
+    strategy:
+        matrix:
+            isPr:
+                - ${{ github.event_name == 'pull_request' }}
+            # Architectures / Platforms for which we will build Docker images
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
+            arch: ['linux/amd64', 'linux/arm64']
+            os: [ubuntu-latest]
+            exclude:
+                - isPr: true
+                  os: ubuntu-latest
+                  arch: linux/arm64
+
+    runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
@@ -116,7 +193,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
+        if: ${{ ! matrix.isPr }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -128,10 +205,10 @@ jobs:
         id: meta_build_dist
         uses: docker/metadata-action@v4
         with:
-          images: dspace/dspace-angular
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
           # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
-          # tagging logic as the primary 'dspace/dspace-angular' image above.
+          # tagging logic as the primary '${{ env.REGISTRY_IMAGE }}' image above.
           flavor: ${{ env.TAGS_FLAVOR }}
             suffix=-dist
 
@@ -141,10 +218,66 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.dist
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.arch }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ ! matrix.isPr }}
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build_dist.outputs.tags }}
           labels: ${{ steps.meta_build_dist.outputs.labels }}
+
+      - name: Export digest
+        if: ${{ ! matrix.isPr }}
+        run: |
+            mkdir -p /tmp/digests/dist
+            digest="${{ steps.docker_build_dist.outputs.digest }}"
+            touch "/tmp/digests/dist/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/dist/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-dist:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - dspace-angular-dist
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta_dist
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
+          # tagging logic as the primary '${{ env.REGISTRY_IMAGE }}' image above.
+          flavor: ${{ env.TAGS_FLAVOR }}
+            suffix=-dist
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests/dist
+        run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta_dist.outputs.version }}


### PR DESCRIPTION
This PR enables building of the amd64 and arm64 images simultaneously.

## References

Logic borrowed from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

## Description
Once both images finish, the manifest is sent to Docker Hub, allowing for a single image that has both the amd64/arm64 images.

This will allow for faster building of the amd64 image, and being sent to Docker Hub, while the arm64 image is still being built.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Creates a matrix for the target arch (amd64, arc64).
* Merges the two docker images and pushes the manifest to Docker Hub at completion

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
