### PR TITLE
Disable `inlineCriticalCss` by default for better SSR performance

### DIFF
--- a/src/config/ssr-config.interface.ts
+++ b/src/config/ssr-config.interface.ts
@@ -14,8 +14,10 @@ export interface SSRConfig extends Config {
   enablePerformanceProfiler: boolean;
 
   /**
-   * Reduce render blocking requests by inlining critical CSS.
-   * Defaults to true.
+   * When set to true, reduce render blocking requests by inlining critical CSS.
+   * Determining which styles are critical can be an expensive operation;
+   * this option can be disabled to boost server performance at the expense of loading smoothness.
+   * For improved SSR performance, DSpace defaults this to false (disabled).
    */
   inlineCriticalCss: boolean;
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -3,10 +3,10 @@ import { BuildConfig } from '../config/build-config.interface';
 export const environment: Partial<BuildConfig> = {
   production: true,
 
-  // Angular SSR settings
+  // Angular SSR (Server Side Rendering) settings
   ssr: {
     enabled: true,
     enablePerformanceProfiler: false,
-    inlineCriticalCss: true,
+    inlineCriticalCss: false,
   },
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -7,11 +7,11 @@ import { NotificationAnimationsType } from '../app/shared/notifications/models/n
 export const environment: BuildConfig = {
   production: false,
 
-  // Angular SSR settings
+  // Angular SSR (Server Side Rendering) settings
   ssr: {
     enabled: true,
     enablePerformanceProfiler: false,
-    inlineCriticalCss: true,
+    inlineCriticalCss: false,
   },
 
   // Angular express server settings.

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,11 +8,11 @@ import { BuildConfig } from '../config/build-config.interface';
 export const environment: Partial<BuildConfig> = {
   production: false,
 
-  // Angular SSR settings
+  // Angular SSR (Server Side Rendering) settings
   ssr: {
     enabled: false,
     enablePerformanceProfiler: false,
-    inlineCriticalCss: true,
+    inlineCriticalCss: false,
   },
 };
 


### PR DESCRIPTION
## References
* Follow-up to #2067 and #2934 

## Description
This PR changes the default setting of `inlineCriticalCss` to `false` (disabled) in order to improve the SSR (Server Side Rendering) performance.

For details about this change, see discussion in #2067, especially https://github.com/DSpace/dspace-angular/pull/2067#issuecomment-2015441135

Also see other references on web about poor performance of `inlineCriticalCss`:
* https://github.com/angular/universal/issues/2106
* https://medium.com/@e94kai/angular-12-server-side-rendering-optimization-2b8a30208c11

## Instructions for Reviewers
* For detailed testing, I'm going to **deploy this minor change immediately to https://sandbox.dspace.org** .  That will allow us to test this new default setting via Testathon and beyond.


## Porting to dspace-7_x

If accepted, this should be ported to `dspace-7_x`.  However, it will need to be a manual port because the `inlineCriticalCss` setting has changed in Angular 17 (see #2934 ). So this setting is slightly different on `main` and `dspace-7_x` branches.