### PR TITLE
Simplified ThemedComponent by using Angular's new build in setInput()

### DIFF
--- a/src/app/admin/admin-sidebar/themed-admin-sidebar.component.ts
+++ b/src/app/admin/admin-sidebar/themed-admin-sidebar.component.ts
@@ -27,8 +27,6 @@ export class ThemedAdminSidebarComponent extends ThemedComponent<AdminSidebarCom
    */
   @Input() collapsedSidebarWidth$: Observable<string>;
 
-  protected inAndOutputNames: (keyof AdminSidebarComponent & keyof this)[] = ['collapsedSidebarWidth$', 'expandedSidebarWidth$'];
-
   protected getComponentName(): string {
     return 'AdminSidebarComponent';
   }

--- a/src/app/community-page/sections/sub-com-col-section/sub-collection-list/themed-community-page-sub-collection-list.component.ts
+++ b/src/app/community-page/sections/sub-com-col-section/sub-collection-list/themed-community-page-sub-collection-list.component.ts
@@ -15,7 +15,6 @@ import { CommunityPageSubCollectionListComponent } from './community-page-sub-co
 export class ThemedCollectionPageSubCollectionListComponent extends ThemedComponent<CommunityPageSubCollectionListComponent> {
   @Input() community: Community;
   @Input() pageSize: number;
-  protected inAndOutputNames: (keyof CommunityPageSubCollectionListComponent & keyof this)[] = ['community', 'pageSize'];
 
   protected getComponentName(): string {
     return 'CommunityPageSubCollectionListComponent';

--- a/src/app/community-page/sections/sub-com-col-section/sub-community-list/themed-community-page-sub-community-list.component.ts
+++ b/src/app/community-page/sections/sub-com-col-section/sub-community-list/themed-community-page-sub-community-list.component.ts
@@ -16,7 +16,6 @@ export class ThemedCommunityPageSubCommunityListComponent extends ThemedComponen
 
   @Input() community: Community;
   @Input() pageSize: number;
-  protected inAndOutputNames: (keyof CommunityPageSubCommunityListComponent & keyof this)[] = ['community', 'pageSize'];
 
   protected getComponentName(): string {
     return 'CommunityPageSubCommunityListComponent';

--- a/src/app/dso-shared/dso-edit-metadata/themed-dso-edit-metadata.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/themed-dso-edit-metadata.component.ts
@@ -19,8 +19,6 @@ export class ThemedDsoEditMetadataComponent extends ThemedComponent<DsoEditMetad
 
   @Input() updateDataService: UpdateDataService<DSpaceObject>;
 
-  protected inAndOutputNames: (keyof DsoEditMetadataComponent & keyof this)[] = ['dso', 'updateDataService'];
-
   protected getComponentName(): string {
     return 'DsoEditMetadataComponent';
   }

--- a/src/app/home-page/top-level-community-list/themed-top-level-community-list.component.ts
+++ b/src/app/home-page/top-level-community-list/themed-top-level-community-list.component.ts
@@ -9,7 +9,6 @@ import { TopLevelCommunityListComponent } from './top-level-community-list.compo
   templateUrl: '../../shared/theme-support/themed.component.html',
 })
 export class ThemedTopLevelCommunityListComponent extends ThemedComponent<TopLevelCommunityListComponent> {
-  protected inAndOutputNames: (keyof TopLevelCommunityListComponent & keyof this)[];
 
   protected getComponentName(): string {
     return 'TopLevelCommunityListComponent';

--- a/src/app/item-page/alerts/themed-item-alerts.component.ts
+++ b/src/app/item-page/alerts/themed-item-alerts.component.ts
@@ -16,7 +16,6 @@ import { ItemAlertsComponent } from './item-alerts.component';
   templateUrl: '../../shared/theme-support/themed.component.html',
 })
 export class ThemedItemAlertsComponent extends ThemedComponent<ItemAlertsComponent> {
-  protected inAndOutputNames: (keyof ItemAlertsComponent & keyof this)[] = ['item'];
 
   @Input() item: Item;
 

--- a/src/app/item-page/full/field-components/file-section/themed-full-file-section.component.ts
+++ b/src/app/item-page/full/field-components/file-section/themed-full-file-section.component.ts
@@ -19,8 +19,6 @@ export class ThemedFullFileSectionComponent extends ThemedComponent<FullFileSect
 
   @Input() item: Item;
 
-  protected inAndOutputNames: (keyof FullFileSectionComponent & keyof this)[] = ['item'];
-
   protected getComponentName(): string {
     return 'FullFileSectionComponent';
   }

--- a/src/app/item-page/media-viewer/media-viewer-image/themed-media-viewer-image.component.ts
+++ b/src/app/item-page/media-viewer/media-viewer-image/themed-media-viewer-image.component.ts
@@ -21,12 +21,6 @@ export class ThemedMediaViewerImageComponent extends ThemedComponent<MediaViewer
   @Input() preview?: boolean;
   @Input() image?: string;
 
-  protected inAndOutputNames: (keyof MediaViewerImageComponent & keyof this)[] = [
-    'images',
-    'preview',
-    'image',
-  ];
-
   protected getComponentName(): string {
     return 'MediaViewerImageComponent';
   }

--- a/src/app/item-page/media-viewer/media-viewer-video/themed-media-viewer-video.component.ts
+++ b/src/app/item-page/media-viewer/media-viewer-video/themed-media-viewer-video.component.ts
@@ -22,11 +22,6 @@ export class ThemedMediaViewerVideoComponent extends ThemedComponent<MediaViewer
 
   @Input() captions: Bitstream[];
 
-  protected inAndOutputNames: (keyof MediaViewerVideoComponent & keyof this)[] = [
-    'medias',
-    'captions',
-  ];
-
   protected getComponentName(): string {
     return 'MediaViewerVideoComponent';
   }

--- a/src/app/item-page/media-viewer/themed-media-viewer.component.ts
+++ b/src/app/item-page/media-viewer/themed-media-viewer.component.ts
@@ -21,11 +21,6 @@ export class ThemedMediaViewerComponent extends ThemedComponent<MediaViewerCompo
   @Input() item: Item;
   @Input() mediaOptions: MediaViewerConfig;
 
-  protected inAndOutputNames: (keyof MediaViewerComponent & keyof this)[] = [
-    'item',
-    'mediaOptions',
-  ];
-
   protected getComponentName(): string {
     return 'MediaViewerComponent';
   }

--- a/src/app/item-page/simple/field-components/file-section/themed-file-section.component.ts
+++ b/src/app/item-page/simple/field-components/file-section/themed-file-section.component.ts
@@ -15,8 +15,6 @@ export class ThemedFileSectionComponent extends ThemedComponent<FileSectionCompo
 
     @Input() item: Item;
 
-    protected inAndOutputNames: (keyof FileSectionComponent & keyof this)[] = ['item'];
-
     protected getComponentName(): string {
       return 'FileSectionComponent';
     }

--- a/src/app/item-page/simple/field-components/specific-field/title/themed-item-page-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/title/themed-item-page-field.component.ts
@@ -17,10 +17,6 @@ import { ItemPageTitleFieldComponent } from './item-page-title-field.component';
 })
 export class ThemedItemPageTitleFieldComponent extends ThemedComponent<ItemPageTitleFieldComponent> {
 
-  protected inAndOutputNames: (keyof ItemPageTitleFieldComponent & keyof this)[] = [
-    'item',
-  ];
-
   @Input() item: Item;
 
   protected getComponentName(): string {

--- a/src/app/item-page/simple/metadata-representation-list/themed-metadata-representation-list.component.ts
+++ b/src/app/item-page/simple/metadata-representation-list/themed-metadata-representation-list.component.ts
@@ -13,7 +13,6 @@ import { MetadataRepresentationListComponent } from './metadata-representation-l
   templateUrl: '../../../shared/theme-support/themed.component.html',
 })
 export class ThemedMetadataRepresentationListComponent extends ThemedComponent<MetadataRepresentationListComponent> {
-  protected inAndOutputNames: (keyof MetadataRepresentationListComponent & keyof this)[] = ['parentItem', 'itemType', 'metadataFields', 'label', 'incrementBy'];
 
   @Input() parentItem: Item;
 

--- a/src/app/register-email-form/themed-registry-email-form.component.ts
+++ b/src/app/register-email-form/themed-registry-email-form.component.ts
@@ -20,11 +20,6 @@ export class ThemedRegisterEmailFormComponent extends ThemedComponent<RegisterEm
 
   @Input() typeRequest: string;
 
-  protected inAndOutputNames: (keyof RegisterEmailFormComponent & keyof this)[] = [
-    'MESSAGE_PREFIX',
-    'typeRequest',
-  ];
-
   protected getComponentName(): string {
     return 'RegisterEmailFormComponent';
   }

--- a/src/app/request-copy/email-request-copy/themed-email-request-copy.component.ts
+++ b/src/app/request-copy/email-request-copy/themed-email-request-copy.component.ts
@@ -33,8 +33,6 @@ export class ThemedEmailRequestCopyComponent extends ThemedComponent<EmailReques
    */
   @Input() message: string;
 
-  protected inAndOutputNames: (keyof EmailRequestCopyComponent & keyof this)[] = ['send', 'subject', 'message'];
-
   protected getComponentName(): string {
     return 'EmailRequestCopyComponent';
   }

--- a/src/app/root/themed-root.component.ts
+++ b/src/app/root/themed-root.component.ts
@@ -22,8 +22,6 @@ export class ThemedRootComponent extends ThemedComponent<RootComponent> {
    */
   @Input() shouldShowRouteLoader: boolean;
 
-  protected inAndOutputNames: (keyof RootComponent & keyof this)[] = ['shouldShowRouteLoader', 'shouldShowFullscreenLoader'];
-
   protected getComponentName(): string {
     return 'RootComponent';
   }

--- a/src/app/search-page/themed-configuration-search-page.component.ts
+++ b/src/app/search-page/themed-configuration-search-page.component.ts
@@ -57,9 +57,6 @@ export class ThemedConfigurationSearchPageComponent extends ThemedComponent<Conf
   @Input()
     context: Context;
 
-  protected inAndOutputNames: (keyof ConfigurationSearchPageComponent & keyof this)[] =
-    ['context', 'configuration', 'fixedFilterQuery', 'inPlaceSearch', 'searchEnabled', 'sideBarWidth'];
-
   protected getComponentName(): string {
     return 'ConfigurationSearchPageComponent';
   }

--- a/src/app/shared/auth-nav-menu/user-menu/themed-user-menu.component.ts
+++ b/src/app/shared/auth-nav-menu/user-menu/themed-user-menu.component.ts
@@ -21,8 +21,6 @@ export class ThemedUserMenuComponent extends ThemedComponent<UserMenuComponent>{
    */
   @Input() inExpandableNavbar: boolean;
 
-  protected inAndOutputNames: (keyof UserMenuComponent & keyof this)[] = ['inExpandableNavbar'];
-
   protected getComponentName(): string {
     return 'UserMenuComponent';
   }

--- a/src/app/shared/browse-by/themed-browse-by.component.ts
+++ b/src/app/shared/browse-by/themed-browse-by.component.ts
@@ -54,22 +54,6 @@ export class ThemedBrowseByComponent extends ThemedComponent<BrowseByComponent> 
 
   @Output() sortDirectionChange: EventEmitter<SortDirection> = new EventEmitter();
 
-  protected inAndOutputNames: (keyof BrowseByComponent & keyof this)[] = [
-    'title',
-    'displayTitle',
-    'objects$',
-    'paginationConfig',
-    'sortConfig',
-    'type',
-    'startsWithOptions',
-    'showPaginator',
-    'hideGear',
-    'prev',
-    'next',
-    'pageSizeChange',
-    'sortDirectionChange',
-  ];
-
   protected getComponentName(): string {
     return 'BrowseByComponent';
   }

--- a/src/app/shared/collection-dropdown/themed-collection-dropdown.component.ts
+++ b/src/app/shared/collection-dropdown/themed-collection-dropdown.component.ts
@@ -26,8 +26,6 @@ export class ThemedCollectionDropdownComponent extends ThemedComponent<Collectio
 
   @Output() selectionChange = new EventEmitter();
 
-  protected inAndOutputNames: (keyof CollectionDropdownComponent & keyof this)[] = ['entityType', 'searchComplete', 'theOnlySelectable', 'selectionChange'];
-
   protected getComponentName(): string {
     return 'CollectionDropdownComponent';
   }

--- a/src/app/shared/comcol/comcol-page-browse-by/themed-comcol-page-browse-by.component.ts
+++ b/src/app/shared/comcol/comcol-page-browse-by/themed-comcol-page-browse-by.component.ts
@@ -21,8 +21,6 @@ export class ThemedComcolPageBrowseByComponent extends ThemedComponent<ComcolPag
   @Input() id: string;
   @Input() contentType: string;
 
-  inAndOutputNames: (keyof ComcolPageBrowseByComponent & keyof this)[] = ['id', 'contentType'];
-
   protected getComponentName(): string {
     return 'ComcolPageBrowseByComponent';
   }

--- a/src/app/shared/comcol/comcol-page-handle/themed-comcol-page-handle.component.ts
+++ b/src/app/shared/comcol/comcol-page-handle/themed-comcol-page-handle.component.ts
@@ -24,8 +24,6 @@ export class ThemedComcolPageHandleComponent extends ThemedComponent<ComcolPageH
   // The value of "handle"
   @Input() content: string;
 
-  inAndOutputNames: (keyof ComcolPageHandleComponent & keyof this)[] = ['title', 'content'];
-
   protected getComponentName(): string {
     return 'ComcolPageHandleComponent';
   }

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/themed-create-item-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/themed-create-item-parent-selector.component.ts
@@ -18,8 +18,6 @@ export class ThemedCreateItemParentSelectorComponent
   extends ThemedComponent<CreateItemParentSelectorComponent> {
     @Input() entityType: string;
 
-    protected inAndOutputNames: (keyof CreateItemParentSelectorComponent & keyof this)[] = ['entityType'];
-
     protected getComponentName(): string {
       return 'CreateItemParentSelectorComponent';
     }

--- a/src/app/shared/file-download-link/themed-file-download-link.component.ts
+++ b/src/app/shared/file-download-link/themed-file-download-link.component.ts
@@ -25,8 +25,6 @@ export class ThemedFileDownloadLinkComponent extends ThemedComponent<FileDownloa
 
   @Input() enableRequestACopy: boolean;
 
-  protected inAndOutputNames: (keyof FileDownloadLinkComponent & keyof this)[] = ['bitstream', 'item', 'cssClasses', 'isBlank', 'enableRequestACopy'];
-
   protected getComponentName(): string {
     return 'FileDownloadLinkComponent';
   }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/themed-dynamic-lookup-relation-external-source-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/themed-dynamic-lookup-relation-external-source-tab.component.ts
@@ -20,8 +20,6 @@ import { DsDynamicLookupRelationExternalSourceTabComponent } from './dynamic-loo
   templateUrl: '../../../../../theme-support/themed.component.html',
 })
 export class ThemedDynamicLookupRelationExternalSourceTabComponent extends ThemedComponent<DsDynamicLookupRelationExternalSourceTabComponent> {
-  protected inAndOutputNames: (keyof DsDynamicLookupRelationExternalSourceTabComponent & keyof this)[] = ['label', 'listId',
-    'item', 'collection', 'relationship', 'context', 'query', 'repeatable', 'importedObject', 'externalSource'];
 
   @Input() label: string;
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/themed-dynamic-lookup-relation-search-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/themed-dynamic-lookup-relation-search-tab.component.ts
@@ -23,9 +23,6 @@ import { DsDynamicLookupRelationSearchTabComponent } from './dynamic-lookup-rela
   templateUrl: '../../../../../theme-support/themed.component.html',
 })
 export class ThemedDynamicLookupRelationSearchTabComponent extends ThemedComponent<DsDynamicLookupRelationSearchTabComponent> {
-  protected inAndOutputNames: (keyof DsDynamicLookupRelationSearchTabComponent & keyof this)[] = ['relationship', 'listId',
-    'query', 'repeatable', 'selection$', 'context', 'relationshipType', 'item', 'isLeft', 'toRemove', 'isEditRelationship',
-    'deselectObject', 'selectObject', 'resultFound'];
 
   @Input() relationship: RelationshipOptions;
 

--- a/src/app/shared/loading/themed-loading.component.ts
+++ b/src/app/shared/loading/themed-loading.component.ts
@@ -20,8 +20,6 @@ export class ThemedLoadingComponent extends ThemedComponent<LoadingComponent> {
   @Input() showMessage: boolean;
   @Input() spinner: boolean;
 
-  protected inAndOutputNames: (keyof LoadingComponent & keyof this)[] = ['message', 'showMessage', 'spinner'];
-
   protected getComponentName(): string {
     return 'LoadingComponent';
   }

--- a/src/app/shared/loading/themed-loading.component.ts
+++ b/src/app/shared/loading/themed-loading.component.ts
@@ -1,10 +1,8 @@
 import {
-  ChangeDetectorRef,
   Component,
   Input,
 } from '@angular/core';
 
-import { ThemeService } from '../theme-support/theme.service';
 import { ThemedComponent } from '../theme-support/themed.component';
 import { LoadingComponent } from './loading.component';
 
@@ -23,13 +21,6 @@ export class ThemedLoadingComponent extends ThemedComponent<LoadingComponent> {
   @Input() spinner: boolean;
 
   protected inAndOutputNames: (keyof LoadingComponent & keyof this)[] = ['message', 'showMessage', 'spinner'];
-
-  constructor(
-    protected cdr: ChangeDetectorRef,
-    protected themeService: ThemeService,
-  ) {
-    super(cdr, themeService);
-  }
 
   protected getComponentName(): string {
     return 'LoadingComponent';

--- a/src/app/shared/log-in/themed-log-in.component.ts
+++ b/src/app/shared/log-in/themed-log-in.component.ts
@@ -18,10 +18,6 @@ export class ThemedLogInComponent extends ThemedComponent<LogInComponent> {
 
   @Input() isStandalonePage: boolean;
 
-  protected inAndOutputNames: (keyof LogInComponent & keyof this)[] = [
-    'isStandalonePage',
-  ];
-
   protected getComponentName(): string {
     return 'LogInComponent';
   }

--- a/src/app/shared/object-collection/shared/badges/access-status-badge/themed-access-status-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/access-status-badge/themed-access-status-badge.component.ts
@@ -18,8 +18,6 @@ import { AccessStatusBadgeComponent } from './access-status-badge.component';
 export class ThemedAccessStatusBadgeComponent extends ThemedComponent<AccessStatusBadgeComponent> {
   @Input() object: DSpaceObject;
 
-  protected inAndOutputNames: (keyof AccessStatusBadgeComponent & keyof this)[] = ['object'];
-
   protected getComponentName(): string {
     return 'AccessStatusBadgeComponent';
   }

--- a/src/app/shared/object-collection/shared/badges/my-dspace-status-badge/themed-my-dspace-status-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/my-dspace-status-badge/themed-my-dspace-status-badge.component.ts
@@ -18,8 +18,6 @@ import { MyDSpaceStatusBadgeComponent } from './my-dspace-status-badge.component
 export class ThemedMyDSpaceStatusBadgeComponent extends ThemedComponent<MyDSpaceStatusBadgeComponent> {
   @Input() context: Context;
 
-  protected inAndOutputNames: (keyof MyDSpaceStatusBadgeComponent & keyof this)[] = ['context'];
-
   protected getComponentName(): string {
     return 'MyDSpaceStatusBadgeComponent';
   }

--- a/src/app/shared/object-collection/shared/badges/status-badge/themed-status-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/status-badge/themed-status-badge.component.ts
@@ -18,8 +18,6 @@ import { StatusBadgeComponent } from './status-badge.component';
 export class ThemedStatusBadgeComponent extends ThemedComponent<StatusBadgeComponent> {
   @Input() object: DSpaceObject;
 
-  protected inAndOutputNames: (keyof StatusBadgeComponent & keyof this)[] = ['object'];
-
   protected getComponentName(): string {
     return 'StatusBadgeComponent';
   }

--- a/src/app/shared/object-collection/shared/badges/themed-badges.component.ts
+++ b/src/app/shared/object-collection/shared/badges/themed-badges.component.ts
@@ -19,9 +19,7 @@ import { BadgesComponent } from './badges.component';
 export class ThemedBadgesComponent extends ThemedComponent<BadgesComponent> {
   @Input() object: DSpaceObject;
   @Input() context: Context;
-  @Input() showAccessStatus = false;
-
-  protected inAndOutputNames: (keyof BadgesComponent & keyof this)[] = ['object', 'context', 'showAccessStatus'];
+  @Input() showAccessStatus: boolean;
 
   protected getComponentName(): string {
     return 'BadgesComponent';

--- a/src/app/shared/object-collection/shared/badges/type-badge/themed-type-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/type-badge/themed-type-badge.component.ts
@@ -18,8 +18,6 @@ import { TypeBadgeComponent } from './type-badge.component';
 export class ThemedTypeBadgeComponent extends ThemedComponent<TypeBadgeComponent> {
   @Input() object: DSpaceObject;
 
-  protected inAndOutputNames: (keyof TypeBadgeComponent & keyof this)[] = ['object'];
-
   protected getComponentName(): string {
     return 'TypeBadgeComponent';
   }

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/themed-item-list-preview.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/themed-item-list-preview.component.ts
@@ -19,7 +19,6 @@ import { ItemListPreviewComponent } from './item-list-preview.component';
   templateUrl: '../../../theme-support/themed.component.html',
 })
 export class ThemedItemListPreviewComponent extends ThemedComponent<ItemListPreviewComponent> {
-  protected inAndOutputNames: (keyof ItemListPreviewComponent & keyof this)[] = ['item', 'object', 'badgeContext', 'showSubmitter', 'workflowItem'];
 
   @Input() item: Item;
 

--- a/src/app/shared/object-list/themed-object-list.component.ts
+++ b/src/app/shared/object-list/themed-object-list.component.ts
@@ -156,36 +156,6 @@ export class ThemedObjectListComponent extends ThemedComponent<ObjectListCompone
    */
   @Output() sortFieldChange: EventEmitter<string> = new EventEmitter();
 
-  inAndOutputNames: (keyof ObjectListComponent & keyof this)[] = [
-    'config',
-    'sortConfig',
-    'hasBorder',
-    'hideGear',
-    'hidePagerWhenSinglePage',
-    'selectable',
-    'selectionConfig',
-    'linkType',
-    'context',
-    'hidePaginationDetail',
-    'importable',
-    'importConfig',
-    'showPaginator',
-    'showThumbnails',
-    'contentChange',
-    'prev',
-    'next',
-    'objects',
-    'change',
-    'pageChange',
-    'pageSizeChange',
-    'sortDirectionChange',
-    'paginationChange',
-    'deselectObject',
-    'selectObject',
-    'importObject',
-    'sortFieldChange',
-  ];
-
   protected getComponentName(): string {
     return 'ObjectListComponent';
   }

--- a/src/app/shared/results-back-button/themed-results-back-button.component.ts
+++ b/src/app/shared/results-back-button/themed-results-back-button.component.ts
@@ -16,9 +16,7 @@ export class ThemedResultsBackButtonComponent extends ThemedComponent<ResultsBac
 
   @Input() buttonLabel?: Observable<any>;
 
-  @Input() back: () => void;
-
-  protected inAndOutputNames: (keyof ResultsBackButtonComponent & keyof this)[] = ['back', 'buttonLabel'];
+  @Input() back;
 
   protected getComponentName(): string {
     return 'ResultsBackButtonComponent';

--- a/src/app/shared/search-form/themed-search-form.component.ts
+++ b/src/app/shared/search-form/themed-search-form.component.ts
@@ -38,19 +38,6 @@ export class ThemedSearchFormComponent extends ThemedComponent<SearchFormCompone
 
   @Output() submitSearch: EventEmitter<any> = new EventEmitter();
 
-  protected inAndOutputNames: (keyof SearchFormComponent & keyof this)[] = [
-    'query',
-    'inPlaceSearch',
-    'scope',
-    'hideScopeInUrl',
-    'currentUrl',
-    'large',
-    'brandColor',
-    'searchPlaceholder',
-    'showScopeSelector',
-    'submitSearch',
-  ];
-
   protected getComponentName(): string {
     return 'SearchFormComponent';
   }

--- a/src/app/shared/search/search-filters/themed-search-filters.component.ts
+++ b/src/app/shared/search/search-filters/themed-search-filters.component.ts
@@ -25,9 +25,6 @@ export class ThemedSearchFiltersComponent extends ThemedComponent<SearchFiltersC
   @Input() refreshFilters: Observable<any>;
   @Input() filters: Observable<RemoteData<SearchFilterConfig[]>>;
 
-  protected inAndOutputNames: (keyof SearchFiltersComponent & keyof this)[] = [
-    'filters', 'currentConfiguration', 'currentScope', 'inPlaceSearch', 'refreshFilters'];
-
   protected getComponentName(): string {
     return 'SearchFiltersComponent';
   }

--- a/src/app/shared/search/search-results/themed-search-results.component.ts
+++ b/src/app/shared/search/search-results/themed-search-results.component.ts
@@ -31,8 +31,6 @@ import {
 })
 export class ThemedSearchResultsComponent extends ThemedComponent<SearchResultsComponent> {
 
-  protected inAndOutputNames: (keyof SearchResultsComponent & keyof this)[] = ['linkType', 'searchResults', 'searchConfig', 'showCsvExport', 'showThumbnails', 'sortConfig', 'viewMode', 'configuration', 'disableHeader', 'selectable', 'context', 'hidePaginationDetail', 'selectionConfig', 'contentChange', 'deselectObject', 'selectObject'];
-
   @Input() linkType: CollectionElementLinkType;
 
   @Input() searchResults: RemoteData<PaginatedList<SearchResult<DSpaceObject>>>;

--- a/src/app/shared/search/search-settings/themed-search-settings.component.ts
+++ b/src/app/shared/search/search-settings/themed-search-settings.component.ts
@@ -19,10 +19,6 @@ export class ThemedSearchSettingsComponent extends ThemedComponent<SearchSetting
   @Input() currentSortOption: SortOptions;
   @Input() sortOptionsList: SortOptions[];
 
-
-  protected inAndOutputNames: (keyof SearchSettingsComponent & keyof this)[] = [
-    'currentSortOption', 'sortOptionsList'];
-
   protected getComponentName(): string {
     return 'SearchSettingsComponent';
   }

--- a/src/app/shared/search/search-sidebar/themed-search-sidebar.component.ts
+++ b/src/app/shared/search/search-sidebar/themed-search-sidebar.component.ts
@@ -35,19 +35,14 @@ export class ThemedSearchSidebarComponent extends ThemedComponent<SearchSidebarC
   @Input() filters: Observable<RemoteData<SearchFilterConfig[]>>;
   @Input() resultCount;
   @Input() viewModeList: ViewMode[];
-  @Input() showViewModes = true;
-  @Input() inPlaceSearch;
+  @Input() showViewModes: boolean;
+  @Input() inPlaceSearch: boolean;
   @Input() searchOptions: PaginatedSearchOptions;
   @Input() sortOptionsList: SortOptions[];
   @Input() refreshFilters: BehaviorSubject<boolean>;
   @Output() toggleSidebar = new EventEmitter<boolean>();
   @Output() changeConfiguration: EventEmitter<SearchConfigurationOption> = new EventEmitter<SearchConfigurationOption>();
   @Output() changeViewMode: EventEmitter<ViewMode> = new EventEmitter<ViewMode>();
-
-  protected inAndOutputNames: (keyof SearchSidebarComponent & keyof this)[] = [
-    'configuration', 'configurationList', 'currentScope', 'currentSortOption',
-    'resultCount', 'filters', 'viewModeList', 'showViewModes', 'inPlaceSearch',
-    'searchOptions', 'sortOptionsList', 'refreshFilters', 'toggleSidebar', 'changeConfiguration', 'changeViewMode'];
 
   protected getComponentName(): string {
     return 'SearchSidebarComponent';

--- a/src/app/shared/search/themed-search.component.ts
+++ b/src/app/shared/search/themed-search.component.ts
@@ -25,36 +25,6 @@ import { SearchConfigurationOption } from './search-switch-configuration/search-
 })
 export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
 
-  protected inAndOutputNames: (keyof SearchComponent & keyof this)[] = [
-    'configurationList',
-    'context',
-    'configuration',
-    'fixedFilterQuery',
-    'useCachedVersionIfAvailable',
-    'inPlaceSearch',
-    'linkType',
-    'paginationId',
-    'searchEnabled',
-    'sideBarWidth',
-    'searchFormPlaceholder',
-    'selectable',
-    'selectionConfig',
-    'showCsvExport',
-    'showSidebar',
-    'showThumbnails',
-    'showViewModes',
-    'useUniquePageId',
-    'viewModeList',
-    'showScopeSelector',
-    'trackStatistics',
-    'query',
-    'scope',
-    'hideScopeInUrl',
-    'resultFound',
-    'deselectObject',
-    'selectObject',
-  ];
-
   @Input() configurationList: SearchConfigurationOption[];
 
   @Input() context: Context;

--- a/src/app/shared/theme-support/test/custom/themed-test.component.spec.ts
+++ b/src/app/shared/theme-support/test/custom/themed-test.component.spec.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  Input,
+} from '@angular/core';
 
 // noinspection AngularMissingOrInvalidDeclarationInModule
 @Component({
@@ -6,6 +9,6 @@ import { Component } from '@angular/core';
   template: '',
 })
 export class TestComponent {
-  type = 'themed';
-  testInput = 'unset';
+  @Input() type = 'themed';
+  @Input() testInput = 'unset';
 }

--- a/src/app/shared/theme-support/test/test.component.spec.ts
+++ b/src/app/shared/theme-support/test/test.component.spec.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  Input,
+} from '@angular/core';
 
 // noinspection AngularMissingOrInvalidDeclarationInModule
 @Component({
@@ -6,6 +9,6 @@ import { Component } from '@angular/core';
   template: '',
 })
 export class TestComponent {
-  type = 'default';
-  testInput = 'unset';
+  @Input() type = 'default';
+  @Input() testInput = 'unset';
 }

--- a/src/app/shared/theme-support/themed.component.spec.ts
+++ b/src/app/shared/theme-support/themed.component.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import {
   Component,
-  NO_ERRORS_SCHEMA,
+  Input,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -21,9 +21,9 @@ import { ThemedComponent } from './themed.component';
   templateUrl: './themed.component.html',
 })
 class TestThemedComponent extends ThemedComponent<TestComponent> {
-  protected inAndOutputNames: (keyof TestComponent & keyof this)[] = ['testInput'];
+  @Input() type: string;
 
-  testInput = 'unset';
+  @Input() testInput: string;
 
   protected getComponentName(): string {
     return 'TestComponent';
@@ -49,7 +49,6 @@ describe('ThemedComponent', () => {
       providers: [
         { provide: ThemeService, useValue: themeService },
       ],
-      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }
 
@@ -57,7 +56,7 @@ describe('ThemedComponent', () => {
     fixture = TestBed.createComponent(TestThemedComponent);
     component = fixture.componentInstance;
     spyOn(component as any, 'importThemedComponent').and.callThrough();
-    component.testInput = 'changed';
+    fixture.componentRef.setInput('testInput', 'changed');
     fixture.detectChanges();
   }
 

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -41,7 +41,11 @@ export abstract class ThemedComponent<T> implements AfterViewInit, OnDestroy, On
 
   protected subs: Subscription[] = [];
 
-  protected inAndOutputNames: (keyof T & keyof this)[] = [];
+  /**
+   * This variable should not be used anymore, since this has been split into separate lists that are automatically
+   * filled in.
+   */
+  private inAndOutputNames: (keyof T & keyof this)[];
 
   private inputNames: string[] = [];
 

--- a/src/app/submission/sections/upload/file/themed-section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/themed-section-upload-file.component.ts
@@ -78,19 +78,6 @@ export class ThemedSubmissionSectionUploadFileComponent
    */
   @Input() submissionId: string;
 
-  protected inAndOutputNames: (keyof SubmissionSectionUploadFileComponent & keyof this)[] = [
-    'availableAccessConditionOptions',
-    'isPrimary',
-    'collectionId',
-    'collectionPolicyType',
-    'configMetadataForm',
-    'fileId',
-    'fileIndex',
-    'fileName',
-    'sectionId',
-    'submissionId',
-  ];
-
   protected getComponentName(): string {
     return 'SubmissionSectionUploadFileComponent';
   }

--- a/src/app/thumbnail/themed-thumbnail.component.ts
+++ b/src/app/thumbnail/themed-thumbnail.component.ts
@@ -25,14 +25,6 @@ export class ThemedThumbnailComponent extends ThemedComponent<ThumbnailComponent
 
   @Input() limitWidth?: boolean;
 
-  protected inAndOutputNames: (keyof ThumbnailComponent & keyof this)[] = [
-    'thumbnail',
-    'defaultImage',
-    'alt',
-    'placeholder',
-    'limitWidth',
-  ];
-
   protected getComponentName(): string {
     return 'ThumbnailComponent';
   }


### PR DESCRIPTION
## References
* Related #2235

## Description
Since Angular [14.1.0](https://github.com/angular/angular/releases/tag/14.1.0) it is now possible to update the `@Input()`s on a `ComponentRef` using the method `setInput()`. This has some advantages, because now it automatically calls the `ngOnChanges` method, marks the changes as dirty and `fixture.whenStable()` now also waits for the fixture to be stable in child components, so by using this we can simplify our code.

## Instructions for Reviewers
List of changes in this PR:
* To achieve this the `inAndOutputNames` had to be split into 2 separate arrays (this was already done in PR #2339 for the loader components)
* Because Angular also keeps a list of all the `@Input()`s & `@Output()`s and that we can easily forget to manually sync this list, I removed all those lists in the themed components and used Angular's lists instead.
* I did leave the old `inAndOutputNames` list in the `ThemedComponent` for the moment (can probably be removed for 9.0) and put in on private on purpose, so that it throws a compilation error if one is still present in a themed component

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
