### PR TITLE
Follow-up Docker image build fix. Fix directory structure for `latest-dist` digests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -239,9 +239,9 @@ jobs:
       - name: Export digest
         if: ${{ ! matrix.isPr }}
         run: |
-            mkdir -p /tmp/digests/dist
+            mkdir -p /tmp/digests
             digest="${{ steps.docker_build_dist.outputs.digest }}"
-            touch "/tmp/digests/dist/${digest#sha256:}"
+            touch "/tmp/digests/${digest#sha256:}"
 
       # Upload Digest to an artifact, so that it can be used in manifest below
       - name: Upload digest


### PR DESCRIPTION
## References
* Fixes another bug initially in #2644 which I overlooked in #2648

## Description
This is a minor fix to the directory structure of where `latest-dist` digests are stored.  This fix is necessary so that the new matrix process works properly... without it, the `latest-dist` digests cannot be found, resulting in issues in DockerHub.

## Instructions for Reviewers
* Will be merged immediately as this is only possible to test after the PR is merged.  I've triple-checked my work though, so I feel this should *finally* get these parallel Docker image builds working properly

Once this is succeeding on `main`, all these changes will be backported to `dspace-7_x`.