### PR TITLE
Synced the imports of the custom theme with the imports of the base component so custom theme works again

### DIFF
--- a/src/themes/custom/app/browse-by/browse-by-taxonomy/browse-by-taxonomy.component.ts
+++ b/src/themes/custom/app/browse-by/browse-by-taxonomy/browse-by-taxonomy.component.ts
@@ -3,7 +3,7 @@ import {
   NgIf,
 } from '@angular/common';
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { BrowseByTaxonomyComponent as BaseComponent } from '../../../../../app/browse-by/browse-by-taxonomy/browse-by-taxonomy.component';
@@ -32,16 +32,16 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
     ComcolPageHeaderComponent,
     ComcolPageLogoComponent,
     NgIf,
-    RouterModule,
     ThemedComcolPageHandleComponent,
     ComcolPageContentComponent,
     DsoEditMenuComponent,
     ThemedComcolPageBrowseByComponent,
-    VocabularyTreeviewComponent,
     BrowseByComponent,
     TranslateModule,
     ThemedLoadingComponent,
     ThemedBrowseByComponent,
+    VocabularyTreeviewComponent,
+    RouterLink,
   ],
 })
 export class BrowseByTaxonomyComponent extends BaseComponent {

--- a/src/themes/custom/app/collection-page/collection-page.component.ts
+++ b/src/themes/custom/app/collection-page/collection-page.component.ts
@@ -43,7 +43,6 @@ import { ViewTrackerComponent } from '../../../../app/statistics/angulartics/dsp
     ComcolPageContentComponent,
     ErrorComponent,
     NgIf,
-    RouterOutlet,
     ThemedLoadingComponent,
     TranslateModule,
     ViewTrackerComponent,
@@ -55,6 +54,7 @@ import { ViewTrackerComponent } from '../../../../app/statistics/angulartics/dsp
     DsoEditMenuComponent,
     ThemedComcolPageBrowseByComponent,
     ObjectCollectionComponent,
+    RouterOutlet,
   ],
 })
 /**

--- a/src/themes/custom/app/collection-page/edit-item-template-page/edit-item-template-page.component.ts
+++ b/src/themes/custom/app/collection-page/edit-item-template-page/edit-item-template-page.component.ts
@@ -11,6 +11,7 @@ import { ThemedDsoEditMetadataComponent } from '../../../../../app/dso-shared/ds
 import { AlertComponent } from '../../../../../app/shared/alert/alert.component';
 import { ThemedLoadingComponent } from '../../../../../app/shared/loading/themed-loading.component';
 import { VarDirective } from '../../../../../app/shared/utils/var.directive';
+import { DsoEditMetadataComponent } from '../../dso-shared/dso-edit-metadata/dso-edit-metadata.component';
 
 @Component({
   selector: 'ds-edit-item-template-page',
@@ -20,6 +21,7 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
   standalone: true,
   imports: [
     ThemedDsoEditMetadataComponent,
+    DsoEditMetadataComponent,
     RouterLink,
     AsyncPipe,
     VarDirective,

--- a/src/themes/custom/app/community-page/community-page.component.ts
+++ b/src/themes/custom/app/community-page/community-page.component.ts
@@ -6,7 +6,10 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import {
+  RouterModule,
+  RouterOutlet,
+} from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { CommunityPageComponent as BaseComponent } from '../../../../app/community-page/community-page.component';
@@ -50,6 +53,7 @@ import { ViewTrackerComponent } from '../../../../app/statistics/angulartics/dsp
     AsyncPipe,
     ViewTrackerComponent,
     VarDirective,
+    RouterOutlet,
     RouterModule,
   ],
 })

--- a/src/themes/custom/app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component.ts
+++ b/src/themes/custom/app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component.ts
@@ -1,6 +1,15 @@
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import { Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { CommunityPageSubCollectionListComponent as BaseComponent } from '../../../../../../../app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component';
+import { ErrorComponent } from '../../../../../../../app/shared/error/error.component';
+import { ThemedLoadingComponent } from '../../../../../../../app/shared/loading/themed-loading.component';
+import { ObjectCollectionComponent } from '../../../../../../../app/shared/object-collection/object-collection.component';
+import { VarDirective } from '../../../../../../../app/shared/utils/var.directive';
 
 @Component({
   selector: 'ds-community-page-sub-collection-list',
@@ -8,6 +17,15 @@ import { CommunityPageSubCollectionListComponent as BaseComponent } from '../../
   styleUrls: ['../../../../../app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component.scss'],
   // templateUrl: './community-page-sub-collection-list.component.html',
   templateUrl: '../../../../../app/community-page/sections/sub-com-col-section/sub-collection-list/community-page-sub-collection-list.component.html',
+  imports: [
+    ObjectCollectionComponent,
+    ErrorComponent,
+    ThemedLoadingComponent,
+    NgIf,
+    TranslateModule,
+    AsyncPipe,
+    VarDirective,
+  ],
   standalone: true,
 })
 export class CommunityPageSubCollectionListComponent extends BaseComponent {

--- a/src/themes/custom/app/forgot-password/forgot-password-email/forgot-email.component.ts
+++ b/src/themes/custom/app/forgot-password/forgot-password-email/forgot-email.component.ts
@@ -12,8 +12,7 @@ import { RegisterEmailFormComponent } from '../../../../../app/register-email-fo
   templateUrl: '../../../../../app/forgot-password/forgot-password-email/forgot-email.component.html',
   standalone: true,
   imports: [
-    RegisterEmailFormComponent,
-    ThemedRegisterEmailFormComponent,
+    RegisterEmailFormComponent, ThemedRegisterEmailFormComponent,
   ],
 })
 /**

--- a/src/themes/custom/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
+++ b/src/themes/custom/app/forgot-password/forgot-password-form/forgot-password-form.component.ts
@@ -18,8 +18,8 @@ import { BrowserOnlyPipe } from '../../../../../app/shared/utils/browser-only.pi
   standalone: true,
   imports: [
     TranslateModule,
-    ProfilePageSecurityFormComponent,
     BrowserOnlyPipe,
+    ProfilePageSecurityFormComponent,
     AsyncPipe,
     NgIf,
   ],

--- a/src/themes/custom/app/header/header.component.ts
+++ b/src/themes/custom/app/header/header.component.ts
@@ -1,3 +1,7 @@
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
@@ -21,7 +25,7 @@ import { LangSwitchComponent } from '../../../../app/shared/lang-switch/lang-swi
   // templateUrl: 'header.component.html',
   templateUrl: '../../../../app/header/header.component.html',
   standalone: true,
-  imports: [RouterLink, ThemedLangSwitchComponent, NgbDropdownModule, ThemedSearchNavbarComponent, LangSwitchComponent, ContextHelpToggleComponent, ThemedAuthNavMenuComponent, ImpersonateNavbarComponent, TranslateModule],
+  imports: [RouterLink, ThemedLangSwitchComponent, NgbDropdownModule, ThemedSearchNavbarComponent, LangSwitchComponent, ContextHelpToggleComponent, ThemedAuthNavMenuComponent, ImpersonateNavbarComponent, TranslateModule, AsyncPipe, NgIf],
 })
 export class HeaderComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/home-page/home-page.component.ts
+++ b/src/themes/custom/app/home-page/home-page.component.ts
@@ -2,6 +2,7 @@ import {
   AsyncPipe,
   NgClass,
   NgIf,
+  NgTemplateOutlet,
 } from '@angular/common';
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -25,7 +26,7 @@ import { ViewTrackerComponent } from '../../../../app/statistics/angulartics/dsp
   // templateUrl: './home-page.component.html'
   templateUrl: '../../../../app/home-page/home-page.component.html',
   standalone: true,
-  imports: [ThemedHomeNewsComponent, NgIf, ViewTrackerComponent, ThemedSearchFormComponent, ThemedTopLevelCommunityListComponent, RecentItemListComponent, AsyncPipe, TranslateModule, NgClass, ConfigurationSearchPageComponent, SuggestionsPopupComponent, ThemedConfigurationSearchPageComponent, PageWithSidebarComponent, HomeCoarComponent],
+  imports: [ThemedHomeNewsComponent, NgTemplateOutlet, NgIf, ViewTrackerComponent, ThemedSearchFormComponent, ThemedTopLevelCommunityListComponent, RecentItemListComponent, AsyncPipe, TranslateModule, NgClass, ConfigurationSearchPageComponent, SuggestionsPopupComponent, ThemedConfigurationSearchPageComponent, PageWithSidebarComponent, HomeCoarComponent],
 })
 export class HomePageComponent extends BaseComponent {
 

--- a/src/themes/custom/app/item-page/simple/item-page.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-page.component.ts
@@ -44,11 +44,11 @@ import { ViewTrackerComponent } from '../../../../../app/statistics/angulartics/
     ItemVersionsComponent,
     ErrorComponent,
     ThemedLoadingComponent,
-    NotifyRequestsStatusComponent,
-    QaEventNotificationComponent,
     TranslateModule,
     AsyncPipe,
     NgIf,
+    NotifyRequestsStatusComponent,
+    QaEventNotificationComponent,
   ],
 })
 export class ItemPageComponent extends BaseComponent {

--- a/src/themes/custom/app/item-page/simple/item-types/publication/publication.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/publication/publication.component.ts
@@ -1,4 +1,7 @@
-import { CommonModule } from '@angular/common';
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -39,26 +42,7 @@ import { ThemedThumbnailComponent } from '../../../../../../../app/thumbnail/the
   templateUrl: '../../../../../../../app/item-page/simple/item-types/publication/publication.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [
-    CommonModule,
-    ThemedResultsBackButtonComponent,
-    MiradorViewerComponent,
-    ThemedItemPageTitleFieldComponent,
-    DsoEditMenuComponent,
-    MetadataFieldWrapperComponent,
-    ThemedThumbnailComponent,
-    ThemedMediaViewerComponent,
-    ThemedFileSectionComponent,
-    ItemPageDateFieldComponent,
-    ThemedMetadataRepresentationListComponent,
-    GenericItemPageFieldComponent,
-    RelatedItemsComponent,
-    ItemPageAbstractFieldComponent,
-    TranslateModule,
-    ItemPageUriFieldComponent,
-    CollectionsComponent,
-    RouterLink,
-  ],
+  imports: [NgIf, ThemedResultsBackButtonComponent, MiradorViewerComponent, ThemedItemPageTitleFieldComponent, DsoEditMenuComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, ThemedMediaViewerComponent, ThemedFileSectionComponent, ItemPageDateFieldComponent, ThemedMetadataRepresentationListComponent, GenericItemPageFieldComponent, RelatedItemsComponent, ItemPageAbstractFieldComponent, ItemPageUriFieldComponent, CollectionsComponent, RouterLink, AsyncPipe, TranslateModule],
 })
 export class PublicationComponent extends BaseComponent {
 

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
@@ -1,4 +1,7 @@
-import { CommonModule } from '@angular/common';
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -38,25 +41,7 @@ import { ThemedThumbnailComponent } from '../../../../../../../app/thumbnail/the
   templateUrl: '../../../../../../../app/item-page/simple/item-types/untyped-item/untyped-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [
-    CommonModule,
-    ThemedItemPageTitleFieldComponent,
-    DsoEditMenuComponent,
-    MetadataFieldWrapperComponent,
-    ThemedThumbnailComponent,
-    ThemedMediaViewerComponent,
-    ThemedFileSectionComponent,
-    ItemPageDateFieldComponent,
-    ThemedMetadataRepresentationListComponent,
-    GenericItemPageFieldComponent,
-    TranslateModule,
-    MiradorViewerComponent,
-    ThemedResultsBackButtonComponent,
-    CollectionsComponent,
-    RouterLink,
-    ItemPageUriFieldComponent,
-    ItemPageAbstractFieldComponent,
-  ],
+  imports: [NgIf, ThemedResultsBackButtonComponent, MiradorViewerComponent, ThemedItemPageTitleFieldComponent, DsoEditMenuComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, ThemedMediaViewerComponent, ThemedFileSectionComponent, ItemPageDateFieldComponent, ThemedMetadataRepresentationListComponent, GenericItemPageFieldComponent, ItemPageAbstractFieldComponent, ItemPageUriFieldComponent, CollectionsComponent, RouterLink, AsyncPipe, TranslateModule],
 })
 export class UntypedItemComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/login-page/login-page.component.ts
+++ b/src/themes/custom/app/login-page/login-page.component.ts
@@ -15,7 +15,7 @@ import { LogInComponent } from '../../../../app/shared/log-in/log-in.component';
   // templateUrl: './login-page.component.html'
   templateUrl: '../../../../app/login-page/login-page.component.html',
   standalone: true,
-  imports: [LogInComponent, ThemedLogInComponent ,TranslateModule],
+  imports: [LogInComponent, ThemedLogInComponent, TranslateModule],
 })
 export class LoginPageComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/my-dspace-page/my-dspace-page.component.ts
+++ b/src/themes/custom/app/my-dspace-page/my-dspace-page.component.ts
@@ -40,11 +40,11 @@ import { ThemedSearchComponent } from '../../../../app/shared/search/themed-sear
   imports: [
     ThemedSearchComponent,
     MyDSpaceNewSubmissionComponent,
-    MyDspaceQaEventsNotificationsComponent,
-    SuggestionsNotificationComponent,
     AsyncPipe,
     RoleDirective,
     NgIf,
+    SuggestionsNotificationComponent,
+    MyDspaceQaEventsNotificationsComponent,
   ],
 })
 export class MyDSpacePageComponent extends BaseComponent {

--- a/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -1,7 +1,15 @@
+import {
+  AsyncPipe,
+  NgComponentOutlet,
+  NgFor,
+  NgIf,
+} from '@angular/common';
 import { Component } from '@angular/core';
+import { RouterLinkActive } from '@angular/router';
 
 import { ExpandableNavbarSectionComponent as BaseComponent } from '../../../../../app/navbar/expandable-navbar-section/expandable-navbar-section.component';
 import { slide } from '../../../../../app/shared/animations/slide';
+import { VarDirective } from '../../../../../app/shared/utils/var.directive';
 
 /**
  * Represents an expandable section in the navbar
@@ -14,6 +22,7 @@ import { slide } from '../../../../../app/shared/animations/slide';
   styleUrls: ['../../../../../app/navbar/expandable-navbar-section/expandable-navbar-section.component.scss'],
   animations: [slide],
   standalone: true,
+  imports: [VarDirective, RouterLinkActive, NgComponentOutlet, NgIf, NgFor, AsyncPipe],
 })
 export class ExpandableNavbarSectionComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/profile-page/profile-page.component.ts
+++ b/src/themes/custom/app/profile-page/profile-page.component.ts
@@ -23,13 +23,13 @@ import { VarDirective } from '../../../../app/shared/utils/var.directive';
   imports: [
     ProfilePageMetadataFormComponent,
     ProfilePageSecurityFormComponent,
-    SuggestionsNotificationComponent,
     AsyncPipe,
     TranslateModule,
     ProfilePageResearcherFormComponent,
     VarDirective,
     NgIf,
     NgForOf,
+    SuggestionsNotificationComponent,
   ],
 })
 /**

--- a/src/themes/custom/app/register-page/register-email/register-email.component.ts
+++ b/src/themes/custom/app/register-page/register-email/register-email.component.ts
@@ -12,8 +12,7 @@ import { RegisterEmailComponent as BaseComponent } from '../../../../../app/regi
   templateUrl: '../../../../../app/register-page/register-email/register-email.component.html',
   standalone: true,
   imports: [
-    RegisterEmailFormComponent,
-    ThemedRegisterEmailFormComponent,
+    RegisterEmailFormComponent, ThemedRegisterEmailFormComponent,
   ],
 })
 /**

--- a/src/themes/custom/app/shared/browse-by/browse-by.component.ts
+++ b/src/themes/custom/app/shared/browse-by/browse-by.component.ts
@@ -30,8 +30,7 @@ import { StartsWithLoaderComponent } from '../../../../../app/shared/starts-with
     fadeInOut,
   ],
   standalone: true,
-  imports: [VarDirective, NgClass, NgComponentOutlet, NgIf, ThemedResultsBackButtonComponent, ObjectCollectionComponent,
-    ThemedLoadingComponent, ErrorComponent, AsyncPipe, TranslateModule, StartsWithLoaderComponent],
+  imports: [VarDirective, NgClass, NgComponentOutlet, NgIf, ThemedResultsBackButtonComponent, ObjectCollectionComponent, ThemedLoadingComponent, ErrorComponent, AsyncPipe, TranslateModule, StartsWithLoaderComponent],
 })
 export class BrowseByComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/shared/comcol-page-browse-by/comcol-page-browse-by.component.ts
+++ b/src/themes/custom/app/shared/comcol-page-browse-by/comcol-page-browse-by.component.ts
@@ -1,6 +1,7 @@
 import {
   AsyncPipe,
   NgForOf,
+  NgIf,
 } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -30,6 +31,7 @@ import { ComcolPageBrowseByComponent as BaseComponent } from '../../../../../app
     RouterLinkActive,
     TranslateModule,
     AsyncPipe,
+    NgIf,
   ],
 })
 export class ComcolPageBrowseByComponent extends BaseComponent {}

--- a/src/themes/custom/app/shared/lang-switch/lang-switch.component.ts
+++ b/src/themes/custom/app/shared/lang-switch/lang-switch.component.ts
@@ -1,5 +1,5 @@
 import {
-  NgForOf,
+  NgFor,
   NgIf,
 } from '@angular/common';
 import { Component } from '@angular/core';
@@ -15,7 +15,7 @@ import { LangSwitchComponent as BaseComponent } from '../../../../../app/shared/
   // templateUrl: './lang-switch.component.html',
   templateUrl: '../../../../../app/shared/lang-switch/lang-switch.component.html',
   standalone: true,
-  imports: [NgIf, NgbDropdownModule, NgForOf, TranslateModule],
+  imports: [NgIf, NgbDropdownModule, NgFor, TranslateModule],
 })
 export class LangSwitchComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/shared/loading/loading.component.ts
+++ b/src/themes/custom/app/shared/loading/loading.component.ts
@@ -1,3 +1,4 @@
+import { NgIf } from '@angular/common';
 import { Component } from '@angular/core';
 
 import { LoadingComponent as BaseComponent } from '../../../../../app/shared/loading/loading.component';
@@ -9,6 +10,7 @@ import { LoadingComponent as BaseComponent } from '../../../../../app/shared/loa
   templateUrl: '../../../../../app/shared/loading/loading.component.html',
   // templateUrl: './loading.component.html'
   standalone: true,
+  imports: [NgIf],
 })
 export class LoadingComponent extends BaseComponent {
 

--- a/src/themes/custom/app/shared/object-list/object-list.component.ts
+++ b/src/themes/custom/app/shared/object-list/object-list.component.ts
@@ -22,10 +22,7 @@ import { BrowserOnlyPipe } from '../../../../../app/shared/utils/browser-only.pi
   styleUrls: ['../../../../../app/shared/object-list/object-list.component.scss'],
   // templateUrl: './object-list.component.html'
   templateUrl: '../../../../../app/shared/object-list/object-list.component.html',
-  imports: [
-    PaginationComponent, NgIf, NgClass, NgFor, SelectableListItemControlComponent,
-    ImportableListItemControlComponent, ListableObjectComponentLoaderComponent, BrowserOnlyPipe,
-  ],
+  imports: [PaginationComponent, NgIf, NgClass, NgFor, SelectableListItemControlComponent, ImportableListItemControlComponent, ListableObjectComponentLoaderComponent, BrowserOnlyPipe],
   standalone: true,
 })
 


### PR DESCRIPTION

## References

-   Fixes #2977
## Description

This PR fixes the issue where running the DSpace UI with the "custom" theme resulted in many features not working properly. The root cause was identified as the themed components having mismatched imports compared to their base components. The PR addresses this by ensuring that all themed components have the same imports as their base components.

## Instructions for Reviewers

The changes made in this PR include:

-   Ensuring consistency in imports between themed components and their base components.
-   Verifying that all fixed components now work correctly in the custom theme.

**Testing Instructions:**

1.  Enable the custom theme.
2.  Build the UI in production mode using `yarn build:prod` and serve using `yarn serve:ssr`.
3.  Access the homepage and ensure that all features are working as expected.
4.  Repeat the above steps for individual item pages to ensure proper functionality.
## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).