### PR TITLE
Fix sync-i18n script throwing a compile error & added some missing translation keys

### DIFF
--- a/scripts/sync-i18n-files.ts
+++ b/scripts/sync-i18n-files.ts
@@ -275,7 +275,9 @@ function readFileIfExists(pathToFile) {
     try {
       return fs.readFileSync(pathToFile, 'utf8');
     } catch (e) {
-      console.error('Error:', e.stack);
+      if (e instanceof Error) {
+        console.error('Error:', e.stack);
+      }
     }
   }
   return null;

--- a/src/app/item-page/edit-item-page/item-move/item-move.component.html
+++ b/src/app/item-page/edit-item-page/item-move/item-move.component.html
@@ -6,7 +6,7 @@
             <div class="row">
                 <div class="col-12">
                   <div class="card mb-3">
-                    <div class="card-header">{{'dso-selector.placeholder' | translate: { type: 'collection' } }}</div>
+                    <div class="card-header">{{'dso-selector.placeholder' | translate: { type: 'dso-selector.placeholder.type.collection' | translate } }}</div>
                     <div class="card-body">
                       <ds-authorized-collection-selector [types]="COLLECTIONS"
                                                          [currentDSOId]="selectedCollection ? selectedCollection.id : originalCollection.id"

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -185,7 +185,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    * The search will always start with the initial currentDSOId value
    */
   ngOnInit(): void {
-    this.typesString = this.types.map((type: string) => type.toString().toLowerCase()).join(', ');
+    this.typesString = this.types.map((type: string) => this.translate.instant(`dso-selector.placeholder.type.${type.toString().toLowerCase()}`)).join(', ');
 
     // Create an observable searching for the current DSO (return empty list if there's no current DSO)
     let currentDSOResult$: Observable<PaginatedList<SearchResult<DSpaceObject>>>;

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1718,6 +1718,12 @@
 
   "dso-selector.placeholder": "Search for a {{ type }}",
 
+  "dso-selector.placeholder.type.community": "community",
+
+  "dso-selector.placeholder.type.collection": "collection",
+
+  "dso-selector.placeholder.type.item": "item",
+
   "dso-selector.select.collection.head": "Select a collection",
 
   "dso-selector.set-scope.community.head": "Select a search scope",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -176,7 +176,8 @@
 
   // "admin.registries.bitstream-formats.table.name": "Name",
   "admin.registries.bitstream-formats.table.name": "Nom",
-  // TODO New key - Add a translation
+
+  // "admin.registries.bitstream-formats.table.id": "ID",
   "admin.registries.bitstream-formats.table.id": "ID",
 
   // "admin.registries.bitstream-formats.table.return": "Back",
@@ -253,7 +254,8 @@
 
   // "admin.registries.schema.fields.table.field": "Field",
   "admin.registries.schema.fields.table.field": "Champ",
-  // TODO New key - Add a translation
+
+  // "admin.registries.schema.fields.table.id": "ID",
   "admin.registries.schema.fields.table.id": "ID",
 
   // "admin.registries.schema.fields.table.scopenote": "Scope Note",
@@ -748,9 +750,6 @@
   //"admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
   "admin.reports.collections.match_all_selected_filters": "Correspondant à tous les filtres sélectionnés",
 
-
-  //"admin.reports.items.title": "Metadata Query Report",
-  "admin.reports.items.title": "Rapport de requête de métadonnées",
 
   //"admin.reports.items.breadcrumbs": "Metadata Query Report",
   "admin.reports.items.breadcrumbs": "Requête de métadonnées",
@@ -2186,6 +2185,15 @@
 
   // "dso-selector.placeholder": "Search for a {{ type }}",
   "dso-selector.placeholder": "Rechercher un(e) {{ type }}",
+
+  // "dso-selector.placeholder.type.community": "community",
+  "dso-selector.placeholder.type.community": "communauté",
+
+  // "dso-selector.placeholder.type.collection": "collection",
+  "dso-selector.placeholder.type.collection": "collection",
+
+  // "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.item": "item",
 
   // "dso-selector.select.collection.head": "Select a collection",
   "dso-selector.select.collection.head": "Sélectionner une collection",
@@ -6400,9 +6408,6 @@
   "supervisedWorkspace.search.results.head": "Documents supervisés",
 
   //"workspace.search.results.head": "Your submissions",
-  "workspace.search.results.head": "Vos dépôts",
-
-  // "workspace.search.results.head": "Your submissions",
   "workspace.search.results.head": "Vos dépôts",
 
   // "workflowAdmin.search.results.head": "Administer Workflow",

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -839,10 +839,6 @@
   "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
 
 
-  //"admin.reports.items.title": "Metadata Query Report",
-  // TODO New key - Add a translation
-  "admin.reports.items.title": "Metadata Query Report",
-
   //"admin.reports.items.breadcrumbs": "Metadata Query Report",
   // TODO New key - Add a translation
   "admin.reports.items.breadcrumbs": "Metadata Query Report",
@@ -2376,6 +2372,15 @@
 
   // "dso-selector.placeholder": "Search for a {{ type }}",
   "dso-selector.placeholder": "Zoek een {{ type }}",
+
+  // "dso-selector.placeholder.type.community": "community",
+  "dso-selector.placeholder.type.community": "community",
+
+  // "dso-selector.placeholder.type.collection": "collection",
+  "dso-selector.placeholder.type.collection": "collectie",
+
+  // "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.item": "item",
 
 
 


### PR DESCRIPTION
## References
* Fixes #598

## Description
Currently the `sync-i18n` script can't be executed because of a type issue caused by [the Typescript 4.4 update](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables). Because this PR was ridiculously small I also fixed another issue at the same time. The second fix makes the DSO type in the `dso-selector` translatable.

## Instructions for Reviewers
List of changes in this PR:
- Added an if statement to `sync-i18n-files.ts` to verify that the variable returned by the catch block is of type `Error`
- Added translation keys for the 3 DSO types that use the `dso-selector`: Community, Collection & Item

**Guidance for how to test/review this PR:**
- Verify that you can run the `sync-i18n` script again
- Verify that the DSO selector now show the translated `community`/`collection`/`item` in French/Dutch
- Verify that it also works when a DSo selector contains multiple different types of DSO types (for example the scope selector on the search page)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
