### PR TITLE
GitHub Actions Updates: Redeploy Sandbox via Docker & Fix retry of Codecov upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/setup-node
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -118,7 +118,7 @@ jobs:
       # https://github.com/cypress-io/github-action
       # (NOTE: to run these e2e tests locally, just use 'ng e2e')
       - name: Run e2e tests (integration tests)
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           # Run tests in Chrome, headless mode (default)
           browser: chrome
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Download artifacts from previous 'tests' job
       - name: Download coverage artifacts
@@ -203,10 +203,14 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.0.36
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           action: codecov/codecov-action@v3
-          # Try upload 5 times max
+          # Ensure codecov-action throws an error when it fails to upload
+          # This allows us to auto-restart the action if an error is thrown
+          with: |
+            fail_ci_if_error: true
+          # Try re-running action 5 times max
           attempt_limit: 5
           # Run again in 30 seconds
           attempt_delay: 30000

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       # https://github.com/github/codeql-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,8 @@ env:
   # For a new commit on other branches, use the branch name as the tag for Docker image.
   # For a new tag, copy that tag name as the tag for Docker image.
   IMAGE_TAGS: |
-    type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-    type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+    type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
+    type=ref,event=branch,enable=${{ github.ref_name != github.event.repository.default_branch }}
     type=ref,event=tag
   # Define default tag "flavor" for docker/metadata-action per
   # https://github.com/docker/metadata-action#flavor-input
@@ -300,3 +300,25 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta_dist.outputs.version }}
+
+  # Deploy latest -dist image to Demo or Sandbox site, based on the branch updated
+  dspace-angular-dist_deploy:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      # Requires manifest to be fully updated on DockerHub
+      - dspace-angular-dist_manifest
+    steps:
+      - name: Redeploy sandbox.dspace.org (based on main branch)
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
+        run: |
+            curl -X POST -d '{}' $REDEPLOY_SANDBOX_URL
+        env:
+          REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
+
+      - name: Redeploy demo.dspace.org (based on maintenace branch)
+        if: ${{ github.ref_name == 'dspace-7_x' }}
+        run: |
+            curl -X POST -d '{}' $REDEPLOY_DEMO_URL
+        env:
+            REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}

--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -23,11 +23,11 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       # Checkout code
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@v2
         with:
           # Trigger based on a "port to [branch]" label on PR
           # (This label must specify the branch name to port to)

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -21,4 +21,4 @@ jobs:
     # Assign the PR to whomever created it. This is useful for visualizing assignments on project boards
     # See https://github.com/toshimaru/auto-author-assign
     - name: Assign PR to creator
-      uses: toshimaru/auto-author-assign@v1.6.2
+      uses: toshimaru/auto-author-assign@v2.0.1


### PR DESCRIPTION
Follow-up to #2650 

## Description
This PR is just updates to our GitHub actions including:
1. Deploying to demo.dspace.org or sandbox.dspace.org after updates to our DockerHub images.  (This used to be done via a webhook on DockerHub. But, moving it to GitHub actions so that we can have better control over when the re-deployment is called.)
2. Fixing a minor bug in the `build.yml` where the Codecov.io (code coverage) upload is not automatically retrying on failure.  The issue seems to be that an upload failure doesn't throw an error by default, so we have to set `fail_ci_if_error: true` in the Codecov action to get the retry process to work properly.
3. Upgrading all action plugins to latest versions

## Instructions for Reviewers
* No review is necessary. If these actions continue to work properly then this is a successful update.