### PR TITLE
Error loading the initial value when editing an authority field in edit item page

### DIFF
--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
@@ -9,12 +9,12 @@
     <ds-dynamic-scrollable-dropdown *ngIf="mdValue.editing && (isScrollableVocabulary() | async)"
                                     [bindId]="mdField"
                                     [group]="group"
-                                    [model]="getModel() | async"
+                                    [model]="getModel()"
                                     (change)="onChangeAuthorityField($event)">
     </ds-dynamic-scrollable-dropdown>
     <ds-dynamic-onebox *ngIf="mdValue.editing && ((isHierarchicalVocabulary() | async) || (isSuggesterVocabulary() | async))"
                       [group]="group"
-                      [model]="getModel() | async"
+                      [model]="getModel()"
                       (change)="onChangeAuthorityField($event)">
     </ds-dynamic-onebox>
     <div *ngIf="!isVirtual && !mdValue.editing && mdValue.newValue.authority && mdValue.newValue.confidence !== ConfidenceTypeEnum.CF_UNSET && mdValue.newValue.confidence !== ConfidenceTypeEnum.CF_NOVALUE">

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -10,10 +10,7 @@ import {
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  Observable,
-  of,
-} from 'rxjs';
+import { of } from 'rxjs';
 import { MetadataField } from 'src/app/core/metadata/metadata-field.model';
 import { MetadataSchema } from 'src/app/core/metadata/metadata-schema.model';
 import { RegistryService } from 'src/app/core/registry/registry.service';
@@ -346,14 +343,11 @@ describe('DsoEditMetadataValueComponent', () => {
     });
 
     it('getModel should return a DynamicScrollableDropdownModel', () => {
-      const result = component.getModel();
+      const model = component.getModel();
 
-      expect(result instanceof Observable).toBe(true);
+      expect(model instanceof DynamicScrollableDropdownModel).toBe(true);
+      expect(model.vocabularyOptions.name).toBe(mockVocabularyScrollable.name);
 
-      result.subscribe((model) => {
-        expect(model instanceof DynamicScrollableDropdownModel).toBe(true);
-        expect(model.vocabularyOptions.name).toBe(mockVocabularyScrollable.name);
-      });
     });
   });
 
@@ -380,14 +374,10 @@ describe('DsoEditMetadataValueComponent', () => {
     });
 
     it('getModel should return a DynamicOneboxModel', () => {
-      const result = component.getModel();
+      const model = component.getModel();
 
-      expect(result instanceof Observable).toBe(true);
-
-      result.subscribe((model) => {
-        expect(model instanceof DynamicOneboxModel).toBe(true);
-        expect(model.vocabularyOptions.name).toBe(mockVocabularyHierarchical.name);
-      });
+      expect(model instanceof DynamicOneboxModel).toBe(true);
+      expect(model.vocabularyOptions.name).toBe(mockVocabularyHierarchical.name);
     });
   });
 
