### PR TITLE
Add more automated accessibility scanning to e2e tests & fix a few minor accessibility bugs

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
     openMode: 0,
   },
   env: {
-    // Global constants used in DSpace e2e tests (see also ./cypress/support/e2e.ts)
-    // May be overridden in our cypress.json config file using specified environment variables.
+    // Global DSpace environment variables used in all our Cypress e2e tests
+    // May be modified in this config, or overridden in a variety of ways.
+    // See Cypress environment variable docs: https://docs.cypress.io/guides/guides/environment-variables
     // Default values listed here are all valid for the Demo Entities Data set available at
     // https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
     // (This is the data set used in our CI environment)

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     // Community/collection/publication used for view/edit tests
     DSPACE_TEST_COMMUNITY: '0958c910-2037-42a9-81c7-dca80e3892b4',
     DSPACE_TEST_COLLECTION: '282164f5-d325-4740-8dd1-fa4d6d3e7200',
-    DSPACE_TEST_ENTITY_PUBLICATION: 'e98b0f27-5c19-49a0-960d-eb6ad5287067',
+    DSPACE_TEST_ENTITY_PUBLICATION: '6160810f-1e53-40db-81ef-f6621a727398',
     // Search term (should return results) used in search tests
     DSPACE_TEST_SEARCH_TERM: 'test',
     // Collection used for submission tests

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -25,9 +25,11 @@ export default defineConfig({
     DSPACE_TEST_ENTITY_PUBLICATION: '6160810f-1e53-40db-81ef-f6621a727398',
     // Search term (should return results) used in search tests
     DSPACE_TEST_SEARCH_TERM: 'test',
-    // Collection used for submission tests
+    // Main Collection used for submission tests. Should be able to accept normal Item objects
     DSPACE_TEST_SUBMIT_COLLECTION_NAME: 'Sample Collection',
     DSPACE_TEST_SUBMIT_COLLECTION_UUID: '9d8334e9-25d3-4a67-9cea-3dffdef80144',
+    // Collection used for Person entity submission tests. MUST be configured with EntityType=Person.
+    DSPACE_TEST_SUBMIT_PERSON_COLLECTION_NAME: 'People',
     // Account used to test basic submission process
     DSPACE_TEST_SUBMIT_USER: 'dspacedemo+submit@gmail.com',
     DSPACE_TEST_SUBMIT_USER_PASSWORD: 'dspace',

--- a/cypress/e2e/admin-sidebar.cy.ts
+++ b/cypress/e2e/admin-sidebar.cy.ts
@@ -1,0 +1,28 @@
+import { Options } from 'cypress-axe';
+import { testA11y } from 'cypress/support/utils';
+
+describe('Admin Sidebar', () => {
+    beforeEach(() => {
+        // Must login as an Admin for sidebar to appear
+        cy.visit('/login');
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+    });
+
+    it('should be pinnable and pass accessibility tests', () => {
+        // Pin the sidebar open
+        cy.get('#sidebar-collapse-toggle').click();
+
+        // Click on every expandable section to open all menus
+        cy.get('ds-expandable-admin-sidebar-section').click({multiple: true});
+
+        // Analyze <ds-admin-sidebar> for accessibility
+        testA11y('ds-admin-sidebar',
+        {
+            rules: {
+                // Currently all expandable sections have nested interactive elements
+                // See https://github.com/DSpace/dspace-angular/issues/2178
+                'nested-interactive': { enabled: false },
+            }
+        } as Options);
+    });
+});

--- a/cypress/e2e/breadcrumbs.cy.ts
+++ b/cypress/e2e/breadcrumbs.cy.ts
@@ -1,10 +1,9 @@
-import { TEST_ENTITY_PUBLICATION } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Breadcrumbs', () => {
     it('should pass accessibility tests', () => {
         // Visit an Item, as those have more breadcrumbs
-        cy.visit('/entities/publication/'.concat(TEST_ENTITY_PUBLICATION));
+        cy.visit('/entities/publication/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION')));
 
         // Wait for breadcrumbs to be visible
         cy.get('ds-breadcrumbs').should('be.visible');

--- a/cypress/e2e/collection-edit.cy.ts
+++ b/cypress/e2e/collection-edit.cy.ts
@@ -1,0 +1,86 @@
+import { testA11y } from 'cypress/support/utils';
+
+const COLLECTION_EDIT_PAGE = '/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')).concat('/edit');
+
+beforeEach(() => {
+    // All tests start with visiting the Edit Collection Page
+    cy.visit(COLLECTION_EDIT_PAGE);
+
+    // This page is restricted, so we will be shown the login form. Fill it out & submit.
+    cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+});
+
+describe('Edit Collection > Edit Metadata tab', () => {
+    it('should pass accessibility tests', () => {
+        // <ds-edit-collection> tag must be loaded
+        cy.get('ds-edit-collection').should('be.visible');
+
+        // Analyze <ds-edit-collection> for accessibility issues
+        testA11y('ds-edit-collection');
+    });
+});
+
+describe('Edit Collection > Assign Roles tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="roles"]').click();
+
+        // <ds-collection-roles> tag must be loaded
+        cy.get('ds-collection-roles').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-collection-roles');
+    });
+});
+
+describe('Edit Collection > Curate tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="curate"]').click();
+
+        // <ds-collection-curate> tag must be loaded
+        cy.get('ds-collection-curate').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-collection-curate');
+    });
+});
+
+describe('Edit Collection > Access Control tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="access-control"]').click();
+
+        // <ds-collection-access-control> tag must be loaded
+        cy.get('ds-collection-access-control').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-collection-access-control');
+    });
+});
+
+describe('Edit Collection > Authorizations tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="authorizations"]').click();
+
+        // <ds-collection-authorizations> tag must be loaded
+        cy.get('ds-collection-authorizations').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-collection-authorizations');
+    });
+});
+
+describe('Edit Collection > Delete page', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="delete-button"]').click();
+
+        // <ds-delete-collection> tag must be loaded
+        cy.get('ds-delete-collection').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-delete-collection');
+    });
+});

--- a/cypress/e2e/collection-edit.cy.ts
+++ b/cypress/e2e/collection-edit.cy.ts
@@ -33,6 +33,25 @@ describe('Edit Collection > Assign Roles tab', () => {
     });
 });
 
+describe('Edit Collection > Content Source tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="source"]').click();
+
+        // <ds-collection-source> tag must be loaded
+        cy.get('ds-collection-source').should('be.visible');
+
+        // Check the external source checkbox (to display all fields on the page)
+        cy.get('#externalSourceCheck').check();
+
+        // Wait for the source controls to appear
+        cy.get('ds-collection-source-controls').should('be.visible');
+
+        // Analyze entire page for accessibility issues
+        testA11y('ds-collection-source');
+    });
+});
+
 describe('Edit Collection > Curate tab', () => {
 
     it('should pass accessibility tests', () => {
@@ -71,6 +90,29 @@ describe('Edit Collection > Authorizations tab', () => {
         testA11y('ds-collection-authorizations');
     });
 });
+
+describe('Edit Collection > Item Mapper tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="mapper"]').click();
+
+        // <ds-collection-item-mapper> tag must be loaded
+        cy.get('ds-collection-item-mapper').should('be.visible');
+
+        // Analyze entire page for accessibility issues
+        testA11y('ds-collection-item-mapper');
+
+        // Click on the "Map new Items" tab
+        cy.get('li[data-test="mapTab"] a').click();
+
+        // Make sure search form is now visible
+        cy.get('ds-search-form').should('be.visible');
+
+        // Analyze entire page (again) for accessibility issues
+        testA11y('ds-collection-item-mapper');
+    });
+});
+
 
 describe('Edit Collection > Delete page', () => {
 

--- a/cypress/e2e/collection-page.cy.ts
+++ b/cypress/e2e/collection-page.cy.ts
@@ -1,10 +1,9 @@
-import { TEST_COLLECTION } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Collection Page', () => {
 
     it('should pass accessibility tests', () => {
-        cy.visit('/collections/'.concat(TEST_COLLECTION));
+        cy.visit('/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')));
 
         // <ds-collection-page> tag must be loaded
         cy.get('ds-collection-page').should('be.visible');

--- a/cypress/e2e/collection-statistics.cy.ts
+++ b/cypress/e2e/collection-statistics.cy.ts
@@ -1,11 +1,11 @@
-import { REGEX_MATCH_NON_EMPTY_TEXT, TEST_COLLECTION } from 'cypress/support/e2e';
+import { REGEX_MATCH_NON_EMPTY_TEXT } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Collection Statistics Page', () => {
-    const COLLECTIONSTATISTICSPAGE = '/statistics/collections/'.concat(TEST_COLLECTION);
+    const COLLECTIONSTATISTICSPAGE = '/statistics/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION'));
 
     it('should load if you click on "Statistics" from a Collection page', () => {
-        cy.visit('/collections/'.concat(TEST_COLLECTION));
+        cy.visit('/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')));
         cy.get('ds-navbar ds-link-menu-item a[title="Statistics"]').click();
         cy.location('pathname').should('eq', COLLECTIONSTATISTICSPAGE);
     });
