### PR TITLE
[Port dspace-7_x] Port recent GitHub Action changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,11 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/setup-node
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -118,7 +118,7 @@ jobs:
       # https://github.com/cypress-io/github-action
       # (NOTE: to run these e2e tests locally, just use 'ng e2e')
       - name: Run e2e tests (integration tests)
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           # Run tests in Chrome, headless mode (default)
           browser: chrome
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Download artifacts from previous 'tests' job
       - name: Download coverage artifacts
@@ -203,10 +203,14 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.0.36
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           action: codecov/codecov-action@v3
-          # Try upload 5 times max
+          # Ensure codecov-action throws an error when it fails to upload
+          # This allows us to auto-restart the action if an error is thrown
+          with: |
+            fail_ci_if_error: true
+          # Try re-running action 5 times max
           attempt_limit: 5
           # Run again in 30 seconds
           attempt_delay: 30000

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       # https://github.com/github/codeql-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ permissions:
 
 
 env:
+  REGISTRY_IMAGE: dspace/dspace-angular
   # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
   # For a new commit on default branch (main), use the literal tag 'latest' on Docker image.
   # For a new commit on other branches, use the branch name as the tag for Docker image.
@@ -30,21 +31,30 @@ env:
   # We manage the 'latest' tag ourselves to the 'main' branch (see settings above)
   TAGS_FLAVOR: |
     latest=false
-  # Architectures / Platforms for which we will build Docker images
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
-  PLATFORMS: linux/amd64${{ github.event_name != 'pull_request' && ', linux/arm64' || '' }}
-
 
 jobs:
-  ###############################################
-  # Build/Push the 'dspace/dspace-angular' image
-  ###############################################
+  #############################################################
+  # Build/Push the '${{ env.REGISTRY_IMAGE }}' image
+  #############################################################
   dspace-angular:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
     if: github.repository == 'dspace/dspace-angular'
-    runs-on: ubuntu-latest
 
+    strategy:
+        matrix:
+            isPr:
+                - ${{ github.event_name == 'pull_request' }}
+            # Architectures / Platforms for which we will build Docker images
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
+            arch: ['linux/amd64', 'linux/arm64']
+            os: [ubuntu-latest]
+            exclude:
+                - isPr: true
+                  os: ubuntu-latest
+                  arch: linux/arm64
+
+    runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
@@ -61,7 +71,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
+        if: ${{ ! matrix.isPr }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -73,7 +83,7 @@ jobs:
         id: meta_build
         uses: docker/metadata-action@v4
         with:
-          images: dspace/dspace-angular
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
@@ -84,22 +94,89 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.arch }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ ! matrix.isPr }}
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
 
+      - name: Export digest
+        if: ${{ ! matrix.isPr }}
+        run: |
+            mkdir -p /tmp/digests
+            digest="${{ steps.docker_build.outputs.digest }}"
+            touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - dspace-angular
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
   #############################################################
-  # Build/Push the 'dspace/dspace-angular' image ('-dist' tag)
+  # Build/Push the '${{ env.REGISTRY_IMAGE }}' image ('-dist' tag)
   #############################################################
   dspace-angular-dist:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
     if: github.repository == 'dspace/dspace-angular'
-    runs-on: ubuntu-latest
 
+    strategy:
+        matrix:
+            isPr:
+                - ${{ github.event_name == 'pull_request' }}
+            # Architectures / Platforms for which we will build Docker images
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
+            arch: ['linux/amd64', 'linux/arm64']
+            os: [ubuntu-latest]
+            exclude:
+                - isPr: true
+                  os: ubuntu-latest
+                  arch: linux/arm64
+
+    runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
@@ -116,7 +193,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
+        if: ${{ ! matrix.isPr }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -128,10 +205,10 @@ jobs:
         id: meta_build_dist
         uses: docker/metadata-action@v4
         with:
-          images: dspace/dspace-angular
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
           # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
-          # tagging logic as the primary 'dspace/dspace-angular' image above.
+          # tagging logic as the primary '${{ env.REGISTRY_IMAGE }}' image above.
           flavor: ${{ env.TAGS_FLAVOR }}
             suffix=-dist
 
@@ -141,10 +218,66 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.dist
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.arch }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ ! matrix.isPr }}
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build_dist.outputs.tags }}
           labels: ${{ steps.meta_build_dist.outputs.labels }}
