### PR TITLE
Fix browse-by-date year filter option generation

### DIFF
--- a/src/app/browse-by/browse-by-date/browse-by-date.component.ts
+++ b/src/app/browse-by/browse-by-date/browse-by-date.component.ts
@@ -142,7 +142,7 @@ export class BrowseByDateComponent extends BrowseByMetadataComponent implements 
         // TODO: it appears that getFullYear (based on local time) is sometimes unreliable. Switching to UTC.
         return isNaN(dateObj.getUTCFullYear()) ? limit : dateObj.getUTCFullYear();
       } else {
-        return new Date().getUTCFullYear();
+        return new Date(limit).getUTCFullYear();
       }
     }
   }


### PR DESCRIPTION
Empty issued dates incorrectly defaulted to current year instead of lower year limit, resulting in zero year options for the year picker, in turn resulting in a page that never finishes loading.

## References
Fixes #2808 

## Description
A bug in the logic of the browse-by-date year picker resulted in the Browse by Issue Date page never loading.

## Instructions for Reviewers
Ensure Browse by Issue Date still works as expected. 
Items with empty dc.date.issued should default to the configured browseBy.defaultLowerLimit, not the current year.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
