### PR TITLE
DSpace#1306 - Implementation that makes it possible to customize thum…

### DIFF
--- a/src/app/collection-page/collection-form/collection-form.models.ts
+++ b/src/app/collection-page/collection-form/collection-form.models.ts
@@ -35,6 +35,11 @@ export const collectionFormModels: DynamicFormControlModel[] = [
     spellCheck: environment.form.spellCheck,
   }),
   new DynamicTextAreaModel({
+    id: 'thumbnail',
+    name: 'dc.description.thumbnail',
+    spellCheck: environment.form.spellCheck,
+  }),
+  new DynamicTextAreaModel({
     id: 'rights',
     name: 'dc.rights',
     spellCheck: environment.form.spellCheck,

--- a/src/app/collection-page/collection-page.component.html
+++ b/src/app/collection-page/collection-page.component.html
@@ -10,12 +10,11 @@
                   <ds-comcol-page-header
                           [name]="dsoNameService.getName(collection)">
                   </ds-comcol-page-header>
-                  <!-- Collection logo -->
-                  <ds-comcol-page-logo *ngIf="logoRD$"
-                                   [logo]="(logoRD$ | async)?.payload"
-                                   [alternateText]="'Collection Logo'">
+                  <!-- Collection logo with custom description -->
+                  <ds-comcol-page-logo *ngIf="logoRD$ && collection.descriptionThumbnail"
+                          [logo]="(logoRD$ | async)?.payload"
+                          [alternateText]="collection.descriptionThumbnail">
                   </ds-comcol-page-logo>
-
                   <!-- Handle -->
                   <ds-themed-comcol-page-handle
                           [content]="collection.handle"

--- a/src/app/community-page/community-form/community-form.component.ts
+++ b/src/app/community-page/community-form/community-form.component.ts
@@ -61,6 +61,11 @@ export class CommunityFormComponent extends ComColFormComponent<Community> imple
       spellCheck: environment.form.spellCheck,
     }),
     new DynamicTextAreaModel({
+      id: 'thumbnail',
+      name: 'dc.description.thumbnail',
+      spellCheck: environment.form.spellCheck,
+    }),
+    new DynamicTextAreaModel({
       id: 'rights',
       name: 'dc.rights',
       spellCheck: environment.form.spellCheck,

--- a/src/app/community-page/community-page.component.html
+++ b/src/app/community-page/community-page.component.html
@@ -6,9 +6,11 @@
         <header class="comcol-header mr-auto">
           <!-- Community name -->
           <ds-comcol-page-header [name]="dsoNameService.getName(communityPayload)"></ds-comcol-page-header>
-          <!-- Community logo -->
-          <ds-comcol-page-logo *ngIf="logoRD$" [logo]="(logoRD$ | async)?.payload" [alternateText]="'Community Logo'">
+          <!-- Community logo with custom description -->
+          <ds-comcol-page-logo *ngIf="logoRD$ && communityPayload.descriptionThumbnail" [logo]="(logoRD$ | async)?.payload" [alternateText]="communityPayload.descriptionThumbnail">
           </ds-comcol-page-logo>
+          <!-- Community logo with simple description -->
+          <ds-comcol-page-logo *ngIf="logoRD$  && !communityPayload.descriptionThumbnail" [logo]="(logoRD$ | async)?.payload" [alternateText]="'Community Logo'">
           <!-- Handle -->
           <ds-themed-comcol-page-handle [content]="communityPayload.handle" [title]="'community.page.handle'">
           </ds-themed-comcol-page-handle>

--- a/src/app/core/shared/collection.model.ts
+++ b/src/app/core/shared/collection.model.ts
@@ -91,6 +91,14 @@ export class Collection extends DSpaceObject implements ChildHALResource, Handle
   }
 
   /**
+   * The thumbail description of this Collection
+   * Corresponds to the metadata field dc.description.thumbnail
+   */
+  get descriptionThumbnail(): string {
+    return this.firstMetadataValue('dc.description.thumbnail');
+  }
+
+  /**
    * The short description: HTML
    * Corresponds to the metadata field dc.description.abstract
    */

--- a/src/app/core/shared/community.model.ts
+++ b/src/app/core/shared/community.model.ts
@@ -80,6 +80,14 @@ export class Community extends DSpaceObject implements ChildHALResource, HandleO
   }
 
   /**
+   * The thumbail description of this Community
+   * Corresponds to the metadata field dc.description.thumbnail
+   */
+  get descriptionThumbnail(): string {
+    return this.firstMetadataValue('dc.description.thumbnail');
+  }
+
+  /**
    * The short description: HTML
    * Corresponds to the metadata field dc.description.abstract
    */

--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -8,7 +8,9 @@
   </div>
   <ng-container *ngVar="(src$ | async) as src">
     <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-    <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+    <img *ngIf="src !== null && customDescription !== undefined" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+         [src]="src | dsSafeUrl" [alt]="customDescription" (error)="errorHandler()" (load)="successHandler()">
