### PR TITLE
Clicking save on create community and collection pages provides user feedback

### DIFF
--- a/cypress/e2e/collection-create.cy.ts
+++ b/cypress/e2e/collection-create.cy.ts
@@ -1,0 +1,13 @@
+beforeEach(() => {
+  cy.visit('/collections/create');
+  cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+});
+
+it('should show loading component while saving', () => {
+  const title = 'Test Collection Title';
+  cy.get('#title').type(title);
+
+  cy.get('button[type="submit"]').click();
+
+  cy.get('ds-themed-loading').should('be.visible');
+});

--- a/cypress/e2e/collection-create.cy.ts
+++ b/cypress/e2e/collection-create.cy.ts
@@ -1,5 +1,5 @@
 beforeEach(() => {
-  cy.visit('/collections/create');
+  cy.visit('/collections/create?parent='.concat(Cypress.env('DSPACE_TEST_COMMUNITY')));
   cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 });
 
@@ -9,5 +9,5 @@ it('should show loading component while saving', () => {
 
   cy.get('button[type="submit"]').click();
 
-  cy.get('ds-themed-loading').should('be.visible');
+  cy.get('ds-loading').should('be.visible');
 });

--- a/cypress/e2e/community-create.cy.ts
+++ b/cypress/e2e/community-create.cy.ts
@@ -1,0 +1,13 @@
+beforeEach(() => {
+  cy.visit('/communities/create');
+  cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+});
+
+it('should show loading component while saving', () => {
+  const title = 'Test Community Title';
+  cy.get('#title').type(title);
+
+  cy.get('button[type="submit"]').click();
+
+  cy.get('ds-themed-loading').should('be.visible');
+});

--- a/cypress/e2e/community-create.cy.ts
+++ b/cypress/e2e/community-create.cy.ts
@@ -9,5 +9,5 @@ it('should show loading component while saving', () => {
 
   cy.get('button[type="submit"]').click();
 
-  cy.get('ds-themed-loading').should('be.visible');
+  cy.get('ds-loading').should('be.visible');
 });

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.html
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.html
@@ -1,10 +1,15 @@
-<div class="container">
-    <div class="row">
-        <div class="col-12 pb-4">
-            <h2 id="sub-header" class="border-bottom pb-2">{{'collection.create.sub-head' | translate:{ parent: dsoNameService.getName((parentRD$| async)?.payload) } }}</h2>
-        </div>
+<div class="container" *ngIf="(isLoading$ | async) === false">
+  <div class="row">
+    <div class="col-12 pb-4">
+      <h2 id="sub-header"
+          class="border-bottom pb-2">{{ 'collection.create.sub-head' | translate:{ parent: dsoNameService.getName((parentRD$| async)?.payload) } }}</h2>
     </div>
-    <ds-collection-form (submitForm)="onSubmit($event)"
-                        (back)="navigateToHome()"
-                        (finish)="navigateToNewPage()"></ds-collection-form>
+  </div>
+  <ds-collection-form (submitForm)="onSubmit($event)"
+                      (back)="navigateToHome()"
+                      (finish)="navigateToNewPage()"></ds-collection-form>
+</div>
+
+<div class="container">
+  <ds-themed-loading *ngIf="isLoading$ | async"></ds-themed-loading>
 </div>

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.html
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.html
@@ -11,5 +11,5 @@
 </div>
 
 <div class="container">
-  <ds-themed-loading *ngIf="isLoading$ | async"></ds-themed-loading>
+  <ds-loading *ngIf="isLoading$ | async"></ds-loading>
 </div>

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -1,4 +1,7 @@
-import { AsyncPipe, NgIf } from '@angular/common';
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import {
@@ -16,7 +19,6 @@ import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/crea
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
-import { LoadingComponent } from '../../../themes/custom/app/shared/loading/loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection
@@ -30,7 +32,6 @@ import { LoadingComponent } from '../../../themes/custom/app/shared/loading/load
     TranslateModule,
     AsyncPipe,
     ThemedLoadingComponent,
-    LoadingComponent,
     NgIf,
   ],
   standalone: true,

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import {
@@ -16,6 +16,7 @@ import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/crea
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
+import { LoadingComponent } from '../../../themes/custom/app/shared/loading/loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection
@@ -29,6 +30,8 @@ import { CollectionFormComponent } from '../collection-form/collection-form.comp
     TranslateModule,
     AsyncPipe,
     ThemedLoadingComponent,
+    LoadingComponent,
+    NgIf,
   ],
   standalone: true,
 })

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -16,6 +16,7 @@ import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/crea
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -15,6 +15,7 @@ import { Collection } from '../../core/shared/collection.model';
 import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection
@@ -27,6 +28,7 @@ import { CollectionFormComponent } from '../collection-form/collection-form.comp
     CollectionFormComponent,
     TranslateModule,
     AsyncPipe,
+    ThemedLoadingComponent,
   ],
   standalone: true,
 })

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -16,7 +16,6 @@ import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/crea
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
-import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection

--- a/src/app/collection-page/create-collection-page/create-collection-page.component.ts
+++ b/src/app/collection-page/create-collection-page/create-collection-page.component.ts
@@ -13,9 +13,9 @@ import { RequestService } from '../../core/data/request.service';
 import { RouteService } from '../../core/services/route.service';
 import { Collection } from '../../core/shared/collection.model';
 import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
-import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Collection

