### PR TITLE
Add iiif manifest bundle to suggested bundle names when uploading bitstream

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -352,7 +352,7 @@ themes:
 
 # The default bundles that should always be displayed as suggestions when you upload a new bundle
 bundle:
-  standardBundles: [ ORIGINAL, THUMBNAIL, LICENSE ]
+  standardBundles: [ ORIGINAL, THUMBNAIL, LICENSE, IIIF_MANIFEST ]
 
 # Whether to enable media viewer for image and/or video Bitstreams (i.e. Bitstreams whose MIME type starts with 'image' or 'video').
 # For images, this enables a gallery viewer where you can zoom or page through images.

--- a/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
+++ b/src/app/item-page/bitstreams/upload/upload-bitstream.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Observable, Subscription, of as observableOf } from 'rxjs';
+import { Observable, Subscription, combineLatest, of as observableOf } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { Item } from '../../../core/shared/item.model';
 import { map, take, switchMap } from 'rxjs/operators';
@@ -10,7 +10,6 @@ import { ItemDataService } from '../../../core/data/item-data.service';
 import { AuthService } from '../../../core/auth/auth.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
-import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { Bundle } from '../../../core/shared/bundle.model';
 import { BundleDataService } from '../../../core/data/bundle-data.service';
 import { getFirstSucceededRemoteDataPayload, getFirstCompletedRemoteData } from '../../../core/shared/operators';
@@ -20,6 +19,7 @@ import { getBitstreamModuleRoute } from '../../../app-routing-paths';
 import { getEntityEditRoute } from '../../item-page-routing-paths';
 import { environment } from '../../../../environments/environment';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
