### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/src/app/shared/eperson-group-list/eperson-group-list.component.ts
+++ b/src/app/shared/eperson-group-list/eperson-group-list.component.ts
@@ -143,7 +143,6 @@ export class EpersonGroupListComponent implements OnInit, OnDestroy {
     const lazyProvider$: Observable<EPersonDataService | GroupDataService> = lazyDataService(this.dataServiceMap, resourceType.value, this.parentInjector);
     lazyProvider$.subscribe((dataService: EPersonDataService | GroupDataService) => {
       this.dataService = dataService;
-      console.log(dataService);
       this.paginationOptions.id = uniqueId('egl');
       this.paginationOptions.pageSize = 5;
 


### PR DESCRIPTION
This is an extremely small PR to just remove an unnecessary `console.log` line which appears to have been used for debugging.  It's only visible in your browser's DevTools Console when editing a resource policy.