### PR TITLE
Fix display of dso names for EPersons

### DIFF
--- a/src/app/core/breadcrumbs/dso-name.service.spec.ts
+++ b/src/app/core/breadcrumbs/dso-name.service.spec.ts
@@ -9,6 +9,10 @@ describe(`DSONameService`, () => {
   let service: DSONameService;
   let mockPersonName: string;
   let mockPerson: DSpaceObject;
+  let mockEPersonNameFirst: string;
+  let mockEPersonFirst: DSpaceObject;
+  let mockEPersonName: string;
+  let mockEPerson: DSpaceObject;
   let mockOrgUnitName: string;
   let mockOrgUnit: DSpaceObject;
   let mockDSOName: string;
@@ -22,6 +26,26 @@ describe(`DSONameService`, () => {
       },
       getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
         return ['Person', Item, DSpaceObject];
+      },
+    });
+
+    mockEPersonName = 'John Doe';
+    mockEPerson = Object.assign(new DSpaceObject(), {
+      firstMetadataValue(keyOrKeys: string | string[], valueFilter?: MetadataValueFilter): string {
+        return mockEPersonName;
+      },
+      getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
+        return ['EPerson', Item, DSpaceObject];
+      },
+    });
+
+    mockEPersonNameFirst = 'John';
+    mockEPersonFirst = Object.assign(new DSpaceObject(), {
+      firstMetadataValue(keyOrKeys: string | string[], valueFilter?: MetadataValueFilter): string {
+        return mockEPersonNameFirst;
+      },
+      getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
+        return ['EPerson', Item, DSpaceObject];
       },
     });
 
@@ -67,6 +91,15 @@ describe(`DSONameService`, () => {
       expect(result).toBe('Bingo!');
     });
 
+    it(`should use the EPerson factory for EPerson objects`, () => {
+      spyOn((service as any).factories, 'EPerson').and.returnValue('Bingo!');
+
+      const result = service.getName(mockEPerson);
+
+      expect((service as any).factories.EPerson).toHaveBeenCalledWith(mockEPerson);
+      expect(result).toBe('Bingo!');
+    });
+
     it(`should use the Default factory for regular DSpaceObjects`, () => {
       spyOn((service as any).factories, 'Default').and.returnValue('Bingo!');
 
@@ -106,6 +139,35 @@ describe(`DSONameService`, () => {
       });
     });
   });
+
+  describe(`factories.EPerson`, () => {
+    describe(`with eperson.firstname and without eperson.lastname`, () => {
+      beforeEach(() => {
+        spyOn(mockEPerson, 'firstMetadataValue').and.returnValues(...mockEPersonName.split(' '));
+      });
+
+      it(`should return 'eperson.firstname' and 'eperson.lastname'`, () => {
+        const result = (service as any).factories.EPerson(mockEPerson);
+        expect(result).toBe(mockEPersonName);
+        expect(mockEPerson.firstMetadataValue).toHaveBeenCalledWith('eperson.firstname');
+        expect(mockEPerson.firstMetadataValue).toHaveBeenCalledWith('eperson.lastname');
+      });
+    });
+
+    describe(` with eperson.firstname and without eperson.lastname`, () => {
+      beforeEach(() => {
+        spyOn(mockEPersonFirst, 'firstMetadataValue').and.returnValues(mockEPersonNameFirst, undefined);
+      });
+
+      it(`should return 'eperson.firstname'`, () => {
+        const result = (service as any).factories.EPerson(mockEPersonFirst);
+        expect(result).toBe(mockEPersonNameFirst);
+        expect(mockEPersonFirst.firstMetadataValue).toHaveBeenCalledWith('eperson.firstname');
+        expect(mockEPersonFirst.firstMetadataValue).toHaveBeenCalledWith('eperson.lastname');
+      });
+    });
+  });
+
 
   describe(`factories.OrgUnit`, () => {
     beforeEach(() => {

--- a/src/app/core/eperson/models/eperson.model.ts
+++ b/src/app/core/eperson/models/eperson.model.ts
@@ -91,7 +91,7 @@ export class EPerson extends DSpaceObject {
   public groups?: Observable<RemoteData<PaginatedList<Group>>>;
 
   getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
-    return [this.constructor.name, ...super.getRenderTypes()];
+    return ['EPerson', this.constructor.name, ...super.getRenderTypes()];
   }
 
 }


### PR DESCRIPTION
## References
* Fixes #2947

## Description
Extend the EPerson render types to make the dso-name factory for EPersons work.

## Instructions for Reviewers
List of changes in this PR:
* extend Render Type of EPerson with `EPerson` value. Currently the constructor.name is `i` falling back to the default factory. Lists of EPerson seems not to be used currently anywhere and the epeople registry uses some table so this should have no impact on other parts of the code.
* Test Case: people with no last or firstname should now be displayed without leading or trailing whitespace in the epeople registry overview. Before this change these entries should have some whitespace because in the `dso-name.service` the fallback goes to deprecated `dso.name` which constructs the name in some other way.
* provided tests for displaying the eperson name.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
