### PR TITLE
Fixed Font Awesome CSS Pseudo-elements not rendering in v6.x

### DIFF
--- a/src/app/entity-groups/research-entities/submission/item-list-elements/org-unit/org-unit-suggestions/org-unit-input-suggestions.component.scss
+++ b/src/app/entity-groups/research-entities/submission/item-list-elements/org-unit/org-unit-suggestions/org-unit-input-suggestions.component.scss
@@ -3,10 +3,9 @@ form {
     &:before {
         pointer-events: none; // prevent the icon from ‘catching‘ the click
         position: absolute;
-        font-weight: 900;
-        font-family: "Font Awesome 5 Free";
+        font: var(--fa-font-solid);
         content: "\f0d7";
-        top: 7px;
+        top: 10px;
         right: 0;
         height: 20px;
         width: 20px;

--- a/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-suggestions/person-input-suggestions.component.scss
+++ b/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-suggestions/person-input-suggestions.component.scss
@@ -2,10 +2,9 @@ form {
     &:before {
         pointer-events: none; // prevent the icon from ‘catching‘ the click
         position: absolute;
-        font-weight: 900;
-        font-family: "Font Awesome 5 Free";
+        font: var(--fa-font-solid);
         content: "\f0d7";
-        top: 7px;
+        top: 10px;
         right: 0;
         height: 20px;
         width: 20px;


### PR DESCRIPTION
## Description
When Font Awesome was updated from v5.5.0 to v6.2.1 the CSS Pseudo-elements were not correctly updated this small PR fixes this issue. More information on this can be found [here](https://fontawesome.com/docs/web/setup/upgrade/pseudo-elements#updating-font-rule-syntax).

## Instructions for Reviewers
Verify that the icons are now rendered correctly again
<img width="45%" alt="Broken dropdown icon" src="https://github.com/DSpace/dspace-angular/assets/43750381/a95c3564-e6cd-43ce-ab2f-a820d6d4fd24"> <img width="45%" alt="Fixed dropdown icon" src="https://github.com/DSpace/dspace-angular/assets/43750381/9d8e2601-35c2-4619-a45b-33aaccd7ed95">


**Guidance for how to test or review this PR:**
- The easiest way to check this is by going to `Edit Item > Relationships` of a publication and click on `+ Add` on the `Authors (persons)` & `Organizational Units` sections

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