+
+      - name: Export digest
+        if: ${{ ! matrix.isPr }}
+        run: |
+            mkdir -p /tmp/digests/dist
+            digest="${{ steps.docker_build_dist.outputs.digest }}"
+            touch "/tmp/digests/dist/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/dist/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-dist:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - dspace-angular-dist
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta_dist
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
+          # tagging logic as the primary '${{ env.REGISTRY_IMAGE }}' image above.
+          flavor: ${{ env.TAGS_FLAVOR }}
+            suffix=-dist
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests/dist
+        run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta_dist.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -255,6 +255,24 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # If the 'linux/amd64' -dist image was just updated for the 'main' branch,
+      # Then redeploy https://sandbox.dspace.org using that updated image.
+      - name: Redeploy sandbox.dspace.org (based on main branch)
+        if: ${{ ! matrix.isPr && matrix.arch == 'linux/amd64' && github.ref_name == github.event.repository.default_branch }}
+        run: |
+            curl -X POST $REDEPLOY_SANDBOX_URL
+        env:
+          REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
+
+      # If the 'linux/amd64' -dist image was just updated for the maintenance branch,
+      # Then redeploy https://demo.dspace.org using that updated image.
+      - name: Redeploy demo.dspace.org (based on maintenace branch)
+        if: ${{ ! matrix.isPr && matrix.arch == 'linux/amd64' && github.ref_name == 'dspace-7_x' }}
+        run: |
+            curl -X POST $REDEPLOY_DEMO_URL
+        env:
+            REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}
+
   # Merge *-dist digests into a manifest.
   # This runs after all Docker builds complete above, and it tells hub.docker.com
   # that these builds should be all included in the manifest for this tag.
@@ -300,25 +318,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta_dist.outputs.version }}
-
-  # Deploy latest -dist image to Demo or Sandbox site, based on the branch updated
-  dspace-angular-dist_deploy:
-    if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    needs:
-      # Requires manifest to be fully updated on DockerHub
-      - dspace-angular-dist_manifest
-    steps:
-      - name: Redeploy sandbox.dspace.org (based on main branch)
-        if: ${{ github.ref_name == github.event.repository.default_branch }}
-        run: |
-            curl -X POST -d '{}' $REDEPLOY_SANDBOX_URL
-        env:
-          REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
-
-      - name: Redeploy demo.dspace.org (based on maintenace branch)
-        if: ${{ github.ref_name == 'dspace-7_x' }}
-        run: |
-            curl -X POST -d '{}' $REDEPLOY_DEMO_URL
-        env:
-            REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,13 +42,13 @@ jobs:
 
     strategy:
         matrix:
-            isPr:
-                - ${{ github.event_name == 'pull_request' }}
             # Architectures / Platforms for which we will build Docker images
-            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
             arch: ['linux/amd64', 'linux/arm64']
             os: [ubuntu-latest]
+            isPr:
+              - ${{ github.event_name == 'pull_request' }}
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # The below exclude therefore ensures we do NOT build ARM64 for PRs.
             exclude:
                 - isPr: true
                   os: ubuntu-latest
