### PR TITLE
Auto-Reload Page on User Consent Change (DRAFT)

### DIFF
--- a/src/app/shared/cookies/browser-klaro.service.ts
+++ b/src/app/shared/cookies/browser-klaro.service.ts
@@ -340,7 +340,20 @@ export class BrowserKlaroService extends KlaroService {
    * @param user
    */
   updateSettingsForUsers(user: EPerson) {
-    this.setSettingsForUser(user, this.cookieService.get(this.getStorageName(user.uuid)));
+    this.setSettingsForUser(user, this.cookieService.get(this.getStorageName(user.uuid)))
+      .pipe(take(1)) // Ensures the observable completes after the first emitted value
+      .subscribe({
+        next: (result) => {
+          // Logic to check if the settings were successfully updated
+          // This depends on how `setSettingsForUser` is implemented and what it returns
+          if (result.success) {
+            window.location.reload(); // Triggers the page reload
+          }
+        },
+        error: (err) => {
+          console.error('Error updating user settings', err);
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
I wrote this entirely in the browser and haven't tested or linted it yet locally. I will do so I added DRAFT to the title until then.

## References
* Fixes [#9211](https://github.com/DSpace/DSpace/issues/9211)

## Description
This PR introduces functionality to automatically reload the application page when a user changes their consent preferences, specifically consenting to tracking. This change ensures compliance with the initial requirements that the application should not perform any tracking until explicit consent is granted by the user. Once consent is given, the application will reload, allowing tracking scripts like Google Analytics (GTag) to initialize and start collecting data as permitted.

## Instructions for Reviewers
Start a new browser session so that the confirmation pops up. Click consent or decline and the page should reload.

List of changes in this PR:
- Modified the `updateSettingsForUsers` method within `BrowserKlaroService` to trigger a page reload after a user successfully updates their consent settings. This is particularly relevant when a user consents to tracking, as it requires the tracking scripts to be re-initialized.
- Ensured that the page reload logic is only executed after the user's consent settings have been successfully saved, minimizing any disruption to the user experience.
- Added necessary RxJS operators (`take(1)`) to ensure the subscription completes after the first emitted value, following best practices for handling Observable subscriptions.

**Include guidance for how to test or review your PR.** 
Click confirm with Google analytics enabled on the site. Using the Google analytics browser plugin you can see that nothing is being recorded as you navigate the site even after you've consented. Reload the page and the Google analytics tracking will start working.

## Checklist
_Tracking starts after consent and pay reloads.
_No tracking is started after declining.

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [?] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [?] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [?] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [?] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
