### PR TITLE
Add logo max constraints

### DIFF
--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
@@ -1,3 +1,3 @@
 <div *ngIf="logo" class="dso-logo mb-3">
-    <img [src]="logo._links.content.href" class="img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
+    <img [src]="logo._links.content.href" class="w-100 img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
 </div>

--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
@@ -1,3 +1,3 @@
-<div *ngIf="logo" class="dso-logo mb-3 logo-container">
+<div *ngIf="logo" class="dso-logo mb-3">
     <img [src]="logo._links.content.href" class="img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
 </div>

--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.html
@@ -1,3 +1,3 @@
-<div *ngIf="logo" class="dso-logo mb-3">
+<div *ngIf="logo" class="dso-logo mb-3 logo-container">
     <img [src]="logo._links.content.href" class="img-fluid" [attr.alt]="alternateText ? alternateText : null" (error)="errorHandler($event)"/>
 </div>

--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.scss
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.scss
@@ -1,0 +1,4 @@
+.logo-container {
+  max-width: var(--ds-comcol-logo-max-width);
+  max-height: var(--ds-comcol-logo-max-height);
+}

--- a/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.scss
+++ b/src/app/shared/comcol/comcol-page-logo/comcol-page-logo.component.scss
@@ -1,4 +1,4 @@
-.logo-container {
+img {
   max-width: var(--ds-comcol-logo-max-width);
   max-height: var(--ds-comcol-logo-max-height);
 }

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -102,4 +102,7 @@
   --ds-dso-edit-lang-width: 90px;
   --ds-dso-edit-actions-width: 173px;
   --ds-dso-edit-virtual-tooltip-min-width: 300px;
+
+  --ds-comcol-logo-max-width: 500px;
+  --ds-comcol-logo-max-height: 500px;
 }


### PR DESCRIPTION
References
Fixes https://github.com/DSpace/dspace-angular/issues/2745

Description
To prevent logos to be over sized we added a configuration possibility so that on each environment we can restrict the size to a number of defined pixels.

Instructions for Reviewers
In order to test try creating a new collection or community uploading a very large picture as logo to check if it is rendered within the defined configuration sizes.

Checklist
 My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
 My PR passes [ESLint](https://eslint.org/) validation using yarn lint
 My PR doesn't introduce circular dependencies (verified via yarn check-circ-deps)
 My PR includes [TypeDoc](https://typedoc.org/) comments for all new (or modified) public methods and classes. It also includes TypeDoc for large or complex private methods.
 My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
 If my PR includes new libraries/dependencies (in package.json), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
 If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
 If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).