### PR TITLE
Allow submitter users to accept/ignore suggestions

### DIFF
--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -156,7 +156,7 @@
                     </div>
                   </td>
                   <td>
-                    <div *ngIf="(isAdmin$ | async)" class="btn-group button-width">
+                    <div *ngIf="(isAdmin$ | async) || !isReinstateWithdrawnRequest" class="btn-group button-width">
                       <button *ngIf="showTopic.indexOf('/PROJECT') !== -1"
                               class="btn btn-outline-success btn-sm button-width"
                               ngbTooltip="{{'quality-assurance.event.action.import' | translate}}"
@@ -187,6 +187,7 @@
                         <i class="fas fa-ban"></i>
                       </button>
                       <button class="btn btn-outline-danger btn-sm button-width"
+                              *ngIf="(isAdmin$ | async)"
                               ngbTooltip="{{'quality-assurance.event.action.reject' | translate}}"
                               container="body"
                               [disabled]="eventElement.isRunning"
@@ -195,8 +196,17 @@
                       >
                         <i class="fas fa-trash-alt"></i>
                       </button>
+                      <button class="btn btn-outline-danger btn-sm button-width"
+                              *ngIf="(isAdmin$ | async) === false"
+                              ngbTooltip="{{'quality-assurance.event.action.undo' | translate }}"
+                              container="body"
+                              [disabled]="eventElement.isRunning"
+                              [attr.aria-label]="'quality-assurance.event.action.undo' | translate"
+                              (click)="openModal('UNDO', eventElement, undoModal)">
+                        <i class="fas fa-trash-alt"></i>
+                      </button>
                     </div>
-                    <div *ngIf="(isAdmin$ | async) !== true" class="btn-group button-width">
+                    <div *ngIf="(isAdmin$ | async) !== true && isReinstateWithdrawnRequest" class="btn-group button-width">
                       <button class="btn btn-outline-danger btn-sm button-width"
                               ngbTooltip="{{'quality-assurance.event.action.undo' | translate}}"
                               container="body"

--- a/src/app/notifications/qa/events/quality-assurance-events.component.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.ts
@@ -258,6 +258,13 @@ export class QualityAssuranceEventsComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Checks if the current topic is related to a reinstate or withdrawn request.
+   */
+  public get isReinstateWithdrawnRequest(): boolean {
+    return this.showTopic.indexOf('/WITHDRAWN') !== -1 || this.showTopic.indexOf('/REINSTATE') !== -1;
+  }
+
+  /**
    * Open a modal or run the executeAction directly based on the presence of the project.
    *
    * @param {string} action

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -5465,9 +5465,9 @@
   // "quality-assurance.event.action.ignore": "Ignore suggestion",
   "quality-assurance.event.action.ignore": "تجاهل الاقتراح",
 
-  // "quality-assurance.event.action.undo": "DELETE",
+  // "quality-assurance.event.action.undo": "Delete",
   // TODO New key - Add a translation
-  "quality-assurance.event.action.undo": "DELETE",
+  "quality-assurance.event.action.undo": "Delete",
 
   // "quality-assurance.event.action.reject": "Reject suggestion",
   "quality-assurance.event.action.reject": "رفض الاقتراح",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3552,7 +3552,7 @@
 
   "quality-assurance.event.action.ignore": "Ignore suggestion",
 
-  "quality-assurance.event.action.undo": "DELETE",
+  "quality-assurance.event.action.undo": "Delete",
 
   "quality-assurance.event.action.reject": "Reject suggestion",
 


### PR DESCRIPTION
## References

* Fixes https://github.com/DSpace/dspace-angular/issues/3023

## Description
There were initially two different button groups: for admin users and the other for non-admin users (which was allowing non-admin users only to undo an action).

Now, when the topic is marked as `WITHDRAWN` or `REINSTATED`, we display only the button group containing a delete button for submitter users. Conversely, for other topics, submitter users will see all three buttons.  Although the button group remains the same for admin and non-admin users, the delete button's functionality varies. For non-admin users, it acts as  '`UNDO`' action (as it was in the previous behavior for non admin users) and for the administrator it will be a '`REJECTED`’ action.

**Screenshots**

![image](https://github.com/DSpace/dspace-angular/assets/126179045/ce136771-1084-447f-b179-fa7d1719c2dd)
![image](https://github.com/DSpace/dspace-angular/assets/126179045/a7118aa8-6908-4e5e-988a-b031d99e9830)

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