@@ -18,7 +18,7 @@ describe('Collection Statistics Page', () => {
     it('should contain a "Total visits per month" section', () => {
         cy.visit(COLLECTIONSTATISTICSPAGE);
         // Check just for existence because this table is empty in CI environment as it's historical data
-        cy.get('.'.concat(TEST_COLLECTION).concat('_TotalVisitsPerMonth')).should('exist');
+        cy.get('.'.concat(Cypress.env('DSPACE_TEST_COLLECTION')).concat('_TotalVisitsPerMonth')).should('exist');
     });
 
     it('should pass accessibility tests', () => {

--- a/cypress/e2e/community-edit.cy.ts
+++ b/cypress/e2e/community-edit.cy.ts
@@ -70,18 +70,6 @@ describe('Edit Community > Authorizations tab', () => {
         // Analyze for accessibility issues
         testA11y('ds-community-authorizations');
     });
-
-    it('should have an edit policy page which also passes accessibility tests', () => {
-        cy.visit(COMMUNITY_EDIT_PAGE.concat('/authorizations'));
-
-        cy.get('button[title="Edit policy"]').click();
-
-        // <ds-resource-policy-edit> tag must be loaded
-        cy.get('ds-resource-policy-edit').should('be.visible');
-
-        // Analyze for accessibility issues
-        testA11y('ds-resource-policy-edit');
-    });
 });
 
 describe('Edit Community > Delete page', () => {

--- a/cypress/e2e/community-edit.cy.ts
+++ b/cypress/e2e/community-edit.cy.ts
@@ -1,0 +1,98 @@
+import { testA11y } from 'cypress/support/utils';
+
+const COMMUNITY_EDIT_PAGE = '/communities/'.concat(Cypress.env('DSPACE_TEST_COMMUNITY')).concat('/edit');
+
+beforeEach(() => {
+    // All tests start with visiting the Edit Community Page
+    cy.visit(COMMUNITY_EDIT_PAGE);
+
+    // This page is restricted, so we will be shown the login form. Fill it out & submit.
+    cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+});
+
+describe('Edit Community > Edit Metadata tab', () => {
+    it('should pass accessibility tests', () => {
+        // <ds-edit-community> tag must be loaded
+        cy.get('ds-edit-community').should('be.visible');
+
+        // Analyze <ds-edit-community> for accessibility issues
+        testA11y('ds-edit-community');
+    });
+});
+
+describe('Edit Community > Assign Roles tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="roles"]').click();
+
+        // <ds-community-roles> tag must be loaded
+        cy.get('ds-community-roles').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-community-roles');
+    });
+});
+
+describe('Edit Community > Curate tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="curate"]').click();
+
+        // <ds-community-curate> tag must be loaded
+        cy.get('ds-community-curate').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-community-curate');
+    });
+});
+
+describe('Edit Community > Access Control tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="access-control"]').click();
+
+        // <ds-community-access-control> tag must be loaded
+        cy.get('ds-community-access-control').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-community-access-control');
+    });
+});
+
+describe('Edit Community > Authorizations tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="authorizations"]').click();
+
+        // <ds-community-authorizations> tag must be loaded
+        cy.get('ds-community-authorizations').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-community-authorizations');
+    });
+
+    it('should have an edit policy page which also passes accessibility tests', () => {
+        cy.visit(COMMUNITY_EDIT_PAGE.concat('/authorizations'));
+
+        cy.get('button[title="Edit policy"]').click();
+
+        // <ds-resource-policy-edit> tag must be loaded
+        cy.get('ds-resource-policy-edit').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-resource-policy-edit');
+    });
+});
+
+describe('Edit Community > Delete page', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="delete-button"]').click();
+
+        // <ds-delete-community> tag must be loaded
+        cy.get('ds-delete-community').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-delete-community');
+    });
+});

--- a/cypress/e2e/community-page.cy.ts
+++ b/cypress/e2e/community-page.cy.ts
@@ -1,10 +1,9 @@
-import { TEST_COMMUNITY } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Community Page', () => {
 
     it('should pass accessibility tests', () => {
-        cy.visit('/communities/'.concat(TEST_COMMUNITY));
+        cy.visit('/communities/'.concat(Cypress.env('DSPACE_TEST_COMMUNITY')));
 
         // <ds-community-page> tag must be loaded
         cy.get('ds-community-page').should('be.visible');

--- a/cypress/e2e/community-page.cy.ts
+++ b/cypress/e2e/community-page.cy.ts
@@ -9,6 +9,6 @@ describe('Community Page', () => {
         cy.get('ds-community-page').should('be.visible');
 
         // Analyze <ds-community-page> for accessibility issues
-        testA11y('ds-community-page',);
+        testA11y('ds-community-page');
     });
 });

--- a/cypress/e2e/community-statistics.cy.ts
+++ b/cypress/e2e/community-statistics.cy.ts
@@ -1,11 +1,11 @@
-import { REGEX_MATCH_NON_EMPTY_TEXT, TEST_COMMUNITY } from 'cypress/support/e2e';
+import { REGEX_MATCH_NON_EMPTY_TEXT } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Community Statistics Page', () => {
-    const COMMUNITYSTATISTICSPAGE = '/statistics/communities/'.concat(TEST_COMMUNITY);
+    const COMMUNITYSTATISTICSPAGE = '/statistics/communities/'.concat(Cypress.env('DSPACE_TEST_COMMUNITY'));
 
     it('should load if you click on "Statistics" from a Community page', () => {
-        cy.visit('/communities/'.concat(TEST_COMMUNITY));
+        cy.visit('/communities/'.concat(Cypress.env('DSPACE_TEST_COMMUNITY')));
         cy.get('ds-navbar ds-link-menu-item a[title="Statistics"]').click();
         cy.location('pathname').should('eq', COMMUNITYSTATISTICSPAGE);
     });
@@ -18,7 +18,7 @@ describe('Community Statistics Page', () => {
     it('should contain a "Total visits per month" section', () => {
         cy.visit(COMMUNITYSTATISTICSPAGE);
         // Check just for existence because this table is empty in CI environment as it's historical data
-        cy.get('.'.concat(TEST_COMMUNITY).concat('_TotalVisitsPerMonth')).should('exist');
+        cy.get('.'.concat(Cypress.env('DSPACE_TEST_COMMUNITY')).concat('_TotalVisitsPerMonth')).should('exist');
     });
 
     it('should pass accessibility tests', () => {

--- a/cypress/e2e/homepage-statistics.cy.ts
+++ b/cypress/e2e/homepage-statistics.cy.ts
@@ -1,4 +1,4 @@
-import { REGEX_MATCH_NON_EMPTY_TEXT, TEST_ENTITY_PUBLICATION } from 'cypress/support/e2e';
+import { REGEX_MATCH_NON_EMPTY_TEXT } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 import '../support/commands';
 
@@ -11,8 +11,8 @@ describe('Site Statistics Page', () => {
 
     it('should pass accessibility tests', () => {
         // generate 2 view events on an Item's page
-        cy.generateViewEvent(TEST_ENTITY_PUBLICATION, 'item');
-        cy.generateViewEvent(TEST_ENTITY_PUBLICATION, 'item');
+        cy.generateViewEvent(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'), 'item');
+        cy.generateViewEvent(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'), 'item');
 
         cy.visit('/statistics');
 

--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -1,0 +1,135 @@
+import { Options } from 'cypress-axe';
+import { testA11y } from 'cypress/support/utils';
+
+const ITEM_EDIT_PAGE = '/items/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION')).concat('/edit');
+
+beforeEach(() => {
+    // All tests start with visiting the Edit Item Page
+    cy.visit(ITEM_EDIT_PAGE);
+
+    // This page is restricted, so we will be shown the login form. Fill it out & submit.
+    cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+});
+
+describe('Edit Item > Edit Metadata tab', () => {
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="metadata"]').click();
+
+        // <ds-edit-item-page> tag must be loaded
+        cy.get('ds-edit-item-page').should('be.visible');
+
+        // Analyze <ds-edit-item-page> for accessibility issues
+        testA11y('ds-edit-item-page');
+    });
+});
+
+describe('Edit Item > Status tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="status"]').click();
+
+        // <ds-item-status> tag must be loaded
+        cy.get('ds-item-status').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-status');
+    });
+});
+
+describe('Edit Item > Bitstreams tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="bitstreams"]').click();
+
+        // <ds-item-bitstreams> tag must be loaded
+        cy.get('ds-item-bitstreams').should('be.visible');
+
+        // Table of item bitstreams must also be loaded
+        cy.get('div.item-bitstreams').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-bitstreams',
+            {
+                rules: {
+                    // Currently Bitstreams page loads a pagination component per Bundle
+                    // and they all use the same 'id="p-dad"'.
+                    'duplicate-id': { enabled: false },
+                }
+            } as Options
+        );
+    });
+});
+
+describe('Edit Item > Curate tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="curate"]').click();
+
+        // <ds-item-curate> tag must be loaded
+        cy.get('ds-item-curate').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-curate');
+    });
+});
+
+describe('Edit Item > Relationships tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="relationships"]').click();
+
+        // <ds-item-relationships> tag must be loaded
+        cy.get('ds-item-relationships').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-relationships');
+    });
+});
+
+describe('Edit Item > Version History tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="versionhistory"]').click();
+
+        // <ds-item-version-history> tag must be loaded
+        cy.get('ds-item-version-history').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-version-history');
+    });
+});
+
+describe('Edit Item > Access Control tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="access-control"]').click();
+
+        // <ds-item-access-control> tag must be loaded
+        cy.get('ds-item-access-control').should('be.visible');
+
+        // Analyze for accessibility issues
+        testA11y('ds-item-access-control');
+    });
+});
+
+describe('Edit Item > Collection Mapper tab', () => {
+
+    it('should pass accessibility tests', () => {
+        cy.get('a[data-test="mapper"]').click();
+
+        // <ds-item-collection-mapper> tag must be loaded
+        cy.get('ds-item-collection-mapper').should('be.visible');
+
+        // Analyze entire page for accessibility issues
+        testA11y('ds-item-collection-mapper');
+
+        // Click on the "Map new collections" tab
+        cy.get('li[data-test="mapTab"] a').click();
+
+        // Make sure search form is now visible
+        cy.get('ds-search-form').should('be.visible');
+
+        // Analyze entire page (again) for accessibility issues
+        testA11y('ds-item-collection-mapper');
+    });
+});

