### PR TITLE
use localized error message

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -119,7 +119,7 @@ export class AuthService {
         if (hasValue(rd.payload) && rd.payload.authenticated) {
           return rd.payload;
         } else {
-          throw (new Error('Invalid email or password'));
+          throw (new Error('auth.errors.invalid-user'));
         }
       }));
 


### PR DESCRIPTION
## Description

This PR removes the hard coded error message in `AuthService` that is displayed when a user supplies invalid username and/or password.

Please note, that `AuthService` still contains two other hard coded error messages ("Not authenticated").