### PR TITLE
Fix for not all CREATE/DELETE Relationship requests coming through, during submission entity lookup

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -182,6 +182,8 @@ describe('RelationshipEffects', () => {
         let action;
         describe('When the last value in the debounceMap is also an ADD_RELATIONSHIP action', () => {
           beforeEach(() => {
+            jasmine.getEnv().allowRespy(true);
+            spyOn((relationEffects as any), 'addRelationship').and.returnValue(createSuccessfulRemoteDataObject$(relationship));
             (relationEffects as any).initialActionMap[identifier] = RelationshipActionTypes.ADD_RELATIONSHIP;
             ((relationEffects as any).debounceTime as jasmine.Spy).and.returnValue((v) => v);
           });
@@ -247,6 +249,8 @@ describe('RelationshipEffects', () => {
         let action;
         describe('When the last value in the debounceMap is also an REMOVE_RELATIONSHIP action', () => {
           beforeEach(() => {
+            jasmine.getEnv().allowRespy(true);
+            spyOn((relationEffects as any), 'removeRelationship').and.returnValue(createSuccessfulRemoteDataObject$(undefined));
             ((relationEffects as any).debounceTime as jasmine.Spy).and.returnValue((v) => v);
             (relationEffects as any).initialActionMap[identifier] = RelationshipActionTypes.REMOVE_RELATIONSHIP;
           });
@@ -256,7 +260,7 @@ describe('RelationshipEffects', () => {
             actions = hot('--a-|', { a: action });
             const expected = cold('--b-|', { b: undefined });
             expect(relationEffects.mapLastActions$).toBeObservable(expected);
-            expect((relationEffects as any).removeRelationship).toHaveBeenCalledWith(leftItem, rightItem, relationshipType.leftwardType, '1234',);
+            expect((relationEffects as any).removeRelationship).toHaveBeenCalledWith(leftItem, rightItem, relationshipType.leftwardType);
           });
         });
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.html
@@ -15,27 +15,7 @@
            (selectObject)="selectObject.emit($event)">
   <div additionalSearchOptions *ngIf="repeatable" class="position-absolute">
     <div class="input-group mb-3">
-      <div class="input-group-prepend">
-        <div class="input-group-text">
-          <!-- In theory we don't need separate checkboxes for this,
-               but I wasn't able to get this to work correctly without them.
-               Checkboxes that are in the indeterminate state always switch to checked when clicked
-               This seemed like the cleanest and clearest solution to solve this issue for now. -->
-
-          <input *ngIf="!allSelected && !(someSelected$ | async)"
-                 type="checkbox"
-                 [indeterminate]="false"
-                 (change)="selectAll()">
-          <input *ngIf="!allSelected && (someSelected$ | async)"
-                 type="checkbox"
-                 [indeterminate]="true"
-                 (change)="deselectAll()">
-          <input *ngIf="allSelected" type="checkbox"
-                 [checked]="true"
-                 (change)="deselectAll()">
-        </div>
-      </div>
-      <div ngbDropdown class="input-group-append">
+      <div ngbDropdown class="input-group dropdown-button">
         <button *ngIf="selectAllLoading" type="button"
                 class="btn btn-outline-secondary rounded-right">
                             <span class="spinner-border spinner-border-sm" role="status"
@@ -55,8 +35,6 @@
                   (click)="selectPage(resultsRD?.page)">{{ ('submission.sections.describe.relationship-lookup.search-tab.select-page' | translate) }}</button>
           <button class="dropdown-item"
                   (click)="deselectPage(resultsRD?.page)">{{ ('submission.sections.describe.relationship-lookup.search-tab.deselect-page' | translate) }}</button>
-          <button class="dropdown-item" (click)="selectAll()">{{ ('submission.sections.describe.relationship-lookup.search-tab.select-all' | translate) }}</button>
-          <button class="dropdown-item" (click)="deselectAll()">{{ ('submission.sections.describe.relationship-lookup.search-tab.deselect-all' | translate) }}</button>
         </div>
       </div>
     </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.scss
@@ -1,3 +1,7 @@
 .position-absolute {
     right: var(--bs-spacer);
 }
+
+.dropdown-button {
+  z-index: 3;
+}


### PR DESCRIPTION
## Description

The entity lookup modal used during submission has options to create/remove multiple relationships at a time. Currently however, REST is sometimes overwhelmed by getting too many of these requests at once, and some relationship creations/deletions might not come through. 

This PR ensures that the requests are sent synchronously. This makes it so REST only receives them one at the time, and can process them one by one. 

Ideally, these type of issues can be avoid all together with the proposed submission refactor ( #858  ).

## Instructions for Reviewers

**List of changes**
- Removed the "Select/Deselect all" options from the dropdown in the DynamicLookupRelationSearchTab template, as well as the select button next to the dropdown.
    - Until #858 is resolved, the load would be too high anyways.
    - Users can still choose a larger page size, choose "Select page", and create a large amount of relationships that way.
- Added a `requestQueue` to RelationshipEffects. 
- The constructor starts the `executeRequestsInQueue()` method, which listens to the queue and calls either `addRelationship()` or `removeRelationship()`. It'll only start with the next request, after the previous one has completed.
- Added a `RelationOperationType` enum and `RelationOperation` interface. This is how the queue gets its relationship info and knows what to include in the request.
- Instead of calling `addRelationship()` or `removeRelationship()` directly, the effect just adds Operations to the queue.

**How to test**
- Make sure entities are enabled.
- Make sure you already have multiple, local Person entities.
- Start a submission in a collection which has the `submission-process` "Publication" configured. 
- Open the author lookup modal (and the Network tab in DevTools).
- On the tab "Local Authors", when clicking "Select page", verify the POST request are being sent one by one, and don't overlap.
- On the tab "Local Authors", when clicking "Deselect page", verify the DELETE request are being sent one by one, and don't overlap.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).