--- a/cypress/e2e/item-page.cy.ts
+++ b/cypress/e2e/item-page.cy.ts
@@ -1,9 +1,8 @@
-import { TEST_ENTITY_PUBLICATION } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Item  Page', () => {
-    const ITEMPAGE = '/items/'.concat(TEST_ENTITY_PUBLICATION);
-    const ENTITYPAGE = '/entities/publication/'.concat(TEST_ENTITY_PUBLICATION);
+    const ITEMPAGE = '/items/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'));
+    const ENTITYPAGE = '/entities/publication/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'));
 
     // Test that entities will redirect to /entities/[type]/[uuid] when accessed via /items/[uuid]
     it('should redirect to the entity page when navigating to an item page', () => {

--- a/cypress/e2e/item-statistics.cy.ts
+++ b/cypress/e2e/item-statistics.cy.ts
@@ -1,11 +1,11 @@
-import { REGEX_MATCH_NON_EMPTY_TEXT, TEST_ENTITY_PUBLICATION } from 'cypress/support/e2e';
+import { REGEX_MATCH_NON_EMPTY_TEXT } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Item Statistics Page', () => {
-    const ITEMSTATISTICSPAGE = '/statistics/items/'.concat(TEST_ENTITY_PUBLICATION);
+    const ITEMSTATISTICSPAGE = '/statistics/items/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'));
 
     it('should load if you click on "Statistics" from an Item/Entity page', () => {
-        cy.visit('/entities/publication/'.concat(TEST_ENTITY_PUBLICATION));
+        cy.visit('/entities/publication/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION')));
         cy.get('ds-navbar ds-link-menu-item a[title="Statistics"]').click();
         cy.location('pathname').should('eq', ITEMSTATISTICSPAGE);
     });
