### PR TITLE
Element reference for typeahead directive is only defined when model has authority

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
@@ -151,7 +151,7 @@ export class DsDynamicTagComponent extends DsDynamicVocabularyComponent implemen
    * @param event The value to emit.
    */
   onBlur(event: Event) {
-    if (isNotEmpty(this.currentValue) && !this.instance.isPopupOpen()) {
+    if (isNotEmpty(this.currentValue) && (!this.model.hasAuthority || !this.instance.isPopupOpen())) {
       this.addTagsToChips();
     }
     this.blur.emit(event);


### PR DESCRIPTION
## References

## Description
The condition within the `onBlur` event handler method for the tag input field has an error when the [model.hasAuthority](https://github.com/DSpace/dspace-angular/blob/main/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.html#L24) is falsy.

This causes the text entered to not be converted to a subject "chip" and is not added to the form for patch submission.

## Instructions for Reviewers

Check the [view template](https://github.com/DSpace/dspace-angular/blob/main/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.html#L49) for whether an [element reference](https://github.com/DSpace/dspace-angular/blob/main/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts#L42) will be rendered or not. Minimizing cyclomatic complexity helps avoid this but still requires mental mapping between the component and template when using conditions in the template and referencing elements from the component logic.

List of changes in this PR:
- amend condition whether to `addTagsToChips` to check if `model.hasAuthority` before invoking the `ViewChild` decorated class member `instance` `isPopupOpen` method. 


In [submission-forms.xml](https://github.com/DSpace/DSpace/blob/main/dspace/config/submission-forms.xml) define a form field with input type tag without a control vocabulary. Then during a item submission type in the tag input field and tab or click away. The value will remain a free form text and there will be an error in the console log.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
