### PR TITLE
Fix missing Register DOI button if configuration enabled

### DIFF
--- a/src/app/item-page/edit-item-page/item-status/item-status.component.ts
+++ b/src/app/item-page/edit-item-page/item-status/item-status.component.ts
@@ -117,7 +117,7 @@ export class ItemStatusComponent implements OnInit {
        * The value is supposed to be a href for the button
        */
       const currentUrl = this.getCurrentUrl(item);
-      const inititalOperations: ItemOperation[] = [
+      const initialOperations: ItemOperation[] = [
         new ItemOperation('authorizations', `${currentUrl}/authorizations`, FeatureID.CanManagePolicies, true),
         new ItemOperation('mappedCollections', `${currentUrl}/mapper`, FeatureID.CanManageMappings, true),
         item.isWithdrawn
@@ -130,7 +130,7 @@ export class ItemStatusComponent implements OnInit {
         new ItemOperation('delete', `${currentUrl}/delete`, FeatureID.CanDelete, true)
       ];
 
-      this.operations$.next(inititalOperations);
+      this.operations$.next(initialOperations);
 
         /**
          *  When the identifier data stream changes, determine whether the register DOI button should be shown or not.
@@ -170,12 +170,12 @@ export class ItemStatusComponent implements OnInit {
           }),
           // Switch map pushes the register DOI operation onto a copy of the base array then returns to the pipe
           switchMap((showDoi: boolean) => {
-            const ops = [...inititalOperations];
+            const ops = [...initialOperations];
             if (showDoi) {
               const op = new ItemOperation('register-doi', `${currentUrl}/register-doi`, FeatureID.CanRegisterDOI, true);
               ops.splice(ops.length - 1, 0, op); // Add item before last
             }
-            return inititalOperations;
+            return ops;
           }),
           concatMap((op: ItemOperation) => {
             if (hasValue(op.featureID)) {

--- a/src/app/item-page/edit-item-page/item-status/item-status.component.ts
+++ b/src/app/item-page/edit-item-page/item-status/item-status.component.ts
@@ -3,7 +3,7 @@ import { fadeIn, fadeInOut } from '../../../shared/animations/fade';
 import { Item } from '../../../core/shared/item.model';
 import { ActivatedRoute } from '@angular/router';
 import { ItemOperation } from '../item-operation/itemOperation.model';
-import { concatMap, distinctUntilChanged, first, map, mergeMap, switchMap, toArray } from 'rxjs/operators';
+import {concatMap, distinctUntilChanged, first, map, mergeMap, switchMap, tap, toArray} from 'rxjs/operators';
 import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { getItemEditRoute, getItemPageRoute } from '../../item-page-routing-paths';
@@ -17,6 +17,7 @@ import { ConfigurationProperty } from '../../../core/shared/configuration-proper
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 import { IdentifierData } from '../../../shared/object-list/identifier-data/identifier-data.model';
 import { OrcidAuthService } from '../../../core/orcid/orcid-auth.service';
+import {getDSORoute} from "../../../app-routing-paths";
 
 @Component({
   selector: 'ds-item-status',
@@ -107,7 +108,19 @@ export class ItemStatusComponent implements OnInit {
       // Observable for configuration determining whether the Register DOI feature is enabled
       let registerConfigEnabled$: Observable<boolean> = this.configurationService.findByPropertyName('identifiers.item-status.register-doi').pipe(
         getFirstCompletedRemoteData(),
-        map((enabledRD: RemoteData<ConfigurationProperty>) => enabledRD.hasSucceeded && enabledRD.payload.values.length > 0)
+        map((response: RemoteData<ConfigurationProperty>) => {
+          // Return true if a successful response with a 'true' value was retrieved, otherwise return false
+          if (response.hasSucceeded) {
+            const payload = response.payload;
+            if (payload.values.length > 0 && hasValue(payload.values[0])) {
+              return payload.values[0] === 'true';
+            } else {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        })
       );
 
       /**

--- a/src/app/item-page/edit-item-page/item-status/item-status.component.ts
+++ b/src/app/item-page/edit-item-page/item-status/item-status.component.ts
@@ -3,7 +3,7 @@ import { fadeIn, fadeInOut } from '../../../shared/animations/fade';
 import { Item } from '../../../core/shared/item.model';
 import { ActivatedRoute } from '@angular/router';
 import { ItemOperation } from '../item-operation/itemOperation.model';
-import {concatMap, distinctUntilChanged, first, map, mergeMap, switchMap, tap, toArray} from 'rxjs/operators';
+import {concatMap, distinctUntilChanged, first, map, mergeMap, switchMap, toArray} from 'rxjs/operators';
 import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { getItemEditRoute, getItemPageRoute } from '../../item-page-routing-paths';
@@ -17,7 +17,6 @@ import { ConfigurationProperty } from '../../../core/shared/configuration-proper
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 import { IdentifierData } from '../../../shared/object-list/identifier-data/identifier-data.model';
 import { OrcidAuthService } from '../../../core/orcid/orcid-auth.service';
-import {getDSORoute} from "../../../app-routing-paths";
 
 @Component({
   selector: 'ds-item-status',


### PR DESCRIPTION
Fix for missing Register DOI button under Edit Item > Status tab
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #2765 

## Description
Fix initialOperations variable typo and return ops array with register-doi op successfully added is the register doi configuration is enabled

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [X] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
