### PR TITLE
site search should not adopt existing URL query string parameters

### DIFF
--- a/src/app/search-navbar/search-navbar.component.spec.ts
+++ b/src/app/search-navbar/search-navbar.component.spec.ts
@@ -88,7 +88,7 @@ describe('SearchNavbarComponent', () => {
           fixture.detectChanges();
         }));
         it('to search page with empty query', () => {
-          const extras: NavigationExtras = { queryParams: { query: '' }, queryParamsHandling: 'merge' };
+          const extras: NavigationExtras = { queryParams: { query: '' } };
           expect(component.onSubmit).toHaveBeenCalledWith({ query: '' });
           expect(router.navigate).toHaveBeenCalledWith(['search'], extras);
         });
@@ -113,7 +113,7 @@ describe('SearchNavbarComponent', () => {
           fixture.detectChanges();
         }));
         it('to search page with query', async () => {
-          const extras: NavigationExtras = { queryParams: { query: 'test' }, queryParamsHandling: 'merge' };
+          const extras: NavigationExtras = { queryParams: { query: 'test' } };
           expect(component.onSubmit).toHaveBeenCalledWith({ query: 'test' });
 
           expect(router.navigate).toHaveBeenCalledWith(['search'], extras);

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -66,8 +66,7 @@ export class SearchNavbarComponent {
     this.searchForm.reset();
 
     this.router.navigate(linkToNavigateTo, {
-      queryParams: queryParams,
-      queryParamsHandling: 'merge'
+      queryParams: queryParams
     });
   }
 }


### PR DESCRIPTION
## Description

A site search (issued by the search box in the navigation bar) should not adopt existing URL query parameters. For example, a site search that is issued in the context of MyDSpace will adopt `configuration=workspace` as a URL query parameter.

The normal user would not expect that a site search considers only a subset of all items in the repository. It is commonly expected that a site search behaves consistent regardless of the context from which the search was started.