+import { isIiifEnabled } from '../../simple/item-types/shared/item-iiif-utils';
 
 @Component({
   selector: 'ds-upload-bitstream',
@@ -112,36 +112,51 @@ export class UploadBitstreamComponent implements OnInit, OnDestroy {
     this.entityType = this.route.snapshot.params['entity-type'];
     this.itemRD$ = this.route.data.pipe(map((data) => data.dso));
     const bundlesRD$ = this.itemService.getBundles(this.itemId).pipe(
-      getFirstCompletedRemoteData(),
-      switchMap((remoteData: RemoteData<PaginatedList<Bundle>>) => {
-        if (remoteData.hasSucceeded) {
-          if (remoteData.payload.page) {
-            this.bundles = remoteData.payload.page;
-            for (const defaultBundle of environment.bundle.standardBundles) {
-              let check = true;
-              remoteData.payload.page.forEach((bundle: Bundle) => {
-                // noinspection JSDeprecatedSymbols
-                if (defaultBundle === bundle.name) {
-                  check = false;
+      getFirstCompletedRemoteData()
+    );
+
+    this.subs.push(combineLatest([this.itemRD$, bundlesRD$])
+      .pipe(
+        switchMap(([item, bundles]) => {
+          // If no item has resolved, then something is very wrong
+          // is there a fallback if this somehow happens?
+          if (item.hasSucceeded && bundles.hasSucceeded) {
+            if (bundles.payload.page) {
+              this.bundles = bundles.payload.page;
+              // For each default bundle, check to see if any exists in the item.bundles
+              // If not, add it to the bundles
+              for (const defaultBundle of this.filteredStandardBundles(item.payload)) {
+                let check = true;
+                bundles.payload.page.forEach((bundle: Bundle) => {
+                  // noinspection JSDeprecatedSymbols
+                  if (defaultBundle === bundle.name) {
+                    check = false;
+                  }
+                });
+                if (check) {
+                  this.bundles.push(Object.assign(new Bundle(), {
+                    _name: defaultBundle,
+                    type: 'bundle'
+                  }));
                 }
-              });
-              if (check) {
-                this.bundles.push(Object.assign(new Bundle(), {
-                  _name: defaultBundle,
-                  type: 'bundle'
-                }));
               }
+            } else {
+              // No bundles found on item, add default bundles
+              this.bundles = this.filteredStandardBundles(item.payload)
+                .map((defaultBundle: string) => Object.assign(new Bundle(), {
+                    _name: defaultBundle,
+                    type: 'bundle'
+                  })
+                );
             }
-          } else {
-            this.bundles = environment.bundle.standardBundles.map((defaultBundle: string) => Object.assign(new Bundle(), {
-                _name: defaultBundle,
-                type: 'bundle'
-              })
-            );
+            return observableOf(bundles.payload.page);
           }
-          return observableOf(remoteData.payload.page);
-        }
-      }));
+        })
+      )
+      .subscribe()
+    );
+
+
     this.selectedBundleId = this.route.snapshot.queryParams.bundle;
     if (isNotEmpty(this.selectedBundleId)) {
       this.subs.push(this.bundleService.findById(this.selectedBundleId).pipe(
@@ -151,7 +166,18 @@ export class UploadBitstreamComponent implements OnInit, OnDestroy {
       }));
       this.setUploadUrl();
     }
-    this.subs.push(bundlesRD$.subscribe());
+  }
+
+  filteredStandardBundles(item: Item) {
+    if (!isIiifEnabled(item)) {
+      return environment.bundle.standardBundles.filter((defaultBundle: string) => {
+        // TODO: This should be a contstant from somewhere?
+        return defaultBundle !== 'IIIF_MANIFEST';
+      });
+    }
+
+    // Else, return standard bundles including IIIF_MANIFEST
+    return environment.bundle.standardBundles;
   }
 
   /**

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -388,9 +388,9 @@ export class DefaultAppConfig implements AppConfig {
     },
   ];
   // The default bundles that should always be displayed when you edit or add a bundle even when no bundle has been
-  // added to the item yet.
+  // added to the item yet. IIIF_MANIFEST will only appear if IIIF is enabled for the item.
   bundle: BundleConfig = {
-    standardBundles: ['ORIGINAL', 'THUMBNAIL', 'LICENSE']
+    standardBundles: ['ORIGINAL', 'THUMBNAIL', 'LICENSE', 'IIIF_MANIFEST']
   };
   // Whether to enable media viewer for image and/or video Bitstreams (i.e. Bitstreams whose MIME type starts with "image" or "video").
   // For images, this enables a gallery viewer where you can zoom or page through images.

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -288,7 +288,7 @@ export const environment: BuildConfig = {
     },
   ],
   bundle: {
-    standardBundles: ['ORIGINAL', 'THUMBNAIL', 'LICENSE'],
+    standardBundles: ['ORIGINAL', 'THUMBNAIL', 'LICENSE', 'IIIF_MANIFEST'],
   },
   mediaViewer: {
     image: true,


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Relates to ticket https://github.com/DSpace/DSpace/issues/9143
* Requires this DSpace PR: https://github.com/DSpace/DSpace/pull/9172

## Description
This change will add `IIIF_MANIFEST` as a default bundle suggestion when uploading bitstreams on an item if that item has IIIF enabled. This bundle is intended to hold a custom IIIF manifest file that would be used in place of DSpace's generated manifest (see linked PR to `DSpace/DSpace`).

_Note the DSpace backend change supporting custom manifests can still function without this change. Without this, an admin adding a bitstream would have to manually input `IIIF_MANIFEST` as the bitstream's target bundle_

### Changes
- Add `IIIF_MANIFEST` as a default bundle suggestion
- Update `upload-bitstream` component to filter out the `IIIF_MANIFEST` bundle suggestion if the item does not have IIIF enabled

## Instructions for Reviewers
We need to make sure the DSpace UI under test has the config changes from this PR: adding `IIIF_MANIFEST` to the standard bundles.

Default items in DSpace generally don't have IIIF enabled, so we can start by investigating any item in the default test data.

#### IIIF disabled item
- Login as admin
- Edit an item
  - Verify that the item's metadata does not include `dspace.iiif.enabled = true`
- Navigate to Bitstreams tab, and click on the Upload button
  - This will bring up the Upload Bitstream screen with an input field for the target bundle for the new bitstream
- Click on the Bundle input to bring up the bundle suggestions
  - Verify that `IIIF_MANIFEST` does NOT appear, as this item does not have IIIF enabled

#### IIIF Enabled item
We can reuse the same item as above for convenience, or we can use any other item or create a new item

- Login as admin, edit an item
- In metadata, click Add
  - Enter `Field: dspace.iiif.enabled, Value: true` and the green checkbox to confirm
  - Verify the metadata field was entered correctly and click Save to commit
- Once the save goes through, navigate to the Bitstreams tab (still in the item's admin interface)
- Click the Upload button
- Click the Bundle input
  - Verify `IIIF_MANIFEST` appears in the suggestion list

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
