### PR TITLE
Fixed ePerson link on edit group page

### DIFF
--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.html
@@ -24,8 +24,7 @@
         <tr *ngFor="let eperson of (ePeopleMembersOfGroup | async)?.page">
           <td class="align-middle">{{eperson.id}}</td>
           <td class="align-middle">
-            <a (click)="ePersonDataService.startEditingNewEPerson(eperson)"
-               [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">
+            <a [routerLink]="getEPersonEditRoute(eperson.id)">
               {{ dsoNameService.getName(eperson) }}
             </a>
           </td>
@@ -106,8 +105,7 @@
         <tr *ngFor="let eperson of (ePeopleSearch | async)?.page">
           <td class="align-middle">{{eperson.id}}</td>
           <td class="align-middle">
-            <a (click)="ePersonDataService.startEditingNewEPerson(eperson)"
-               [routerLink]="[ePersonDataService.getEPeoplePageRouterLink()]">
+            <a [routerLink]="getEPersonEditRoute(eperson.id)">
               {{ dsoNameService.getName(eperson) }}
             </a>
           </td>

--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.spec.ts
@@ -68,9 +68,6 @@ describe('MembersListComponent', () => {
       clearLinkRequests() {
         // empty
       },
-      getEPeoplePageRouterLink(): string {
-        return '/access-control/epeople';
-      }
     };
     groupsDataServiceStub = {
       activeGroup: activeGroup,

--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.ts
@@ -23,6 +23,7 @@ import { NotificationsService } from '../../../../shared/notifications/notificat
 import { PaginationComponentOptions } from '../../../../shared/pagination/pagination-component-options.model';
 import { PaginationService } from '../../../../core/pagination/pagination.service';
 import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
+import { getEPersonEditRoute } from '../../../access-control-routing-paths';
 
 /**
  * Keys to keep track of specific subscriptions
@@ -130,6 +131,8 @@ export class MembersListComponent implements OnInit, OnDestroy {
 
   // current active group being edited
   groupBeingEdited: Group;
+
+  readonly getEPersonEditRoute = getEPersonEditRoute;
 
   constructor(
     protected groupDataService: GroupDataService,

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -34,7 +34,7 @@ import { PatchData, PatchDataImpl } from '../data/base/patch-data';
 import { DeleteData, DeleteDataImpl } from '../data/base/delete-data';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { dataService } from '../data/base/data-service.decorator';
-import { getEPersonEditRoute, getEPersonsRoute } from '../../access-control/access-control-routing-paths';
+import { getEPersonEditRoute } from '../../access-control/access-control-routing-paths';
 
 const ePeopleRegistryStateSelector = (state: AppState) => state.epeopleRegistry;
 const editEPersonSelector = createSelector(ePeopleRegistryStateSelector, (ePeopleRegistryState: EPeopleRegistryState) => ePeopleRegistryState.editEPerson);
@@ -311,13 +311,6 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
       }
     });
     return getEPersonEditRoute(ePerson.id);
-  }
-
-  /**
-   * Get EPeople admin page
-   */
-  public getEPeoplePageRouterLink(): string {
-    return getEPersonsRoute();
   }
 
   /**

--- a/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.spec.ts
+++ b/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.spec.ts
@@ -72,9 +72,6 @@ describe('ReviewersListComponent', () => {
       clearLinkRequests() {
         // empty
       },
-      getEPeoplePageRouterLink(): string {
-        return '/access-control/epeople';
-      }
     };
     groupsDataServiceStub = {
       activeGroup: activeGroup,


### PR DESCRIPTION
## References
* Fixes #2661
* Related #2391

## Description
Since the creation of the new separate ePerson pages the ePerson route includes the id of the ePerson. This PR now fixes this route in both the display ePerson tab & the search ePerson tab on the edit group page.

## Instructions for Reviewers
List of changes in this PR:
* Fixed the link on edit group for both the display ePerson tab & the search ePerson tab
* Removed the now unused method `EPersonDataService.getEPeoplePageRouterLink()` since it's better to use `getEPersonsRoute()` directly

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
