### PR TITLE
Stabilize submission e2e tests by waiting for form sections to load

### DIFF
--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -18,14 +18,14 @@ describe('New Submission page', () => {
     // The Submission edit form tag should be visible
     cy.get('ds-submission-edit').should('be.visible');
 
-    // A Collection menu button should exist & it's value should be the selected collection
-    cy.get('#collectionControlsMenuButton span').should('have.text', Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME'));
-
     // 4 sections should be visible by default
     cy.get('div#section_traditionalpageone').should('be.visible');
     cy.get('div#section_traditionalpagetwo').should('be.visible');
     cy.get('div#section_upload').should('be.visible');
     cy.get('div#section_license').should('be.visible');
+
+    // A Collection menu button should exist (at top of form) & its value should be the selected collection
+    cy.get('#collectionControlsMenuButton span').should('have.text', Cypress.env('DSPACE_TEST_SUBMIT_COLLECTION_NAME'));
 
     // Test entire page for accessibility
     testA11y('ds-submission-edit',
@@ -58,6 +58,9 @@ describe('New Submission page', () => {
 
     // This page is restricted, so we will be shown the login form. Fill it out & submit.
     cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
+
+    // Wait until the sections appear on form
+    cy.get('div#section_traditionalpageone').should('be.visible');
 
     // Attempt an immediate deposit without filling out any fields
     cy.get('button#deposit').click();
@@ -118,6 +121,9 @@ describe('New Submission page', () => {
 
     // This page is restricted, so we will be shown the login form. Fill it out & submit.
     cy.loginViaForm(Cypress.env('DSPACE_TEST_SUBMIT_USER'), Cypress.env('DSPACE_TEST_SUBMIT_USER_PASSWORD'));
+
+    // Wait until the sections appear on form
+    cy.get('div#section_traditionalpageone').should('be.visible');
 
     // Fill out all required fields (Title, Date)
     cy.get('input#dc_title').type('DSpace logo uploaded via e2e tests');


### PR DESCRIPTION
## References
* Seems related to #2988 fixes?

## Description
After merging Submission performance fixes, the submission e2e tests are randomly failing.  From local testing, it appears that Cypress is trying to perform actions *too quickly* (before the submission form finishes loading).   In GitHub CI, these failures are appearing _more frequently_ than they do locally (when I run `yarn e2e`).

This PR reorganizes a few checks to first ensure that the Submission form has loaded (by waiting on sections to appear) before doing any actions or more detailed checks.  At least locally, this stabilizes the random failures.  

We'll see if this fixes things in GitHub CI.

## Instructions for Reviewers
* No code changes to DSpace.  This only fixes e2e tests.  If they succeed then this is safe to merge.