### PR TITLE
Ensure `item` is also embedded in submission form

### DIFF
--- a/src/app/core/submission/submission-rest.service.spec.ts
+++ b/src/app/core/submission/submission-rest.service.spec.ts
@@ -26,7 +26,7 @@ describe('SubmissionRestService test suite', () => {
   const resourceEndpoint = 'workspaceitems';
   const resourceScope = '260';
   const body = { test: new FormFieldMetadataValueObject('test') };
-  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope + '?embed=sections,collection';
+  const resourceHref = resourceEndpointURL + '/' + resourceEndpoint + '/' + resourceScope + '?embed=item,sections,collection';
   const timestampResponse = 1545994811992;
 
   function initTestService() {

--- a/src/app/core/submission/submission-rest.service.ts
+++ b/src/app/core/submission/submission-rest.service.ts
@@ -78,7 +78,7 @@ export class SubmissionRestService {
    */
   protected getEndpointByIDHref(endpoint, resourceID, collectionId?: string): string {
     let url = isNotEmpty(resourceID) ? `${endpoint}/${resourceID}` : `${endpoint}`;
-    url = new URLCombiner(url, '?embed=sections,collection').toString();
+    url = new URLCombiner(url, '?embed=item,sections,collection').toString();
     if (collectionId) {
       url = new URLCombiner(url, `&owningCollection=${collectionId}`).toString();
     }


### PR DESCRIPTION
## References
* Fixes a small bug in #2988 discovered via our e2e tests (`submission.cy.ts`)

## Description
On `main` and `dspace-7_x` after #2988 was merged, the submission e2e tests began to fail (almost randomly). 

After digging into the issue locally, I found the cause was that the Submission Form would occasionally **hang indefinitely** at a "Loading ..." page.  After testing locally, I found I was able to reproduce that on my local machine via the following steps:

1. Start the UI in production mode (`yarn build:prod; yarn serve:ssr`).  Might also be reproducible in dev mode.
2. Login and visit any "In Progress Submission" (i.e. WorkspaceItem) from MyDSpace
3. While the submission form is visible, click the reload button in your browser several times.
4. Eventually (sometimes on first reload) you'll find the form will hang with a "Loading ... " message.  It will no longer be possible to see the form unless you leave the page and go back via MyDSpace
5. If you look in your DevTools Console, you'll see this error like this has occurred:
```
main.js:23 ERROR TypeError: Cannot read properties of undefined (reading 'metadata')
    at main.js:1:1340638
    at Array.forEach (<anonymous>)
    at main.js:1:1340091
    at main.js:1:2010833
    at c._next (main.js:1:2007228)
    at c.next (main.js:1:1996090)
    at main.js:1:2009564
    at c._next (main.js:1:2007228)
    at c.next (main.js:1:1996090)
    at main.js:1:1994053
```

After debugging the issue, I found the line producing this error is here:
https://github.com/DSpace/dspace-angular/blob/main/src/app/submission/objects/submission-objects.effects.ts#L108

The error appears to be that the Submission form will somehow "lose access" to the `item` object (similar to described in #2940 and fixed by #2962)

This PR fixes the issue by updating the newly added code in #2988 to also embed the `item` object.


## Instructions for Reviewers
* This should allow e2e tests to succeed again, as the failures in the `submission.cy.ts` e2e tests are a side effect of this bug.
