### PR TITLE
System-wide alert shouldn't be created when the message is empty

### DIFF
--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
@@ -311,6 +311,14 @@ describe('SystemWideAlertFormComponent', () => {
       expect(comp.back).not.toHaveBeenCalled();
 
     });
+    it('should not create the new alert when the enable button is clicked on an invalid the form', () => {
+      spyOn(comp as any, 'handleResponse');
+
+      comp.formMessage.patchValue('');
+      comp.save();
+
+      expect((comp as any).handleResponse).not.toHaveBeenCalled();
+    });
   });
   describe('back', () => {
     it('should navigate back to the home page', () => {

--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
@@ -256,11 +256,13 @@ export class SystemWideAlertFormComponent implements OnInit {
     } else {
       alert.countdownTo = null;
     }
-    if (hasValue(this.currentAlert)) {
-      const updatedAlert = Object.assign(new SystemWideAlert(), this.currentAlert, alert);
-      this.handleResponse(this.systemWideAlertDataService.put(updatedAlert), 'system-wide-alert.form.update', navigateToHomePage);
-    } else {
-      this.handleResponse(this.systemWideAlertDataService.create(alert), 'system-wide-alert.form.create', navigateToHomePage);
+    if (this.alertForm.valid) {
+      if (hasValue(this.currentAlert)) {
+        const updatedAlert = Object.assign(new SystemWideAlert(), this.currentAlert, alert);
+        this.handleResponse(this.systemWideAlertDataService.put(updatedAlert), 'system-wide-alert.form.update', navigateToHomePage);
+      } else {
+        this.handleResponse(this.systemWideAlertDataService.create(alert), 'system-wide-alert.form.create', navigateToHomePage);
+      }
     }
   }
 


### PR DESCRIPTION
## References
* Fixes #2876

## Description
This PR fixes an issue where alerts can be activated with empty message string. This made it impossible to disble it until you added a message

## Instructions for Reviewers
I simply added a check to not update/create the system wide alert if the form is invalid. I can also create a backend PR if this is a rule we want to inforce there too

**Guidance for how to test or review this PR:**
- Run `DELETE FROM systemwidealert;` to remove existing alert messages if you have any
- Click on the activate button an verify that if the rest of the form has not been filled in correctly the alert isn't created
- After filling in a message the button should still work like before (directly updating the alert without having to click on the save button)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
