### PR TITLE
Remove obsolete "version" tag from Docker Compose files (Angular version)

### DIFF
--- a/docker/cli.assetstore.yml
+++ b/docker/cli.assetstore.yml
@@ -12,8 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.assetstore.yml
 #
 # Therefore, it should be kept in sync with that file
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/docker/cli.ingest.yml
+++ b/docker/cli.ingest.yml
@@ -12,8 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.ingest.yml
 #
 # Therefore, it should be kept in sync with that file
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -12,7 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/docker-compose-cli.yml
 #
 # Therefore, it should be kept in sync with that file
-version: "3.7"
 networks:
   # Default to using network named 'dspacenet' from docker-compose-rest.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -12,8 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
 #
 # # Therefore, it should be kept in sync with that file
-version: "3.7"
-
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:loadsql

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -10,7 +10,6 @@
 # This is used by our GitHub CI at .github/workflows/build.yml
 # It is based heavily on the Backend's Docker Compose:
 # https://github.com/DSpace/DSpace/blob/main/docker-compose.yml
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -8,7 +8,6 @@
 
 # Docker Compose for running the DSpace Angular UI dist build
 # for previewing with the DSpace Demo site backend
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -10,7 +10,6 @@
 # This is based heavily on the docker-compose.yml that is available in the DSpace/DSpace
 # (Backend) at:
 # https://github.com/DSpace/DSpace/blob/main/docker-compose.yml
-version: '3.7'
 networks:
   dspacenet:
     ipam:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,6 @@
 # Docker Compose for running the DSpace Angular UI for testing/development
 # Requires also running a REST API backend (either locally or remotely),
 # for example via 'docker-compose-rest.yml'
-version: '3.7'
 networks:
   dspacenet:
 services:


### PR DESCRIPTION
## References
* Related to DSpace/DSpace#9522 , which made the same changes to the backend docker compose scripts.

## Description
The "version" tag in a Docker Compose file is now obsolete.  See docs at https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete

This PR just removes all those tags as we are now seeing warnings like this when rebuilding Docker images:
```
time="2024-05-01T11:14:05-05:00" level=warning msg="C:\\DSpace\\docker-compose.yml: `version` is obsolete"
time="2024-05-01T11:14:05-05:00" level=warning msg="C:\\DSpace\\docker-compose-cli.yml: `version` is obsolete"
```

## Instructions for Reviewers
* This is an extremely minor change.  As long as warning disappears & builds all succeed, I'll merge immediately.