### PR TITLE
add import of missing Angular interfaces

### DIFF
--- a/src/app/admin/admin-search-page/admin-search-results/admin-search-result-grid-element/collection-search-result/collection-admin-search-result-grid-element.component.ts
+++ b/src/app/admin/admin-search-page/admin-search-results/admin-search-result-grid-element/collection-search-result/collection-admin-search-result-grid-element.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
-
 import { getCollectionEditRoute } from '../../../../../collection-page/collection-page-routing-paths';
 import { Collection } from '../../../../../core/shared/collection.model';
 import { Context } from '../../../../../core/shared/context.model';
@@ -21,10 +23,10 @@ import { SearchResultGridElementComponent } from '../../../../../shared/object-g
 /**
  * The component for displaying a list element for a collection search result on the admin search page
  */
-export class CollectionAdminSearchResultGridElementComponent extends SearchResultGridElementComponent<CollectionSearchResult, Collection> {
+export class CollectionAdminSearchResultGridElementComponent extends SearchResultGridElementComponent<CollectionSearchResult, Collection> implements OnInit {
   editPath: string;
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.editPath = getCollectionEditRoute(this.dso.uuid);
   }

--- a/src/app/admin/admin-search-page/admin-search-results/admin-search-result-grid-element/community-search-result/community-admin-search-result-grid-element.component.ts
+++ b/src/app/admin/admin-search-page/admin-search-results/admin-search-result-grid-element/community-search-result/community-admin-search-result-grid-element.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { getCommunityEditRoute } from '../../../../../community-page/community-page-routing-paths';
@@ -21,10 +24,10 @@ import { SearchResultGridElementComponent } from '../../../../../shared/object-g
 /**
  * The component for displaying a list element for a community search result on the admin search page
  */
-export class CommunityAdminSearchResultGridElementComponent extends SearchResultGridElementComponent<CommunitySearchResult, Community> {
+export class CommunityAdminSearchResultGridElementComponent extends SearchResultGridElementComponent<CommunitySearchResult, Community> implements OnInit {
   editPath: string;
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.editPath = getCommunityEditRoute(this.dso.uuid);
   }

--- a/src/app/admin/admin-search-page/admin-search-results/admin-search-result-list-element/collection-search-result/collection-admin-search-result-list-element.component.ts
+++ b/src/app/admin/admin-search-page/admin-search-results/admin-search-result-list-element/collection-search-result/collection-admin-search-result-list-element.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -22,10 +25,10 @@ import { SearchResultListElementComponent } from '../../../../../shared/object-l
 /**
  * The component for displaying a list element for a collection search result on the admin search page
  */
-export class CollectionAdminSearchResultListElementComponent extends SearchResultListElementComponent<CollectionSearchResult, Collection> {
+export class CollectionAdminSearchResultListElementComponent extends SearchResultListElementComponent<CollectionSearchResult, Collection> implements OnInit {
   editPath: string;
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.editPath = getCollectionEditRoute(this.dso.uuid);
   }

--- a/src/app/admin/admin-search-page/admin-search-results/admin-search-result-list-element/community-search-result/community-admin-search-result-list-element.component.ts
+++ b/src/app/admin/admin-search-page/admin-search-results/admin-search-result-list-element/community-search-result/community-admin-search-result-list-element.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -22,10 +25,10 @@ import { SearchResultListElementComponent } from '../../../../../shared/object-l
 /**
  * The component for displaying a list element for a community search result on the admin search page
  */
-export class CommunityAdminSearchResultListElementComponent extends SearchResultListElementComponent<CommunitySearchResult, Community> {
+export class CommunityAdminSearchResultListElementComponent extends SearchResultListElementComponent<CommunitySearchResult, Community> implements OnInit {
   editPath: string;
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.editPath = getCommunityEditRoute(this.dso.uuid);
   }

--- a/src/app/collection-page/edit-collection-page/collection-curate/collection-curate.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-curate/collection-curate.component.ts
@@ -1,5 +1,8 @@
 import { AsyncPipe } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -28,7 +31,7 @@ import { hasValue } from '../../../shared/empty.util';
   ],
   standalone: true,
 })
-export class CollectionCurateComponent {
+export class CollectionCurateComponent implements OnInit {
   dsoRD$: Observable<RemoteData<Collection>>;
   collectionName$: Observable<string>;
 

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source-controls/collection-source-controls.component.ts
@@ -95,7 +95,7 @@ export class CollectionSourceControlsComponent implements OnInit, OnDestroy {
   ) {
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     // ensure the contentSource gets updated after being set to stale
     this.contentSource$ = this.collectionService.findByHref(this.collection._links.self.href, false).pipe(
       getAllSucceededRemoteDataPayload(),

--- a/src/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
+++ b/src/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
@@ -2,7 +2,10 @@ import {
   AsyncPipe,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import {
   ActivatedRoute,
   Router,
@@ -45,7 +48,7 @@ import { BrowserOnlyPipe } from '../../shared/utils/browser-only.pipe';
 /**
  * Component for a user to enter a new password for a forgot token.
  */
-export class ForgotPasswordFormComponent {
+export class ForgotPasswordFormComponent implements OnInit {
 
   registration$: Observable<Registration>;
 

--- a/src/app/item-page/edit-item-page/item-register-doi/item-register-doi.component.ts
+++ b/src/app/item-page/edit-item-page/item-register-doi/item-register-doi.component.ts
@@ -3,7 +3,10 @@ import {
   NgForOf,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import {
   ActivatedRoute,
   Router,
@@ -47,7 +50,7 @@ import { AbstractSimpleItemActionComponent } from '../simple-item-action/abstrac
 /**
  * Component responsible for rendering the Item Register DOI page
  */
-export class ItemRegisterDoiComponent extends AbstractSimpleItemActionComponent {
+export class ItemRegisterDoiComponent extends AbstractSimpleItemActionComponent implements OnInit {
 
   protected messageKey = 'register-doi';
   doiToUpdateMessage = 'item.edit.' + this.messageKey + '.to-update';

--- a/src/app/item-page/edit-item-page/item-version-history/item-version-history.component.ts
+++ b/src/app/item-page/edit-item-page/item-version-history/item-version-history.component.ts
@@ -2,7 +2,10 @@ import {
   AsyncPipe,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -28,7 +31,7 @@ import { ItemVersionsComponent } from '../../versions/item-versions.component';
 /**
  * Component for listing and managing an item's version history
  */
-export class ItemVersionHistoryComponent {
+export class ItemVersionHistoryComponent implements OnInit {
   /**
    * The item to display the version history for
    */

--- a/src/app/item-page/simple/related-items/related-items-component.ts
+++ b/src/app/item-page/simple/related-items/related-items-component.ts
@@ -10,6 +10,7 @@ import {
   ElementRef,
   Inject,
   Input,
+  OnInit,
   PLATFORM_ID,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -43,7 +44,7 @@ import { AbstractIncrementalListComponent } from '../abstract-incremental-list/a
  * This component is used for displaying relations between items
  * It expects a parent item and relationship type, as well as a label to display on top
  */
-export class RelatedItemsComponent extends AbstractIncrementalListComponent<Observable<RemoteData<PaginatedList<Item>>>> {
+export class RelatedItemsComponent extends AbstractIncrementalListComponent<Observable<RemoteData<PaginatedList<Item>>>> implements OnInit {
 
   /**
    * The parent of the list of related items to display

--- a/src/app/process-page/form/process-parameters/parameter-value-input/date-value-input/date-value-input.component.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/date-value-input/date-value-input.component.ts
@@ -2,6 +2,7 @@ import { NgIf } from '@angular/common';
 import {
   Component,
   Input,
+  OnInit,
   Optional,
 } from '@angular/core';
 import {
@@ -27,7 +28,7 @@ import { ValueInputComponent } from '../value-input.component';
   standalone: true,
   imports: [FormsModule, NgIf, TranslateModule],
 })
-export class DateValueInputComponent extends ValueInputComponent<string> {
+export class DateValueInputComponent extends ValueInputComponent<string> implements OnInit {
   /**
    * The current value of the date string
    */
@@ -38,7 +39,7 @@ export class DateValueInputComponent extends ValueInputComponent<string> {
    */
   @Input() initialValue;
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.value = this.initialValue;
   }
 

--- a/src/app/process-page/form/process-parameters/parameter-value-input/string-value-input/string-value-input.component.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/string-value-input/string-value-input.component.ts
@@ -2,6 +2,7 @@ import { NgIf } from '@angular/common';
 import {
   Component,
   Input,
+  OnInit,
   Optional,
 } from '@angular/core';
 import {
@@ -27,7 +28,7 @@ import { ValueInputComponent } from '../value-input.component';
   standalone: true,
   imports: [FormsModule, NgIf, TranslateModule],
 })
-export class StringValueInputComponent extends ValueInputComponent<string> {
+export class StringValueInputComponent extends ValueInputComponent<string> implements OnInit {
   /**
    * The current value of the string
    */
@@ -38,7 +39,7 @@ export class StringValueInputComponent extends ValueInputComponent<string> {
    */
   @Input() initialValue;
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.value = this.initialValue;
   }
 

--- a/src/app/process-page/form/process-parameters/process-parameters.component.ts
+++ b/src/app/process-page/form/process-parameters/process-parameters.component.ts
@@ -7,6 +7,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnInit,
   Optional,
   Output,
   SimpleChanges,
@@ -39,7 +40,7 @@ import { ParameterSelectComponent } from './parameter-select/parameter-select.co
   standalone: true,
   imports: [NgIf, NgFor, ParameterSelectComponent, TranslateModule],
 })
-export class ProcessParametersComponent implements OnChanges {
+export class ProcessParametersComponent implements OnChanges, OnInit {
   /**
    * The currently selected script
    */
@@ -59,7 +60,7 @@ export class ProcessParametersComponent implements OnChanges {
    */
   parameterValues: ProcessParameter[];
 
-  ngOnInit() {
+  ngOnInit(): void {
     if (hasValue(this.initialParams)) {
       this.parameterValues = this.initialParams;
     }

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-expandable-menu-section/dso-edit-menu-expandable-section.component.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-expandable-menu-section/dso-edit-menu-expandable-section.component.ts
@@ -8,6 +8,7 @@ import {
   Component,
   Inject,
   Injector,
+  OnInit,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import {
@@ -34,7 +35,7 @@ import { MenuService } from '../../../menu/menu.service';
   standalone: true,
   imports: [NgbDropdownModule, NgbTooltipModule, NgFor, NgIf, NgComponentOutlet, TranslateModule, AsyncPipe],
 })
-export class DsoEditMenuExpandableSectionComponent extends MenuSectionComponent {
+export class DsoEditMenuExpandableSectionComponent extends MenuSectionComponent implements OnInit {
 
   menuID: MenuID = MenuID.DSO_EDIT;
   itemModel;

--- a/src/app/shared/error/error.component.ts
+++ b/src/app/shared/error/error.component.ts
@@ -1,6 +1,8 @@
 import {
   Component,
   Input,
+  OnDestroy,
+  OnInit,
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
@@ -15,7 +17,7 @@ import { AlertType } from '../alert/alert-type';
   standalone: true,
   imports: [AlertComponent],
 })
-export class ErrorComponent {
+export class ErrorComponent implements OnDestroy, OnInit {
 
   @Input() message = 'Error...';
 
@@ -31,7 +33,7 @@ export class ErrorComponent {
 
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     if (this.message === undefined) {
       this.subscription = this.translate.get('error.default').subscribe((message: string) => {
         this.message = message;
@@ -39,7 +41,7 @@ export class ErrorComponent {
     }
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     if (this.subscription !== undefined) {
       this.subscription.unsubscribe();
     }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/selection-tab/dynamic-lookup-relation-selection-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/selection-tab/dynamic-lookup-relation-selection-tab.component.ts
@@ -6,6 +6,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnInit,
   Output,
 } from '@angular/core';
 import { Router } from '@angular/router';
@@ -57,7 +58,7 @@ import { PaginatedSearchOptions } from '../../../../../search/models/paginated-s
 /**
  * Tab for inside the lookup model that represents the currently selected relationships
  */
-export class DsDynamicLookupRelationSelectionTabComponent {
+export class DsDynamicLookupRelationSelectionTabComponent implements OnInit {
   /**
    * A string that describes the type of relationship
    */
@@ -120,7 +121,7 @@ export class DsDynamicLookupRelationSelectionTabComponent {
   /**
    * Set up the selection and pagination on load
    */
-  ngOnInit() {
+  ngOnInit(): void {
     this.resetRoute();
     this.selectionRD$ = this.searchConfigService.paginatedSearchOptions
       .pipe(

--- a/src/app/shared/object-collection/shared/badges/access-status-badge/access-status-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/access-status-badge/access-status-badge.component.ts
@@ -5,6 +5,8 @@ import {
 import {
   Component,
   Input,
+  OnDestroy,
+  OnInit,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -35,7 +37,7 @@ import { AccessStatusObject } from './access-status.model';
 /**
  * Component rendering the access status of an item as a badge
  */
-export class AccessStatusBadgeComponent {
+export class AccessStatusBadgeComponent implements OnDestroy, OnInit {
 
   @Input() object: DSpaceObject;
   accessStatus$: Observable<string>;

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/workflow-item-search-result/workflow-item-search-result-detail-element.component.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/workflow-item-search-result/workflow-item-search-result-detail-element.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 import { find } from 'rxjs/operators';
 import { Context } from 'src/app/core/shared/context.model';
@@ -29,7 +32,7 @@ import { SearchResultDetailElementComponent } from '../search-result-detail-elem
 })
 
 @listableObjectComponent(WorkflowItemSearchResult, ViewMode.DetailedListElement)
-export class WorkflowItemSearchResultDetailElementComponent extends SearchResultDetailElementComponent<WorkflowItemSearchResult, WorkflowItem> {
+export class WorkflowItemSearchResultDetailElementComponent extends SearchResultDetailElementComponent<WorkflowItemSearchResult, WorkflowItem> implements OnInit {
 
   /**
    * The item object that belonging to the result object
@@ -51,7 +54,7 @@ export class WorkflowItemSearchResultDetailElementComponent extends SearchResult
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.linkService.resolveLink(this.dso, followLink('item'));
     this.initItem(this.dso.item as Observable<RemoteData<Item>>);

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/workspace-item-search-result/workspace-item-search-result-detail-element.component.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/workspace-item-search-result/workspace-item-search-result-detail-element.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 import { find } from 'rxjs/operators';
 
@@ -29,7 +32,7 @@ import { SearchResultDetailElementComponent } from '../search-result-detail-elem
 })
 
 @listableObjectComponent(WorkspaceItemSearchResult, ViewMode.DetailedListElement)
-export class WorkspaceItemSearchResultDetailElementComponent extends SearchResultDetailElementComponent<WorkspaceItemSearchResult, WorkspaceItem> {
+export class WorkspaceItemSearchResultDetailElementComponent extends SearchResultDetailElementComponent<WorkspaceItemSearchResult, WorkspaceItem> implements OnInit {
 
   /**
    * The item object that belonging to the result object
@@ -51,7 +54,7 @@ export class WorkspaceItemSearchResultDetailElementComponent extends SearchResul
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.linkService.resolveLink(this.dso, followLink('item'));
     this.initItem(this.dso.item as Observable<RemoteData<Item>>);

--- a/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.ts
@@ -3,7 +3,10 @@ import {
   NgFor,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -35,7 +38,7 @@ import { SearchResultGridElementComponent } from '../../search-result-grid-eleme
 /**
  * The component for displaying a grid element for an item search result of the type Publication
  */
-export class ItemSearchResultGridElementComponent extends SearchResultGridElementComponent<ItemSearchResult, Item> {
+export class ItemSearchResultGridElementComponent extends SearchResultGridElementComponent<ItemSearchResult, Item> implements OnInit {
   /**
    * Route to the item's page
    */

--- a/src/app/shared/object-list/identifier-data/identifier-data.component.ts
+++ b/src/app/shared/object-list/identifier-data/identifier-data.component.ts
@@ -5,6 +5,7 @@ import {
 import {
   Component,
   Input,
+  OnInit,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -28,7 +29,7 @@ import { IdentifierData } from './identifier-data.model';
 /**
  * Component rendering an identifier, eg. DOI or handle
  */
-export class IdentifierDataComponent {
+export class IdentifierDataComponent implements OnInit {
 
   @Input() item: Item;
   identifiers$: Observable<IdentifierData>;

--- a/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-approved-search-result/claimed-approved-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-approved-search-result/claimed-approved-search-result-list-element.component.ts
@@ -5,6 +5,7 @@ import {
 import {
   Component,
   Inject,
+  OnInit,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -40,7 +41,7 @@ import { ThemedItemListPreviewComponent } from '../../item-list-preview/themed-i
   imports: [NgIf, ThemedItemListPreviewComponent, AsyncPipe, TranslateModule, VarDirective],
 })
 @listableObjectComponent(ClaimedApprovedTaskSearchResult, ViewMode.ListElement)
-export class ClaimedApprovedSearchResultListElementComponent extends SearchResultListElementComponent<ClaimedTaskSearchResult, ClaimedTask> {
+export class ClaimedApprovedSearchResultListElementComponent extends SearchResultListElementComponent<ClaimedTaskSearchResult, ClaimedTask> implements OnInit {
 
   /**
    * A boolean representing if to show submitter information
@@ -69,7 +70,7 @@ export class ClaimedApprovedSearchResultListElementComponent extends SearchResul
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.linkService.resolveLinks(this.dso,
       followLink('workflowitem',

--- a/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-declined-search-result/claimed-declined-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/claimed-search-result/claimed-declined-search-result/claimed-declined-search-result-list-element.component.ts
@@ -5,6 +5,7 @@ import {
 import {
   Component,
   Inject,
+  OnInit,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -40,7 +41,7 @@ import { ThemedItemListPreviewComponent } from '../../item-list-preview/themed-i
   imports: [NgIf, ThemedItemListPreviewComponent, AsyncPipe, TranslateModule, VarDirective],
 })
 @listableObjectComponent(ClaimedDeclinedTaskSearchResult, ViewMode.ListElement)
-export class ClaimedDeclinedSearchResultListElementComponent extends SearchResultListElementComponent<ClaimedTaskSearchResult, ClaimedTask> {
+export class ClaimedDeclinedSearchResultListElementComponent extends SearchResultListElementComponent<ClaimedTaskSearchResult, ClaimedTask> implements OnInit {
 
   /**
    * A boolean representing if to show submitter information
@@ -69,7 +70,7 @@ export class ClaimedDeclinedSearchResultListElementComponent extends SearchResul
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.linkService.resolveLinks(this.dso,
       followLink('workflowitem',

--- a/src/app/shared/object-list/my-dspace-result-list-element/workflow-item-search-result/workflow-item-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/workflow-item-search-result/workflow-item-search-result-list-element.component.ts
@@ -6,6 +6,7 @@ import {
 import {
   Component,
   Inject,
+  OnInit,
 } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
@@ -43,7 +44,7 @@ import { SearchResultListElementComponent } from '../../search-result-list-eleme
 })
 
 @listableObjectComponent(WorkflowItemSearchResult, ViewMode.ListElement)
-export class WorkflowItemSearchResultListElementComponent extends SearchResultListElementComponent<WorkflowItemSearchResult, WorkflowItem> {
+export class WorkflowItemSearchResultListElementComponent extends SearchResultListElementComponent<WorkflowItemSearchResult, WorkflowItem> implements OnInit {
   LinkTypes = CollectionElementLinkType;
 
   ViewModes = ViewMode;
@@ -75,7 +76,7 @@ export class WorkflowItemSearchResultListElementComponent extends SearchResultLi
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.deriveSearchResult();
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;

--- a/src/app/shared/object-list/my-dspace-result-list-element/workspace-item-search-result/workspace-item-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/workspace-item-search-result/workspace-item-search-result-list-element.component.ts
@@ -6,6 +6,7 @@ import {
 import {
   Component,
   Inject,
+  OnInit,
 } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
@@ -43,7 +44,7 @@ import { SearchResultListElementComponent } from '../../search-result-list-eleme
 })
 
 @listableObjectComponent(WorkspaceItemSearchResult, ViewMode.ListElement)
-export class  WorkspaceItemSearchResultListElementComponent extends SearchResultListElementComponent<WorkspaceItemSearchResult, WorkspaceItem> {
+export class  WorkspaceItemSearchResultListElementComponent extends SearchResultListElementComponent<WorkspaceItemSearchResult, WorkspaceItem> implements OnInit {
   LinkTypes = CollectionElementLinkType;
 
   ViewModes = ViewMode;
@@ -75,7 +76,7 @@ export class  WorkspaceItemSearchResultListElementComponent extends SearchResult
   /**
    * Initialize all instance variables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.deriveSearchResult();
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;

--- a/src/app/shared/object-list/search-result-list-element/collection-search-result/collection-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/collection-search-result/collection-search-result-list-element.component.ts
@@ -2,7 +2,10 @@ import {
   NgClass,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Collection } from '../../../../core/shared/collection.model';
@@ -23,7 +26,7 @@ import { SearchResultListElementComponent } from '../search-result-list-element.
  * Component representing a collection search result in list view
  */
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement)
-export class CollectionSearchResultListElementComponent extends SearchResultListElementComponent<CollectionSearchResult, Collection> {
+export class CollectionSearchResultListElementComponent extends SearchResultListElementComponent<CollectionSearchResult, Collection> implements OnInit {
 
   /**
    * Display thumbnails if required by configuration

--- a/src/app/shared/object-list/search-result-list-element/community-search-result/community-search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/community-search-result/community-search-result-list-element.component.ts
@@ -2,7 +2,10 @@ import {
   NgClass,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Community } from '../../../../core/shared/community.model';
@@ -23,12 +26,11 @@ import { SearchResultListElementComponent } from '../search-result-list-element.
  * Component representing a community search result in list view
  */
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement)
-export class CommunitySearchResultListElementComponent extends SearchResultListElementComponent<CommunitySearchResult, Community> {
+export class CommunitySearchResultListElementComponent extends SearchResultListElementComponent<CommunitySearchResult, Community> implements OnInit {
   /**
    * Display thumbnails if required by configuration
    */
   showThumbnails: boolean;
-
 
   ngOnInit(): void {
     super.ngOnInit();

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
@@ -3,7 +3,10 @@ import {
   NgClass,
   NgIf,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   Observable,
@@ -41,7 +44,7 @@ import { SearchResultListElementComponent } from '../search-result-list-element/
  * It displays the name of the parent, title and description of the object. All of which are customizable in the child
  * component by overriding the relevant methods of this component
  */
-export class SidebarSearchListElementComponent<T extends SearchResult<K>, K extends DSpaceObject> extends SearchResultListElementComponent<T, K> {
+export class SidebarSearchListElementComponent<T extends SearchResult<K>, K extends DSpaceObject> extends SearchResultListElementComponent<T, K> implements OnInit {
   /**
    * Observable for the title of the parent object (displayed above the object's title)
    */

--- a/src/app/shared/object-select/collection-select/collection-select.component.ts
+++ b/src/app/shared/object-select/collection-select/collection-select.component.ts
@@ -15,7 +15,6 @@ import {
   map,
   Observable,
 } from 'rxjs';
-
 import { getCollectionPageRoute } from '../../../collection-page/collection-page-routing-paths';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { Collection } from '../../../core/shared/collection.model';

--- a/src/app/shared/pagination-drag-and-drop/abstract-paginated-drag-and-drop-list.component.ts
+++ b/src/app/shared/pagination-drag-and-drop/abstract-paginated-drag-and-drop-list.component.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   EventEmitter,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
 } from '@angular/core';
@@ -65,7 +66,7 @@ export const compareArraysUsingFieldUuids = () =>
   selector: 'ds-paginated-drag-drop-abstract',
   template: '',
 })
-export abstract class AbstractPaginatedDragAndDropListComponent<T extends DSpaceObject> implements OnDestroy {
+export abstract class AbstractPaginatedDragAndDropListComponent<T extends DSpaceObject> implements OnInit, OnDestroy {
   /**
    * A view on the child pagination component
    */
@@ -142,7 +143,7 @@ export abstract class AbstractPaginatedDragAndDropListComponent<T extends DSpace
   /**
    * Initialize the observables
    */
-  ngOnInit() {
+  ngOnInit(): void {
     this.initializeObjectsRD();
     this.initializeURL();
     this.initializeUpdates();

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -1,12 +1,14 @@
 import { CommonModule } from '@angular/common';
 import { HttpXsrfTokenExtractor } from '@angular/common/http';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
   HostListener,
   Input,
+  OnInit,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
@@ -42,7 +44,7 @@ import { UploaderProperties } from './uploader-properties.model';
   standalone: true,
   imports: [TranslateModule, FileUploadModule, CommonModule],
 })
-export class UploaderComponent {
+export class UploaderComponent implements OnInit, AfterViewInit {
 
   /**
    * The message to show when drag files on the drop zone
@@ -122,7 +124,7 @@ export class UploaderComponent {
   /**
    * Method provided by Angular. Invoked after the constructor.
    */
-  ngOnInit() {
+  ngOnInit(): void {
     this.uploaderId = 'ds-drag-and-drop-uploader' + uniqueId();
     this.checkConfig(this.uploadFilesOptions);
     this.uploader = new FileUploader({
@@ -147,7 +149,7 @@ export class UploaderComponent {
     }
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     this.uploader.onAfterAddingAll = ((items) => {
       this.onFileSelected.emit(items);
     });

--- a/src/app/submission/sections/identifiers/section-identifiers.component.ts
+++ b/src/app/submission/sections/identifiers/section-identifiers.component.ts
@@ -7,6 +7,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   Inject,
+  OnInit,
 } from '@angular/core';
 import {
   TranslateModule,
@@ -46,8 +47,7 @@ import { SectionsService } from '../sections.service';
   ],
   standalone: true,
 })
-
-export class SubmissionSectionIdentifiersComponent extends SectionModelComponent {
+export class SubmissionSectionIdentifiersComponent extends SectionModelComponent implements OnInit {
   /**
    * The Alert categories.
    * @type {AlertType}
@@ -93,7 +93,7 @@ export class SubmissionSectionIdentifiersComponent extends SectionModelComponent
     super(injectedCollectionId, injectedSectionData, injectedSubmissionId);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
   }
 


### PR DESCRIPTION
## Description

This PR adds imports of missing Angular interfaces, e.g. `OnInit`, `OnDestroy` etc.

@tdonohue , is it possible to add an appropriate lint check?