@@ -416,14 +406,10 @@ describe('DsoEditMetadataValueComponent', () => {
     });
 
     it('getModel should return a DynamicOneboxModel', () => {
-      const result = component.getModel();
+      const model = component.getModel();
 
-      expect(result instanceof Observable).toBe(true);
-
-      result.subscribe((model) => {
-        expect(model instanceof DynamicOneboxModel).toBe(true);
-        expect(model.vocabularyOptions.name).toBe(mockVocabularySuggester.name);
-      });
+      expect(model instanceof DynamicOneboxModel).toBe(true);
+      expect(model.vocabularyOptions.name).toBe(mockVocabularySuggester.name);
     });
 
     describe('authority key edition', () => {

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
@@ -29,6 +29,7 @@ import {
   TranslateService,
 } from '@ngx-translate/core';
 import {
+  BehaviorSubject,
   EMPTY,
   Observable,
   of as observableOf,
@@ -37,6 +38,7 @@ import {
   map,
   switchMap,
   take,
+  tap,
 } from 'rxjs/operators';
 import { RegistryService } from 'src/app/core/registry/registry.service';
 import { VocabularyService } from 'src/app/core/submission/vocabularies/vocabulary.service';
@@ -195,9 +197,9 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges {
   group = new UntypedFormGroup({ authorityField : new UntypedFormControl() });
 
   /**
-   * Observable property of the model to use for editinf authorities values
+   * Model to use for editing authorities values
    */
-  private model$: Observable<DynamicOneboxModel | DynamicScrollableDropdownModel>;
+  private model$: BehaviorSubject<DynamicOneboxModel | DynamicScrollableDropdownModel> = new BehaviorSubject(null);
 
   /**
    * Observable with information about the authority vocabulary used
@@ -274,6 +276,8 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges {
     }
 
     this.isAuthorityControlled$ = this.vocabulary$.pipe(
+      // Create the model used by the authority fields to ensure its existence when the field is initialized
+      tap((v: Vocabulary) => this.model$.next(this.createModel(v))),
       map((result: Vocabulary) => isNotEmpty(result)),
     );
 
@@ -289,54 +293,62 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges {
       map((result: Vocabulary) => isNotEmpty(result) && !result.hierarchical && !result.scrollable),
     );
 
-    this.model$ = this.vocabulary$.pipe(
-      map((vocabulary: Vocabulary) => {
-        let formFieldValue;
-        if (isNotEmpty(this.mdValue.newValue.value)) {
-          formFieldValue = new FormFieldMetadataValueObject();
-          formFieldValue.value = this.mdValue.newValue.value;
-          formFieldValue.display = this.mdValue.newValue.value;
-          if (this.mdValue.newValue.authority) {
-            formFieldValue.authority = this.mdValue.newValue.authority;
-            formFieldValue.confidence = this.mdValue.newValue.confidence;
-          }
-        } else {
-          formFieldValue = this.mdValue.newValue.value;
-        }
+  }
 
-        const vocabularyOptions = vocabulary ? {
-          closed: false,
-          name: vocabulary.name,
-        } as VocabularyOptions : null;
-
-        if (!vocabulary.scrollable) {
-          const model: DsDynamicOneboxModelConfig = {
-            id: 'authorityField',
-            label: `${this.dsoType}.edit.metadata.edit.value`,
-            vocabularyOptions: vocabularyOptions,
-            metadataFields: [this.mdField],
-            value: formFieldValue,
-            repeatable: false,
-            submissionId: 'edit-metadata',
-            hasSelectableMetadata: false,
-          };
-          return new DynamicOneboxModel(model);
-        } else {
-          const model: DynamicScrollableDropdownModelConfig = {
-            id: 'authorityField',
-            label: `${this.dsoType}.edit.metadata.edit.value`,
-            placeholder: `${this.dsoType}.edit.metadata.edit.value`,
-            vocabularyOptions: vocabularyOptions,
-            metadataFields: [this.mdField],
-            value: formFieldValue,
-            repeatable: false,
-            submissionId: 'edit-metadata',
-            hasSelectableMetadata: false,
-            maxOptions: 10,
-          };
-          return new DynamicScrollableDropdownModel(model);
+  /**
+   * Returns a {@link DynamicOneboxModel} or {@link DynamicScrollableDropdownModel} model based on the
+   * vocabulary used.
+   */
+  private createModel(vocabulary: Vocabulary): DynamicOneboxModel | DynamicScrollableDropdownModel {
+    if (isNotEmpty(vocabulary)) {
+      let formFieldValue;
+      if (isNotEmpty(this.mdValue.newValue.value)) {
+        formFieldValue = new FormFieldMetadataValueObject();
+        formFieldValue.value = this.mdValue.newValue.value;
+        formFieldValue.display = this.mdValue.newValue.value;
+        if (this.mdValue.newValue.authority) {
+          formFieldValue.authority = this.mdValue.newValue.authority;
+          formFieldValue.confidence = this.mdValue.newValue.confidence;
         }
-      }));
+      } else {
+        formFieldValue = this.mdValue.newValue.value;
+      }
+
+      const vocabularyOptions = vocabulary ? {
+        closed: false,
+        name: vocabulary.name,
+      } as VocabularyOptions : null;
+
+      if (!vocabulary.scrollable) {
+        const model: DsDynamicOneboxModelConfig = {
+          id: 'authorityField',
+          label: `${this.dsoType}.edit.metadata.edit.value`,
+          vocabularyOptions: vocabularyOptions,
+          metadataFields: [this.mdField],
+          value: formFieldValue,
+          repeatable: false,
+          submissionId: 'edit-metadata',
+          hasSelectableMetadata: false,
+        };
+        return new DynamicOneboxModel(model);
+      } else {
+        const model: DynamicScrollableDropdownModelConfig = {
+          id: 'authorityField',
+          label: `${this.dsoType}.edit.metadata.edit.value`,
+          placeholder: `${this.dsoType}.edit.metadata.edit.value`,
+          vocabularyOptions: vocabularyOptions,
+          metadataFields: [this.mdField],
+          value: formFieldValue,
+          repeatable: false,
+          submissionId: 'edit-metadata',
+          hasSelectableMetadata: false,
+          maxOptions: 10,
+        };
+        return new DynamicScrollableDropdownModel(model);
+      }
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -434,11 +446,11 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Returns an observable with the {@link DynamicOneboxModel} or {@link DynamicScrollableDropdownModel} model used
+   * Returns the {@link DynamicOneboxModel} or {@link DynamicScrollableDropdownModel} model used
    * for the authority field
    */
-  getModel(): Observable<DynamicOneboxModel | DynamicScrollableDropdownModel> {
-    return this.model$;
+  getModel(): DynamicOneboxModel | DynamicScrollableDropdownModel {
+    return this.model$.value;
   }
 
   /**


### PR DESCRIPTION
## References
* Related to #2653

## Description
While testing the functionality introduced by #2653 to edit authority-controlled values in the current main branch, I have observed that it is failing to load the initial values of the authority field because the model parameter used by these fields are not properly initialized. This PR changes how this model parameter is created to ensure its existence when the field is initialized.

## Instructions for Reviewers

To reproduce the bug, edit an existing authority-controlled field value in edit item page, such as 'dc.type', 'dc.subject', or 'dc.contributor.author'. The field should load the initial value, but it remains empty, and the console shows the following error: `ERROR TypeError: this.model is null `

![image](https://github.com/DSpace/dspace-angular/assets/3812525/9f5bc9c5-1d1c-43ff-a288-fe3b692bad49)


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).