### PR TITLE
fix German translation of admin.workflow.item.workflow 

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -731,9 +731,6 @@
   // "admin.workflow.title": "Administer Workflow",
   "admin.workflow.title": "Workflows verwalten",
 
-  // "admin.workflow.item.workflow": "Workflow",
-  "admin.workflow.item.workflow": "Workflows",
-
   // "admin.workflow.item.delete": "Delete",
   "admin.workflow.item.delete": "Löschen",
 


### PR DESCRIPTION
## Description

This PR removes the German translation of `admin.workflow.item.workflow` which use the plural form instead of the singular form. 

As this translation is used as the text of an item badge it should the singular form.

![image](https://github.com/DSpace/dspace-angular/assets/952735/7d25ff6c-2478-43b5-a65c-e27271d884f4)

