### PR TITLE
Fix `TypeError: Cannot read properties of undefined (reading 'userAgent')`

### DIFF
--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -144,7 +144,7 @@ export class RootComponent implements OnInit {
   }
 
   getBrowserName(): string {
-    const userAgent = this._window.nativeWindow.navigator.userAgent;
+    const userAgent = this._window.nativeWindow.navigator?.userAgent;
     if (/Firefox/.test(userAgent)) {
       return 'firefox';
     }
@@ -155,7 +155,7 @@ export class RootComponent implements OnInit {
   }
 
   getOSName(): string {
-    const userAgent = this._window.nativeWindow.navigator.userAgent;
+    const userAgent = this._window.nativeWindow.navigator?.userAgent;
     if (/Windows/.test(userAgent)) {
       return 'windows';
     }


### PR DESCRIPTION
## References
* Fixes #3000

## Description
Fix bug where "navigator" may be null in SSR mode

## Instructions for Reviewers
* Verify error no longer occurs as described in #3000
* This error has also displayed in e2e test logs in GitHub CI.  If it's no longer displayed there, then this is working as well.