### PR TITLE
fix 'undefined' error on anonymous item page landing

### DIFF
--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -3,7 +3,7 @@
         <div class="col-12">
             <h1 class="border-bottom">{{'item.edit.head' | translate}}</h1>
             <div class="pt-2">
-                <ul class="nav nav-tabs justify-content-start" role="tablist">
+              <ul *ngIf="pages.length > 0" class="nav nav-tabs justify-content-start" role="tablist">
                     <li *ngFor="let page of pages" class="nav-item" role="presentation">
                         <a *ngIf="(page.enabled | async)"
                            [attr.aria-selected]="page.page === currentPage"

--- a/src/app/item-page/simple/item-page.component.ts
+++ b/src/app/item-page/simple/item-page.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit, PLATFORM
 import { ActivatedRoute, Router } from '@angular/router';
 import { isPlatformServer } from '@angular/common';
 
-import { Observable, combineLatest } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 
 import { ItemDataService } from '../../core/data/item-data.service';
@@ -155,6 +155,8 @@ export class ItemPageComponent implements OnInit, OnDestroy {
       switchMap((coarLdnEnabled: boolean) => {
         if (coarLdnEnabled) {
           return this.notifyInfoService.getCoarLdnLocalInboxUrls();
+        } else {
+          return of([]);
         }
       })
     );


### PR DESCRIPTION
## References
_Related issue:_
* Fixes #2842

## Description
when configuration ldn.enabled=false, anonymous item page landing shows an 'undefined' error on browser console.

## Instructions for Reviewers
Error is not present landing on item page as anonymous or logged user, with the ldn.enabled configuration evaluated as true or false.