@@ -58,21 +58,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: ${{ ! matrix.isPr }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
       # Get Metadata for docker_build step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-angular' image
         id: meta_build
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
@@ -90,7 +90,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push 'dspace-angular' image
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -102,6 +102,7 @@ jobs:
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
 
+      # Export the digest of Docker build locally (for non PRs only)
       - name: Export digest
         if: ${{ ! matrix.isPr }}
         run: |
@@ -109,6 +110,7 @@ jobs:
             digest="${{ steps.docker_build.outputs.digest }}"
             touch "/tmp/digests/${digest#sha256:}"
 
+      # Upload digest to an artifact, so that it can be used in manifest below
       - name: Upload digest
         if: ${{ ! matrix.isPr }}
         uses: actions/upload-artifact@v3
@@ -118,7 +120,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  # Merge digests into a manifest.
+  # This runs after all Docker builds complete above, and it tells hub.docker.com
+  # that these builds should be all included in the manifest for this tag.
+  # (e.g. AMD64 and ARM64 should be listed as options under the same tagged Docker image)
+  # Borrowed from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+  dspace-angular_manifest:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs:
@@ -129,9 +136,11 @@ jobs:
         with:
           name: digests
           path: /tmp/digests
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Docker meta
+
+      - name: Add Docker metadata for image
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -145,7 +154,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Create manifest list and push
+      - name: Create manifest list from digests and push
         working-directory: /tmp/digests
         run: |
             docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
@@ -164,13 +173,13 @@ jobs:
 
     strategy:
         matrix:
-            isPr:
-                - ${{ github.event_name == 'pull_request' }}
             # Architectures / Platforms for which we will build Docker images
-            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-            # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64.
             arch: ['linux/amd64', 'linux/arm64']
             os: [ubuntu-latest]
+            isPr:
+                - ${{ github.event_name == 'pull_request' }}
+            # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+            # The below exclude therefore ensures we do NOT build ARM64 for PRs.
             exclude:
                 - isPr: true
                   os: ubuntu-latest
@@ -180,21 +189,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: ${{ ! matrix.isPr }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -203,7 +212,7 @@ jobs:
       # Get Metadata for docker_build_dist step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-angular-dist' image
         id: meta_build_dist
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: ${{ env.IMAGE_TAGS }}
@@ -214,7 +223,7 @@ jobs:
 
       - name: Build and push 'dspace-angular-dist' image
         id: docker_build_dist
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.dist
@@ -226,6 +235,7 @@ jobs:
           tags: ${{ steps.meta_build_dist.outputs.tags }}
           labels: ${{ steps.meta_build_dist.outputs.labels }}
 
+      # Export the digest of Docker build locally (for non PRs only)
       - name: Export digest
         if: ${{ ! matrix.isPr }}
         run: |
@@ -233,29 +243,38 @@ jobs:
             digest="${{ steps.docker_build_dist.outputs.digest }}"
             touch "/tmp/digests/dist/${digest#sha256:}"
 
+      # Upload Digest to an artifact, so that it can be used in manifest below
       - name: Upload digest
         if: ${{ ! matrix.isPr }}
         uses: actions/upload-artifact@v3
         with:
-          name: digests
-          path: /tmp/digests/dist/*
+          # NOTE: It's important that this artifact has a unique name so that two
+          # image builds don't upload digests to the same artifact.
+          name: digests-dist
+          path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  merge-dist:
+  # Merge *-dist digests into a manifest.
+  # This runs after all Docker builds complete above, and it tells hub.docker.com
+  # that these builds should be all included in the manifest for this tag.
+  # (e.g. AMD64 and ARM64 should be listed as options under the same tagged Docker image)
+  dspace-angular-dist_manifest:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs:
       - dspace-angular-dist
     steps:
-      - name: Download digests
+      - name: Download digests for -dist builds
         uses: actions/download-artifact@v3
         with:
-          name: digests
+          name: digests-dist
           path: /tmp/digests
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Docker meta
+
+      - name: Add Docker metadata for image
         id: meta_dist
         uses: docker/metadata-action@v5
         with:
@@ -272,8 +291,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests/dist
+      - name: Create manifest list from digests and push
+        working-directory: /tmp/digests
         run: |
             docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -239,9 +239,9 @@ jobs:
       - name: Export digest
         if: ${{ ! matrix.isPr }}
         run: |
-            mkdir -p /tmp/digests/dist
+            mkdir -p /tmp/digests
             digest="${{ steps.docker_build_dist.outputs.digest }}"
-            touch "/tmp/digests/dist/${digest#sha256:}"
+            touch "/tmp/digests/${digest#sha256:}"
 
       # Upload Digest to an artifact, so that it can be used in manifest below
       - name: Upload digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,8 @@ env:
   # For a new commit on other branches, use the branch name as the tag for Docker image.
   # For a new tag, copy that tag name as the tag for Docker image.
   IMAGE_TAGS: |
-    type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-    type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+    type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
+    type=ref,event=branch,enable=${{ github.ref_name != github.event.repository.default_branch }}
     type=ref,event=tag
   # Define default tag "flavor" for docker/metadata-action per
   # https://github.com/docker/metadata-action#flavor-input
@@ -300,3 +300,25 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta_dist.outputs.version }}
+
+  # Deploy latest -dist image to Demo or Sandbox site, based on the branch updated
+  dspace-angular-dist_deploy:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      # Requires manifest to be fully updated on DockerHub
+      - dspace-angular-dist_manifest
+    steps:
+      - name: Redeploy sandbox.dspace.org (based on main branch)
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
+        run: |
+            curl -X POST -d '{}' $REDEPLOY_SANDBOX_URL
+        env:
+          REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
+
+      - name: Redeploy demo.dspace.org (based on maintenace branch)
+        if: ${{ github.ref_name == 'dspace-7_x' }}
+        run: |
+            curl -X POST -d '{}' $REDEPLOY_DEMO_URL
+        env:
+            REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}

--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -23,11 +23,11 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       # Checkout code
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@v2
         with:
           # Trigger based on a "port to [branch]" label on PR
           # (This label must specify the branch name to port to)

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -21,4 +21,4 @@ jobs:
     # Assign the PR to whomever created it. This is useful for visualizing assignments on project boards
     # See https://github.com/toshimaru/auto-author-assign
     - name: Assign PR to creator
-      uses: toshimaru/auto-author-assign@v1.6.2
+      uses: toshimaru/auto-author-assign@v2.0.1


### PR DESCRIPTION
## Description
This PR is a direct port (cherry-pick) of all the following PRs to `dspace-7_x`:
* #2644
* #2648
* #2650
* #2649
* #2658

The purpose of this PR is to simply "synchronize" the GitHub Actions configuration between `main` and `dspace-7_x`.  No code changes to DSpace have been made.