--- a/src/app/community-page/create-community-page/create-community-page.component.html
+++ b/src/app/community-page/create-community-page/create-community-page.component.html
@@ -14,5 +14,5 @@
 </div>
 
 <div class="container">
-  <ds-themed-loading *ngIf="isLoading$ | async"></ds-themed-loading>
+  <ds-loading *ngIf="isLoading$ | async"></ds-loading>
 </div>

--- a/src/app/community-page/create-community-page/create-community-page.component.html
+++ b/src/app/community-page/create-community-page/create-community-page.component.html
@@ -1,13 +1,18 @@
-<div class="container">
+<div class="container" *ngIf="(isLoading$ | async) === false">
   <div class="row">
     <div class="col-12 pb-4">
       <ng-container *ngVar="(parentRD$ | async)?.payload as parent">
         <h2 *ngIf="!parent" id="header" class="border-bottom pb-2">{{ 'community.create.head' | translate }}</h2>
-        <h2 *ngIf="parent" id="sub-header" class="border-bottom pb-2">{{ 'community.create.sub-head' | translate:{ parent: dsoNameService.getName(parent) } }}</h2>
+        <h2 *ngIf="parent" id="sub-header"
+            class="border-bottom pb-2">{{ 'community.create.sub-head' | translate:{ parent: dsoNameService.getName(parent) } }}</h2>
       </ng-container>
     </div>
   </div>
   <ds-community-form (submitForm)="onSubmit($event)"
                      (back)="navigateToHome()"
                      (finish)="navigateToNewPage()"></ds-community-form>
+</div>
+
+<div class="container">
+  <ds-themed-loading *ngIf="isLoading$ | async"></ds-themed-loading>
 </div>

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -19,7 +19,6 @@ import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.comp
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
-import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -15,10 +15,10 @@ import { RequestService } from '../../core/data/request.service';
 import { RouteService } from '../../core/services/route.service';
 import { Community } from '../../core/shared/community.model';
 import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
-import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -19,6 +19,7 @@ import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.comp
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
+import { LoadingComponent } from '../../../themes/custom/app/shared/loading/loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community
@@ -34,6 +35,7 @@ import { CommunityFormComponent } from '../community-form/community-form.compone
     NgIf,
     AsyncPipe,
     ThemedLoadingComponent,
+    LoadingComponent,
   ],
   standalone: true,
 })

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -18,6 +18,7 @@ import { CreateComColPageComponent } from '../../shared/comcol/comcol-forms/crea
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community
@@ -32,6 +33,7 @@ import { CommunityFormComponent } from '../community-form/community-form.compone
     VarDirective,
     NgIf,
     AsyncPipe,
+    ThemedLoadingComponent,
   ],
   standalone: true,
 })

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -19,6 +19,7 @@ import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.comp
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
+import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community

--- a/src/app/community-page/create-community-page/create-community-page.component.ts
+++ b/src/app/community-page/create-community-page/create-community-page.component.ts
@@ -19,7 +19,6 @@ import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.comp
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { CommunityFormComponent } from '../community-form/community-form.component';
-import { LoadingComponent } from '../../../themes/custom/app/shared/loading/loading.component';
 
 /**
  * Component that represents the page where a user can create a new Community
@@ -35,7 +34,6 @@ import { LoadingComponent } from '../../../themes/custom/app/shared/loading/load
     NgIf,
     AsyncPipe,
     ThemedLoadingComponent,
-    LoadingComponent,
   ],
   standalone: true,
 })

--- a/src/app/shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -4,7 +4,10 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+} from 'rxjs';
 import {
   mergeMap,
   take,

--- a/src/app/shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component.ts
+++ b/src/app/shared/comcol/comcol-forms/create-comcol-page/create-comcol-page.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import {
   mergeMap,
   take,
@@ -62,6 +62,11 @@ export class CreateComColPageComponent<TDomain extends Collection | Community> i
    */
   protected type: ResourceType;
 
+  /**
+   * The
+   */
+  isLoading$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
   public constructor(
     protected dsoDataService: ComColDataService<TDomain>,
     public dsoNameService: DSONameService,
@@ -89,6 +94,7 @@ export class CreateComColPageComponent<TDomain extends Collection | Community> i
    * @param event   The event returned by the community/collection form. Contains the new dso and logo uploader
    */
   onSubmit(event) {
+    this.isLoading$.next(true);
     const dso = event.dso;
     const uploader = event.uploader;
 
@@ -101,6 +107,7 @@ export class CreateComColPageComponent<TDomain extends Collection | Community> i
           );
       }))
       .subscribe((dsoRD: TDomain) => {
+        this.isLoading$.next(false);
         if (isNotUndefined(dsoRD)) {
           this.newUUID = dsoRD.uuid;
           if (uploader.queue.length > 0) {


### PR DESCRIPTION
## References
* Fixes #2941

## Description
Fixes the bug where clicking "Save" when creating a new Community or Collection doesn't provide any visual feedback to the user. This PR introduces a loading animation to indicate that the backend is processing the request.
## Instructions for Reviewers

List of changes in this PR:
-   Added `isLoading$: BehaviorSubject<boolean>` property to the `CreateComColPageComponent`.
-   Implemented logic to show and hide the loading animation in `onSubmit` method.
-   Added `ds-themed-loading` component to the HTML files of `CreateCollectionPageComponent` and `CreateCommunityPageComponent`.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).