### PR TITLE
Update REST and CI docker compose scripts to sync with 8.0 backend

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ the Docker compose scripts in this 'docker' folder.
 
 ### Dockerfile
 
-This Dockerfile is used to build a *development* DSpace 7 Angular UI image, published as 'dspace/dspace-angular'
+This Dockerfile is used to build a *development* DSpace Angular UI image, published as 'dspace/dspace-angular'
 
 ```
 docker build -t dspace/dspace-angular:latest .
@@ -46,11 +46,11 @@ A default/demo version of this image is built *automatically*.
 
 ## 'docker' directory
 - docker-compose.yml
-  - Starts DSpace Angular with Docker Compose from the current branch.  This file assumes that a DSpace 7 REST instance will also be started in Docker.
+  - Starts DSpace Angular with Docker Compose from the current branch.  This file assumes that a DSpace REST instance will also be started in Docker.
 - docker-compose-rest.yml
-  - Runs a published instance of the DSpace 7 REST API - persists data in Docker volumes
+  - Runs a published instance of the DSpace REST API - persists data in Docker volumes
 - docker-compose-ci.yml
-  - Runs a published instance of the DSpace 7 REST API for CI testing.  The database is re-populated from a SQL dump on each startup.
+  - Runs a published instance of the DSpace REST API for CI testing.  The database is re-populated from a SQL dump on each startup.
 - cli.yml
   - Docker compose file that provides a DSpace CLI container to work with a running DSpace REST container.
 - cli.assetstore.yml
@@ -71,7 +71,7 @@ docker-compose -f docker/docker-compose.yml build
 
 This command provides a quick way to start both the frontend & backend from this single codebase
 ```
-docker-compose -p d7 -f docker/docker-compose.yml -f docker/docker-compose-rest.yml up -d
+docker-compose -p d8 -f docker/docker-compose.yml -f docker/docker-compose-rest.yml up -d
 ```
 
 Keep in mind, you may also start the backend by cloning the 'DSpace/DSpace' GitHub repository separately. See the next section.
@@ -86,14 +86,14 @@ _The system will be started in 2 steps. Each step shares the same docker network
 
 From 'DSpace/DSpace' clone (build first as needed):
 ```
-docker-compose -p d7 up -d
+docker-compose -p d8 up -d
 ```
 
 NOTE: More detailed instructions on starting the backend via Docker can be found in the [Docker Compose instructions for the Backend](https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/README.md).
 
 From 'DSpace/dspace-angular' clone (build first as needed)
 ```
-docker-compose -p d7 -f docker/docker-compose.yml up -d
+docker-compose -p d8 -f docker/docker-compose.yml up -d
 ```
 
 At this point, you should be able to access the UI from http://localhost:4000,
@@ -107,19 +107,19 @@ This allows you to run the Angular UI in *production* mode, pointing it at the d
 ```
 docker-compose -f docker/docker-compose-dist.yml pull
 docker-compose -f docker/docker-compose-dist.yml build
-docker-compose -p d7 -f docker/docker-compose-dist.yml up -d
+docker-compose -p d8 -f docker/docker-compose-dist.yml up -d
 ```
 
 ## Ingest test data from AIPDIR
 
 Create an administrator
 ```
-docker-compose -p d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose -p d8 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
 ```
 
 Load content from AIP files
 ```
-docker-compose -p d7 -f docker/cli.yml -f ./docker/cli.ingest.yml run --rm dspace-cli
+docker-compose -p d8 -f docker/cli.yml -f ./docker/cli.ingest.yml run --rm dspace-cli
 ```
 
 ## Alternative Ingest - Use Entities dataset
@@ -127,12 +127,12 @@ _Delete your docker volumes or use a unique project (-p) name_
 
 Start DSpace with Database Content from a database dump
 ```
-docker-compose -p d7 -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f docker/db.entities.yml up -d
+docker-compose -p d8 -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f docker/db.entities.yml up -d
 ```
 
 Load assetstore content and trigger a re-index of the repository
 ```
