### PR TITLE
Restore hierarchical tree original behaviour

### DIFF
--- a/src/app/browse-by/browse-by-taxonomy-page/browse-by-taxonomy-page.component.html
+++ b/src/app/browse-by/browse-by-taxonomy-page/browse-by-taxonomy-page.component.html
@@ -1,7 +1,9 @@
 <div class="container">
   <div class="mb-3">
-    <ds-vocabulary-treeview [vocabularyOptions]=vocabularyOptions
+    <ds-vocabulary-treeview [description]="description"
+                            [vocabularyOptions]=vocabularyOptions
                             [multiSelect]="true"
+                            [showAdd]="false"
                             (select)="onSelect($event)"
                             (deselect)="onDeselect($event)">
     </ds-vocabulary-treeview>

--- a/src/app/browse-by/browse-by-taxonomy-page/browse-by-taxonomy-page.component.ts
+++ b/src/app/browse-by/browse-by-taxonomy-page/browse-by-taxonomy-page.component.ts
@@ -1,12 +1,15 @@
-import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { Observable, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
+
 import { VocabularyOptions } from '../../core/submission/vocabularies/models/vocabulary-options.model';
 import { VocabularyEntryDetail } from '../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
-import { ActivatedRoute } from '@angular/router';
-import { Observable, Subscription } from 'rxjs';
 import { BrowseDefinition } from '../../core/shared/browse-definition.model';
 import { GenericConstructor } from '../../core/shared/generic-constructor';
 import { BROWSE_BY_COMPONENT_FACTORY } from '../browse-by-switcher/browse-by-decorator';
-import { map } from 'rxjs/operators';
 import { ThemeService } from 'src/app/shared/theme-support/theme.service';
 import { HierarchicalBrowseDefinition } from '../../core/shared/hierarchical-browse-definition.model';
 
@@ -60,8 +63,14 @@ export class BrowseByTaxonomyPageComponent implements OnInit, OnDestroy {
    */
   browseByComponentSubs: Subscription[] = [];
 
+  /**
+   * Browse description
+   */
+  description: string;
+
   public constructor( protected route: ActivatedRoute,
                       protected themeService: ThemeService,
+                      protected translate: TranslateService,
                       @Inject(BROWSE_BY_COMPONENT_FACTORY) private getComponentByBrowseByType: (browseByType, theme) => GenericConstructor<any>) {
   }
 
@@ -73,9 +82,11 @@ export class BrowseByTaxonomyPageComponent implements OnInit, OnDestroy {
       })
     );
     this.browseByComponentSubs.push(this.browseByComponent.subscribe((browseDefinition: HierarchicalBrowseDefinition) => {
+      this.selectedItems = [];
       this.facetType = browseDefinition.facetType;
       this.vocabularyName = browseDefinition.vocabulary;
       this.vocabularyOptions = { name: this.vocabularyName, closed: true };
+      this.description = this.translate.instant(`browse.metadata.${this.vocabularyName}.tree.descrption`);
     }));
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
@@ -22,16 +22,17 @@ import { hasValue, isEmpty, isNotEmpty, isNotNull } from '../../../../../empty.u
 import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
 import { ConfidenceType } from '../../../../../../core/shared/confidence-type';
 import { getFirstSucceededRemoteDataPayload } from '../../../../../../core/shared/operators';
-import {
-  PaginatedList,
-  buildPaginatedList
-} from '../../../../../../core/data/paginated-list.model';
+import { buildPaginatedList, PaginatedList } from '../../../../../../core/data/paginated-list.model';
 import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { PageInfo } from '../../../../../../core/shared/page-info.model';
 import { DsDynamicVocabularyComponent } from '../dynamic-vocabulary.component';
 import { Vocabulary } from '../../../../../../core/submission/vocabularies/models/vocabulary.model';
