### PR TITLE
Fix broken links on subscriptions page

### DIFF
--- a/src/app/shared/subscriptions/subscription-view/subscription-view.component.html
+++ b/src/app/shared/subscriptions/subscription-view/subscription-view.component.html
@@ -1,7 +1,7 @@
 <td class="dso-info">
   <ng-container *ngIf="!!dso">
     <ds-type-badge [object]="dso"></ds-type-badge>
-    <p><a [routerLink]="[getPageRoutePrefix(), dso.id]">{{ dsoNameService.getName(dso) }}</a></p>
+    <p><a [routerLink]="getPageRoute(dso)">{{ dsoNameService.getName(dso) }}</a></p>
   </ng-container>
   <ng-container *ngIf="!dso">
     <p class="my-0">{{ 'subscriptions.table.not-available' | translate }}</p>

--- a/src/app/shared/subscriptions/subscription-view/subscription-view.component.ts
+++ b/src/app/shared/subscriptions/subscription-view/subscription-view.component.ts
@@ -15,12 +15,10 @@ import {
 } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { take } from 'rxjs/operators';
+import { getDSORoute } from 'src/app/app-routing-paths';
 
-import { getCollectionModuleRoute } from '../../../collection-page/collection-page-routing-paths';
-import { getCommunityModuleRoute } from '../../../community-page/community-page-routing-paths';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
-import { getItemModuleRoute } from '../../../item-page/item-page-routing-paths';
 import { ConfirmationModalComponent } from '../../confirmation-modal/confirmation-modal.component';
 import { hasValue } from '../../empty.util';
 import { ThemedTypeBadgeComponent } from '../../object-collection/shared/badges/type-badge/themed-type-badge.component';
@@ -73,22 +71,10 @@ export class SubscriptionViewComponent {
   ) { }
 
   /**
-   * Return the prefix of the route to the dso object page ( e.g. "items")
+   * Return the route to the dso object page
    */
-  getPageRoutePrefix(): string {
-    let routePrefix;
-    switch (this.dso.type.value) {
-      case 'community':
-        routePrefix = getCommunityModuleRoute();
-        break;
-      case 'collection':
-        routePrefix = getCollectionModuleRoute();
-        break;
-      case 'item':
-        routePrefix = getItemModuleRoute();
-        break;
-    }
-    return routePrefix;
+  getPageRoute(dso: DSpaceObject): string {
+    return getDSORoute(dso);
   }
 
   /**


### PR DESCRIPTION
## Description
Currently, if you access your "Subscriptions", the links to any community/collection are **broken**.

To Reproduce:
1. Login to DSpace (e.g. on https://sandbox.dspace.org this bug is reproducible)
2. Subscribe to at least on Community/Collection.  Visit the Community/Collection page and click subscription button
3. Go to your profile icon & select "Subscriptions" from dropdown. This will display your list of all subscriptions in a table format
4. In the first column of that table is the Community/Collection name as a link.  Click the link.  It will go to a 404 page, as the link is not correct.

This small PR fixes the bug by properly building the link.

## Instructions for Reviewers
* Test process above to verify the link is now fixed.  It should send you to the Community or Collection homepage.