### PR TITLE
accesibility issue

### DIFF
--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -4,7 +4,9 @@
     (keyup.space)="isActive ? deactivateSection($event) : activateSection($event)"
     (keydown.space)="$event.preventDefault()"
     (mouseenter)="activateSection($event)"
-    (mouseleave)="deactivateSection($event)">
+    (mouseleave)="deactivateSection($event)"
+    aria-haspopup="menu"
+    aria-expanded="false">
     <button class="btn btn-link nav-link dropdown-toggle" routerLinkActive="active" type="button"
        [class.disabled]="section.model?.disabled"
        (click)="toggleSection($event)"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -39,11 +39,17 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param {Event} event The user event that triggered this function
    */
   activateSection(event): void {
+
+    console.log(event.target);
+    
+
     this.windowService.isXsOrSm().pipe(
       first()
     ).subscribe((isMobile) => {
       if (!isMobile) {
+        const targetElement = event.target as HTMLElement;
         super.activateSection(event);
+        targetElement.setAttribute('aria-expanded', 'true'); 
       }
     });
   }
@@ -58,7 +64,9 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
       first()
     ).subscribe((isMobile) => {
       if (!isMobile) {
+        const targetElement = event.target as HTMLElement;
         super.deactivateSection(event);
+        targetElement.setAttribute('aria-expanded', 'false'); 
       }
     });
   }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #2699 (if this fixes an issue ticket)
* Requires DSpace/DSpace#`pr-number` (if a REST API PR is required to test this)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
i added attributes in the html component, and the aria-expanded equals to true.

List of changes in this PR:
* aria-haspopu and aria-expanded added in expandable-navbar-section.component.html
* programmaticly 

**Include guidance for how to test or review your PR.**
1. go to https://demo.ktheia.com/
2. put the mouse over "All of DSpace"
3. Open de console, you should see how the aria-expanded change from false to true when mouse is over

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