-import { VocabularyEntryDetail } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
-import { VocabularyTreeviewModalComponent } from '../../../../vocabulary-treeview-modal/vocabulary-treeview-modal.component';
+import {
+  VocabularyEntryDetail
+} from '../../../../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
+import {
+  VocabularyTreeviewModalComponent
+} from '../../../../vocabulary-treeview-modal/vocabulary-treeview-modal.component';
 
 /**
  * Component representing a onebox input field.
@@ -228,7 +229,7 @@ export class DsDynamicOneboxComponent extends DsDynamicVocabularyComponent imple
       const modalRef: NgbModalRef = this.modalService.open(VocabularyTreeviewModalComponent, { size: 'lg', windowClass: 'treeview' });
       modalRef.componentInstance.vocabularyOptions = this.model.vocabularyOptions;
       modalRef.componentInstance.preloadLevel = preloadLevel;
-      modalRef.componentInstance.selectedItems = this.currentValue ? [this.currentValue.value] : [];
+      modalRef.componentInstance.selectedItems = this.currentValue ? [this.currentValue] : [];
       modalRef.result.then((result: VocabularyEntryDetail) => {
         if (result) {
           this.currentValue = result;

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
@@ -7,6 +7,7 @@
 <div class="modal-body">
   <div class="p-3">
     <ds-vocabulary-treeview [vocabularyOptions]="vocabularyOptions"
+                            [description]="description"
                             [preloadLevel]="preloadLevel"
                             [selectedItems]="selectedItems"
                             [multiSelect]="multiSelect"

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
@@ -11,6 +11,7 @@
                             [preloadLevel]="preloadLevel"
                             [selectedItems]="selectedItems"
                             [multiSelect]="multiSelect"
+                            [showAdd]="showAdd"
                             (select)="onSelect($event)">
     </ds-vocabulary-treeview>
   </div>

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.spec.ts
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.spec.ts
@@ -1,14 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { VocabularyTreeviewModalComponent } from './vocabulary-treeview-modal.component';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
+
+import { VocabularyTreeviewModalComponent } from './vocabulary-treeview-modal.component';
+import { VocabularyOptions } from '../../../core/submission/vocabularies/models/vocabulary-options.model';
 
 describe('VocabularyTreeviewModalComponent', () => {
   let component: VocabularyTreeviewModalComponent;
   let fixture: ComponentFixture<VocabularyTreeviewModalComponent>;
 
   const modalStub = jasmine.createSpyObj('modalStub', ['close']);
+  const vocabularyOptions = new VocabularyOptions('vocabularyTest', false);
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,10 +27,16 @@ describe('VocabularyTreeviewModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(VocabularyTreeviewModalComponent);
     component = fixture.componentInstance;
+    component.vocabularyOptions = vocabularyOptions;
+    spyOn(component as any, 'setDescription').and.callThrough();
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should init descrption message', () => {
+    expect((component as any).setDescription).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.ts
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.ts
@@ -1,5 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateService } from '@ngx-translate/core';
+
 import { VocabularyOptions } from '../../../core/submission/vocabularies/models/vocabulary-options.model';
 import { VocabularyEntryDetail } from '../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
 
@@ -11,7 +14,7 @@ import { VocabularyEntryDetail } from '../../../core/submission/vocabularies/mod
 /**
  * Component that contains a modal to display a VocabularyTreeviewComponent
  */
