### PR TITLE
Fixed page and admin menu for Shibboleth auth

### DIFF
--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -32,9 +32,11 @@ import { AppState } from '../../app/app.reducer';
 import { BreadcrumbsService } from '../../app/breadcrumbs/breadcrumbs.service';
 import { AuthService } from '../../app/core/auth/auth.service';
 import { coreSelector } from '../../app/core/core.selectors';
+import { RequestService } from '../../app/core/data/request.service';
 import { RootDataService } from '../../app/core/data/root-data.service';
 import { LocaleService } from '../../app/core/locale/locale.service';
 import { HeadTagService } from '../../app/core/metadata/head-tag.service';
+import { HALEndpointService } from '../../app/core/shared/hal-endpoint.service';
 import { CorrelationIdService } from '../../app/correlation-id/correlation-id.service';
 import { InitService } from '../../app/init.service';
 import { KlaroService } from '../../app/shared/cookies/klaro.service';
@@ -81,6 +83,9 @@ export class BrowserInitService extends InitService {
     protected menuService: MenuService,
     private rootDataService: RootDataService,
     protected router: Router,
+    private requestService: RequestService,
+    private halService: HALEndpointService,
+
   ) {
     super(
       store,
@@ -169,17 +174,15 @@ export class BrowserInitService extends InitService {
   }
 
   /**
-   * During an external authentication flow invalidate the SSR transferState
+   * During an external authentication flow invalidate the
    * data in the cache. This allows the app to fetch fresh content.
    * @private
    */
   private externalAuthCheck() {
-
     this.sub = this.authService.isExternalAuthentication().pipe(
       filter((externalAuth: boolean) => externalAuth),
     ).subscribe(() => {
-      // Clear the transferState data.
-      this.rootDataService.invalidateRootCache();
+      this.requestService.setStaleByHrefSubstring(this.halService.getRootHref());
       this.authService.setExternalAuthStatus(false);
     },
     );


### PR DESCRIPTION
Page content and admin menu weren't updating correctly after Shibboleth authentication. The change here forces the browser app to request fresh content after obtaining an auth token.

## References
* Fixes #1953 and #1665

## Description
Changes in 7.6.1 reintroduced the bugs reported in #1953 and #1665.  This PR implements the original step of setting all of cached objects stale. Unfortunately, I was only able to test this on a production 7.6.1 instance but it should work with 8.0 as well.

## Instructions for Reviewers
Testing with Shibboleth has become more difficult since https://samltest.id/ is no longer available. If anyone has a test instance running with Shib that would be a great help. 

List of changes in this PR:
* Updated the browser init service to call requestSerice.setStaleByHrefSubstring() directly rather than via the root data service (which has changed). 



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
