### PR TITLE
Hide search text field when number of facet values is less than the maximum

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-authority-filter/search-authority-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-authority-filter/search-authority-filter.component.html
@@ -26,5 +26,6 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
+                          *ngIf="!(isAvailableForShowSearchText | async)"
                           ngDefaultControl></ds-filter-input-suggestions>
 </div>

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
@@ -62,6 +62,10 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
   isLastPage$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   /**
+   * Emits true if show the search text
+   */
+  isAvailableForShowSearchText: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  /**
    * The value of the input field that is used to query for possible values for this filter
    */
   filter: string;
@@ -297,6 +301,8 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
             getFirstSucceededRemoteData(),
             tap((rd: RemoteData<FacetValues>) => {
               this.isLastPage$.next(hasNoValue(rd?.payload?.next));
+              const hasLimitFacets =  rd?.payload?.page.length < rd?.payload?.facetLimit;
+              this.isAvailableForShowSearchText.next(hasLimitFacets && hasNoValue(rd?.payload?.next));
             }),
             map((rd: RemoteData<FacetValues>) => ({
                 values: observableOf(rd),

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.html
@@ -26,6 +26,7 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
+                          *ngIf="!(isAvailableForShowSearchText | async)"
                           ngDefaultControl
     ></ds-filter-input-suggestions>
 </div>

--- a/src/app/shared/search/search-filters/search-filter/search-text-filter/search-text-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-text-filter/search-text-filter.component.html
@@ -26,5 +26,6 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
+                          *ngIf="!(isAvailableForShowSearchText | async)"
                           ngDefaultControl></ds-filter-input-suggestions>
 </div>


### PR DESCRIPTION
Hi @tdonohue, I'm @jtimal partner. We have been working on this issue and we will send you the PR.


## References
* Fixes #2352

## Description
Validation for hide search text field in the filter section if the number of facet values does not exceed the maximum number of facet values shown

## Instructions for Reviewers
The change is applied in the filters: Subject, Item Type and Authors

For replicate, you realize a general search and  select a filter with few results or search directament a term with few filter


For example, this is the view general
<img width="1388" alt="image" src="https://github.com/DSpace/dspace-angular/assets/25066032/c748912b-df21-44e4-a89f-fd62e61de981">

this is the same view with a filter wit few results:
<img width="1388" alt="image" src="https://github.com/DSpace/dspace-angular/assets/25066032/3c428235-aae2-41c9-bece-9af9d16a2a28">




List of changes in this PR:
* First, the main change is applied in: search-facet-filter.component.ts  
* Second, i created a validation for control  for show or not, considering the maximum number of facet and the current number of facet and assign in a observable for use it in the view


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
