### PR TITLE
Submission performance

### DIFF
--- a/src/app/core/submission/submission-rest.service.spec.ts
+++ b/src/app/core/submission/submission-rest.service.spec.ts
@@ -26,7 +26,7 @@ describe('SubmissionRestService test suite', () => {
   const resourceEndpoint = 'workspaceitems';
   const resourceScope = '260';
   const body = { test: new FormFieldMetadataValueObject('test') };
-  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope + '?projection=full';
+  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope + '?embed=sections,collection';
   const timestampResponse = 1545994811992;
 
   function initTestService() {

--- a/src/app/core/submission/submission-rest.service.ts
+++ b/src/app/core/submission/submission-rest.service.ts
@@ -78,7 +78,7 @@ export class SubmissionRestService {
    */
   protected getEndpointByIDHref(endpoint, resourceID, collectionId?: string): string {
     let url = isNotEmpty(resourceID) ? `${endpoint}/${resourceID}` : `${endpoint}`;
-    url = new URLCombiner(url, '?projection=full').toString();
+    url = new URLCombiner(url, '?embed=sections,collection').toString();
     if (collectionId) {
       url = new URLCombiner(url, `&owningCollection=${collectionId}`).toString();
     }


### PR DESCRIPTION
## References
* [7_x REST PR](https://github.com/DSpace/DSpace/pull/9507)
* [7_x angular PR](https://github.com/DSpace/dspace-angular/pull/2987)
* [main REST PR](https://github.com/DSpace/DSpace/pull/9508)
* [main angular PR](https://github.com/DSpace/dspace-angular/pull/2988) (this PR)

## Description
This PR aims to improve performance for submission by removing default full projection for workflow/workspace items and instead allowing support for embedded properties.

## Instructions for Reviewers
Changes:
* Added links for "item", "submitter" and "collection" on workflow/workspace items (annotations, link repositories etc.)
* Removed `projection=full` from submission item on angular side and replaced with embed parameters, this should reduce _a lot_ of the server and page's load.
* Modified test cases that expect embedded properties to either remove the expectation or add embedded parameter to the request

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [ ] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