+         <img *ngIf="src !== null && customDescription == undefined" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
          [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
     <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
       <div class="inner">

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { Bitstream } from '../core/shared/bitstream.model';
 import { hasNoValue, hasValue } from '../shared/empty.util';
 import { RemoteData } from '../core/data/remote-data';
@@ -19,17 +19,27 @@ import { FileService } from '../core/shared/file.service';
   styleUrls: ['./thumbnail.component.scss'],
   templateUrl: './thumbnail.component.html',
 })
-export class ThumbnailComponent implements OnChanges {
+export class ThumbnailComponent implements OnInit, OnChanges {
   /**
    * The thumbnail Bitstream
    */
   @Input() thumbnail: Bitstream | RemoteData<Bitstream>;
+
+   /**
+   * Variable that listens to the thumbnail value
+   */
+   listenThumbnail: any;
 
   /**
    * The default image, used if the thumbnail isn't set or can't be downloaded.
    * If defaultImage is null, a HTML placeholder is used instead.
    */
   @Input() defaultImage? = null;
+
+  /**
+   * Custom thumbnail description for alt text
+   */
+  customDescription: string;
 
   /**
    * The src attribute used in the template to render the image.
@@ -64,6 +74,15 @@ export class ThumbnailComponent implements OnChanges {
     protected authorizationService: AuthorizationDataService,
     protected fileService: FileService,
   ) {
+  }
+
+  /**
+   * Getting the description from the thumbnail file
+   * when rendering the screen.
+   */
+  ngOnInit(): void{
+    this.listenThumbnail = this.thumbnail;
+    this.customDescription = this.listenThumbnail.payload.metadata['dc.description'][0].value;
   }
 
   /**

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5300,4 +5300,8 @@
 
   "vocabulary-treeview.search.form.add": "Add",
 
+  "community.form.thumbnail": "Thumbnail Description",
+
+  "collection.form.thumbnail": "Thumbnail Description",
+
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -7825,6 +7825,10 @@
   // "access-control-option-end-date-note": "Select the date until which the related access condition is applied",
   "access-control-option-end-date-note": "Escoja la fecha hasta la cuál se aplicarán las condiciones de acceso especificadas",
 
+  // "community.form.thumbnail": "Thumbnail Description",
+  "community.form.thumbnail": "Descripción del logotipo",
 
+  // "collection.form.thumbnail": "Thumbnail Description",
+  "collection.form.thumbnail": "Descripción del logotipo",
 
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -7850,4 +7850,11 @@
 
   // "access-control-option-end-date-note": "Select the date until which the related access condition is applied", (Auto-Translated)
   "access-control-option-end-date-note": "Selecione a data até a qual a condição de acesso relacionada é aplicada",
+
+  // "community.form.thumbnail": "Thumbnail Description",
+  "community.form.thumbnail": "Descrição do logotipo",
+
+  // "collection.form.thumbnail": "Thumbnail Description",
+  "collection.form.thumbnail": "Descrição do logotipo",
+
 }

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -7821,4 +7821,9 @@
   // "item.preview.dc.identifier.eisbn": "EISBN",
   "item.preview.dc.identifier.eisbn": "EISBN",
 
+  // "community.form.thumbnail": "Thumbnail Description",
+  "community.form.thumbnail": "Descrição do logotipo",
+
+  // "collection.form.thumbnail": "Thumbnail Description",
+  "collection.form.thumbnail": "Descrição do logotipo",
 }


### PR DESCRIPTION
…bnail descriptions of items, collections and communities

## References
Fixes #1306 
This change was aimed at #1306 which now allows a detailed description of the thumbnail logo images of items, collections and communities (also recognized by screen readers).

## Description
First, logic was created using OnInit in the thumbnail component to bring the value of the thumbnail description to the "alt" text contained in the image tag in the html. Fields were then created for insertion in the creation and editing of communities and collections that allowed the insertion of details about the logos involved and finally the creation of translation keys for these fields.

## Instructions for reviewers
First of all, it is necessary to create the "dc.description.thumbnail" metadata in the backend where the test is carried out.

List of changes in this PR:
* Creating logic in the thumbnail component to pull the item thumbnail description (using the onInit function and using variables created to obtain the thumbnail description through the thumbnail object);
* Making conditionals in the html to check if there is a customized description and passing it in the alt of the thumbnail;
* A field was created in the community form and collection form using the new metadata "dc.description.thumbnail" to accept descriptions;
* Functions were created in the collection model and community model that provide thumbnail descriptions of collections and communities;
* In the html of the community page and collection page components, conditionals were inserted and check if there is a customized description and insert the variable with the description in the alternative text.
* The appropriate translation keys "community.form.thumbnail" and "collection.form.thumbnail" were created for the field created for communities and collections (translations made in English, Portuguese and Spanish)

**Include guidance on how to test or review your PR.**

To test, simply create a collection and community that contains a logo. In the "Thumbnail Description" field, fill in details of this logo and finally inspect the logo or use a screen reader on the logo to validate the description entered. Now as for the items, just insert a bitstream and create the thumb by running filter-media in the backend. After that, go to item editing and go to the bitstream tab and edit the thumbnail description and then go to the item and hover the screen reader over the image or inspect it to see if the description matches the one entered.