### PR TITLE
Allow opening ds-metadata-uri-values links in a new window

### DIFF
--- a/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.html
+++ b/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.html
@@ -1,5 +1,5 @@
 <ds-metadata-field-wrapper [label]="label | translate">
-    <a class="dont-break-out" *ngFor="let mdValue of mdValues; let last=last;" [href]="mdValue.value">
+    <a class="dont-break-out" *ngFor="let mdValue of mdValues; let last=last;" [href]="mdValue.value" [target]="linkTarget">
        {{ linktext || mdValue.value }}<span *ngIf="!last" [innerHTML]="separator"></span>
     </a>
 </ds-metadata-field-wrapper>

--- a/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.spec.ts
+++ b/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.spec.ts
@@ -73,6 +73,13 @@ describe('MetadataUriValuesComponent', () => {
     expect(separators.length).toBe(mockMetadata.length - 1);
   });
 
+  it('should contain the correct target attribute for metadata links', () => {
+    const links = fixture.debugElement.queryAll(By.css('a'));
+    for (const link of links) {
+      expect(link.nativeElement.getAttribute('target')).toBe('_blank');
+    }
+  });
+
   describe('when linktext is defined', () => {
 
     beforeEach(() => {

--- a/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.ts
+++ b/src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.ts
@@ -37,4 +37,10 @@ export class MetadataUriValuesComponent extends MetadataValuesComponent {
    * The label for this iteration of metadata values
    */
   @Input() label: string;
+
+  /**
+   * The target attribute for the metadata links.
+   * Defaults to '_blank' to open links in a new window/tab.
+   */
+  @Input() linkTarget = '_blank';
 }


### PR DESCRIPTION
## References
* Fixes #2834
## Description
This feature request proposes adding a new optional input parameter to the `<ds-metadata-uri-values>` component in order to specify the link target, allowing metadata links to open in a new window/tab.
## Instructions for Reviewers
List of changes in this PR:
* Added a new optional input parameter `linkTarget` to the `<ds-metadata-uri-values>` component. The default value of this parameter is `_blank`, this will make sure the link is opened in a new window/tab.
* Added a test case in the `src/app/item-page/field-components/metadata-uri-values/metadata-uri-values.component.spec.ts` to verify the correct application of the `linkTarget` attribute to metadata links.

How to test: 
* Go to an item page, for example a publication
* Click on the link that's under the URI-title
* The link now opens in a new tab/window

Reason for changes: If the user clicks a link that leads away from DSpace, we want it to open in a new window.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