@@ -24,7 +24,7 @@ describe('Item Statistics Page', () => {
     it('should contain a "Total visits per month" section', () => {
         cy.visit(ITEMSTATISTICSPAGE);
         // Check just for existence because this table is empty in CI environment as it's historical data
-        cy.get('.'.concat(TEST_ENTITY_PUBLICATION).concat('_TotalVisitsPerMonth')).should('exist');
+        cy.get('.'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION')).concat('_TotalVisitsPerMonth')).should('exist');
     });
 
     it('should pass accessibility tests', () => {

--- a/cypress/e2e/login-modal.cy.ts
+++ b/cypress/e2e/login-modal.cy.ts
@@ -1,4 +1,3 @@
-import { TEST_ADMIN_PASSWORD, TEST_ADMIN_USER, TEST_ENTITY_PUBLICATION } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 const page = {
@@ -37,7 +36,7 @@ const page = {
 
 describe('Login Modal', () => {
     it('should login when clicking button & stay on same page', () => {
-        const ENTITYPAGE = '/entities/publication/'.concat(TEST_ENTITY_PUBLICATION);
+        const ENTITYPAGE = '/entities/publication/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION'));
         cy.visit(ENTITYPAGE);
 
         // Login menu should exist
@@ -47,7 +46,7 @@ describe('Login Modal', () => {
         page.openLoginMenu();
         cy.get('.form-login').should('be.visible');
 
-        page.submitLoginAndPasswordByPressingButton(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        page.submitLoginAndPasswordByPressingButton(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
         cy.get('ds-log-in').should('not.exist');
 
         // Verify we are still on the same page
@@ -67,7 +66,7 @@ describe('Login Modal', () => {
         cy.get('.form-login').should('be.visible');
 
         // Login, and the <ds-log-in> tag should no longer exist
-        page.submitLoginAndPasswordByPressingEnter(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        page.submitLoginAndPasswordByPressingEnter(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
         cy.get('.form-login').should('not.exist');
 
         // Verify we are still on homepage
@@ -81,7 +80,7 @@ describe('Login Modal', () => {
 
     it('should support logout', () => {
         // First authenticate & access homepage
-        cy.login(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        cy.login(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
         cy.visit('/');
 
         // Verify ds-log-in tag doesn't exist, but ds-log-out tag does exist
@@ -140,7 +139,7 @@ describe('Login Modal', () => {
         testA11y('ds-log-in');
 
         // Now login
-        page.submitLoginAndPasswordByPressingButton(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        page.submitLoginAndPasswordByPressingButton(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
         cy.get('ds-log-in').should('not.exist');
 
         // Open user menu, verify user menu accesibility

--- a/cypress/e2e/login-modal.cy.ts
+++ b/cypress/e2e/login-modal.cy.ts
@@ -109,6 +109,9 @@ describe('Login Modal', () => {
         cy.get('ds-themed-navbar [data-test="register"]').click();
         cy.location('pathname').should('eq', '/register');
         cy.get('ds-register-email').should('exist');
+
+        // Test accessibility of this page
+        testA11y('ds-register-email');
     });
 
     it('should allow forgot password', () => {
@@ -123,16 +126,26 @@ describe('Login Modal', () => {
         cy.get('ds-themed-navbar [data-test="forgot"]').click();
         cy.location('pathname').should('eq', '/forgot');
         cy.get('ds-forgot-email').should('exist');
+
+        // Test accessibility of this page
+        testA11y('ds-forgot-email');
     });
 
-    it('should pass accessibility tests', () => {
+    it('should pass accessibility tests in menus', () => {
         cy.visit('/');
 
+        // Open login menu & verify accessibility
         page.openLoginMenu();
-
         cy.get('ds-log-in').should('exist');
-
-        // Analyze <ds-log-in> for accessibility issues
         testA11y('ds-log-in');
+
+        // Now login
+        page.submitLoginAndPasswordByPressingButton(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        cy.get('ds-log-in').should('not.exist');
+
+        // Open user menu, verify user menu accesibility
+        page.openUserMenu();
+        cy.get('ds-user-menu').should('be.visible');
+        testA11y('ds-user-menu');
     });
 });

--- a/cypress/e2e/my-dspace.cy.ts
+++ b/cypress/e2e/my-dspace.cy.ts
@@ -1,4 +1,3 @@
-import { Options } from 'cypress-axe';
 import { TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD, TEST_SUBMIT_COLLECTION_NAME } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
@@ -35,16 +34,8 @@ describe('My DSpace page', () => {
 
         cy.get('ds-object-detail').should('be.visible');
 
-        // Analyze <ds-search-page> for accessibility issues
-        testA11y('ds-my-dspace-page',
-            {
-                rules: {
-                    // Search filters fail these two "moderate" impact rules
-                    'heading-order': { enabled: false },
-                    'landmark-unique': { enabled: false }
-                }
-            } as Options
-        );
+        // Analyze <ds-my-dspace-page> for accessibility issues
+        testA11y('ds-my-dspace-page');
     });
 
     // NOTE: Deleting existing submissions is exercised by submission.spec.ts
@@ -136,6 +127,9 @@ describe('My DSpace page', () => {
 
         // The external import searchbox should be visible
         cy.get('ds-submission-import-external-searchbar').should('be.visible');
+
+        // Test for accessibility issues
+        testA11y('ds-submission-import-external');
     });
 
 });

--- a/cypress/e2e/my-dspace.cy.ts
+++ b/cypress/e2e/my-dspace.cy.ts
@@ -1,4 +1,3 @@
-import { TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD, TEST_SUBMIT_COLLECTION_NAME } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('My DSpace page', () => {
@@ -6,7 +5,7 @@ describe('My DSpace page', () => {
         cy.visit('/mydspace');
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         cy.get('ds-my-dspace-page').should('be.visible');
 
@@ -25,7 +24,7 @@ describe('My DSpace page', () => {
         cy.visit('/mydspace');
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         cy.get('ds-my-dspace-page').should('be.visible');
 
@@ -43,7 +42,7 @@ describe('My DSpace page', () => {
         cy.visit('/mydspace');
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         // Open the New Submission dropdown
         cy.get('button[data-test="submission-dropdown"]').click();
@@ -54,10 +53,10 @@ describe('My DSpace page', () => {
         cy.get('ds-create-item-parent-selector').should('be.visible');
 
         // Type in a known Collection name in the search box
-        cy.get('ds-authorized-collection-selector input[type="search"]').type(TEST_SUBMIT_COLLECTION_NAME);
+        cy.get('ds-authorized-collection-selector input[type="search"]').type(Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME'));
 
         // Click on the button matching that known Collection name
-        cy.get('ds-authorized-collection-selector button[title="'.concat(TEST_SUBMIT_COLLECTION_NAME).concat('"]')).click();
+        cy.get('ds-authorized-collection-selector button[title="'.concat(Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME')).concat('"]')).click();
 
         // New URL should include /workspaceitems, as we've started a new submission
         cy.url().should('include', '/workspaceitems');
@@ -66,7 +65,7 @@ describe('My DSpace page', () => {
         cy.get('ds-submission-edit').should('be.visible');
 
         // A Collection menu button should exist & its value should be the selected collection
-        cy.get('#collectionControlsMenuButton span').should('have.text', TEST_SUBMIT_COLLECTION_NAME);
+        cy.get('#collectionControlsMenuButton span').should('have.text', Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME'));
 
         // Now that we've created a submission, we'll test that we can go back and Edit it.
         // Get our Submission URL, to parse out the ID of this new submission
@@ -115,7 +114,7 @@ describe('My DSpace page', () => {
         cy.visit('/mydspace');
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         // Open the New Import dropdown
         cy.get('button[data-test="import-dropdown"]').click();

--- a/cypress/e2e/search-navbar.cy.ts
+++ b/cypress/e2e/search-navbar.cy.ts
@@ -1,5 +1,3 @@
-import { TEST_SEARCH_TERM } from 'cypress/support/e2e';
-
 const page = {
     fillOutQueryInNavBar(query) {
         // Click the magnifying glass
@@ -17,7 +15,7 @@ const page = {
 
 describe('Search from Navigation Bar', () => {
     // NOTE: these tests currently assume this query will return results!
-    const query = TEST_SEARCH_TERM;
+    const query = Cypress.env('DSPACE_TEST_SEARCH_TERM');
 
     it('should go to search page with correct query if submitted (from home)', () => {
         cy.visit('/');

--- a/cypress/e2e/search-page.cy.ts
+++ b/cypress/e2e/search-page.cy.ts
@@ -1,8 +1,10 @@
 import { Options } from 'cypress-axe';
-import { TEST_SEARCH_TERM } from 'cypress/support/e2e';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Search Page', () => {
+    // NOTE: these tests currently assume this query will return results!
+    const query = Cypress.env('DSPACE_TEST_SEARCH_TERM');
+
     it('should redirect to the correct url when query was set and submit button was triggered', () => {
         const queryString = 'Another interesting query string';
         cy.visit('/search');
@@ -13,8 +15,8 @@ describe('Search Page', () => {
     });
 
     it('should load results and pass accessibility tests', () => {
-        cy.visit('/search?query='.concat(TEST_SEARCH_TERM));
-        cy.get('[data-test="search-box"]').should('have.value', TEST_SEARCH_TERM);
+        cy.visit('/search?query='.concat(query));
+        cy.get('[data-test="search-box"]').should('have.value', query);
 
         // <ds-search-page> tag must be loaded
         cy.get('ds-search-page').should('be.visible');
@@ -31,7 +33,7 @@ describe('Search Page', () => {
     });
 
     it('should have a working grid view that passes accessibility tests', () => {
-        cy.visit('/search?query='.concat(TEST_SEARCH_TERM));
+        cy.visit('/search?query='.concat(query));
 
         // Click button in sidebar to display grid view
         cy.get('ds-search-sidebar [data-test="grid-view"]').click();

--- a/cypress/e2e/search-page.cy.ts
+++ b/cypress/e2e/search-page.cy.ts
@@ -46,9 +46,8 @@ describe('Search Page', () => {
         testA11y('ds-search-page',
             {
                 rules: {
-                    // Search filters fail these two "moderate" impact rules
-                    'heading-order': { enabled: false },
-                    'landmark-unique': { enabled: false }
+                    // Card titles fail this test currently
+                    'heading-order': { enabled: false }
                 }
             } as Options
         );

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -1,5 +1,5 @@
 import { testA11y } from 'cypress/support/utils';
-import { TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD, TEST_SUBMIT_COLLECTION_NAME, TEST_SUBMIT_COLLECTION_UUID, TEST_ADMIN_USER, TEST_ADMIN_PASSWORD } from 'cypress/support/e2e';
+//import { TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD, TEST_SUBMIT_COLLECTION_NAME, TEST_SUBMIT_COLLECTION_UUID, TEST_ADMIN_USER, TEST_ADMIN_PASSWORD } from 'cypress/support/e2e';
 import { Options } from 'cypress-axe';
 
 describe('New Submission page', () => {
@@ -7,10 +7,10 @@ describe('New Submission page', () => {
     // NOTE: We already test that new Item submissions can be started from MyDSpace in my-dspace.spec.ts
     it('should create a new submission when using /submit path & pass accessibility', () => {
         // Test that calling /submit with collection & entityType will create a new submission
-        cy.visit('/submit?collection='.concat(TEST_SUBMIT_COLLECTION_UUID).concat('&entityType=none'));
+        cy.visit('/submit?collection='.concat(Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_UUID')).concat('&entityType=none'));
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         // Should redirect to /workspaceitems, as we've started a new submission
         cy.url().should('include', '/workspaceitems');
@@ -19,7 +19,7 @@ describe('New Submission page', () => {
         cy.get('ds-submission-edit').should('be.visible');
 
         // A Collection menu button should exist & it's value should be the selected collection
-        cy.get('#collectionControlsMenuButton span').should('have.text', TEST_SUBMIT_COLLECTION_NAME);
+        cy.get('#collectionControlsMenuButton span').should('have.text', Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME'));
 
         // 4 sections should be visible by default
         cy.get('div#section_traditionalpageone').should('be.visible');
@@ -51,10 +51,10 @@ describe('New Submission page', () => {
 
     it('should block submission & show errors if required fields are missing', () => {
         // Create a new submission
-        cy.visit('/submit?collection='.concat(TEST_SUBMIT_COLLECTION_UUID).concat('&entityType=none'));
+        cy.visit('/submit?collection='.concat(Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_UUID')).concat('&entityType=none'));
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         // Attempt an immediate deposit without filling out any fields
         cy.get('button#deposit').click();
@@ -111,10 +111,10 @@ describe('New Submission page', () => {
 
     it('should allow for deposit if all required fields completed & file uploaded', () => {
         // Create a new submission
-        cy.visit('/submit?collection='.concat(TEST_SUBMIT_COLLECTION_UUID).concat('&entityType=none'));
+        cy.visit('/submit?collection='.concat(Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_UUID')).concat('&entityType=none'));
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
-        cy.loginViaForm(TEST_SUBMIT_USER, TEST_SUBMIT_USER_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
 
         // Fill out all required fields (Title, Date)
         cy.get('input#dc_title').type('DSpace logo uploaded via e2e tests');
@@ -155,7 +155,7 @@ describe('New Submission page', () => {
 
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
         // NOTE: At this time, we MUST login as admin to submit Person objects
-        cy.loginViaForm(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
+        cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 
         // Open the New Submission dropdown
         cy.get('button[data-test="submission-dropdown"]').click();

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -168,14 +168,20 @@ describe('New Submission page', () => {
         // This should display the <ds-create-item-parent-selector> (popup window)
         cy.get('ds-create-item-parent-selector').should('be.visible');
 
-        // Click on the first Collection button to seelect a collection (actual collection doesn't matter)
-        cy.get('ds-authorized-collection-selector button:first-child').click();
+        // Type in a known Collection name in the search box
+        cy.get('ds-authorized-collection-selector input[type="search"]').type(Cypress.env('DSPACE_TEST_SUBMIT_PERSON_COLLECTION_NAME'));
+
+        // Click on the button matching that known Collection name
+        cy.get('ds-authorized-collection-selector button[title="'.concat(Cypress.env('DSPACE_TEST_SUBMIT_PERSON_COLLECTION_NAME')).concat('"]')).click();
 
         // New URL should include /workspaceitems, as we've started a new submission
         cy.url().should('include', '/workspaceitems');
 
         // The Submission edit form tag should be visible
         cy.get('ds-submission-edit').should('be.visible');
+
+        // A Collection menu button should exist & its value should be the selected collection
+        cy.get('#collectionControlsMenuButton span').should('have.text', Cypress.env('DSPACE_TEST_SUBMIT_PERSON_COLLECTION_NAME'));
 
         // 3 sections should be visible by default
         cy.get('div#section_personStep').should('be.visible');

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -31,12 +31,15 @@ describe('New Submission page', () => {
         testA11y('ds-submission-edit',
             {
                 rules: {
-                    // Author & Subject fields have invalid "aria-multiline" attrs, see #1272
+                    // Author & Subject fields have invalid "aria-multiline" attrs.
+                    // See https://github.com/DSpace/dspace-angular/issues/1272
                     'aria-allowed-attr': { enabled: false },
-                    // All panels are accordians & fail "aria-required-children" and "nested-interactive". Seem to require updating ng-bootstrap and #2216
+                    // All panels are accordians & fail "aria-required-children" and "nested-interactive".
+                    // Seem to require updating ng-bootstrap and https://github.com/DSpace/dspace-angular/issues/2216
                     'aria-required-children': { enabled: false },
                     'nested-interactive': { enabled: false },
-                    // All select boxes fail to have a name / aria-label. This is a bug in ng-dynamic-forms and may require #2216
+                    // All select boxes fail to have a name / aria-label.
+                    // This is a bug in ng-dynamic-forms and may require https://github.com/DSpace/dspace-angular/issues/2216
                     'select-name': { enabled: false },
                 }
 
@@ -183,7 +186,8 @@ describe('New Submission page', () => {
         testA11y('ds-submission-edit',
             {
                 rules: {
-                    // All panels are accordians & fail "aria-required-children" and "nested-interactive". Seem to require updating ng-bootstrap and #2216
+                    // All panels are accordians & fail "aria-required-children" and "nested-interactive".
+                    // Seem to require updating ng-bootstrap and https://github.com/DSpace/dspace-angular/issues/2216
                     'aria-required-children': { enabled: false },
                     'nested-interactive': { enabled: false },
                 }

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,5 +1,11 @@
 const fs = require('fs');
 
+// These two global variables are used to store information about the REST API used
+// by these e2e tests. They are filled out prior to running any tests in the before()
+// method of e2e.ts. They can then be accessed by any tests via the getters below.
+let REST_BASE_URL: string;
+let REST_DOMAIN: string;
+
 // Plugins enable you to tap into, modify, or extend the internal behavior of Cypress
 // For more info, visit https://on.cypress.io/plugins-api
 module.exports = (on, config) => {
@@ -30,6 +36,24 @@ module.exports = (on, config) => {
             }
 
             return null;
+        },
+        // Save value of REST Base URL, looked up before all tests.
+        // This allows other tests to use it easily via getRestBaseURL() below.
+        saveRestBaseURL(url: string) {
+            return (REST_BASE_URL = url);
+        },
+        // Retrieve currently saved value of REST Base URL
+        getRestBaseURL() {
+            return REST_BASE_URL ;
+        },
+        // Save value of REST Domain, looked up before all tests.
+        // This allows other tests to use it easily via getRestBaseDomain() below.
+        saveRestBaseDomain(domain: string) {
+            return (REST_DOMAIN = domain);
+        },
+        // Retrieve currently saved value of REST Domain
+        getRestBaseDomain() {
+            return REST_DOMAIN ;
         }
     });
 };

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,11 +5,7 @@
 
 import { AuthTokenInfo, TOKENITEM } from 'src/app/core/auth/models/auth-token-info.model';
 import { DSPACE_XSRF_COOKIE, XSRF_REQUEST_HEADER } from 'src/app/core/xsrf/xsrf.constants';
-
-// NOTE: FALLBACK_TEST_REST_BASE_URL is only used if Cypress cannot read the REST API BaseURL
-// from the Angular UI's config.json. See 'login()'.
-export const FALLBACK_TEST_REST_BASE_URL = 'http://localhost:8080/server';
-export const FALLBACK_TEST_REST_DOMAIN = 'localhost';
+import { v4 as uuidv4 } from 'uuid';
 
 // Declare Cypress namespace to help with Intellisense & code completion in IDEs
 // ALL custom commands MUST be listed here for code completion to work
@@ -41,6 +37,13 @@ declare global {
              * @param dsoType type of DSpace Object (e.g. "item", "collection", "community")
              */
             generateViewEvent(uuid: string, dsoType: string): typeof generateViewEvent;
+
+            /**
+             * Create a new CSRF token and add to required Cookie. CSRF Token is returned
+             * in chainable in order to allow it to be sent also in required CSRF header.
+             * @returns Chainable reference to allow CSRF token to also be sent in header.
+             */
+            createCSRFCookie(): Chainable<any>;
         }
     }
 }
@@ -54,59 +57,32 @@ declare global {
  * @param password password to login as
  */
 function login(email: string, password: string): void {
-    // Cypress doesn't have access to the running application in Node.js.
-    // So, it's not possible to inject or load the AppConfig or environment of the Angular UI.
-    // Instead, we'll read our running application's config.json, which contains the configs &
-    // is regenerated at runtime each time the Angular UI application starts up.
-    cy.task('readUIConfig').then((str: string) => {
-        // Parse config into a JSON object
-        const config = JSON.parse(str);
+    // Create a fake CSRF cookie/token to use in POST
+    cy.createCSRFCookie().then((csrfToken: string) => {
+        // get our REST API's base URL, also needed for POST
+        cy.task('getRestBaseURL').then((baseRestUrl: string) => {
+            // Now, send login POST request including that CSRF token
+            cy.request({
+                method: 'POST',
+                url: baseRestUrl + '/api/authn/login',
+                headers: { [XSRF_REQUEST_HEADER]: csrfToken},
+                form: true, // indicates the body should be form urlencoded
+                body: { user: email, password: password }
+            }).then((resp) => {
+                // We expect a successful login
+                expect(resp.status).to.eq(200);
+                // We expect to have a valid authorization header returned (with our auth token)
+                expect(resp.headers).to.have.property('authorization');
 
-        // Find the URL of our REST API. Have a fallback ready, just in case 'rest.baseUrl' cannot be found.
-        let baseRestUrl = FALLBACK_TEST_REST_BASE_URL;
-        if (!config.rest.baseUrl) {
-            console.warn("Could not load 'rest.baseUrl' from config.json. Falling back to " + FALLBACK_TEST_REST_BASE_URL);
-        } else {
-            //console.log("Found 'rest.baseUrl' in config.json. Using this REST API for login: ".concat(config.rest.baseUrl));
-            baseRestUrl = config.rest.baseUrl;
-        }
+                // Initialize our AuthTokenInfo object from the authorization header.
+                const authheader = resp.headers.authorization as string;
+                const authinfo: AuthTokenInfo = new AuthTokenInfo(authheader);
 
-        // Now find domain of our REST API, again with a fallback.
-        let baseDomain = FALLBACK_TEST_REST_DOMAIN;
-        if (!config.rest.host) {
-            console.warn("Could not load 'rest.host' from config.json. Falling back to " + FALLBACK_TEST_REST_DOMAIN);
-        } else {
-            baseDomain = config.rest.host;
-        }
-
-        // Create a fake CSRF Token.  Set it in the required server-side cookie
-        const csrfToken = 'fakeLoginCSRFToken';
-        cy.setCookie(DSPACE_XSRF_COOKIE, csrfToken, { 'domain': baseDomain });
-
-        // Now, send login POST request including that CSRF token
-        cy.request({
-            method: 'POST',
-            url: baseRestUrl + '/api/authn/login',
-            headers: { [XSRF_REQUEST_HEADER]: csrfToken},
-            form: true, // indicates the body should be form urlencoded
-            body: { user: email, password: password }
-        }).then((resp) => {
-            // We expect a successful login
-            expect(resp.status).to.eq(200);
-            // We expect to have a valid authorization header returned (with our auth token)
-            expect(resp.headers).to.have.property('authorization');
-
-            // Initialize our AuthTokenInfo object from the authorization header.
-            const authheader = resp.headers.authorization as string;
-            const authinfo: AuthTokenInfo = new AuthTokenInfo(authheader);
-
-            // Save our AuthTokenInfo object to our dsAuthInfo UI cookie
-            // This ensures the UI will recognize we are logged in on next "visit()"
-            cy.setCookie(TOKENITEM, JSON.stringify(authinfo));
+                // Save our AuthTokenInfo object to our dsAuthInfo UI cookie
+                // This ensures the UI will recognize we are logged in on next "visit()"
+                cy.setCookie(TOKENITEM, JSON.stringify(authinfo));
+            });
         });
-
-        // Remove cookie with fake CSRF token, as it's no longer needed
-        cy.clearCookie(DSPACE_XSRF_COOKIE);
     });
 }
 // Add as a Cypress command (i.e. assign to 'cy.login')
@@ -141,56 +117,53 @@ Cypress.Commands.add('loginViaForm', loginViaForm);
  * @param dsoType type of DSpace Object (e.g. "item", "collection", "community")
  */
 function generateViewEvent(uuid: string, dsoType: string): void {
-    // Cypress doesn't have access to the running application in Node.js.
-    // So, it's not possible to inject or load the AppConfig or environment of the Angular UI.
-    // Instead, we'll read our running application's config.json, which contains the configs &
-    // is regenerated at runtime each time the Angular UI application starts up.
-    cy.task('readUIConfig').then((str: string) => {
-        // Parse config into a JSON object
-        const config = JSON.parse(str);
-
-        // Find the URL of our REST API. Have a fallback ready, just in case 'rest.baseUrl' cannot be found.
-        let baseRestUrl = FALLBACK_TEST_REST_BASE_URL;
-        if (!config.rest.baseUrl) {
-            console.warn("Could not load 'rest.baseUrl' from config.json. Falling back to " + FALLBACK_TEST_REST_BASE_URL);
-        } else {
-            baseRestUrl = config.rest.baseUrl;
-        }
-
-        // Now find domain of our REST API, again with a fallback.
-        let baseDomain = FALLBACK_TEST_REST_DOMAIN;
-        if (!config.rest.host) {
-            console.warn("Could not load 'rest.host' from config.json. Falling back to " + FALLBACK_TEST_REST_DOMAIN);
-        } else {
-            baseDomain = config.rest.host;
-        }
-
-        // Create a fake CSRF Token.  Set it in the required server-side cookie
-        const csrfToken = 'fakeGenerateViewEventCSRFToken';
-        cy.setCookie(DSPACE_XSRF_COOKIE, csrfToken, { 'domain': baseDomain });
-
-        // Now, send 'statistics/viewevents' POST request including that fake CSRF token in required header
-        cy.request({
-            method: 'POST',
-            url: baseRestUrl + '/api/statistics/viewevents',
-            headers: {
-                [XSRF_REQUEST_HEADER] : csrfToken,
-                // use a known public IP address to avoid being seen as a "bot"
-                'X-Forwarded-For': '1.1.1.1',
-                // Use a user-agent of a Firefox browser on Windows. This again avoids being seen as a "bot"
-                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0',
-            },
-            //form: true, // indicates the body should be form urlencoded
-            body: { targetId: uuid, targetType: dsoType },
-        }).then((resp) => {
-            // We expect a 201 (which means statistics event was created)
-            expect(resp.status).to.eq(201);
+    // Create a fake CSRF cookie/token to use in POST
+    cy.createCSRFCookie().then((csrfToken: string) => {
+        // get our REST API's base URL, also needed for POST
+        cy.task('getRestBaseURL').then((baseRestUrl: string) => {
+            // Now, send 'statistics/viewevents' POST request including that fake CSRF token in required header
+            cy.request({
+                method: 'POST',
+                url: baseRestUrl + '/api/statistics/viewevents',
+                headers: {
+                    [XSRF_REQUEST_HEADER] : csrfToken,
+                    // use a known public IP address to avoid being seen as a "bot"
+                    'X-Forwarded-For': '1.1.1.1',
+                    // Use a user-agent of a Firefox browser on Windows. This again avoids being seen as a "bot"
+                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0',
+                },
+                //form: true, // indicates the body should be form urlencoded
+                body: { targetId: uuid, targetType: dsoType },
+            }).then((resp) => {
+                // We expect a 201 (which means statistics event was created)
+                expect(resp.status).to.eq(201);
+            });
         });
-
-        // Remove cookie with fake CSRF token, as it's no longer needed
-        cy.clearCookie(DSPACE_XSRF_COOKIE);
     });
 }
 // Add as a Cypress command (i.e. assign to 'cy.generateViewEvent')
 Cypress.Commands.add('generateViewEvent', generateViewEvent);
 
+
+/**
+ * Can be used by tests to generate a random XSRF/CSRF token and save it to
+ * the required XSRF/CSRF cookie for usage when sending POST requests or similar.
+ * The generated CSRF token is returned in a Chainable to allow it to be also sent
+ * in the CSRF HTTP Header.
+ * @returns a Cypress Chainable which can be used to get the generated CSRF Token
+ */
+function createCSRFCookie(): Cypress.Chainable {
+    // Generate a new token which is a random UUID
+    const csrfToken: string = uuidv4();
+
+    // Save it to our required cookie
+    cy.task('getRestBaseDomain').then((baseDomain: string) => {
+        // Create a fake CSRF Token.  Set it in the required server-side cookie
+        cy.setCookie(DSPACE_XSRF_COOKIE, csrfToken, { 'domain': baseDomain });
+    });
+
+    // return the generated token wrapped in a chainable
+    return cy.wrap(csrfToken);
+}
+// Add as a Cypress command (i.e. assign to 'cy.createCSRFCookie')
+Cypress.Commands.add('createCSRFCookie', createCSRFCookie);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -63,26 +63,6 @@ beforeEach(() => {
     cy.clearCookie(DSPACE_XSRF_COOKIE);
 });
 
-// Global constants used in tests
-// May be overridden in our cypress.json config file using specified environment variables.
-// Default values listed here are all valid for the Demo Entities Data set available at
-// https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-// (This is the data set used in our CI environment)
-
-// Admin account used for administrative tests
-export const TEST_ADMIN_USER = Cypress.env('DSPACE_TEST_ADMIN_USER') || 'dspacedemo+admin@gmail.com';
-export const TEST_ADMIN_PASSWORD = Cypress.env('DSPACE_TEST_ADMIN_PASSWORD') || 'dspace';
-// Community/collection/publication used for view/edit tests
-export const TEST_COLLECTION = Cypress.env('DSPACE_TEST_COLLECTION') || '282164f5-d325-4740-8dd1-fa4d6d3e7200';
-export const TEST_COMMUNITY = Cypress.env('DSPACE_TEST_COMMUNITY') || '0958c910-2037-42a9-81c7-dca80e3892b4';
-export const TEST_ENTITY_PUBLICATION = Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION') || 'e98b0f27-5c19-49a0-960d-eb6ad5287067';
-// Search term (should return results) used in search tests
-export const TEST_SEARCH_TERM = Cypress.env('DSPACE_TEST_SEARCH_TERM') || 'test';
-// Collection used for submission tests
-export const TEST_SUBMIT_COLLECTION_NAME = Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME') || 'Sample Collection';
-export const TEST_SUBMIT_COLLECTION_UUID = Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_UUID') || '9d8334e9-25d3-4a67-9cea-3dffdef80144';
-export const TEST_SUBMIT_USER = Cypress.env('DSPACE_TEST_SUBMIT_USER') || 'dspacedemo+submit@gmail.com';
-export const TEST_SUBMIT_USER_PASSWORD = Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD') || 'dspace';
 // NOTE: FALLBACK_TEST_REST_BASE_URL is only used if Cypress cannot read the REST API BaseURL
 // from the Angular UI's config.json. See 'before()' above.
 const FALLBACK_TEST_REST_BASE_URL = 'http://localhost:8080/server';

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -19,23 +19,49 @@ import './commands';
 // Import Cypress Axe tools for all tests
 // https://github.com/component-driven/cypress-axe
 import 'cypress-axe';
+import { DSPACE_XSRF_COOKIE } from 'src/app/core/xsrf/xsrf.constants';
+
+
+// Runs once before all tests
+before(() => {
+  // Cypress doesn't have access to the running application in Node.js.
+  // So, it's not possible to inject or load the AppConfig or environment of the Angular UI.
+  // Instead, we'll read our running application's config.json, which contains the configs &
+  // is regenerated at runtime each time the Angular UI application starts up.
+  cy.task('readUIConfig').then((str: string) => {
+    // Parse config into a JSON object
+    const config = JSON.parse(str);
+
+    // Find URL of our REST API & save to global variable via task
+    let baseRestUrl = FALLBACK_TEST_REST_BASE_URL;
+    if (!config.rest.baseUrl) {
+        console.warn("Could not load 'rest.baseUrl' from config.json. Falling back to " + FALLBACK_TEST_REST_BASE_URL);
+    } else {
+        baseRestUrl = config.rest.baseUrl;
+    }
+    cy.task('saveRestBaseURL', baseRestUrl);
+
+    // Find domain of our REST API & save to global variable via task.
+    let baseDomain = FALLBACK_TEST_REST_DOMAIN;
+    if (!config.rest.host) {
+        console.warn("Could not load 'rest.host' from config.json. Falling back to " + FALLBACK_TEST_REST_DOMAIN);
+    } else {
+        baseDomain = config.rest.host;
+    }
+    cy.task('saveRestBaseDomain', baseDomain);
+
+  });
+});
 
 // Runs once before the first test in each "block"
 beforeEach(() => {
     // Pre-agree to all Klaro cookies by setting the klaro-anonymous cookie
     // This just ensures it doesn't get in the way of matching other objects in the page.
     cy.setCookie('klaro-anonymous', '{%22authentication%22:true%2C%22preferences%22:true%2C%22acknowledgement%22:true%2C%22google-analytics%22:true%2C%22google-recaptcha%22:true}');
+
+    // Remove any CSRF cookies saved from prior tests
+    cy.clearCookie(DSPACE_XSRF_COOKIE);
 });
-
-// For better stability between tests, we visit "about:blank" (i.e. blank page) after each test.
-// This ensures any remaining/outstanding XHR requests are killed, so they don't affect the next test.
-// Borrowed from: https://glebbahmutov.com/blog/visit-blank-page-between-tests/
-/*afterEach(() => {
-    cy.window().then((win) => {
-      win.location.href = 'about:blank';
-    });
-});*/
-
 
 // Global constants used in tests
 // May be overridden in our cypress.json config file using specified environment variables.
@@ -57,7 +83,10 @@ export const TEST_SUBMIT_COLLECTION_NAME = Cypress.env('DSPACE_TEST_SUBMIT_COLLE
 export const TEST_SUBMIT_COLLECTION_UUID = Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_UUID') || '9d8334e9-25d3-4a67-9cea-3dffdef80144';
 export const TEST_SUBMIT_USER = Cypress.env('DSPACE_TEST_SUBMIT_USER') || 'dspacedemo+submit@gmail.com';
 export const TEST_SUBMIT_USER_PASSWORD = Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD') || 'dspace';
-
+// NOTE: FALLBACK_TEST_REST_BASE_URL is only used if Cypress cannot read the REST API BaseURL
+// from the Angular UI's config.json. See 'before()' above.
+const FALLBACK_TEST_REST_BASE_URL = 'http://localhost:8080/server';
+const FALLBACK_TEST_REST_DOMAIN = 'localhost';
 
 // USEFUL REGEX for testing
 

--- a/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
+++ b/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
@@ -6,7 +6,7 @@
       <p>{{'collection.edit.item-mapper.description' | translate}}</p>
 
       <ul ngbNav (navChange)="tabChange($event)" [destroyOnHide]="true" #tabs="ngbNav" class="nav-tabs">
-        <li [ngbNavItem]="'browseTab'" role="presentation">
+        <li [ngbNavItem]="'browseTab'" role="presentation" data-test="browseTab">
           <a ngbNavLink>{{'collection.edit.item-mapper.tabs.browse' | translate}}</a>
           <ng-template ngbNavContent>
             <div class="mt-2">
@@ -23,7 +23,7 @@
             </div>
           </ng-template>
         </li>
-        <li [ngbNavItem]="'mapTab'" role="presentation">
+        <li [ngbNavItem]="'mapTab'" role="presentation" data-test="mapTab">
           <a ngbNavLink>{{'collection.edit.item-mapper.tabs.map' | translate}}</a>
           <ng-template ngbNavContent>
             <div class="row mt-2">

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.html
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.html
@@ -1,6 +1,6 @@
 <div *ngVar="(contentSource$ |async) as contentSource">
     <div class="container-fluid space-children-mr" *ngIf="shouldShow">
-        <h4>{{ 'collection.source.controls.head' | translate }}</h4>
+        <h3>{{ 'collection.source.controls.head' | translate }}</h3>
         <div>
             <span class="font-weight-bold">{{'collection.source.controls.harvest.status' | translate}}</span>
             <span>{{contentSource?.harvestStatus}}</span>

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
@@ -26,7 +26,7 @@
                for="externalSourceCheck">{{ 'collection.edit.tabs.source.external' | translate }}</label>
     </div>
     <ds-themed-loading *ngIf="!contentSource" [message]="'loading.content-source' | translate"></ds-themed-loading>
-    <h4 *ngIf="contentSource && (contentSource?.harvestType !== harvestTypeNone)">{{ 'collection.edit.tabs.source.form.head' | translate }}</h4>
+    <h3 *ngIf="contentSource && (contentSource?.harvestType !== harvestTypeNone)">{{ 'collection.edit.tabs.source.form.head' | translate }}</h3>
 </div>
 <div class="row">
     <ds-form *ngIf="formGroup && contentSource && (contentSource?.harvestType !== harvestTypeNone)"

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
@@ -21,25 +21,25 @@
     <div class="btn-group">
       <div class="edit-field">
         <div class="btn-group edit-buttons" [ngbTooltip]="isVirtual ? (dsoType + '.edit.metadata.edit.buttons.virtual' | translate) : null">
-          <button class="btn btn-outline-primary btn-sm ng-star-inserted" id="metadata-edit-btn" *ngIf="!mdValue.editing"
+          <button class="btn btn-outline-primary btn-sm ng-star-inserted" data-test="metadata-edit-btn" *ngIf="!mdValue.editing"
                   [title]="dsoType + '.edit.metadata.edit.buttons.edit' | translate"
                   ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.edit' | translate }}"
                   [disabled]="isVirtual || mdValue.change === DsoEditMetadataChangeTypeEnum.REMOVE || (saving$ | async)" (click)="edit.emit()">
             <i class="fas fa-edit fa-fw"></i>
           </button>
-          <button class="btn btn-outline-success btn-sm ng-star-inserted" id="metadata-confirm-btn" *ngIf="mdValue.editing"
+          <button class="btn btn-outline-success btn-sm ng-star-inserted" data-test="metadata-confirm-btn" *ngIf="mdValue.editing"
                   [title]="dsoType + '.edit.metadata.edit.buttons.confirm' | translate"
                   ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.confirm' | translate }}"
                   [disabled]="isVirtual || (saving$ | async)" (click)="confirm.emit(true)">
             <i class="fas fa-check fa-fw"></i>
           </button>
-          <button class="btn btn-outline-danger btn-sm" id="metadata-remove-btn"
+          <button class="btn btn-outline-danger btn-sm" data-test="metadata-remove-btn"
                   [title]="dsoType + '.edit.metadata.edit.buttons.remove' | translate"
                   ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.remove' | translate }}"
                   [disabled]="isVirtual || (mdValue.change && mdValue.change !== DsoEditMetadataChangeTypeEnum.ADD) || mdValue.editing || (saving$ | async)" (click)="remove.emit()">
             <i class="fas fa-trash-alt fa-fw"></i>
           </button>
-          <button class="btn btn-outline-warning btn-sm" id="metadata-undo-btn"
+          <button class="btn btn-outline-warning btn-sm" data-test="metadata-undo-btn"
                   [title]="dsoType + '.edit.metadata.edit.buttons.undo' | translate"
                   ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.undo' | translate }}"
                   [disabled]="isVirtual || (!mdValue.change && mdValue.reordered) || (!mdValue.change && !mdValue.editing) || (saving$ | async)" (click)="undo.emit()">
@@ -47,7 +47,7 @@
           </button>
         </div>
       </div>
-      <button class="btn btn-outline-secondary ds-drag-handle btn-sm" id="metadata-drag-btn" *ngVar="(isOnlyValue || (saving$ | async)) as disabled"
+      <button class="btn btn-outline-secondary ds-drag-handle btn-sm" data-test="metadata-drag-btn" *ngVar="(isOnlyValue || (saving$ | async)) as disabled"
               cdkDragHandle [cdkDragHandleDisabled]="disabled" [ngClass]="{'disabled': disabled}" [disabled]="disabled"
               [title]="dsoType + '.edit.metadata.edit.buttons.drag' | translate"
               ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.drag' | translate }}">

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -149,7 +149,7 @@ describe('DsoEditMetadataValueComponent', () => {
       let btn: DebugElement;
 
       beforeEach(() => {
-        btn = fixture.debugElement.query(By.css(`#metadata-${name}-btn`));
+        btn = fixture.debugElement.query(By.css(`button[data-test="metadata-${name}-btn"]`));
       });
 
       if (exists) {

--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -10,6 +10,7 @@
                            class="nav-link"
                            [ngClass]="{'active' : page.page === currentPage}"
                            [routerLink]="['./' + page.page]"
+                           [attr.data-test]="page.page"
                            role="tab">
                             {{'item.edit.tabs.' + page.page + '.head' | translate}}
                         </a>

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
@@ -6,7 +6,7 @@
       <p>{{'item.edit.item-mapper.description' | translate}}</p>
 
       <ul ngbNav (navChange)="tabChange($event)" [destroyOnHide]="true" #tabs="ngbNav" class="nav-tabs">
-        <li [ngbNavItem]="'browseTab'" role="presentation">
+        <li [ngbNavItem]="'browseTab'" role="presentation" data-test="browseTab">
           <a ngbNavLink>{{'item.edit.item-mapper.tabs.browse' | translate}}</a>
           <ng-template ngbNavContent>
             <div class="mt-2">
@@ -22,7 +22,7 @@
             </div>
           </ng-template>
         </li>
-        <li [ngbNavItem]="'mapTab'" role="presentation">
+        <li [ngbNavItem]="'mapTab'" role="presentation" data-test="mapTab">
           <a ngbNavLink>{{'item.edit.item-mapper.tabs.map' | translate}}</a>
           <ng-template ngbNavContent>
             <div class="row mt-2">

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.html
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.html
@@ -5,7 +5,8 @@
         <h1>{{ type + '.edit.head' | translate }}</h1>
         <div class="my-auto">
           <a class="btn btn-danger"
-             [routerLink]="((type === 'community') ? '/communities/' : '/collections/') + (dsoRD$ | async)?.payload.uuid + '/delete'">
+             [routerLink]="((type === 'community') ? '/communities/' : '/collections/') + (dsoRD$ | async)?.payload.uuid + '/delete'"
+             data-test="delete-button">
             <i class="fas fa-trash"></i> {{type + '.edit.delete' | translate}}</a>
         </div>
       </div>
@@ -14,7 +15,8 @@
           <li *ngFor="let page of pages" class="nav-item">
             <a class="nav-link"
                [ngClass]="{'active' : page === currentPage}"
-               [routerLink]="['./' + page]">
+               [routerLink]="['./' + page]"
+               [attr.data-test]="page">
               {{ type + '.edit.tabs.' + page + '.head' | translate}}
             </a>
           </li>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -45,7 +45,9 @@
       <button class="btn btn-secondary"
               type="button"
               ngbTooltip="{{'form.lookup-help' | translate}}"
+              [attr.aria-label]="'form.lookup-help' | translate"
               placement="top"
+              data-test="lookup-button"
               (click)="openLookup(); $event.stopPropagation();"><i class="fa fa-search"></i>
       </button>
     </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.html
@@ -4,7 +4,7 @@
       {{model.placeholder}} <span *ngIf="model.required">*</span>
     </legend>
     <ds-number-picker
-      tabindex="1"
+      tabindex="0"
       [id]="model.id + '_year'"
       [disabled]="model.disabled"
       [min]="minYear"
@@ -21,7 +21,7 @@
     ></ds-number-picker>
 
     <ds-number-picker
-      tabindex="2"
+      tabindex="0"
       [id]="model.id + '_month'"
       [min]="minMonth"
       [max]="maxMonth"
@@ -37,7 +37,7 @@
     ></ds-number-picker>
 
     <ds-number-picker
-      tabindex="3"
+      tabindex="0"
       [id]="model.id + '_day'"
       [min]="minDay"
       [max]="maxDay"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -2,14 +2,15 @@
   <div class="position-relative right-addon"
        role="combobox"
        [attr.aria-label]="model.label"
-       [attr.aria-owns]="'combobox_' + id + '_listbox'">
+       [attr.aria-owns]="'combobox_' + id + '_listbox'"
+       [attr.aria-expanded]="sdRef.isOpen()"
+       [attr.aria-activedescendant]="(currentValue | async) ? 'combobox_' + id + '_selected' : null">
        <i *ngIf="!model.readOnly" ngbDropdownToggle class="position-absolute scrollable-dropdown-toggle"
           aria-hidden="true"></i>
        <i *ngIf="model.readOnly" class="dropdown-toggle position-absolute toggle-icon"
           aria-hidden="true"></i>
     <input class="form-control"
            [attr.aria-controls]="'combobox_' + id + '_listbox'"
-           [attr.aria-activedescendant]="'combobox_' + id + '_selected'"
            [attr.aria-label]="model.placeholder"
            [attr.autoComplete]="model.autoComplete"
            [class.is-invalid]="showErrorMessages"
@@ -28,8 +29,6 @@
 
   <div ngbDropdownMenu
        class="dropdown-menu scrollable-dropdown-menu w-100"
-       aria-haspopup="true"
-       aria-expanded="false"
        [attr.aria-label]="model.placeholder">
     <div class="scrollable-menu"
          role="listbox"

--- a/src/app/shared/form/number-picker/number-picker.component.html
+++ b/src/app/shared/form/number-picker/number-picker.component.html
@@ -6,7 +6,7 @@
       [disabled]="disabled"
       (click)="toggleUp()">
       <span class="chevron"></span>
-      <span class="sr-only">Increment</span>
+      <span class="sr-only">Increment {{placeholder}}</span>
     </button>
     <input
       id="{{id}}"
@@ -24,6 +24,7 @@
       [disabled]="disabled"
       [ngClass]="{'is-invalid': invalid}"
       title="{{placeholder}}"
+      [attr.aria-label]="placeholder"
     >
     <button
       class="btn btn-link-focus"
@@ -32,6 +33,6 @@
       [disabled]="disabled"
       (click)="toggleDown()">
       <span class="chevron bottom"></span>
-      <span class="sr-only">Decrement</span>
+      <span class="sr-only">Decrement {{placeholder}}</span>
     </button>
 </div>

--- a/src/app/shared/form/number-picker/number-picker.component.html
+++ b/src/app/shared/form/number-picker/number-picker.component.html
@@ -6,7 +6,7 @@
       [disabled]="disabled"
       (click)="toggleUp()">
       <span class="chevron"></span>
-      <span class="sr-only">Increment {{placeholder}}</span>
+      <span class="sr-only">{{'form.number-picker.increment' | translate: {field: name} }}</span>
     </button>
     <input
       id="{{id}}"
@@ -33,6 +33,6 @@
       [disabled]="disabled"
       (click)="toggleDown()">
       <span class="chevron bottom"></span>
-      <span class="sr-only">Decrement {{placeholder}}</span>
+      <span class="sr-only">{{'form.number-picker.decrement' | translate: {field: name} }}</span>
     </button>
 </div>

--- a/src/app/shared/form/number-picker/number-picker.component.spec.ts
+++ b/src/app/shared/form/number-picker/number-picker.component.spec.ts
@@ -42,7 +42,6 @@ describe('NumberPickerComponent test suite', () => {
   beforeEach(() => {
     html = `
       <ds-number-picker
-        tabindex="1"
         [disabled]="disabled"
         [min]="min"
         [max]="max"

--- a/src/app/shared/form/number-picker/number-picker.component.spec.ts
+++ b/src/app/shared/form/number-picker/number-picker.component.spec.ts
@@ -7,6 +7,7 @@ import { By } from '@angular/platform-browser';
 import { NumberPickerComponent } from './number-picker.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { createTestComponent } from '../../testing/utils.test';
+import { TranslateModule } from '@ngx-translate/core';
 
 describe('NumberPickerComponent test suite', () => {
 
@@ -23,7 +24,8 @@ describe('NumberPickerComponent test suite', () => {
       imports: [
         FormsModule,
         ReactiveFormsModule,
-        NgbModule
+        NgbModule,
+        TranslateModule.forRoot()
       ],
       declarations: [
         NumberPickerComponent,

--- a/src/app/shared/form/number-picker/number-picker.component.ts
+++ b/src/app/shared/form/number-picker/number-picker.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, SimpleChanges, } from '@angular/core';
 import { ControlValueAccessor, UntypedFormBuilder, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
 import { isEmpty } from '../../empty.util';
 
 @Component({
@@ -31,7 +32,9 @@ export class NumberPickerComponent implements OnInit, ControlValueAccessor {
 
   startValue: number;
 
-  constructor(private fb: UntypedFormBuilder, private cd: ChangeDetectorRef) {
+  constructor(private fb: UntypedFormBuilder,
+              private cd: ChangeDetectorRef,
+              private translate: TranslateService) {
   }
 
   ngOnInit() {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1770,6 +1770,10 @@
 
   "form.repeatable.sort.tip": "Drop the item in the new position",
 
+  "form.number-picker.decrement": "Decrement {{field}}",
+
+  "form.number-picker.increment": "Increment {{field}}",
+
   "grant-deny-request-copy.deny": "Don't send copy",
 
   "grant-deny-request-copy.email.back": "Back",


### PR DESCRIPTION
## Description
This PR is **primarily** impacting e2e tests (via Cypress), with a few minor changes to DSpace itself.  

It does the following:
* Refactors some of the Cypress code in `commands.ts` and `e2e.ts` to simplify duplicative code & make it easier to perform tasks that require a CSRF token.  Also cleanup code to use `Cypress.env` instead of our own custom variables.
* Add new accessibility scanning to `e2e` testing for the following pages (NOTE: Some pages, like submission form, have specific accessibility checks turned off for them to fully pass. I linked to associated tickets):
    * Admin Sidebar
    * Item Edit page (all tabs on this page)
    * Collection Edit page (all tabs on this page)
    * Community Edit page (all tabs on this page)
    * New User Registration page
    * User Menu (available after authentication)
    * Submission Form (for normal Item and Person entity)

A few minor fixes were applied to DSpace UI itself:
* Added some `data-test` attributes for usage in some tests.  These are harmless and only used in tests.
* Corrected some `<h4>` tags to be `<h3>` in Collection Edit tabs. This fixes an accessibility issue related to header ordering
* Replaced some `id` attributes with `data-test` on Item Edit Metadata page.  These `id` attributes resulted in duplicative IDs on the page (which fails accessibility) and were only used by tests.
* Added/corrected ARIA labels on several fields in Submission form.  Also fixed a `tabindex` issue in `date-picker.component.html`. Both of these were accessibility issues caught by the accessibility scanner.  The `tabindex` fix has been tested and doesn't seem to affect tab ordering.

## Instructions for Reviewers
* Most of the code here is e2e tests and only requires a quick code review (if desired).  It is tested automatically by GitHub CI.
* The Submission form can be retested as minor changes were made there, primarily to `tabindex`.  Verify that tab ordering is still correct when tabbing between month/day/year of date fields.
