### PR TITLE
Fix infinite scroll

### DIFF
--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -6,12 +6,12 @@
            [formControl]="input" ngbAutofocus (keyup.enter)="selectSingleResult()">
 </div>
 <div class="dropdown-divider"></div>
-<div class="scrollable-menu list-group">
+<div id="scrollable-menu-dso-selector-{{randomSeed}}" class="scrollable-menu list-group">
   <div
     infiniteScroll
     [infiniteScrollDistance]="1"
     [infiniteScrollThrottle]="0"
-    [infiniteScrollContainer]="'.scrollable-menu'"
+    [infiniteScrollContainer]="'#scrollable-menu-dso-selector-' + randomSeed"
     [fromRoot]="true"
     (scrolled)="onScrollDown()">
     <ng-container *ngIf="listEntries$ | async">

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -136,6 +136,11 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    */
   public subs: Subscription[] = [];
 
+  /**
+   * Random seed of 4 characters to avoid duplicate ids
+   */
+  randomSeed: string = Math.random().toString(36).substring(2, 6);
+
   constructor(
     protected searchService: SearchService,
     protected notifcationsService: NotificationsService,


### PR DESCRIPTION
## References
- Fixes #2767

## Description
Fix for infinite scroll.

## Instructions for Reviewers
The selector for the infinite scroll wasn't targeting the right infinitescroll container.

List of changes in this PR:
Changed infinitescrollcontainer to use id
Added a random seed made of alphanumerical character to avoid duplicated id

**Include guidance for how to test or review your PR.**

1. Go into MyDSpace
1. Then try to add for example a new publication
1. When the list of collections is shown scroll down
1. Make sure the infinite scrolldown works

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).

