### PR TITLE
added maxlength and hint to resource policy

### DIFF
--- a/src/app/shared/resource-policies/form/resource-policy-form.model.ts
+++ b/src/app/shared/resource-policies/form/resource-policy-form.model.ts
@@ -68,6 +68,8 @@ const policyActionList: DynamicFormOptionConfig<any>[] = [
 export const RESOURCE_POLICY_FORM_NAME_CONFIG: DsDynamicInputModelConfig = {
   id: 'name',
   label: 'resource-policies.form.name.label',
+  maxLength: 30,
+  hint: 'resource-policies.form.name.hint',
   metadataFields: [],
   repeatable: false,
   submissionId: '',

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -5193,6 +5193,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -4619,7 +4619,7 @@
   //"resource-policies.form.name.hint": "Max 30 characters",
   // TODO New key - Add a translation
   "resource-policies.form.name.hint": "Max 30 characters",
-  
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "নীতির টাইপ নির্বাচন করুন",
 

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -4616,6 +4616,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "নাম",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+  
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "নীতির টাইপ নির্বাচন করুন",
 

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -5034,6 +5034,9 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nom",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Màxim 30 caràcters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Seleccioneu el tipus de política",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -5098,6 +5098,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -4238,6 +4238,9 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Maximal 30 Zeichen",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Wählen Sie den Richtlinientyp",
 

--- a/src/assets/i18n/el.json5
+++ b/src/assets/i18n/el.json5
@@ -1687,6 +1687,9 @@
   "resource-policies.form.eperson-group-list.table.headers.id": "ID",
   "resource-policies.form.eperson-group-list.table.headers.name": "Ονομα",
   "resource-policies.form.name.label": "Ονομα",
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
   "resource-policies.form.policy-type.label": "Επιλέξτε τον τύπο πολιτικής",
   "resource-policies.form.policy-type.required": "Πρέπει να επιλέξετε τον τύπο πολιτικής πόρων.",
   "resource-policies.table.headers.action": "Δράση",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3652,6 +3652,8 @@
 
   "resource-policies.form.name.label": "Name",
 
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   "resource-policies.form.policy-type.label": "Select the policy type",
 
   "resource-policies.form.policy-type.required": "You must select the resource policy type.",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -5362,6 +5362,9 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nombre",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Máximo 30 caracteres",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Seleccione el tipo de política",
 

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -5316,6 +5316,9 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nimi",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Enintään 30 merkkiä",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Valitse käytäntötyyppi",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -4559,6 +4559,9 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nom",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "30 caractères maximum",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Sélectionner le type de règle",
 

--- a/src/assets/i18n/gd.json5
+++ b/src/assets/i18n/gd.json5
@@ -4611,6 +4611,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Ainm",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Tagh an seòrsa poileasaidh",
 

--- a/src/assets/i18n/hi.json5
+++ b/src/assets/i18n/hi.json5
@@ -3421,6 +3421,10 @@
 
   "resource-policies.form.name.label": "नाम",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   "resource-policies.form.policy-type.label": "नीति प्रकार चुनें",
 
   "resource-policies.form.policy-type.required": "आपको संसाधन नीति प्रकार का चयन करना होगा।",

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -5906,6 +5906,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Név",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Szabály típus kiválasztása",
 

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -5429,6 +5429,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nome",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Selezionare il tipo di criterio",
 

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -5193,6 +5193,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -4966,6 +4966,14 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Аты",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Саясат түрін таңдаңыз",
 

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -4307,6 +4307,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -4610,6 +4610,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -1535,6 +1535,9 @@
   "resource-policies.form.date.start.label": "Data rozpoczęcia",
   "resource-policies.form.description.label": "Opis",
   "resource-policies.form.name.label": "Nazwa",
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
   "resource-policies.form.policy-type.label": "Wybierz typ polityki",
   "resource-policies.form.policy-type.required": "Musisz wybrać typ polityki zasobu.",
   "resource-policies.table.headers.action": "Akcja",

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -5373,6 +5373,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nome",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Selecione o tipo política",
 

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -5315,6 +5315,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Nome",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Selecione o tipo de política",
 

--- a/src/assets/i18n/sr-cyr.json5
+++ b/src/assets/i18n/sr-cyr.json5
@@ -1787,6 +1787,9 @@
   "resource-policies.form.date.start.label": "Датум почетка",
   "resource-policies.form.description.label": "Опис",
   "resource-policies.form.name.label": "Име",
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
   "resource-policies.form.policy-type.label": "Изаберите тип полисе",
   "resource-policies.form.policy-type.required": "Морате да изаберете тип полисе ресурса.",
   "resource-policies.table.headers.action": "Поступак",

--- a/src/assets/i18n/sr-lat.json5
+++ b/src/assets/i18n/sr-lat.json5
@@ -1787,6 +1787,9 @@
   "resource-policies.form.date.start.label": "Datum početka",
   "resource-policies.form.description.label": "Opis",
   "resource-policies.form.name.label": "Ime",
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
   "resource-policies.form.policy-type.label": "Izaberite tip polise",
   "resource-policies.form.policy-type.required": "Morate da izaberete tip polise resursa.",
   "resource-policies.table.headers.action": "Postupak",

--- a/src/assets/i18n/sv.json5
+++ b/src/assets/i18n/sv.json5
@@ -4737,6 +4737,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Namn",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Välj typ av policy",
 

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -5193,6 +5193,10 @@
   // TODO New key - Add a translation
   "resource-policies.form.name.label": "Name",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   // TODO New key - Add a translation
   "resource-policies.form.policy-type.label": "Select the policy type",

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -3951,6 +3951,10 @@
   // "resource-policies.form.name.label": "Name",
   "resource-policies.form.name.label": "Ad",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "Politika türünü seçin",
 

--- a/src/assets/i18n/uk.json5
+++ b/src/assets/i18n/uk.json5
@@ -4148,6 +4148,10 @@
 
   "resource-policies.form.name.label": "Назва",
 
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
+
   // "resource-policies.form.policy-type.label": "Select the policy type",
 
   "resource-policies.form.policy-type.label": "Виберіть тип політики",

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -1828,6 +1828,9 @@
   "resource-policies.form.eperson-group-list.table.headers.id": "ID",
   "resource-policies.form.eperson-group-list.table.headers.name": "Tên",
   "resource-policies.form.name.label": "Tên",
+  //"resource-policies.form.name.hint": "Max 30 characters",
+  // TODO New key - Add a translation
+  "resource-policies.form.name.hint": "Max 30 characters",
   "resource-policies.form.policy-type.label": "Lựa chọn kiểu chính sách",
   "resource-policies.form.policy-type.required": "Bạn cần lựa chọn kiểu chính sách tài nguyên.",
   "resource-policies.table.headers.action": "Quyền",


### PR DESCRIPTION
Hi @tdonohue, I'm @jtimal partner. We have been working on this issue and we will send you the PR.

## References
* Fixes #1719 

## Description
We have added a maxLength to the name input and a hint to advice max characters.

## Instructions for Reviewers

- Add/Edit a policy
- the input only allows to use 30 characters and shows a hint

List of changes in this PR:
* Policy name input max length
* Policy name input hint
* i18n values

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
