### PR TITLE
Handle Null Users Gracefully in Process Overview Page

### DIFF
--- a/src/app/process-page/form/process-form.component.ts
+++ b/src/app/process-page/form/process-form.component.ts
@@ -100,11 +100,11 @@ export class ProcessFormComponent implements OnInit {
     }
 
     const stringParameters: ProcessParameter[] = this.parameters.map((parameter: ProcessParameter) => {
-      return {
-        name: parameter.name,
-        value: this.checkValue(parameter),
-      };
-    },
+        return {
+          name: parameter.name,
+          value: this.checkValue(parameter),
+        };
+      },
     );
     this.scriptService.invoke(this.selectedScript.id, stringParameters, this.files)
       .pipe(getFirstCompletedRemoteData())
@@ -177,5 +177,36 @@ export class ProcessFormComponent implements OnInit {
     };
     void this.router.navigate([getProcessListRoute()], extras);
   }
-}
 
+  updateScript($event: Script) {
+    this.selectedScript = $event;
+    this.parameters = undefined;
+    this.updateName();
+  }
+
+  updateName(): void {
+    if (isEmpty(this.customName)) {
+      this.processName = this.generatedProcessName;
+    } else {
+      this.processName = this.customName;
+    }
+  }
+
+  get generatedProcessName() {
+    const paramsString = this.parameters?.map((p: ProcessParameter) => {
+      const value = this.parseValue(p.value);
+      return isEmpty(value) ? p.name : `${p.name} ${value}`;
+    }).join(' ') || '';
+    return isEmpty(paramsString) ? this.selectedScript.name : `${this.selectedScript.name} ${paramsString}`;
+  }
+
+  private parseValue(value: any) {
+    if (typeof value === 'boolean') {
+      return undefined;
+    }
+    if (value instanceof File) {
+      return value.name;
+    }
+    return value?.toString();
+  }
+}

--- a/src/app/process-page/form/process-form.component.ts
+++ b/src/app/process-page/form/process-form.component.ts
@@ -100,11 +100,11 @@ export class ProcessFormComponent implements OnInit {
     }
 
     const stringParameters: ProcessParameter[] = this.parameters.map((parameter: ProcessParameter) => {
-        return {
-          name: parameter.name,
-          value: this.checkValue(parameter),
-        };
-      },
+      return {
+        name: parameter.name,
+        value: this.checkValue(parameter),
+      };
+    },
     );
     this.scriptService.invoke(this.selectedScript.id, stringParameters, this.files)
       .pipe(getFirstCompletedRemoteData())
