### PR TITLE
Fix Author search result without co-author

### DIFF
--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
@@ -29,7 +29,7 @@
           <span *ngIf="dso.firstMetadataValue('dc.date.issued')" class="item-list-date" [innerHTML]="firstMetadataValue('dc.date.issued')"></span>)
           </ng-container>
           <span *ngIf="dso.allMetadata(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']).length > 0" class="item-list-authors">
-            <span *ngFor="let author of allMetadataNoExcludingValues(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']); let last=last;">
+            <span *ngFor="let author of allMetadataValues(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']); let last=last;">
                 <span [innerHTML]="author"><span [innerHTML]="author"></span></span>
                 <span *ngIf="!last">; </span>
             </span>

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
@@ -29,7 +29,7 @@
           <span *ngIf="dso.firstMetadataValue('dc.date.issued')" class="item-list-date" [innerHTML]="firstMetadataValue('dc.date.issued')"></span>)
           </ng-container>
           <span *ngIf="dso.allMetadata(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']).length > 0" class="item-list-authors">
-            <span *ngFor="let author of allMetadataValues(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']); let last=last;">
+            <span *ngFor="let author of allMetadataNoExcludingValues(['dc.contributor.author', 'dc.creator', 'dc.contributor.*']); let last=last;">
                 <span [innerHTML]="author"><span [innerHTML]="author"></span></span>
                 <span *ngIf="!last">; </span>
             </span>

--- a/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
@@ -58,14 +58,11 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
     let highlights: string[] = Metadata.allValues([this.object.hitHighlights], keyOrKeys);
     let removedHighlights: string[] = highlights.map(str => str.replace(/<\/?em>/g, ''));
     for (let i = 0; i < removedHighlights.length; i++) {
-        let index = dsoMetadata.indexOf(removedHighlights[i]);        
+        let index = dsoMetadata.indexOf(removedHighlights[i]);
         if (index !== -1) {
           dsoMetadata[index] = highlights[i];
         }
     }
-    console.log(dsoMetadata);
-    console.log(highlights);
-    console.log(removedHighlights);
     return dsoMetadata;
   }
 

--- a/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
@@ -48,6 +48,28 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
   }
 
   /**
+   * Gets all matching metadata string values from hitHighlights or dso metadata.
+   *
+   * @param {string|string[]} keyOrKeys The metadata key(s) in scope. Wildcards are supported; see [[Metadata]].
+   * @returns {string[]} the matching string values or an empty array.
+   */
+  allMetadataNoExcludingValues(keyOrKeys: string | string[]): string[] {
+    let dsoMetadata: string[] = Metadata.allValues([this.dso.metadata], keyOrKeys);
+    let highlights: string[] = Metadata.allValues([this.object.hitHighlights], keyOrKeys);
+    let removedHighlights: string[] = highlights.map(str => str.replace(/<\/?em>/g, ''));
+    for (let i = 0; i < removedHighlights.length; i++) {
+        let index = dsoMetadata.indexOf(removedHighlights[i]);        
+        if (index !== -1) {
+          dsoMetadata[index] = highlights[i];
+        }
+    }
+    console.log(dsoMetadata);
+    console.log(highlights);
+    console.log(removedHighlights);
+    return dsoMetadata;
+  }
+
+  /**
    * Gets the first matching metadata string value from hitHighlights or dso metadata, preferring hitHighlights.
    *
    * @param {string|string[]} keyOrKeys The metadata key(s) in scope. Wildcards are supported; see [[Metadata]].

--- a/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
@@ -38,22 +38,12 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
   }
 
   /**
-   * Gets all matching metadata string values from hitHighlights or dso metadata, preferring hitHighlights.
-   *
-   * @param {string|string[]} keyOrKeys The metadata key(s) in scope. Wildcards are supported; see [[Metadata]].
-   * @returns {string[]} the matching string values or an empty array.
-   */
-  allMetadataValues(keyOrKeys: string | string[]): string[] {
-    return Metadata.allValues([this.object.hitHighlights, this.dso.metadata], keyOrKeys);
-  }
-
-  /**
    * Gets all matching metadata string values from hitHighlights or dso metadata.
    *
    * @param {string|string[]} keyOrKeys The metadata key(s) in scope. Wildcards are supported; see [[Metadata]].
    * @returns {string[]} the matching string values or an empty array.
    */
-  allMetadataNoExcludingValues(keyOrKeys: string | string[]): string[] {
+  allMetadataValues(keyOrKeys: string | string[]): string[] {
     let dsoMetadata: string[] = Metadata.allValues([this.dso.metadata], keyOrKeys);
     let highlights: string[] = Metadata.allValues([this.object.hitHighlights], keyOrKeys);
     let removedHighlights: string[] = highlights.map(str => str.replace(/<\/?em>/g, ''));


### PR DESCRIPTION
Hi @tdonohue, I'm @jtimal partner, I like to share this PR with you:

## References
* Fixes #2203 

## Description
Add a method to search-result-list-element component to show all the authors and if the author's name is highlighted its displayed anyways (if author's list length allow it)

## Instructions for Reviewers
To reproduce the error we need an item with two or more dc.contributor.author:

- Create and deposit a new item
- Add to metadata two or more dc.contributor.author
- Use search tool to find the item

List of changes in this PR:
* Added a method to combine the highlighted authors and other authors' name
* Changed the method used to displayed the list of authors in result list

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
