### PR TITLE
Encode all `RequestParam` values

### DIFF
--- a/src/app/core/cache/models/request-param.model.ts
+++ b/src/app/core/cache/models/request-param.model.ts
@@ -1,9 +1,14 @@
-
 /**
  * Class representing a query parameter (query?fieldName=fieldValue) used in FindListOptions object
  */
 export class RequestParam {
-  constructor(public fieldName: string, public fieldValue: any) {
-
+  constructor(
+    public fieldName: string,
+    public fieldValue: any,
+    public encodeValue = true,
+  ) {
+    if (encodeValue) {
+      this.fieldValue = encodeURIComponent(fieldValue);
+    }
   }
 }

--- a/src/app/core/data/relationship-data.service.ts
+++ b/src/app/core/data/relationship-data.service.ts
@@ -531,40 +531,18 @@ export class RelationshipDataService extends IdentifiableDataService<Relationshi
    * @param arrayOfItemIds The uuid of the items to be found on the other side of returned relationships
    */
   searchByItemsAndType(typeId: string,itemUuid: string,relationshipLabel: string, arrayOfItemIds: string[] ): Observable<RemoteData<PaginatedList<Relationship>>> {
-
-    const searchParams = [
-      {
-        fieldName: 'typeId',
-        fieldValue: typeId,
-      },
-      {
-        fieldName: 'focusItem',
-        fieldValue: itemUuid,
-      },
-      {
-        fieldName: 'relationshipLabel',
-        fieldValue: relationshipLabel,
-      },
-      {
-        fieldName: 'size',
-        fieldValue: arrayOfItemIds.length,
-      },
-      {
-        fieldName: 'embed',
-        fieldValue: 'leftItem',
-      },
-      {
-        fieldName: 'embed',
-        fieldValue: 'rightItem',
-      },
+    const searchParams: RequestParam[] = [
+      new RequestParam('typeId', typeId),
+      new RequestParam('focusItem', itemUuid),
+      new RequestParam('relationshipLabel', relationshipLabel),
+      new RequestParam('size', arrayOfItemIds.length),
+      new RequestParam('embed', 'leftItem'),
+      new RequestParam('embed', 'rightItem'),
     ];
 
     arrayOfItemIds.forEach( (itemId) => {
       searchParams.push(
-        {
-          fieldName: 'relatedItem',
-          fieldValue: itemId,
-        },
+        new RequestParam('relatedItem', itemId),
       );
     });
 

--- a/src/app/core/data/relationship-type-data.service.ts
+++ b/src/app/core/data/relationship-type-data.service.ts
@@ -16,6 +16,7 @@ import {
   FollowLinkConfig,
 } from '../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { RequestParam } from '../cache/models/request-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { ItemType } from '../shared/item-relationships/item-type.model';
@@ -143,14 +144,8 @@ export class RelationshipTypeDataService extends BaseDataService<RelationshipTyp
       'byEntityType',
       {
         searchParams: [
-          {
-            fieldName: 'type',
-            fieldValue: type,
-          },
-          {
-            fieldName: 'size',
-            fieldValue: 100,
-          },
+          new RequestParam('type', type),
+          new RequestParam('size', 100),
         ],
       }, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow,
     ).pipe(

--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -114,7 +114,7 @@ describe('EPersonDataService', () => {
     it('search by default scope (byMetadata) and no query', () => {
       service.searchByScope(null, '');
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('query', encodeURIComponent('')))],
+        searchParams: [Object.assign(new RequestParam('query', ''))],
       });
       expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options, true, true);
     });
@@ -122,7 +122,7 @@ describe('EPersonDataService', () => {
     it('search metadata scope and no query', () => {
       service.searchByScope('metadata', '');
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('query', encodeURIComponent('')))],
+        searchParams: [Object.assign(new RequestParam('query', ''))],
       });
       expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options, true, true);
     });
@@ -130,7 +130,7 @@ describe('EPersonDataService', () => {
     it('search metadata scope and with query', () => {
       service.searchByScope('metadata', 'test');
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('query', encodeURIComponent('test')))],
+        searchParams: [Object.assign(new RequestParam('query', 'test'))],
       });
       expect(service.searchBy).toHaveBeenCalledWith('byMetadata', options, true, true);
     });