-docker-compose -p d7 -f docker/cli.yml -f docker/cli.assetstore.yml run --rm dspace-cli
+docker-compose -p d8 -f docker/cli.yml -f docker/cli.assetstore.yml run --rm dspace-cli
 ```
 
 ## End to end testing of the REST API (runs in GitHub Actions CI).
@@ -140,5 +140,5 @@ _In this instance, only the REST api runs in Docker using the Entities dataset. 
 
 This command is only really useful for testing our Continuous Integration process.
 ```
-docker-compose -p d7ci -f docker/docker-compose-ci.yml up -d
+docker-compose -p d8ci -f docker/docker-compose-ci.yml up -d
 ```

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -33,6 +33,7 @@ services:
       # Tell Statistics to commit all views immediately instead of waiting on Solr's autocommit.
       # This allows us to generate statistics in e2e tests so that statistics pages can be tested thoroughly.
       solr__D__statistics__P__autoCommit: 'false'
+      LOGGING_CONFIG: /dspace/config/log4j2-container.xml
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     depends_on:
     - dspacedb
@@ -60,15 +61,19 @@ services:
   # NOTE: This is customized to use our loadsql image, so that we are using a database with existing test data
   dspacedb:
     container_name: dspacedb
+    image: "${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-latest-loadsql}"
     environment:
       # This LOADSQL should be kept in sync with the LOADSQL in
       # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       LOADSQL: https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql
       PGDATA: /pgdata
-    image: dspace/dspace-postgres-pgcrypto:loadsql
+      POSTGRES_PASSWORD: dspace
     networks:
       - dspacenet
+    ports:
+    - published: 5432
+      target: 5432
     stdin_open: true
     tty: true
     volumes:
@@ -105,6 +110,8 @@ services:
       cp -r /opt/solr/server/solr/configsets/statistics/* statistics
       precreate-core qaevent /opt/solr/server/solr/configsets/qaevent
       cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent
+      precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
+      cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
       exec solr -f
 volumes:
   assetstore:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -29,8 +29,9 @@ services:
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # dspace.dir, dspace.server.url, dspace.ui.url and dspace.name
       dspace__P__dir: /dspace
-      dspace__P__server__P__url: http://localhost:8080/server
-      dspace__P__ui__P__url: http://localhost:4000
+      # Uncomment to set a non-default value for dspace.server.url or dspace.ui.url
+      # dspace__P__server__P__url: http://localhost:8080/server
+      # dspace__P__ui__P__url: http://localhost:4000
       dspace__P__name: 'DSpace Started with Docker Compose'
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
@@ -39,6 +40,7 @@ services:
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests 
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: '172.23.0'
+      LOGGING_CONFIG: /dspace/config/log4j2-container.xml
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     depends_on:
     - dspacedb
@@ -50,6 +52,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
+    # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
@@ -65,9 +68,11 @@ services:
   # DSpace database container    
   dspacedb:
     container_name: dspacedb
+    # Uses a custom Postgres image with pgcrypto installed
+    image: "${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}"
     environment:
       PGDATA: /pgdata
-    image: "${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}"
+      POSTGRES_PASSWORD: dspace
     networks:
       - dspacenet
     ports:
@@ -113,6 +118,8 @@ services:
       cp -r /opt/solr/server/solr/configsets/statistics/* statistics
       precreate-core qaevent /opt/solr/server/solr/configsets/qaevent
       cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent
+      precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
+      cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
       exec solr -f
 volumes:
   assetstore:


### PR DESCRIPTION
## Description
This small PR ensures that our `docker-compose-rest.yml` (for running backend) and `docker-compose-ci.yml` (for running e2e tests) are up-to-date and synced with the [Backend's `docker-compose.yml`](https://github.com/DSpace/DSpace/blob/main/docker-compose.yml)

This fixes an error that also occurs if you attempt to run the backend using the guide at https://wiki.lyrasis.org/display/DSPACE/Try+out+DSpace+8   When doing so, the `dspacedb` container will fail to start with this error:
```
Error: Database is uninitialized and superuser password is not specified.
        You must specify POSTGRES_PASSWORD to a non-empty value for the
        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
```

## Instructions for Reviewers
* Assuming CI tests all succeed, I plant to merge this immediately.  Without it, the instructions at https://wiki.lyrasis.org/display/DSPACE/Try+out+DSpace+8  do not work