### PR TITLE
Set color black on filter section for mobile

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.html
@@ -6,7 +6,7 @@
           [attr.aria-label]="(((collapsed$ | async) ? 'search.filters.filter.expand' : 'search.filters.filter.collapse') | translate) + ' ' + (('search.filters.filter.' + filter.name + '.head') | translate | lowercase)"
           [attr.data-test]="'filter-toggle' | dsBrowserOnly"
   >
-    <span class="h4 d-inline-block text-left mt-auto mb-auto">
+    <span class="h4 d-inline-block text-left mt-auto mb-auto dark:text-white text-dark">
       {{'search.filters.filter.' + filter.name + '.head'| translate}}
     </span>
     <i class="filter-toggle flex-grow-1 fas p-auto"


### PR DESCRIPTION
Hi @tdonohue, I'm @jtimal partner, I like to share this PR with you:

## References
* Fixes #2682

## Description
I change the color for the text in the section of filters on search view

## Instructions for Reviewers
I used tailwind for fix that bug and i was able replicated that bug on emulator IOS using Iphone 14 PRO MAX

List of changes in this PR:
* First set color black default on text in filter section
* Second set color white default on text in filter section when the phone has mode dark on, this validation was by tailwind

Evidences:
Bug replicated
![image](https://github.com/VictorHugoDuranS/dspace-angular/assets/25066032/bf2e34a4-7827-4c92-a9a9-17b1baf2546f)

Fix applicated
![image](https://github.com/VictorHugoDuranS/dspace-angular/assets/25066032/c2ed71f7-0f4f-4c88-aff3-8878759d0384)

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
