### PR TITLE
Make 'id's unique in PaginationComponent

### DIFF
--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -7,8 +7,8 @@
       </div>
       <div class="col">
         <div *ngIf="!hideGear" ngbDropdown #paginationControls="ngbDropdown" placement="bottom-right" class="d-inline-block float-right">
-          <button class="btn btn-secondary" id="paginationControls" ngbDropdownToggle [title]="'pagination.options.description' | translate" [attr.aria-label]="'pagination.options.description' | translate" aria-haspopup="true" aria-expanded="false"><i class="fas fa-cog" aria-hidden="true"></i></button>
-          <ul id="paginationControlsDropdownMenu" aria-labelledby="paginationControls" role="menu" ngbDropdownMenu>
+          <button class="btn btn-secondary" [attr.id]="'paginationControls' + elementId" ngbDropdownToggle [title]="'pagination.options.description' | translate" [attr.aria-label]="'pagination.options.description' | translate" aria-haspopup="true" aria-expanded="false"><i class="fas fa-cog" aria-hidden="true"></i></button>
+          <ul [attr.id]="'paginationControlsDropdownMenu' + elementId" [attr.aria-labelledby]="'paginationControls' + elementId" role="menu" ngbDropdownMenu>
             <li role="menuitem">
               <span class="dropdown-header" id="pagination-control_results-per-page" role="heading">{{ 'pagination.results-per-page' | translate}}</span>
               <ul aria-labelledby="pagination-control_results-per-page" class="list-unstyled" role="listbox">

--- a/src/app/shared/pagination/pagination.component.spec.ts
+++ b/src/app/shared/pagination/pagination.component.spec.ts
@@ -34,6 +34,7 @@ import { storeModuleConfig } from '../../app.reducer';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { BehaviorSubject } from 'rxjs';
 import { FindListOptions } from '../../core/data/find-list-options.model';
+import { UUIDService } from 'src/app/core/shared/uuid.service';
 
 function expectPages(fixture: ComponentFixture<any>, pagesDef: string[]): void {
   const de = fixture.debugElement.query(By.css('.pagination'));
@@ -157,7 +158,9 @@ describe('Pagination component', () => {
         NgbModule,
         RouterTestingModule.withRoutes([
           { path: 'home', component: TestComponent }
-        ])],
+        ]),
+        UUIDService,
+        ],
       declarations: [
         PaginationComponent,
         TestComponent,
@@ -169,7 +172,8 @@ describe('Pagination component', () => {
         { provide: HostWindowService, useValue: hostWindowServiceStub },
         { provide: PaginationService, useValue: paginationService },
         ChangeDetectorRef,
-        PaginationComponent
+        PaginationComponent,
+        UUIDService,
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/app/shared/pagination/pagination.component.ts
+++ b/src/app/shared/pagination/pagination.component.ts
@@ -24,6 +24,7 @@ import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { ListableObject } from '../object-collection/shared/listable-object.model';
 import { ViewMode } from '../../core/shared/view-mode.model';
+import { UUIDService } from 'src/app/core/shared/uuid.service';
 
 /**
  * The default pagination controls component.
@@ -196,6 +197,12 @@ export class PaginationComponent implements OnDestroy, OnInit {
    * @type {Array}
    */
   private subs: Subscription[] = [];
+ 
+  /**
+   * Unique element 'id' property value, in case this class is used multiply
+   * in one page.
+   */
+  public elementId: String;
 
   /**
    * If showPaginator is set to true, emit when the previous button is clicked
@@ -206,6 +213,7 @@ export class PaginationComponent implements OnDestroy, OnInit {
    * If showPaginator is set to true, emit when the next button is clicked
    */
   @Output() next = new EventEmitter<boolean>();
+
   /**
    * Method provided by Angular. Invoked after the constructor.
    */
@@ -268,7 +276,9 @@ export class PaginationComponent implements OnDestroy, OnInit {
    */
   constructor(private cdRef: ChangeDetectorRef,
               private paginationService: PaginationService,
-              public hostWindowService: HostWindowService) {
+              public hostWindowService: HostWindowService,
+              private uuidService: UUIDService) {
+    this.elementId = uuidService.generate();
   }
 
   /**


### PR DESCRIPTION
## Description
When displaying a Community which has enough Collections *and* many sub-Communities, so that both lists are paginated, the pagination controls will have duplicate `id` attributes.  SiteImprove considers this an ARIA issue.  This patch generates a UUID member in PaginationComponent and uses it in the template to make the `id`s unique.

## Instructions for Reviewers
To test, you will need a Community with at least eleven Collections and eleven sub-Communities, so that both lists must be paginated.

List of changes in this PR:
* The component's class exposes a public `elementId` field, which is initialized to a UUID in the constructor.
* The template appends this to `id` attributes as appropriate.
* The `.spec` is updated to provide UUIDService for injection.

NOTE:  the `.spec` is broken:  "NullInjectorError: No provider for UUIDService!"
NOTE:  after the above is fixed, the `.spec` will probably fail because it is looking for fixed attribute values.  I will work on that after the suite is repaired enough to run at all.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).