### PR TITLE
Fix self link don't match warnings for authorization endpoint

### DIFF
--- a/src/app/core/data/feature-authorization/authorization-data.service.spec.ts
+++ b/src/app/core/data/feature-authorization/authorization-data.service.spec.ts
@@ -72,7 +72,7 @@ describe('AuthorizationDataService', () => {
     const ePersonUuid = 'fake-eperson-uuid';
 
     function createExpected(providedObjectUrl: string, providedEPersonUuid?: string, providedFeatureId?: FeatureID): FindListOptions {
-      const searchParams = [new RequestParam('uri', providedObjectUrl)];
+      const searchParams = [new RequestParam('uri', providedObjectUrl, false)];
       if (hasValue(providedFeatureId)) {
         searchParams.push(new RequestParam('feature', providedFeatureId));
       }

--- a/src/app/core/data/feature-authorization/authorization-data.service.ts
+++ b/src/app/core/data/feature-authorization/authorization-data.service.ts
@@ -147,7 +147,8 @@ export class AuthorizationDataService extends BaseDataService<Authorization> imp
     if (isNotEmpty(options.searchParams)) {
       params = [...options.searchParams];
     }
-    params.push(new RequestParam('uri', objectUrl));
+    // TODO fix encode the uri parameter in the self link in the backend and set encodeValue to true afterwards
+    params.push(new RequestParam('uri', objectUrl, false));
     if (hasValue(featureId)) {
       params.push(new RequestParam('feature', featureId));
     }


### PR DESCRIPTION
## References
* Fixes #3045

## Description
Because in PR #2725 all `RequestParam` values were encoded, and that the self link don't encode all the characters (for example it doesn't encode slashes and colons) it causes the frontend to think that the links are not identical. To fix this issue now the uri parameter is simply not encoded in angular so that it doesn't complain about this issues anymore, this was how it was done before PR #2725. The ideal fix would be to fix this in the backend but this might require more changes in the core of DSpace, so we should probably wait until after the 8.0 release for that in order to have enough time to test everything. [This is an example](https://sandbox.dspace.org/server/api/discover/search/objects?f.author=%2F,equals) of another endpoint where the same behaviour can be reproduced, so this is a general issues.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
