### PR TITLE
Fix issue with the admin sidebar scrollbar on Firefox/Windows

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.scss
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.scss
@@ -138,3 +138,9 @@
     }
   }
 }
+
+::ng-deep {
+  .browser-firefox-windows {
+    --ds-dark-scrollbar-width: 20px;
+  }
+}

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -2,7 +2,7 @@
   {{ 'root.skip-to-content' | translate }}
 </button>
 
-<div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [@slideSidebarPadding]="{
+<div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [ngClass]="browserOsClasses.asObservable() | async" [@slideSidebarPadding]="{
      value: ((isSidebarVisible$ | async) !== true ? 'hidden' : (slideSidebarOver$ | async) ? 'unpinned' : 'pinned'),
      params: { collapsedWidth: (collapsedSidebarWidth$ | async), expandedWidth: (expandedSidebarWidth$ | async) }
     }">

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -1,9 +1,11 @@
 import {
   AsyncPipe,
+  NgClass,
   NgIf,
 } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
@@ -13,6 +15,7 @@ import {
 } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
+  BehaviorSubject,
   combineLatest as combineLatestObservable,
   Observable,
   of,
@@ -30,6 +33,10 @@ import { environment } from '../../environments/environment';
 import { ThemedAdminSidebarComponent } from '../admin/admin-sidebar/themed-admin-sidebar.component';
 import { getPageInternalServerErrorRoute } from '../app-routing-paths';
 import { ThemedBreadcrumbsComponent } from '../breadcrumbs/themed-breadcrumbs.component';
+import {
+  NativeWindowRef,
+  NativeWindowService,
+} from '../core/services/window.service';
 import { ThemedFooterComponent } from '../footer/themed-footer.component';
 import { ThemedHeaderNavbarWrapperComponent } from '../header-nav-wrapper/themed-header-navbar-wrapper.component';
 import { slideSidebarPadding } from '../shared/animations/slide';
@@ -47,7 +54,20 @@ import { SystemWideAlertBannerComponent } from '../system-wide-alert/alert-banne
   styleUrls: ['./root.component.scss'],
   animations: [slideSidebarPadding],
   standalone: true,
-  imports: [TranslateModule, ThemedAdminSidebarComponent, SystemWideAlertBannerComponent, ThemedHeaderNavbarWrapperComponent, ThemedBreadcrumbsComponent, NgIf, ThemedLoadingComponent, RouterOutlet, ThemedFooterComponent, NotificationsBoardComponent, AsyncPipe],
+  imports: [
+    TranslateModule,
+    ThemedAdminSidebarComponent,
+    SystemWideAlertBannerComponent,
+    ThemedHeaderNavbarWrapperComponent,
+    ThemedBreadcrumbsComponent,
+    NgIf,
+    NgClass,
+    ThemedLoadingComponent,
+    RouterOutlet,
+    ThemedFooterComponent,
+    NotificationsBoardComponent,
+    AsyncPipe,
+  ],
 })
 export class RootComponent implements OnInit {
   theme: Observable<ThemeConfig> = of({} as any);
@@ -57,6 +77,8 @@ export class RootComponent implements OnInit {
   expandedSidebarWidth$: Observable<string>;
   notificationOptions: INotificationBoardOptions;
   models: any;
+
+  browserOsClasses = new BehaviorSubject<string[]>([]);
 
   /**
    * Whether or not to show a full screen loader
@@ -73,11 +95,23 @@ export class RootComponent implements OnInit {
     private cssService: CSSVariableService,
     private menuService: MenuService,
     private windowService: HostWindowService,
+    @Inject(NativeWindowService) private _window: NativeWindowRef,
   ) {
     this.notificationOptions = environment.notifications;
   }
 
   ngOnInit() {
+    const browserName = this.getBrowserName();
+    if (browserName) {
+      const browserOsClasses = new Array<string>();
+      browserOsClasses.push(`browser-${browserName}`);
+      const osName = this.getOSName();
+      if (osName) {
+        browserOsClasses.push(`browser-${browserName}-${osName}`);
+      }
+      this.browserOsClasses.next(browserOsClasses);
+    }
+
     this.isSidebarVisible$ = this.menuService.isMenuVisibleWithVisibleSections(MenuID.ADMIN);
 
     this.expandedSidebarWidth$ = this.cssService.getVariable('--ds-admin-sidebar-total-width').pipe(
@@ -107,5 +141,24 @@ export class RootComponent implements OnInit {
       mainContent.tabIndex = -1;
       mainContent.focus();
     }
+  }
+
+  getBrowserName(): string {
+    const userAgent = this._window.nativeWindow.navigator.userAgent;
+    if (/Firefox/.test(userAgent)) {
+      return 'firefox';
+    }
+    if (/Safari/.test(userAgent)) {
+      return 'safari';
+    }
+    return undefined;
+  }
+
+  getOSName(): string {
+    const userAgent = this._window.nativeWindow.navigator.userAgent;
+    if (/Windows/.test(userAgent)) {
+      return 'windows';
+    }
+    return undefined;
   }
 }

--- a/src/themes/custom/app/root/root.component.ts
+++ b/src/themes/custom/app/root/root.component.ts
@@ -1,5 +1,6 @@
 import {
   AsyncPipe,
+  NgClass,
   NgIf,
 } from '@angular/common';
 import { Component } from '@angular/core';
@@ -24,7 +25,20 @@ import { SystemWideAlertBannerComponent } from '../../../../app/system-wide-aler
   templateUrl: '../../../../app/root/root.component.html',
   animations: [slideSidebarPadding],
   standalone: true,
-  imports: [TranslateModule, ThemedAdminSidebarComponent, SystemWideAlertBannerComponent, ThemedHeaderNavbarWrapperComponent, ThemedBreadcrumbsComponent, NgIf, ThemedLoadingComponent, RouterOutlet, ThemedFooterComponent, NotificationsBoardComponent, AsyncPipe],
+  imports: [
+    TranslateModule,
+    ThemedAdminSidebarComponent,
+    SystemWideAlertBannerComponent,
+    ThemedHeaderNavbarWrapperComponent,
+    ThemedBreadcrumbsComponent,
+    NgIf,
+    NgClass,
+    ThemedLoadingComponent,
+    RouterOutlet,
+    ThemedFooterComponent,
+    NotificationsBoardComponent,
+    AsyncPipe,
+  ],
 })
 export class RootComponent extends BaseComponent {
 


### PR DESCRIPTION
## References
* Fixes #2927

## Description
This PR fixes the issues with the admin sidebar scrollbar on Firefox on Windows by allocating more space to the scrollbar.

## List of changes
* In the root component a class is added to identify the browser and the OS according to the user agent (e.g. `browser-firefox browser-firefox-windows`
* In the `admin-sidebar` component the value of `--ds-dark-scrollbar-width` is overridden when `browser-firefox-window` class is present

### Implementation notes
Note that `--ds-dark-scrollbar-width` has two purposes:
* define the scrollbar width (this is not supported by Firefox)
* allocate space to the scrollbar (`min-width: calc(var(--ds-admin-sidebar-collapsible-element-width) - var(--ds-dark-scrollbar-width));`)

## Additional notes
This PR allows to override any property of a CSS class as follows:

```css
.my-class {
  // class properties
  ::ng-deep {
    @at-root .browser-safari & {
      // override properties here
    }
  }
}
```

Currently only Safari and Firefox browsers and Windows OS are supported, but other browsers and OSs can be easily added.

## Further improvements

This PR solves the issue, but further improvements are required to make the scrollbar width smaller: see [this comment](https://github.com/DSpace/dspace-angular/issues/2927#issuecomment-2071941669)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
