### PR TITLE
fix selector value in CommunitySidebarSearchListElementComponent

### DIFF
--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
@@ -9,7 +9,7 @@ import { Community } from '../../../../core/shared/community.model';
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
 @Component({
-  selector: 'ds-collection-sidebar-search-list-element',
+  selector: 'ds-community-sidebar-search-list-element',
   templateUrl: '../sidebar-search-list-element.component.html'
 })
 /**


### PR DESCRIPTION
## Description

This PR corrects the selector value of `CommunitySidebarSearchListElementComponent`. It was previously discussed in Slack: https://dspace-org.slack.com/archives/C3TTSEB1V/p1709632996100769