@@ -181,15 +181,6 @@ export class ProcessFormComponent implements OnInit {
   updateScript($event: Script) {
     this.selectedScript = $event;
     this.parameters = undefined;
-    this.updateName();
-  }
-
-  updateName(): void {
-    if (isEmpty(this.customName)) {
-      this.processName = this.generatedProcessName;
-    } else {
-      this.processName = this.customName;
-    }
   }
 
   get generatedProcessName() {

--- a/src/app/process-page/overview/table/process-overview-table.component.spec.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.spec.ts
@@ -18,6 +18,16 @@ import { AuthService } from '../../../core/auth/auth.service';
 import { ProcessDataService } from '../../../core/data/processes/process-data.service';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { ProcessBulkDeleteService } from '../process-bulk-delete.service';
+import { ProcessStatus } from '../../processes/process-status.model';
+import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
+import { createPaginatedList } from '../../../shared/testing/utils.test';
+import { PaginationServiceStub } from '../../../shared/testing/pagination-service.stub';
+import { BehaviorSubject } from 'rxjs';
+import { NgbModal, NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
+import { VarDirective } from '../../../shared/utils/var.directive';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { RouterTestingModule } from '@angular/router/testing';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { RouteService } from '../../../core/services/route.service';
 import { ThemedLoadingComponent } from '../../../shared/loading/themed-loading.component';
@@ -46,6 +56,7 @@ describe('ProcessOverviewTableComponent', () => {
   let modalService: NgbModal;
   let authService; // : AuthService; Not typed as the mock does not fully implement AuthService
   let routeService: RouteService;
+  let translateService: TranslateService;
 
   let processes: Process[];
   let ePerson: EPerson;
@@ -217,4 +228,50 @@ describe('ProcessOverviewTableComponent', () => {
     });
 
   });
+/*
+  describe('getEPersonName', () => {
+    beforeEach(() => {
+      init();
+      translateService = getMockTranslateService();
+    });
+
+    it('should return the name when the ID is valid', () => {
+      const id = 'valid_id';
+      const expectedName = 'John Doe';
+
+      spyOn(dsoNameService, 'getName').and.returnValue(expectedName);
+
+      component.getEPersonName(id).subscribe(name => {
+        expect(name).toEqual(expectedName);
+      });
+
+      expect(ePersonService.findById).toHaveBeenCalledWith(id);
+    });
+
+    fit('should return "Unknown" when the ID is invalid', () => {
+      const id = 'invalid_id';
+      const translationKey = 'unknown_user';
+      const expectedMessage = 'Unknown';
+
+      spyOn(translateService, 'get').and.returnValue(of(expectedMessage));
+
+      component.getEPersonName(id).subscribe(name => {
+        expect(name).toEqual(expectedMessage);
+      });
+
+      expect(ePersonService.findById).toHaveBeenCalledWith(id);
+      expect(translateService.get).toHaveBeenCalledWith(translationKey);
+    });
+
+    it('should return an empty observable when the ID is null', () => {
+      const id = null;
+
+      component.getEPersonName(id).subscribe(name => {
+        expect(name).toBeUndefined();
+      });
+
+      expect(ePersonService.findById).not.toHaveBeenCalled();
+    });
+  });
+*/
 });

--- a/src/app/process-page/overview/table/process-overview-table.component.spec.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.spec.ts
@@ -10,7 +10,10 @@ import {
   NgbCollapse,
   NgbModal,
 } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import { BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -18,16 +21,6 @@ import { AuthService } from '../../../core/auth/auth.service';
 import { ProcessDataService } from '../../../core/data/processes/process-data.service';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
-import { ProcessBulkDeleteService } from '../process-bulk-delete.service';
-import { ProcessStatus } from '../../processes/process-status.model';
-import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
-import { createPaginatedList } from '../../../shared/testing/utils.test';
-import { PaginationServiceStub } from '../../../shared/testing/pagination-service.stub';
-import { BehaviorSubject } from 'rxjs';
-import { NgbModal, NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
-import { VarDirective } from '../../../shared/utils/var.directive';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { RouterTestingModule } from '@angular/router/testing';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { RouteService } from '../../../core/services/route.service';
 import { ThemedLoadingComponent } from '../../../shared/loading/themed-loading.component';

--- a/src/app/process-page/overview/table/process-overview-table.component.spec.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.spec.ts
@@ -56,10 +56,11 @@ describe('ProcessOverviewTableComponent', () => {
   let modalService: NgbModal;
   let authService; // : AuthService; Not typed as the mock does not fully implement AuthService
   let routeService: RouteService;
-  let translateService: TranslateService;
 
   let processes: Process[];
   let ePerson: EPerson;
+
+  let translateServiceSpy: jasmine.SpyObj<TranslateService>;
 
   function init() {
     processes = [
@@ -69,6 +70,7 @@ describe('ProcessOverviewTableComponent', () => {
         startTime: '2020-03-19 00:30:00',
         endTime: '2020-03-19 23:30:00',
         processStatus: ProcessStatus.COMPLETED,
+        userId: 'testid',
       }),
       Object.assign(new Process(), {
         processId: 2,
@@ -76,6 +78,7 @@ describe('ProcessOverviewTableComponent', () => {
         startTime: '2020-03-20 00:30:00',
         endTime: '2020-03-20 23:30:00',
         processStatus: ProcessStatus.FAILED,
+        userId: 'testid',
       }),
       Object.assign(new Process(), {
         processId: 3,
@@ -83,9 +86,12 @@ describe('ProcessOverviewTableComponent', () => {
         startTime: '2020-03-21 00:30:00',
         endTime: '2020-03-21 23:30:00',
         processStatus: ProcessStatus.RUNNING,
+        userId: 'testid',
       }),
     ];
     ePerson = Object.assign(new EPerson(), {
+      id: 'testid',
+      uuid: 'testid',
       metadata: {
         'eperson.firstname': [
           {
@@ -143,6 +149,8 @@ describe('ProcessOverviewTableComponent', () => {
 
   beforeEach(waitForAsync(() => {
     init();
+
+    translateServiceSpy = jasmine.createSpyObj('TranslateService', ['get']);
 
     void TestBed.configureTestingModule({
       declarations: [NgbCollapse],
@@ -228,50 +236,43 @@ describe('ProcessOverviewTableComponent', () => {
     });
 
   });
-/*
-  describe('getEPersonName', () => {
-    beforeEach(() => {
-      init();
-      translateService = getMockTranslateService();
+
+  describe('getEPersonName function', () => {
+    it('should return unknown user when id is null', (done: DoneFn) => {
+      const id = null;
+      const expectedTranslation = 'process.overview.unknown.user';
+
+      translateServiceSpy.get(expectedTranslation);
+
+      component.getEPersonName(id).subscribe((result: string) => {
+        expect(result).toBe(expectedTranslation);
+        done();
+      });
+      expect(translateServiceSpy.get).toHaveBeenCalledWith('process.overview.unknown.user');
     });
 
-    it('should return the name when the ID is valid', () => {
-      const id = 'valid_id';
+    it('should return unknown user when id is invalid', (done: DoneFn) => {
+      const id = '';
+      const expectedTranslation = 'process.overview.unknown.user';
+
+      translateServiceSpy.get(expectedTranslation);
+
+      component.getEPersonName(id).subscribe((result: string) => {
+        expect(result).toBe(expectedTranslation);
+        done();
+      });
+      expect(translateServiceSpy.get).toHaveBeenCalledWith('process.overview.unknown.user');
+    });
+
+    it('should return EPerson name when id is correct', (done: DoneFn) => {
+      const id = 'testid';
       const expectedName = 'John Doe';
 
-      spyOn(dsoNameService, 'getName').and.returnValue(expectedName);
-
-      component.getEPersonName(id).subscribe(name => {
-        expect(name).toEqual(expectedName);
+      component.getEPersonName(id).subscribe((result: string) => {
+        expect(result).toEqual(expectedName);
+        done();
       });
-
-      expect(ePersonService.findById).toHaveBeenCalledWith(id);
-    });
-
-    fit('should return "Unknown" when the ID is invalid', () => {
-      const id = 'invalid_id';
-      const translationKey = 'unknown_user';
-      const expectedMessage = 'Unknown';
-
-      spyOn(translateService, 'get').and.returnValue(of(expectedMessage));
-
-      component.getEPersonName(id).subscribe(name => {
-        expect(name).toEqual(expectedMessage);
-      });
-
-      expect(ePersonService.findById).toHaveBeenCalledWith(id);
-      expect(translateService.get).toHaveBeenCalledWith(translationKey);
-    });
-
-    it('should return an empty observable when the ID is null', () => {
-      const id = null;
-
-      component.getEPersonName(id).subscribe(name => {
-        expect(name).toBeUndefined();
-      });
-
-      expect(ePersonService.findById).not.toHaveBeenCalled();
+      expect(translateServiceSpy.get).not.toHaveBeenCalled();
     });
   });
-*/
 });

--- a/src/app/process-page/overview/table/process-overview-table.component.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.ts
@@ -40,7 +40,7 @@ import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { Component, Input, OnInit, Inject, PLATFORM_ID, OnDestroy } from '@angular/core';
 import { ProcessStatus } from '../../processes/process-status.model';
-import { Observable, mergeMap, from as observableFrom, BehaviorSubject, Subscription, of } from 'rxjs';
+import { Observable, mergeMap, from as observableFrom, BehaviorSubject, Subscription } from 'rxjs';
 import { RemoteData } from '../../../core/data/remote-data';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';

--- a/src/app/process-page/overview/table/process-overview-table.component.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.ts
@@ -18,7 +18,10 @@ import {
   RouterLink,
 } from '@angular/router';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import {
   BehaviorSubject,
   from as observableFrom,
@@ -38,10 +41,6 @@ import { PaginationService } from 'src/app/core/pagination/pagination.service';
 import { AuthService } from '../../../core/auth/auth.service';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { FindListOptions } from '../../../core/data/find-list-options.model';
-import { Component, Input, OnInit, Inject, PLATFORM_ID, OnDestroy } from '@angular/core';
-import { ProcessStatus } from '../../processes/process-status.model';
-import { Observable, mergeMap, from as observableFrom, BehaviorSubject, Subscription } from 'rxjs';
-import { RemoteData } from '../../../core/data/remote-data';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
@@ -50,10 +49,12 @@ import { RouteService } from '../../../core/services/route.service';
 import { redirectOn4xx } from '../../../core/shared/authorized.operators';
 import {
   getAllCompletedRemoteData,
-  getFirstSucceededRemoteDataPayload,
-  getAllCompletedRemoteData, getFirstCompletedRemoteData
+  getFirstCompletedRemoteData,
 } from '../../../core/shared/operators';
-import { hasValue } from '../../../shared/empty.util';
+import {
+  hasValue,
+  isNotEmpty,
+} from '../../../shared/empty.util';
 import { ThemedLoadingComponent } from '../../../shared/loading/themed-loading.component';
 import { PaginationComponent } from '../../../shared/pagination/pagination.component';
 import { PaginationComponentOptions } from '../../../shared/pagination/pagination-component-options.model';
@@ -65,17 +66,6 @@ import {
   ProcessOverviewService,
   ProcessSortField,
 } from '../process-overview.service';
-import { map, switchMap, toArray, take, filter } from 'rxjs/operators';
-import { EPerson } from '../../../core/eperson/models/eperson.model';
-import { PaginationService } from 'src/app/core/pagination/pagination.service';
-import { FindListOptions } from '../../../core/data/find-list-options.model';
-import { redirectOn4xx } from '../../../core/shared/authorized.operators';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../core/auth/auth.service';
-import { isPlatformBrowser } from '@angular/common';
-import { RouteService } from '../../../core/services/route.service';
-import { hasValue, isNotEmpty } from '../../../shared/empty.util';
-import { TranslateService } from '@ngx-translate/core';
 
 const NEW_PROCESS_PARAM = 'new_process_id';
 

--- a/src/app/process-page/overview/table/process-overview-table.component.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.ts
@@ -38,6 +38,10 @@ import { PaginationService } from 'src/app/core/pagination/pagination.service';
 import { AuthService } from '../../../core/auth/auth.service';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { FindListOptions } from '../../../core/data/find-list-options.model';
+import { Component, Input, OnInit, Inject, PLATFORM_ID, OnDestroy } from '@angular/core';
+import { ProcessStatus } from '../../processes/process-status.model';
+import { Observable, mergeMap, from as observableFrom, BehaviorSubject, Subscription, of } from 'rxjs';
+import { RemoteData } from '../../../core/data/remote-data';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
@@ -165,8 +169,8 @@ export class ProcessOverviewTableComponent implements OnInit, OnDestroy {
 
   constructor(protected processOverviewService: ProcessOverviewService,
               protected processBulkDeleteService: ProcessBulkDeleteService,
-              protected ePersonDataService: EPersonDataService,
-              protected dsoNameService: DSONameService,
+              public ePersonDataService: EPersonDataService,
+              public dsoNameService: DSONameService,
               protected paginationService: PaginationService,
               protected routeService: RouteService,
               protected router: Router,
@@ -284,11 +288,11 @@ export class ProcessOverviewTableComponent implements OnInit, OnDestroy {
         getFirstCompletedRemoteData(),
         switchMap((rd: RemoteData<EPerson>) => {
           if (rd.hasSucceeded) {
-            return observableFrom([this.dsoNameService.getName(rd.payload)]);
+            return [this.dsoNameService.getName(rd.payload)];
           } else {
             return this.translateService.get('process.overview.unknown.user');
           }
-        })
+        }),
       );
     } else {
       return this.translateService.get('process.overview.unknown.user');

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3846,6 +3846,8 @@
 
   "process.overview.delete.header": "Delete processes",
 
+  "process.overview.unknown.user": "Unknown",
+
   "process.bulk.delete.error.head": "Error on deleteing process",
 
   "process.bulk.delete.error.body": "The process with ID {{processId}} could not be deleted. The remaining processes will continue being deleted. ",


### PR DESCRIPTION
## References
* Requires DSpace/DSpace#9401
* Replaces #2995

## Description
This pull request addresses the issue of null users causing crashes in the process overview page. It includes changes to handle null users gracefully by returning an i18n message for unknown users and switching from `getFirstSucceededRemoteDataPayload` to `getFirstCompletedRemoteData` to ensure proper emissions.

## Instructions for Reviewers

List of changes in this PR:
-   Wrapping the method in an if/else to check for non-empty IDs and return an i18n message for unknown users if necessary.
-   Changing `getFirstSucceededRemoteDataPayload` to `getFirstCompletedRemoteData` and using `switchMap` to handle emissions based on whether the remote data has succeeded.
-   Writing unit tests to cover all possible cases (valid ID, invalid ID, null ID).

Please ensure to test the following:
1.  Ensure the process overview page no longer crashes when encountering null users.
2.  Verify that the i18n message for unknown users is displayed correctly.
3.  Confirm that the method emits properly based on the success status of remote data.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
