### PR TITLE
Issues/1184

### DIFF
--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -7,7 +7,7 @@
          autofocus
          class="form-control form-control-lg position-relative"
          formControlName="email"
-         placeholder="{{'login.form.email' | translate}}"
+         [attr.placeholder]="'login.form.email' | translate"
          required
          type="email"
          [attr.data-test]="'email' | dsBrowserOnly">
@@ -15,7 +15,7 @@
   <input [attr.aria-label]="'login.form.password' |translate"
          autocomplete="off"
          class="form-control form-control-lg position-relative mb-3"
-         placeholder="{{'login.form.password' | translate}}"
+         [attr.placeholder]="'login.form.password' | translate"
          formControlName="password"
          required
          type="password"

--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -3,7 +3,7 @@
       [formGroup]="form" novalidate>
   <label class="sr-only">{{"login.form.email" | translate}}</label>
   <input [attr.aria-label]="'login.form.email' |translate"
-         autocomplete="off"
+         autocomplete="username"
          autofocus
          class="form-control form-control-lg position-relative"
          formControlName="email"
@@ -13,7 +13,7 @@
          [attr.data-test]="'email' | dsBrowserOnly">
   <label class="sr-only">{{"login.form.password" | translate}}</label>
   <input [attr.aria-label]="'login.form.password' |translate"
-         autocomplete="off"
+         autocomplete="current-password"
          class="form-control form-control-lg position-relative mb-3"
          placeholder="{{'login.form.password' | translate}}"
          formControlName="password"

--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -7,7 +7,7 @@
          autofocus
          class="form-control form-control-lg position-relative"
          formControlName="email"
-         [attr.placeholder]="'login.form.email' | translate"
+         placeholder="{{'login.form.email' | translate}}"
          required
          type="email"
          [attr.data-test]="'email' | dsBrowserOnly">
@@ -15,7 +15,7 @@
   <input [attr.aria-label]="'login.form.password' |translate"
          autocomplete="off"
          class="form-control form-control-lg position-relative mb-3"
-         [attr.placeholder]="'login.form.password' | translate"
+         placeholder="{{'login.form.password' | translate}}"
          formControlName="password"
          required
          type="password"


### PR DESCRIPTION
Hello everyone! i have done the last activity of this issue. I will be attentive to any comments.

## References
* Fixes #1184 (if this fixes an issue ticket)

## Description
email & password inputs have their corresponding autocomplete attributes.

## Instructions for Reviewers
1. Open the login menu.
2. Inspect the email & password input
3. You will see the autocomplete attribute "username" for email & "current-password" for email.
![image](https://github.com/DSpace/dspace-angular/assets/51240376/b13b17d9-8157-4007-af08-aa458d8cd443)

List of changes in this PR:
* email input has `autocomplete="username"`
* password input has `autocomplete="current-password"`

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