@@ -140,7 +140,7 @@ describe('EPersonDataService', () => {
       spyOn(service, 'findByHref').and.returnValue(createSuccessfulRemoteDataObject$(null));
       service.searchByScope('email', '');
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('email', encodeURIComponent('')))],
+        searchParams: [Object.assign(new RequestParam('email', ''))],
       });
       expect((service as any).searchData.getSearchByHref).toHaveBeenCalledWith('byEmail', options);
       expect(service.findByHref).toHaveBeenCalledWith(epersonsEndpoint, true, true);
@@ -151,7 +151,7 @@ describe('EPersonDataService', () => {
       spyOn(service, 'findByHref').and.returnValue(createSuccessfulRemoteDataObject$(EPersonMock));
       service.searchByScope('email', EPersonMock.email);
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('email', encodeURIComponent(EPersonMock.email)))],
+        searchParams: [Object.assign(new RequestParam('email', EPersonMock.email))],
       });
       expect((service as any).searchData.getSearchByHref).toHaveBeenCalledWith('byEmail', options);
       expect(service.findByHref).toHaveBeenCalledWith(epersonsEndpoint, true, true);

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -163,7 +163,7 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
    */
   public getEPersonByEmail(query: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<EPerson>[]): Observable<RemoteData<EPerson | NoContent>> {
     const findListOptions = new FindListOptions();
-    findListOptions.searchParams = [new RequestParam('email', encodeURIComponent(query))];
+    findListOptions.searchParams = [new RequestParam('email', query)];
     const href$ = this.searchData.getSearchByHref(this.searchByEmailPath, findListOptions, ...linksToFollow);
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
@@ -180,7 +180,7 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
    *                                    {@link HALLink}s should be automatically resolved
    */
   private getEpeopleByMetadata(query: string, options?: FindListOptions, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<EPerson>[]): Observable<RemoteData<PaginatedList<EPerson>>> {
-    const searchParams = [new RequestParam('query', encodeURIComponent(query))];
+    const searchParams = [new RequestParam('query', query)];
     return this.getEPeopleBy(searchParams, this.searchByMetadataPath, options, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
 

--- a/src/app/core/notifications/qa/events/quality-assurance-event-data.service.spec.ts
+++ b/src/app/core/notifications/qa/events/quality-assurance-event-data.service.spec.ts
@@ -16,6 +16,7 @@ import { NotificationsService } from '../../../../shared/notifications/notificat
 import { createSuccessfulRemoteDataObject } from '../../../../shared/remote-data.utils';
 import { ObjectCacheServiceStub } from '../../../../shared/testing/object-cache-service.stub';
 import { RemoteDataBuildService } from '../../../cache/builders/remote-data-build.service';
+import { RequestParam } from '../../../cache/models/request-param.model';
 import { ObjectCacheService } from '../../../cache/object-cache.service';
 import { RestResponse } from '../../../cache/response.models';
 import { FindListOptions } from '../../../data/find-list-options.model';
@@ -131,10 +132,7 @@ describe('QualityAssuranceEventDataService', () => {
     it('should proxy the call to searchData.searchBy', () => {
       const options: FindListOptions = {
         searchParams: [
-          {
-            fieldName: 'topic',
-            fieldValue: topic,
-          },
+          new RequestParam('topic', topic),
         ],
       };
       service.getEventsByTopic(topic);

--- a/src/app/core/notifications/qa/events/quality-assurance-event-data.service.ts
+++ b/src/app/core/notifications/qa/events/quality-assurance-event-data.service.ts
@@ -16,6 +16,7 @@ import { hasValue } from '../../../../shared/empty.util';
 import { NotificationsService } from '../../../../shared/notifications/notifications.service';
 import { FollowLinkConfig } from '../../../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../../../cache/builders/remote-data-build.service';
+import { RequestParam } from '../../../cache/models/request-param.model';
 import { ObjectCacheService } from '../../../cache/object-cache.service';
 import {
   CreateData,
@@ -97,10 +98,7 @@ export class QualityAssuranceEventDataService extends IdentifiableDataService<Qu
    */
   public getEventsByTopic(topic: string, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<QualityAssuranceEventObject>[]): Observable<RemoteData<PaginatedList<QualityAssuranceEventObject>>> {
     options.searchParams = [
-      {
-        fieldName: 'topic',
-        fieldValue: topic,
-      },
+      new RequestParam('topic', topic),
     ];
     return this.searchData.searchBy('findByTopic', options, true, true, ...linksToFollow);
   }

--- a/src/app/core/statistics/usage-report-data.service.ts
+++ b/src/app/core/statistics/usage-report-data.service.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { RequestParam } from '../cache/models/request-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { IdentifiableDataService } from '../data/base/identifiable-data.service';
 import {
@@ -49,10 +50,7 @@ export class UsageReportDataService extends IdentifiableDataService<UsageReport>
   searchStatistics(uri: string, page: number, size: number): Observable<UsageReport[]> {
     return this.searchBy('object', {
       searchParams: [
-        {
-          fieldName: `uri`,
-          fieldValue: uri,
-        },
+        new RequestParam('uri', uri),
       ],
       currentPage: page,
       elementsPerPage: size,

--- a/src/app/core/submission/correctiontype-data.service.ts
+++ b/src/app/core/submission/correctiontype-data.service.ts
@@ -76,10 +76,7 @@ export class CorrectionTypeDataService extends IdentifiableDataService<Correctio
   findByTopic(topic: string, useCachedVersionIfAvailable = true, reRequestOnStale = true): Observable<CorrectionType> {
     const options = new FindListOptions();
     options.searchParams = [
-      {
-        fieldName: 'topic',
-        fieldValue: topic,
-      },
+      new RequestParam('topic', topic),
     ];
 
     return this.searchData.searchBy(this.searchByTopic, options, useCachedVersionIfAvailable, reRequestOnStale).pipe(

--- a/src/app/core/submission/submission-cc-license-url-data.service.ts
+++ b/src/app/core/submission/submission-cc-license-url-data.service.ts
@@ -7,6 +7,7 @@ import {
 
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { RequestParam } from '../cache/models/request-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { BaseDataService } from '../data/base/base-data.service';
 import {
@@ -54,17 +55,8 @@ export class SubmissionCcLicenseUrlDataService extends BaseDataService<Submissio
     return this.searchData.getSearchByHref(
       'rightsByQuestions',{
         searchParams: [
-          {
-            fieldName: 'license',
-            fieldValue: ccLicense.id,
-          },
-          ...ccLicense.fields.map(
-            (field) => {
-              return {
-                fieldName: `answer_${field.id}`,
-                fieldValue: options.get(field).id,
-              };
-            }),
+          new RequestParam('license', ccLicense.id),
+          ...ccLicense.fields.map((field: Field) => new RequestParam(`answer_${field.id}`, options.get(field).id)),
         ],
       },
     ).pipe(

--- a/src/app/core/submission/vocabularies/vocabulary.data.service.spec.ts
+++ b/src/app/core/submission/vocabularies/vocabulary.data.service.spec.ts
@@ -33,8 +33,8 @@ describe('VocabularyDataService', () => {
       spyOn(service, 'findByHref').and.returnValue(createSuccessfulRemoteDataObject$(null));
       service.getVocabularyByMetadataAndCollection('dc.contributor.author', '1234-1234');
       const options = Object.assign(new FindListOptions(), {
-        searchParams: [Object.assign(new RequestParam('metadata', encodeURIComponent('dc.contributor.author'))),
-          Object.assign(new RequestParam('collection', encodeURIComponent('1234-1234')))],
+        searchParams: [Object.assign(new RequestParam('metadata', 'dc.contributor.author')),
+          Object.assign(new RequestParam('collection', '1234-1234'))],
       });
       expect((service as any).searchData.getSearchByHref).toHaveBeenCalledWith('byMetadataAndCollection', options);
       expect(service.findByHref).toHaveBeenCalledWith(vocabularyByMetadataAndCollectionEndpoint, true, true);

--- a/src/app/core/submission/vocabularies/vocabulary.data.service.ts
+++ b/src/app/core/submission/vocabularies/vocabulary.data.service.ts
@@ -78,8 +78,8 @@ export class VocabularyDataService extends IdentifiableDataService<Vocabulary> i
    */
   public getVocabularyByMetadataAndCollection(metadataField: string, collectionUUID: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<Vocabulary>[]): Observable<RemoteData<Vocabulary>> {
     const findListOptions = new FindListOptions();
-    findListOptions.searchParams = [new RequestParam('metadata', encodeURIComponent(metadataField)),
-      new RequestParam('collection', encodeURIComponent(collectionUUID))];
+    findListOptions.searchParams = [new RequestParam('metadata', metadataField),
+      new RequestParam('collection', collectionUUID)];
     const href$ = this.searchData.getSearchByHref(this.searchByMetadataAndCollectionPath, findListOptions, ...linksToFollow);
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }

--- a/src/app/core/submission/workflowitem-data.service.ts
+++ b/src/app/core/submission/workflowitem-data.service.ts
@@ -115,7 +115,7 @@ export class WorkflowItemDataService extends IdentifiableDataService<WorkflowIte
    */
   public findByItem(uuid: string, useCachedVersionIfAvailable = false, reRequestOnStale = true, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<WorkspaceItem>[]): Observable<RemoteData<WorkspaceItem>> {
     const findListOptions = new FindListOptions();
-    findListOptions.searchParams = [new RequestParam('uuid', encodeURIComponent(uuid))];
+    findListOptions.searchParams = [new RequestParam('uuid', uuid)];
     const href$ = this.searchData.getSearchByHref(this.searchByItemLinkPath, findListOptions, ...linksToFollow);
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }

--- a/src/app/core/submission/workspaceitem-data.service.spec.ts
+++ b/src/app/core/submission/workspaceitem-data.service.spec.ts
@@ -154,7 +154,7 @@ describe('WorkspaceitemDataService test', () => {
       it('should proxy the call to UpdateDataServiceImpl.findByHref', () => {
         scheduler.schedule(() => service.findByItem('1234-1234', true, true, pageInfo));
         scheduler.flush();
-        const searchUrl = service.getIDHref('item', [new RequestParam('uuid', encodeURIComponent('1234-1234'))]);
+        const searchUrl = service.getIDHref('item', [new RequestParam('uuid', '1234-1234')]);
         expect((service as any).findByHref).toHaveBeenCalledWith(searchUrl, true, true);
       });
 

--- a/src/app/core/submission/workspaceitem-data.service.ts
+++ b/src/app/core/submission/workspaceitem-data.service.ts
@@ -90,7 +90,7 @@ export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceI
    */
   public findByItem(uuid: string, useCachedVersionIfAvailable = false, reRequestOnStale = true, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<WorkspaceItem>[]): Observable<RemoteData<WorkspaceItem>> {
     const findListOptions = new FindListOptions();
-    findListOptions.searchParams = [new RequestParam('uuid', encodeURIComponent(uuid))];
+    findListOptions.searchParams = [new RequestParam('uuid', uuid)];
     const href$ = this.getIDHref(this.searchByItemLinkPath, findListOptions, ...linksToFollow);
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }


### PR DESCRIPTION
## References
* Fixes #2724

## Description
This PR encodes all the `RequestParam`s values. I added an optional parameter to still make it possible to provide already encoded values if needed. This has also an added advantage that it will throw errors for all values that are not created by using the `new RequestParam` constructor, since the third parameter will be missing.

## Instructions for Reviewers
List of changes in this PR:
* Encode the value received in `RequestParam` by default
* Removed the `encodeURIComponent()` of values that were given as parameters to `RequestParam` to prevent values from being encoded twice

**See #2724 ~~& #2727~~ for how to test this PR ~~(#2727 is only reproducible in production mode)~~**

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).