-export class VocabularyTreeviewModalComponent {
+export class VocabularyTreeviewModalComponent implements OnInit {
 
   /**
    * The {@link VocabularyOptions} object
@@ -26,7 +29,7 @@ export class VocabularyTreeviewModalComponent {
   /**
    * The vocabulary entries already selected, if any
    */
-  @Input() selectedItems: string[] = [];
+  @Input() selectedItems: VocabularyEntryDetail[] = [];
 
   /**
    * Whether to allow selecting multiple values with checkboxes
@@ -34,13 +37,25 @@ export class VocabularyTreeviewModalComponent {
   @Input() multiSelect = false;
 
   /**
+   * Contain a descriptive message for this vocabulary retrieved from i18n files
+   */
+  description: string;
+
+  /**
    * Initialize instance variables
    *
    * @param {NgbActiveModal} activeModal
+   * @param {TranslateService} translate
    */
   constructor(
     public activeModal: NgbActiveModal,
+    protected translate: TranslateService
   ) { }
+
+
+  ngOnInit(): void {
+    this.setDescription();
+  }
 
   /**
    * Method called on entry select
@@ -48,4 +63,13 @@ export class VocabularyTreeviewModalComponent {
   onSelect(item: VocabularyEntryDetail) {
     this.activeModal.close(item);
   }
+
+  /**
+   * Set the description message related to the given vocabulary
+   */
+  private setDescription() {
+    const descriptionLabel = 'vocabulary-treeview.tree.description.' + this.vocabularyOptions.name;
+    this.description = this.translate.instant(descriptionLabel);
+  }
+
 }

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.ts
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.ts
@@ -37,6 +37,11 @@ export class VocabularyTreeviewModalComponent implements OnInit {
   @Input() multiSelect = false;
 
   /**
+   * A boolean representing if to show the add button or not
+   */
+  @Input() showAdd = true;
+
+  /**
    * Contain a descriptive message for this vocabulary retrieved from i18n files
    */
   description: string;

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
@@ -1,4 +1,4 @@
-<ds-alert [content]="'vocabulary-treeview.info' | translate" [type]="'alert-info'"></ds-alert>
+<ds-alert *ngIf="description" [content]="description" [type]="'alert-info'"></ds-alert>
 <div class="treeview-header row">
   <div class="col-12">
     <div class="input-group">
@@ -10,7 +10,7 @@
         <button class="btn btn-outline-secondary" type="button" (click)="reset()">
           {{'vocabulary-treeview.search.form.reset' | translate}}
         </button>
-        <button class="btn btn-outline-primary" type="button" (click)="add()" [disabled]="this.vocabularyOptions.closed">
+        <button *ngIf="showAdd && this.vocabularyOptions.closed" class="btn btn-outline-primary" type="button" (click)="add()">
           {{'vocabulary-treeview.search.form.add' | translate}}
         </button>
       </div>

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.spec.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.spec.ts
@@ -16,12 +16,12 @@ import { TreeviewFlatNode, TreeviewNode } from './vocabulary-treeview-node.model
 import { FormFieldMetadataValueObject } from '../builder/models/form-field-metadata-value.model';
 import { VocabularyOptions } from '../../../core/submission/vocabularies/models/vocabulary-options.model';
 import { PageInfo } from '../../../core/shared/page-info.model';
-import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { AuthTokenInfo } from '../../../core/auth/models/auth-token-info.model';
 import { authReducer } from '../../../core/auth/auth.reducer';
 import { storeModuleConfig } from '../../../app.reducer';
 import { By } from '@angular/platform-browser';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
+import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 
 describe('VocabularyTreeviewComponent test suite', () => {
 
@@ -144,10 +144,10 @@ describe('VocabularyTreeviewComponent test suite', () => {
       currentValue.otherInformation = {
         id: 'entryID'
       };
-      comp.selectedItems = [currentValue.value];
+      comp.selectedItems = [currentValue];
       fixture.detectChanges();
       expect(comp.dataSource.data).toEqual([]);
-      expect(vocabularyTreeviewServiceStub.initialize).toHaveBeenCalledWith(comp.vocabularyOptions, new PageInfo(), ['testValue'], null);
+      expect(vocabularyTreeviewServiceStub.initialize).toHaveBeenCalledWith(comp.vocabularyOptions, new PageInfo(), ['entryID'], 'entryID');
     });
 
     it('should should init component properly with init value as VocabularyEntry', () => {
@@ -156,10 +156,20 @@ describe('VocabularyTreeviewComponent test suite', () => {
       currentValue.otherInformation = {
         id: 'entryID'
       };
-      comp.selectedItems = [currentValue.value];
+      comp.selectedItems = [currentValue];
       fixture.detectChanges();
       expect(comp.dataSource.data).toEqual([]);
-      expect(vocabularyTreeviewServiceStub.initialize).toHaveBeenCalledWith(comp.vocabularyOptions, new PageInfo(), ['testValue'], null);
+      expect(vocabularyTreeviewServiceStub.initialize).toHaveBeenCalledWith(comp.vocabularyOptions, new PageInfo(), ['entryID'], 'entryID');
+    });
+
+    it('should should init component properly with init value as VocabularyEntryDetail', () => {
+      const currentValue = new VocabularyEntryDetail();
+      currentValue.value = 'testValue';
+      currentValue.id = 'entryID';
+      comp.selectedItems = [currentValue];
+      fixture.detectChanges();
+      expect(comp.dataSource.data).toEqual([]);
+      expect(vocabularyTreeviewServiceStub.initialize).toHaveBeenCalledWith(comp.vocabularyOptions, new PageInfo(), ['entryID'], 'entryID');
     });
 
     it('should call loadMore function', () => {

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.spec.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.spec.ts
@@ -1,12 +1,11 @@
-import { ChangeDetectorRef, Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
 import { CdkTreeModule } from '@angular/cdk/tree';
+import { By } from '@angular/platform-browser';
 
 import { of as observableOf } from 'rxjs';
-import { StoreModule } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { provideMockStore } from '@ngrx/store/testing';
 
 import { createTestComponent } from '../../testing/utils.test';
 import { VocabularyTreeviewComponent } from './vocabulary-treeview.component';
@@ -16,10 +15,6 @@ import { TreeviewFlatNode, TreeviewNode } from './vocabulary-treeview-node.model
 import { FormFieldMetadataValueObject } from '../builder/models/form-field-metadata-value.model';
 import { VocabularyOptions } from '../../../core/submission/vocabularies/models/vocabulary-options.model';
 import { PageInfo } from '../../../core/shared/page-info.model';
-import { AuthTokenInfo } from '../../../core/auth/models/auth-token-info.model';
-import { authReducer } from '../../../core/auth/auth.reducer';
-import { storeModuleConfig } from '../../../app.reducer';
-import { By } from '@angular/platform-browser';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 
@@ -28,7 +23,6 @@ describe('VocabularyTreeviewComponent test suite', () => {
   let comp: VocabularyTreeviewComponent;
   let compAsAny: any;
   let fixture: ComponentFixture<VocabularyTreeviewComponent>;
-  let initialState;
   let de;
 
   const item = new VocabularyEntryDetail();
@@ -59,25 +53,10 @@ describe('VocabularyTreeviewComponent test suite', () => {
     clearSearchTopRequests: jasmine.createSpy('clearSearchTopRequests')
   });
 
-  initialState = {
-    core: {
-      auth: {
-        authenticated: true,
-        loaded: true,
-        blocking: false,
-        loading: false,
-        authToken: new AuthTokenInfo('test_token'),
-        userId: 'testid',
-        authMethods: []
-      }
-    }
-  };
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         CdkTreeModule,
-        StoreModule.forRoot({ auth: authReducer }, storeModuleConfig),
         TranslateModule.forRoot()
       ],
       declarations: [
@@ -88,8 +67,6 @@ describe('VocabularyTreeviewComponent test suite', () => {
         { provide: VocabularyTreeviewService, useValue: vocabularyTreeviewServiceStub },
         { provide: VocabularyService, useValue: vocabularyServiceStub },
         { provide: NgbActiveModal, useValue: modalStub },
-        provideMockStore({ initialState }),
-        ChangeDetectorRef,
         VocabularyTreeviewComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -1,5 +1,5 @@
 import { FlatTreeControl } from '@angular/cdk/tree';
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 
 import { Observable, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
@@ -16,7 +16,9 @@ import { VocabularyTreeFlattener } from './vocabulary-tree-flattener';
 import { VocabularyTreeFlatDataSource } from './vocabulary-tree-flat-data-source';
 import { CoreState } from '../../../core/core-state.model';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
-import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
+import { FormFieldMetadataValueObject } from '../builder/models/form-field-metadata-value.model';
+
+export type VocabularyTreeItemType = FormFieldMetadataValueObject | VocabularyEntry | VocabularyEntryDetail;
 
 /**
  * Component that shows a hierarchical vocabulary in a tree view
@@ -39,14 +41,24 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   @Input() preloadLevel = 2;
 
   /**
-   * The vocabulary entries already selected, if any
+   * Contain a descriptive message for the tree
    */
-  @Input() selectedItems: string[] = [];
+  @Input() description = '';
 
   /**
    * Whether to allow selecting multiple values with checkboxes
    */
   @Input() multiSelect = false;
+
+  /**
+   * The vocabulary entries already selected, if any
+   */
+  @Input() showAdd = true;
+
+  /**
+   * The vocabulary entries already selected, if any
+   */
+  @Input() selectedItems: VocabularyTreeItemType[] = [];
 
   /**
    * A map containing the current node showed by the tree

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -2,7 +2,6 @@ import { FlatTreeControl } from '@angular/cdk/tree';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 
 import { Observable, Subscription } from 'rxjs';
-import { TranslateService } from '@ngx-translate/core';
 
 import { VocabularyEntryDetail } from '../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
 import { hasValue, isEmpty, isNotEmpty } from '../../empty.util';
@@ -13,7 +12,6 @@ import { PageInfo } from '../../../core/shared/page-info.model';
 import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { VocabularyTreeFlattener } from './vocabulary-tree-flattener';
 import { VocabularyTreeFlatDataSource } from './vocabulary-tree-flat-data-source';
-import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { AlertType } from '../../alert/alert-type';
 import { FormFieldMetadataValueObject } from '../builder/models/form-field-metadata-value.model';
 
@@ -50,7 +48,7 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   @Input() multiSelect = false;
 
   /**
-   * The vocabulary entries already selected, if any
+   * A boolean representing if to show the add button or not
    */
   @Input() showAdd = true;
 
@@ -117,13 +115,9 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * Initialize instance variables
    *
    * @param {VocabularyTreeviewService} vocabularyTreeviewService
-   * @param {vocabularyService} vocabularyService
-   * @param {TranslateService} translate
    */
   constructor(
-    private vocabularyTreeviewService: VocabularyTreeviewService,
-    private vocabularyService: VocabularyService,
-    private translate: TranslateService
+    private vocabularyTreeviewService: VocabularyTreeviewService
   ) {
     this.treeFlattener = new VocabularyTreeFlattener(this.transformer, this.getLevel,
       this.isExpandable, this.getChildren);

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -97,15 +97,15 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
 
   /**
    * An event fired when a vocabulary entry is selected.
-   * Event's payload equals to {@link VocabularyEntryDetail} selected.
+   * Event's payload equals to {@link VocabularyTreeItemType} selected.
    */
-  @Output() select: EventEmitter<VocabularyEntryDetail> = new EventEmitter<VocabularyEntryDetail>(null);
+  @Output() select: EventEmitter<VocabularyTreeItemType> = new EventEmitter<VocabularyTreeItemType>(null);
 
   /**
    * An event fired when a vocabulary entry is deselected.
-   * Event's payload equals to {@link VocabularyEntryDetail} deselected.
+   * Event's payload equals to {@link VocabularyTreeItemType} deselected.
    */
-  @Output() deselect: EventEmitter<VocabularyEntryDetail> = new EventEmitter<VocabularyEntryDetail>(null);
+  @Output() deselect: EventEmitter<VocabularyTreeItemType> = new EventEmitter<VocabularyTreeItemType>(null);
 
   /**
    * A boolean representing if user is authenticated
@@ -151,7 +151,8 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * @param level The node level information
    */
   transformer = (node: TreeviewNode, level: number) => {
-    const existingNode = this.nodeMap.get(node.item.id);
+    const entryId = this.getEntryId(node.item);
+    const existingNode = this.nodeMap.get(entryId);
 
     if (existingNode && existingNode.item.id !== LOAD_MORE && existingNode.item.id !== LOAD_MORE_ROOT) {
       return existingNode;
@@ -168,7 +169,7 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
       node.isInInitValueHierarchy,
       node.isSelected
     );
-    this.nodeMap.set(node.item.id, newNode);
+    this.nodeMap.set(entryId, newNode);
 
     if ((((level + 1) < this.preloadLevel) && newNode.childrenLoaded)
       || (newNode.isSearchNode && newNode.childrenLoaded)
@@ -223,7 +224,8 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
 
     this.loading = this.vocabularyTreeviewService.isLoading();
 
-    this.vocabularyTreeviewService.initialize(this.vocabularyOptions, new PageInfo(), this.selectedItems, null);
+    const entryId: string = (this.selectedItems?.length > 0) ? this.getEntryId(this.selectedItems[0]) : null;
+    this.vocabularyTreeviewService.initialize(this.vocabularyOptions, new PageInfo(), this.getSelectedEntryIds(), entryId);
   }
 
   /**
@@ -231,7 +233,7 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * @param item The VocabularyEntryDetail for which to load more nodes
    */
   loadMore(item: VocabularyEntryDetail) {
-    this.vocabularyTreeviewService.loadMore(item, this.selectedItems);
+    this.vocabularyTreeviewService.loadMore(item, this.getSelectedEntryIds());
   }
 
   /**
@@ -239,7 +241,7 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * @param node The TreeviewFlatNode for which to load more nodes
    */
   loadMoreRoot(node: TreeviewFlatNode) {
-    this.vocabularyTreeviewService.loadMoreRoot(node, this.selectedItems);
+    this.vocabularyTreeviewService.loadMoreRoot(node, this.getSelectedEntryIds());
   }
 
   /**
@@ -247,18 +249,18 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    * @param node The TreeviewFlatNode for which to load children nodes
    */
   loadChildren(node: TreeviewFlatNode) {
-    this.vocabularyTreeviewService.loadMore(node.item, this.selectedItems, true);
+    this.vocabularyTreeviewService.loadMore(node.item, this.getSelectedEntryIds(), true);
   }
 
   /**
    * Method called on entry select/deselect
    */
   onSelect(item: VocabularyEntryDetail) {
-    if (!this.selectedItems.includes(item.id)) {
-      this.selectedItems.push(item.id);
+    if (!this.getSelectedEntryIds().includes(this.getEntryId(item))) {
+      this.selectedItems.push(item);
       this.select.emit(item);
     } else {
-      this.selectedItems = this.selectedItems.filter((detail: string) => { return detail !== item.id; });
+      this.selectedItems = this.selectedItems.filter((detail: VocabularyTreeItemType) => this.getEntryId(detail) !== this.getEntryId(item));
       this.deselect.emit(item);
     }
   }
@@ -272,7 +274,7 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
         this.storedNodeMap = this.nodeMap;
       }
       this.nodeMap = new Map<string, TreeviewFlatNode>();
-      this.vocabularyTreeviewService.searchByQuery(this.searchText, this.selectedItems);
+      this.vocabularyTreeviewService.searchByQuery(this.searchText, this.getSelectedEntryIds());
     }
   }
 
@@ -289,12 +291,8 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   reset() {
     this.searchText = '';
     for (const item of this.selectedItems) {
-      this.subs.push(this.vocabularyService.findEntryDetailById(item, this.vocabularyOptions.name, true, true, false).pipe(
-        getFirstSucceededRemoteDataPayload(),
-      ).subscribe((detail: VocabularyEntryDetail) => {
-        this.deselect.emit(detail);
-      }));
-      this.nodeMap.get(item).isSelected = false;
+      this.deselect.emit(item);
+      this.nodeMap.get(this.getEntryId(item)).isSelected = false;
     }
     this.selectedItems = [];
 
@@ -325,14 +323,27 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   }
 
   /**
-   * Return an id for a given {@link VocabularyEntry}
+   * Return an id for a given {@link VocabularyTreeItemType}
    */
-  private getEntryId(entry: VocabularyEntry): string {
-    return entry.authority || entry.otherInformation.id || undefined;
+  private getEntryId(entry: VocabularyTreeItemType): string {
+    return entry?.authority || entry?.otherInformation?.id || (entry as any)?.id || undefined;
+  }
+
+  /**
+   * Return an ids for all selected entries
+   */
+  private getSelectedEntryIds(): string[] {
+    return this.selectedItems
+      .map((entry: VocabularyTreeItemType) => this.getEntryId(entry))
+      .filter((value) => isNotEmpty(value));
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.reset();
-    this.vocabularyTreeviewService.initialize(this.vocabularyOptions, new PageInfo(), this.selectedItems, null);
+    if (!changes.vocabularyOptions.isFirstChange() && changes.vocabularyOptions.currentValue !== changes.vocabularyOptions.previousValue) {
+      this.selectedItems = [];
+      this.searchText = '';
+      this.vocabularyTreeviewService.cleanTree();
+      this.vocabularyTreeviewService.initialize(this.vocabularyOptions, new PageInfo(), this.getSelectedEntryIds(), null);
+    }
   }
 }

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -2,7 +2,6 @@ import { FlatTreeControl } from '@angular/cdk/tree';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 
 import { Observable, Subscription } from 'rxjs';
-import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 
 import { VocabularyEntryDetail } from '../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
@@ -14,7 +13,6 @@ import { PageInfo } from '../../../core/shared/page-info.model';
 import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { VocabularyTreeFlattener } from './vocabulary-tree-flattener';
 import { VocabularyTreeFlatDataSource } from './vocabulary-tree-flat-data-source';
-import { CoreState } from '../../../core/core-state.model';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { FormFieldMetadataValueObject } from '../builder/models/form-field-metadata-value.model';
 
@@ -108,11 +106,6 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   @Output() deselect: EventEmitter<VocabularyTreeItemType> = new EventEmitter<VocabularyTreeItemType>(null);
 
   /**
-   * A boolean representing if user is authenticated
-   */
-  private isAuthenticated: Observable<boolean>;
-
-  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    */
   private subs: Subscription[] = [];
@@ -122,13 +115,11 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
    *
    * @param {VocabularyTreeviewService} vocabularyTreeviewService
    * @param {vocabularyService} vocabularyService
-   * @param {Store<CoreState>} store
    * @param {TranslateService} translate
    */
   constructor(
     private vocabularyTreeviewService: VocabularyTreeviewService,
     private vocabularyService: VocabularyService,
-    private store: Store<CoreState>,
     private translate: TranslateService
   ) {
     this.treeFlattener = new VocabularyTreeFlattener(this.transformer, this.getLevel,

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.service.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.service.ts
@@ -4,21 +4,13 @@ import { BehaviorSubject, Observable, of as observableOf } from 'rxjs';
 import { map, merge, mergeMap, scan } from 'rxjs/operators';
 import findIndex from 'lodash/findIndex';
 
-import {
-  LOAD_MORE_NODE,
-  LOAD_MORE_ROOT_NODE,
-  TreeviewFlatNode,
-  TreeviewNode
-} from './vocabulary-treeview-node.model';
+import { LOAD_MORE_NODE, LOAD_MORE_ROOT_NODE, TreeviewFlatNode, TreeviewNode } from './vocabulary-treeview-node.model';
 import { VocabularyEntry } from '../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { isEmpty, isNotEmpty } from '../../empty.util';
 import { VocabularyOptions } from '../../../core/submission/vocabularies/models/vocabulary-options.model';
-import {
-  getFirstSucceededRemoteDataPayload,
-  getFirstSucceededRemoteListPayload
-} from '../../../core/shared/operators';
+import { getFirstSucceededRemoteDataPayload, getFirstSucceededRemoteListPayload } from '../../../core/shared/operators';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { VocabularyEntryDetail } from '../../../core/submission/vocabularies/models/vocabulary-entry-detail.model';
 
@@ -249,7 +241,7 @@ export class VocabularyTreeviewService {
     const hasChildren = entry.hasOtherInformation() && (entry.otherInformation as any)!.hasChildren === 'true';
     const pageInfo: PageInfo = this.pageInfo;
     const isInInitValueHierarchy = this.initValueHierarchy.includes(entryId);
-    const isSelected: boolean = selectedItems.some(() => selectedItems.includes(entry.id));
+    const isSelected: boolean = selectedItems.some(() => selectedItems.includes(entryId));
     const result = new TreeviewNode(
       entry,
       hasChildren,

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
@@ -10,7 +10,8 @@ import { SearchService } from '../../../../../core/shared/search/search.service'
 import {
   FILTER_CONFIG,
   IN_PLACE_SEARCH,
-  SearchFilterService, REFRESH_FILTER
+  REFRESH_FILTER,
+  SearchFilterService
 } from '../../../../../core/shared/search/search-filter.service';
 import { Router } from '@angular/router';
 import { RemoteDataBuildService } from '../../../../../core/cache/builders/remote-data-build.service';
@@ -18,14 +19,15 @@ import { SEARCH_CONFIG_SERVICE } from '../../../../../my-dspace-page/my-dspace-p
 import { SearchConfigurationService } from '../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterConfig } from '../../../models/search-filter-config.model';
 import { FacetValue } from '../../../models/facet-value.model';
-import { getFacetValueForType } from '../../../search.utils';
+import { addOperatorToFilterValue, getFacetValueForType } from '../../../search.utils';
 import { filter, map, take } from 'rxjs/operators';
 import { VocabularyService } from '../../../../../core/submission/vocabularies/vocabulary.service';
-import { Observable, BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { PageInfo } from '../../../../../core/shared/page-info.model';
 import { environment } from '../../../../../../environments/environment';
-import { addOperatorToFilterValue } from '../../../search.utils';
-import { VocabularyTreeviewModalComponent } from '../../../../form/vocabulary-treeview-modal/vocabulary-treeview-modal.component';
+import {
+  VocabularyTreeviewModalComponent
+} from '../../../../form/vocabulary-treeview-modal/vocabulary-treeview-modal.component';
 
 @Component({
   selector: 'ds-search-hierarchy-filter',
@@ -91,6 +93,7 @@ export class SearchHierarchyFilterComponent extends SearchFacetFilterComponent i
       name: this.getVocabularyEntry(),
       closed: true
     };
+    modalRef.componentInstance.showAdd = false;
     modalRef.result.then((detail: VocabularyEntryDetail) => {
       this.selectedValues$
         .pipe(take(1))

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -804,7 +804,11 @@
 
   "browse.metadata.srsc.breadcrumbs": "Browse by Subject Category",
 
+  "browse.metadata.srsc.tree.descrption": "Select a subject to add as search filter",
+
   "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
+
+  "browse.metadata.nsi.tree.descrption": "Select an index to add as search filter",
 
   "browse.metadata.title.breadcrumbs": "Browse by Title",
 


### PR DESCRIPTION
## References
* https://github.com/DSpace/dspace-angular/issues/815
* https://github.com/DSpace/dspace-angular/pull/2215


## Description
The goal of this PR is to reinstate a behavior of the hierarchical tree component when it's used for controlled vocabulary fields within the submission form.
Indeed during a submission when opening the hierarchical tree for controlled vocabulary field which already contained a selected value the tree were shown opened directly to the tree element related to the field value, with the value marked as green. e.g.

![Schermata del 2024-01-10 17-17-20](https://github.com/DSpace/dspace-angular/assets/2486489/bc70df63-38a2-4362-a0ff-4ca81d1f55cc)

This behavior has been lost starting from the dspace 7.5 version, probably due to some refactoring done on the hierarchical tree component

## Instructions for Reviewers
- To test this Pr we need to have a submission form configuration which use the hierarchical tree for a controlled vocabulary field. To do so you can simply change the input type from tag to onebox in the [traditionalpagetwo form configuration](https://github.com/DSpace/DSpace/blob/main/dspace/config/submission-forms.xml#L197)
- create a new submission which use a traditionalpagetwo form, for example you can create a new publication
- fill out the controlled vocabulary field by selecting an element in the hierarchical tree
- after saved the form open again the hierarchical tree and verify the tree is shown opened directly to the tree element related to the field value, with the value marked as green

You can verify that this behavior is exactly what happened before 7.5 release by using the tag [dspace-7.4](https://github.com/DSpace/dspace-angular/tree/dspace-7.4) (you can run over the current rest server version, it's working anyway)

List of changes in this PR:
* Reinstate a behavior of the hierarchical tree component
* Added a flag to show/hide add button in the hierarchical tree component. This is because in some case like the when the componente is used for the search filter or the hierarchical browse the add button should not displayed
![Schermata del 2024-01-11 11-30-44](https://github.com/DSpace/dspace-angular/assets/2486489/073ab24a-85d7-42aa-b3f0-946d3aaa1070)
![Schermata del 2024-01-11 11-37-33](https://github.com/DSpace/dspace-angular/assets/2486489/5bafcdaf-6c33-43a0-859c-fb207fb7d1df)


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
