### PR TITLE
Enable type-bind for checkbox inputs during submission

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/list/dynamic-list-radio-group.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/list/dynamic-list-radio-group.model.ts
@@ -1,5 +1,6 @@
 import {
   DynamicFormControlLayout,
+  DynamicFormControlRelation,
   DynamicRadioGroupModel,
   DynamicRadioGroupModelConfig,
   serializable
@@ -15,12 +16,14 @@ export interface DynamicListModelConfig extends DynamicRadioGroupModelConfig<any
   value?: VocabularyEntry[];
   required: boolean;
   hint?: string;
+  typeBindRelations?: DynamicFormControlRelation[];
 }
 
 export class DynamicListRadioGroupModel extends DynamicRadioGroupModel<any> {
 
   @serializable() vocabularyOptions: VocabularyOptions;
   @serializable() repeatable: boolean;
+  @serializable() typeBindRelations: DynamicFormControlRelation[];
   @serializable() groupLength: number;
   @serializable() required: boolean;
   @serializable() hint: string;
@@ -35,6 +38,7 @@ export class DynamicListRadioGroupModel extends DynamicRadioGroupModel<any> {
     this.required = config.required;
     this.hint = config.hint;
     this.value = config.value;
+    this.typeBindRelations = config.typeBindRelations ? config.typeBindRelations : [];
   }
 
   get hasAuthority(): boolean {


### PR DESCRIPTION
## References
* Fixes #2687 and DSpace/DSpace#8678

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers

List of changes in this PR:
* Added type-bind related properties to `DynamicListRadioGroupModel` and `DynamicListModelConfig`

1. Verify that DSpace/DSpace#8678 can be reproduced (#2687 is a duplicate of that), make sure that `repeatable` is set to `false` for the list item
2. Apply this PR
3. Restart the submission and verify, that the list input is only visible for the configured types

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
