### PR TITLE
The docker-compose-rest has defined a network, which is not the same …

### DIFF
--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -43,3 +43,9 @@ volumes:
 
 networks:
   dspacenet:
+    ipam:
+      config:
+        # Define a custom subnet for our DSpace network, so that we can easily trust requests from host to container.
+        # If you customize this value, be sure to customize the 'proxies.trusted.ipranges' env variable below.
+        - subnet: 172.23.0.0/16
+


### PR DESCRIPTION
## Description
The error `docker/cli.yml: (root) must be a mapping` occurred when I tried to create an administrator using docker compose command with these docker compose files `docker-compose.yml`, `docker-compose-rest.yml`, `cli.yml`.
The full command is: `docker compose -p dspace7 -f docker/docker-compose.yml  -f docker/docker-compose-rest.yml -f docker/cli.yml run --rm dspace-cli create-administrator -e admin@admin.test -f admin -l user -p admin -c en`

## Instructions for Reviewers
The `docker-compose-rest.yml` file includes `ipam` in the `networks` section, but this part of code is missing in the `cli.yml`. Consequently, when I run docker compose cli using docker compose files: `docker-compose-rest.yml` and `cli.yml` files in that sequence (`docker-compose-rest.yml` before `cli.yml`), it throws an error.

List of changes in this PR:
- Copied `ipam` network from the `docker-compose-rest.yml` into `cli.yml`

How to reproduce:
1. Run DSpace7.6.1. in the docker
2. Try to create an administrator using the following command: `docker compose -p dspace7 -f docker/docker-compose.yml  -f docker/docker-compose-rest.yml -f docker/cli.yml run --rm dspace-cli create-administrator -e admin@admin.test -f admin -l user -p admin -c en`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
