### PR TITLE
Fixed the problem that creating template item results in page which never finishes loading

### DIFF
--- a/cypress/e2e/item-template.cy.ts
+++ b/cypress/e2e/item-template.cy.ts
@@ -6,7 +6,7 @@ describe('Item Template', () => {
     cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
   });
 
-  it('It should display the elements with specific texts', () => {
+  it('should load properly', () => {
     cy.contains('.ds-header-row .lbl-cell', 'Field', { timeout: 10000 }).should('exist').should('be.visible');
     cy.contains('.ds-header-row b', 'Value', { timeout: 10000 }).should('exist').should('be.visible');
     cy.contains('.ds-header-row b', 'Lang', { timeout: 10000 }).should('exist').should('be.visible');

--- a/cypress/e2e/item-template.cy.ts
+++ b/cypress/e2e/item-template.cy.ts
@@ -1,0 +1,15 @@
+const ADD_TEMPLATE_ITEM_PAGE = '/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')).concat('/itemtemplate');
+
+describe('Item Template', () => {
+  beforeEach(() => {
+    cy.visit(ADD_TEMPLATE_ITEM_PAGE);
+    cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
+  });
+
+  it('It should display the elements with specific texts', () => {
+    cy.contains('.ds-header-row .lbl-cell', 'Field', { timeout: 10000 }).should('exist').should('be.visible');
+    cy.contains('.ds-header-row b', 'Value', { timeout: 10000 }).should('exist').should('be.visible');
+    cy.contains('.ds-header-row b', 'Lang', { timeout: 10000 }).should('exist').should('be.visible');
+    cy.contains('.ds-header-row b', 'Edit', { timeout: 10000 }).should('exist').should('be.visible');
+  });
+});

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata.component.ts
@@ -24,9 +24,9 @@ import {
 import {
   BehaviorSubject,
   combineLatest as observableCombineLatest,
-  EMPTY,
   Observable,
   Subscription,
+  of,
 } from 'rxjs';
 import {
   map,
@@ -188,7 +188,7 @@ export class DsoEditMetadataComponent implements OnInit, OnDestroy {
       const lazyProvider$: Observable<UpdateDataService<DSpaceObject>> = lazyDataService(this.dataServiceMap, this.dsoType, this.parentInjector);
       return lazyProvider$;
     } else {
-      return EMPTY;
+      return of(this.updateDataService);
     }
   }
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata.component.ts
@@ -25,8 +25,8 @@ import {
   BehaviorSubject,
   combineLatest as observableCombineLatest,
   Observable,
-  Subscription,
   of,
+  Subscription,
 } from 'rxjs';
 import {
   map,


### PR DESCRIPTION
## References
* Fixes #2938 

## Description
Updated the `retrieveDataService()` method to address an issue where the Template Item page for creating a new Item Template for a Collection fails to load. The method now correctly returns the `updateDataService` when available instead of returning empty.

## Instructions for Reviewers

List of changes in this PR:
* Updated the `retrieveDataService()` method to return the `updateDataService` when available instead of returning empty, resolving the issue with the non-loading Template Item page.
* Added e2e test to verify the display of specific elements on the item template page.

How to test:

1.  Edit a Collection.
2.  Click "+Add" under Template Item.
3.  Verify that the page successfully loads without any indefinite loading.
4.  Perform additional actions such as canceling, editing, or deleting the Template Item to ensure consistent behavior.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).