### PR TITLE
[Port dspace-7_x] Ensures CSRF token is initialized prior to first modifying (non-GET) request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       #CHROME_VERSION: "90.0.4430.212-1"
       # Bump Node heap size (OOM in CI after upgrading to Angular 15)
       NODE_OPTIONS: '--max-old-space-size=4096'
-      # Project name to use when running docker-compose prior to e2e tests
+      # Project name to use when running "docker compose" prior to e2e tests
       COMPOSE_PROJECT_NAME: 'ci'
     strategy:
       # Create a matrix of Node versions to test against (in parallel)
@@ -108,12 +108,12 @@ jobs:
           path: 'coverage/dspace-angular/lcov.info'
           retention-days: 14
 
-      # Using docker-compose start backend using CI configuration
+      # Using "docker compose" start backend using CI configuration
       # and load assetstore from a cached copy
       - name: Start DSpace REST Backend via Docker (for e2e tests)
         run: |
-          docker-compose -f ./docker/docker-compose-ci.yml up -d
-          docker-compose -f ./docker/cli.yml -f ./docker/cli.assetstore.yml run --rm dspace-cli
+          docker compose -f ./docker/docker-compose-ci.yml up -d
+          docker compose -f ./docker/cli.yml -f ./docker/cli.assetstore.yml run --rm dspace-cli
           docker container ls
 
       # Run integration tests via Cypress.io
@@ -182,7 +182,7 @@ jobs:
         run: kill -9 $(lsof -t -i:4000)
 
       - name: Shutdown Docker containers
-        run: docker-compose -f ./docker/docker-compose-ci.yml down
+        run: docker compose -f ./docker/docker-compose-ci.yml down
 
   # Codecov upload is a separate job in order to allow us to restart this separate from the entire build/test
   # job above. This is necessary because Codecov uploads seem to randomly fail at times.

--- a/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
@@ -23,6 +23,7 @@ import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { UUIDService } from '../../../core/shared/uuid.service';
+import { XSRFService } from '../../../core/xsrf/xsrf.service';
 import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { GroupMock, GroupMock2 } from '../../../shared/testing/group-mock';
@@ -211,6 +212,7 @@ describe('GroupFormComponent', () => {
         { provide: HttpClient, useValue: {} },
         { provide: ObjectCacheService, useValue: {} },
         { provide: UUIDService, useValue: {} },
+        { provide: XSRFService, useValue: {} },
         { provide: Store, useValue: {} },
         { provide: RemoteDataBuildService, useValue: {} },
         { provide: HALEndpointService, useValue: {} },

--- a/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.spec.ts
+++ b/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.spec.ts
@@ -15,6 +15,7 @@ import { NotificationsService } from '../../../shared/notifications/notification
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 import { BitstreamFormat } from '../../../core/shared/bitstream-format.model';
 import { BitstreamFormatSupportLevel } from '../../../core/shared/bitstream-format-support-level';
+import { XSRFService } from '../../../core/xsrf/xsrf.service';
 import { cold, getTestScheduler, hot } from 'jasmine-marbles';
 import { TestScheduler } from 'rxjs/testing';
 import {
@@ -108,7 +109,8 @@ describe('BitstreamFormatsComponent', () => {
         { provide: BitstreamFormatDataService, useValue: bitstreamFormatService },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(0) },
         { provide: NotificationsService, useValue: notificationsServiceStub },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: XSRFService, useValue: {} },
       ]
     }).compileComponents();
   };

--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.spec.ts
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.spec.ts
@@ -9,6 +9,7 @@ import { CollectionElementLinkType } from '../../../../../shared/object-collecti
 import { ViewMode } from '../../../../../core/shared/view-mode.model';
 import { RouterTestingModule } from '@angular/router/testing';
 import { WorkflowItem } from '../../../../../core/submission/models/workflowitem.model';
+import { XSRFService } from '../../../../../core/xsrf/xsrf.service';
 import {
   WorkflowItemSearchResultAdminWorkflowListElementComponent
 } from './workflow-item-search-result-admin-workflow-list-element.component';
@@ -58,7 +59,8 @@ describe('WorkflowItemSearchResultAdminWorkflowListElementComponent', () => {
           { provide: TruncatableService, useValue: mockTruncatableService },
           { provide: LinkService, useValue: linkService },
           { provide: DSONameService, useClass: DSONameServiceMock },
-          { provide: APP_CONFIG, useValue: environment }
+          { provide: APP_CONFIG, useValue: environment },
+          { provide: XSRFService, useValue: {} },
         ],
         schemas: [NO_ERRORS_SCHEMA]
       })

--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -1,6 +1,6 @@
 import { Store, StoreModule } from '@ngrx/store';
 import { cold, getTestScheduler } from 'jasmine-marbles';
-import { EMPTY, Observable, of as observableOf } from 'rxjs';
+import { BehaviorSubject, EMPTY, Observable, of as observableOf } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { getMockObjectCacheService } from '../../shared/mocks/object-cache.service.mock';
@@ -8,6 +8,7 @@ import { defaultUUID, getMockUUIDService } from '../../shared/mocks/uuid.service
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { coreReducers} from '../core.reducers';
 import { UUIDService } from '../shared/uuid.service';
+import { XSRFService } from '../xsrf/xsrf.service';
 import { RequestConfigureAction, RequestExecuteAction, RequestStaleAction } from './request.actions';
 import {
   DeleteRequest,
@@ -35,6 +36,7 @@ describe('RequestService', () => {
   let uuidService: UUIDService;
   let store: Store<CoreState>;
   let mockStore: MockStore<CoreState>;
+  let xsrfService: XSRFService;
 
   const testUUID = '5f2a0d2a-effa-4d54-bd54-5663b960f9eb';
   const testHref = 'https://rest.api/endpoint/selfLink';
@@ -80,10 +82,15 @@ describe('RequestService', () => {
     store = TestBed.inject(Store);
     mockStore = store as MockStore<CoreState>;
     mockStore.setState(initialState);
+    xsrfService = {
+      tokenInitialized$: new BehaviorSubject(false),
+    } as XSRFService;
+
     service = new RequestService(
       objectCache,
       uuidService,
       store,
+      xsrfService,
       undefined
     );
     serviceAsAny = service as any;

--- a/src/app/core/data/request.service.spec.ts
+++ b/src/app/core/data/request.service.spec.ts
@@ -1,6 +1,6 @@
 import { Store, StoreModule } from '@ngrx/store';
 import { cold, getTestScheduler } from 'jasmine-marbles';
-import { BehaviorSubject, EMPTY, Observable, of as observableOf } from 'rxjs';
+import { EMPTY, Observable, of as observableOf } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { getMockObjectCacheService } from '../../shared/mocks/object-cache.service.mock';
@@ -8,7 +8,6 @@ import { defaultUUID, getMockUUIDService } from '../../shared/mocks/uuid.service
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { coreReducers} from '../core.reducers';
 import { UUIDService } from '../shared/uuid.service';
-import { XSRFService } from '../xsrf/xsrf.service';
 import { RequestConfigureAction, RequestExecuteAction, RequestStaleAction } from './request.actions';
 import {
   DeleteRequest,
@@ -36,7 +35,6 @@ describe('RequestService', () => {
   let uuidService: UUIDService;
   let store: Store<CoreState>;
   let mockStore: MockStore<CoreState>;
-  let xsrfService: XSRFService;
 
   const testUUID = '5f2a0d2a-effa-4d54-bd54-5663b960f9eb';
   const testHref = 'https://rest.api/endpoint/selfLink';
@@ -82,16 +80,11 @@ describe('RequestService', () => {
     store = TestBed.inject(Store);
     mockStore = store as MockStore<CoreState>;
     mockStore.setState(initialState);
-    xsrfService = {
-      tokenInitialized$: new BehaviorSubject(false),
-    } as XSRFService;
 
     service = new RequestService(
       objectCache,
       uuidService,
       store,
-      xsrfService,
-      undefined
     );
     serviceAsAny = service as any;
   });

--- a/src/app/core/data/request.service.ts
+++ b/src/app/core/data/request.service.ts
@@ -8,10 +8,9 @@ import cloneDeep from 'lodash/cloneDeep';
 import { hasValue, isEmpty, isNotEmpty, hasNoValue } from '../../shared/empty.util';
 import { ObjectCacheEntry } from '../cache/object-cache.reducer';
 import { ObjectCacheService } from '../cache/object-cache.service';
-import { IndexState, MetaIndexState } from '../index/index.reducer';
+import { IndexState } from '../index/index.reducer';
 import { requestIndexSelector, getUrlWithoutEmbedParams } from '../index/index.selectors';
 import { UUIDService } from '../shared/uuid.service';
-import { XSRFService } from '../xsrf/xsrf.service';
 import {
   RequestConfigureAction,
   RequestExecuteAction,
@@ -137,9 +136,7 @@ export class RequestService {
 
   constructor(private objectCache: ObjectCacheService,
               private uuidService: UUIDService,
-              private store: Store<CoreState>,
-              protected xsrfService: XSRFService,
-              private indexStore: Store<MetaIndexState>) {
+              private store: Store<CoreState>) {
   }
 
   generateRequestId(): string {
@@ -421,17 +418,7 @@ export class RequestService {
    */
   private dispatchRequest(request: RestRequest) {
     this.store.dispatch(new RequestConfigureAction(request));
-    // If it's a GET request, or we have an XSRF token, dispatch it immediately
-    if (request.method === RestRequestMethod.GET || this.xsrfService.tokenInitialized$.getValue() === true) {
-      this.store.dispatch(new RequestExecuteAction(request.uuid));
-    } else {
-      // Otherwise wait for the XSRF token first
-      this.xsrfService.tokenInitialized$.pipe(
-        find((hasInitialized: boolean) => hasInitialized === true),
-      ).subscribe(() => {
-        this.store.dispatch(new RequestExecuteAction(request.uuid));
-      });
-    }
+    this.store.dispatch(new RequestExecuteAction(request.uuid));
   }
 
   /**

--- a/src/app/core/xsrf/browser-xsrf.service.spec.ts
+++ b/src/app/core/xsrf/browser-xsrf.service.spec.ts
@@ -1,0 +1,64 @@
+import { BrowserXSRFService } from './browser-xsrf.service';
+import { HttpClient } from '@angular/common/http';
+import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+describe(`BrowserXSRFService`, () => {
+  let service: BrowserXSRFService;
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+
+  const endpointURL = new RESTURLCombiner('/security/csrf').toString();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule ],
+      providers: [ BrowserXSRFService ]
+    });
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(BrowserXSRFService);
+  });
+
+  describe(`initXSRFToken`, () => {
+    it(`should perform a POST to the csrf endpoint`, () => {
+      service.initXSRFToken(httpClient)();
+
+      const req = httpTestingController.expectOne({
+        url: endpointURL,
+        method: 'POST'
+      });
+
+      req.flush({});
+      httpTestingController.verify();
+    });
+
+    describe(`when the POST succeeds`, () => {
+      it(`should set tokenInitialized$ to true`, () => {
+        service.initXSRFToken(httpClient)();
+
+        const req = httpTestingController.expectOne(endpointURL);
+
+        req.flush({});
+        httpTestingController.verify();
+
+        expect(service.tokenInitialized$.getValue()).toBeTrue();
+      });
+    });
+
+    describe(`when the POST fails`, () => {
+      it(`should set tokenInitialized$ to true`, () => {
+        service.initXSRFToken(httpClient)();
+
+        const req = httpTestingController.expectOne(endpointURL);
+
+        req.error(new ErrorEvent('415'));
+        httpTestingController.verify();
+
+        expect(service.tokenInitialized$.getValue()).toBeTrue();
+      });
+    });
+
+  });
+});

--- a/src/app/core/xsrf/browser-xsrf.service.spec.ts
+++ b/src/app/core/xsrf/browser-xsrf.service.spec.ts
@@ -1,8 +1,12 @@
-import { BrowserXSRFService } from './browser-xsrf.service';
 import { HttpClient } from '@angular/common/http';
-import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+import { BrowserXSRFService } from './browser-xsrf.service';
 
 describe(`BrowserXSRFService`, () => {
   let service: BrowserXSRFService;
@@ -14,7 +18,7 @@ describe(`BrowserXSRFService`, () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpClientTestingModule ],
-      providers: [ BrowserXSRFService ]
+      providers: [ BrowserXSRFService ],
     });
     httpClient = TestBed.inject(HttpClient);
     httpTestingController = TestBed.inject(HttpTestingController);
@@ -22,20 +26,22 @@ describe(`BrowserXSRFService`, () => {
   });
 
   describe(`initXSRFToken`, () => {
-    it(`should perform a POST to the csrf endpoint`, () => {
+    it(`should perform a GET to the csrf endpoint`, (done: DoneFn) => {
       service.initXSRFToken(httpClient)();
 
       const req = httpTestingController.expectOne({
         url: endpointURL,
-        method: 'POST'
+        method: 'GET',
       });
 
       req.flush({});
       httpTestingController.verify();
+      expect().nothing();
+      done();
     });
 
-    describe(`when the POST succeeds`, () => {
-      it(`should set tokenInitialized$ to true`, () => {
+    describe(`when the GET succeeds`, () => {
+      it(`should set tokenInitialized$ to true`, (done: DoneFn) => {
         service.initXSRFToken(httpClient)();
 
         const req = httpTestingController.expectOne(endpointURL);
@@ -44,19 +50,7 @@ describe(`BrowserXSRFService`, () => {
         httpTestingController.verify();
 
         expect(service.tokenInitialized$.getValue()).toBeTrue();
-      });
-    });
-
-    describe(`when the POST fails`, () => {
-      it(`should set tokenInitialized$ to true`, () => {
-        service.initXSRFToken(httpClient)();
-
-        const req = httpTestingController.expectOne(endpointURL);
-
-        req.error(new ErrorEvent('415'));
-        httpTestingController.verify();
-
-        expect(service.tokenInitialized$.getValue()).toBeTrue();
+        done();
       });
     });
 

--- a/src/app/core/xsrf/browser-xsrf.service.ts
+++ b/src/app/core/xsrf/browser-xsrf.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { RESTURLCombiner } from '../url-combiner/rest-url-combiner';
+import { take, catchError } from 'rxjs/operators';
+import { of as observableOf } from 'rxjs';
+import { XSRFService } from './xsrf.service';
+
+@Injectable()
+export class BrowserXSRFService extends XSRFService {
+  initXSRFToken(httpClient: HttpClient): () => Promise<any> {
+    return () => new Promise((resolve) => {
+      httpClient.post(new RESTURLCombiner('/security/csrf').toString(), undefined).pipe(
+        // errors are to be expected if the token and the cookie don't match, that's what we're
+        // trying to fix for future requests, so just emit any observable to end up in the
+        // subscribe
+        catchError(() => observableOf(null)),
+        take(1),
+      ).subscribe(() => {
+        this.tokenInitialized$.next(true);
+      });
+
+      // return immediately, the rest of the app doesn't need to wait for this to finish
+      resolve();
+    });
+  }
+}

--- a/src/app/core/xsrf/server-xsrf.service.spec.ts
+++ b/src/app/core/xsrf/server-xsrf.service.spec.ts
@@ -1,0 +1,32 @@
+import { ServerXSRFService } from './server-xsrf.service';
+import { HttpClient } from '@angular/common/http';
+
+describe(`ServerXSRFService`, () => {
+  let service: ServerXSRFService;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    httpClient = jasmine.createSpyObj(['post', 'get', 'request']);
+    service = new ServerXSRFService();
+  });
+
+  describe(`initXSRFToken`, () => {
+    it(`shouldn't perform any requests`, (done: DoneFn) => {
+      service.initXSRFToken(httpClient)().then(() => {
+        for (const prop in httpClient) {
+          if (httpClient.hasOwnProperty(prop)) {
+            expect(httpClient[prop]).not.toHaveBeenCalled();
+          }
+        }
+        done();
+      });
+    });
+
+    it(`should leave tokenInitialized$ on false`, (done: DoneFn) => {
+      service.initXSRFToken(httpClient)().then(() => {
+        expect(service.tokenInitialized$.getValue()).toBeFalse();
+        done();
+      });
+    });
+  });
+});

--- a/src/app/core/xsrf/server-xsrf.service.spec.ts
+++ b/src/app/core/xsrf/server-xsrf.service.spec.ts
@@ -1,5 +1,6 @@
-import { ServerXSRFService } from './server-xsrf.service';
 import { HttpClient } from '@angular/common/http';
+
+import { ServerXSRFService } from './server-xsrf.service';
 
 describe(`ServerXSRFService`, () => {
   let service: ServerXSRFService;

--- a/src/app/core/xsrf/server-xsrf.service.ts
+++ b/src/app/core/xsrf/server-xsrf.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { XSRFService } from './xsrf.service';
+
+@Injectable()
+export class ServerXSRFService extends XSRFService {
+  initXSRFToken(httpClient: HttpClient): () => Promise<any> {
+    return () => new Promise((resolve) => {
+      // return immediately, and keep tokenInitialized$ false. The server side can make only GET
+      // requests, since it can never get a valid XSRF cookie
+      resolve();
+    });
+  }
+}

--- a/src/app/core/xsrf/server-xsrf.service.ts
+++ b/src/app/core/xsrf/server-xsrf.service.ts
@@ -1,11 +1,16 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
 import { XSRFService } from './xsrf.service';
 
+/**
+ * Server (SSR) Service to obtain a new CSRF/XSRF token. Because SSR only triggers GET
+ * requests a CSRF token is never needed.
+ */
 @Injectable()
 export class ServerXSRFService extends XSRFService {
   initXSRFToken(httpClient: HttpClient): () => Promise<any> {
-    return () => new Promise((resolve) => {
+    return () => new Promise<void>((resolve) => {
       // return immediately, and keep tokenInitialized$ false. The server side can make only GET
       // requests, since it can never get a valid XSRF cookie
       resolve();

--- a/src/app/core/xsrf/xsrf.service.spec.ts
+++ b/src/app/core/xsrf/xsrf.service.spec.ts
@@ -1,0 +1,20 @@
+import { XSRFService } from './xsrf.service';
+import { HttpClient } from '@angular/common/http';
+
+class XSRFServiceImpl extends XSRFService {
+  initXSRFToken(httpClient: HttpClient): () => Promise<any> {
+    return () => null;
+  }
+}
+
+describe(`XSRFService`, () => {
+  let service: XSRFService;
+
+  beforeEach(() => {
+    service = new XSRFServiceImpl();
+  });
+
+  it(`should start with tokenInitialized$.hasValue() === false`, () => {
+    expect(service.tokenInitialized$.getValue()).toBeFalse();
+  });
+});

--- a/src/app/core/xsrf/xsrf.service.spec.ts
+++ b/src/app/core/xsrf/xsrf.service.spec.ts
@@ -1,5 +1,6 @@
-import { XSRFService } from './xsrf.service';
 import { HttpClient } from '@angular/common/http';
+
+import { XSRFService } from './xsrf.service';
 
 class XSRFServiceImpl extends XSRFService {
   initXSRFToken(httpClient: HttpClient): () => Promise<any> {

--- a/src/app/core/xsrf/xsrf.service.ts
+++ b/src/app/core/xsrf/xsrf.service.ts
@@ -2,6 +2,11 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+/**
+ * Abstract CSRF/XSRF Service used to track whether a CSRF token has been received
+ * from the DSpace REST API. Once it is received, the "tokenInitialized$" flag will
+ * be set to "true".
+ */
 @Injectable()
 export abstract class XSRFService {
   public tokenInitialized$: BehaviorSubject<boolean> = new BehaviorSubject(false);

--- a/src/app/core/xsrf/xsrf.service.ts
+++ b/src/app/core/xsrf/xsrf.service.ts
@@ -1,0 +1,10 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export abstract class XSRFService {
+  public tokenInitialized$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
+  abstract initXSRFToken(httpClient: HttpClient): () => Promise<any>;
+}

--- a/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-search-result-list-submission-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-search-result-list-submission-element.component.spec.ts
@@ -20,6 +20,7 @@ import { Bitstream } from '../../../../../core/shared/bitstream.model';
 import { HALEndpointService } from '../../../../../core/shared/hal-endpoint.service';
 import { Item } from '../../../../../core/shared/item.model';
 import { UUIDService } from '../../../../../core/shared/uuid.service';
+import { XSRFService } from '../../../../../core/xsrf/xsrf.service';
 import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
 import { ItemSearchResult } from '../../../../../shared/object-collection/shared/item-search-result.model';
 import { SelectableListService } from '../../../../../shared/object-list/selectable-list/selectable-list.service';
@@ -115,6 +116,7 @@ describe('PersonSearchResultListElementSubmissionComponent', () => {
         { provide: Store, useValue: {}},
         { provide: ObjectCacheService, useValue: {} },
         { provide: UUIDService, useValue: {} },
+        { provide: XSRFService, useValue: {} },
         { provide: RemoteDataBuildService, useValue: {} },
         { provide: CommunityDataService, useValue: {} },
         { provide: HALEndpointService, useValue: {} },

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
@@ -28,6 +28,7 @@ import { ConfigurationDataService } from '../../../../core/data/configuration-da
 import { LinkHeadService } from '../../../../core/services/link-head.service';
 import { SearchConfigurationService } from '../../../../core/shared/search/search-configuration.service';
 import { SearchConfigurationServiceStub } from '../../../../shared/testing/search-configuration-service.stub';
+import { XSRFService } from '../../../../core/xsrf/xsrf.service';
 import { ConfigurationProperty } from '../../../../core/shared/configuration-property.model';
 import { Router } from '@angular/router';
 import { RouterMock } from '../../../../shared/mocks/router.mock';
@@ -230,6 +231,7 @@ describe('EditRelationshipListComponent', () => {
         { provide: ConfigurationDataService, useValue: configurationDataService },
         { provide: SearchConfigurationService, useValue: new SearchConfigurationServiceStub() },
         { provide: EditItemRelationshipsService, useValue: editItemRelationshipsService },
+        { provide: XSRFService, useValue: {} },
         { provide: APP_CONFIG, useValue: environmentUseThumbs }
       ], schemas: [
         NO_ERRORS_SCHEMA

--- a/src/app/item-page/simple/field-components/file-section/file-section.component.spec.ts
+++ b/src/app/item-page/simple/field-components/file-section/file-section.component.spec.ts
@@ -13,6 +13,7 @@ import { of as observableOf } from 'rxjs';
 import { MockBitstreamFormat1 } from '../../../../shared/mocks/item.mock';
 import { FileSizePipe } from '../../../../shared/utils/file-size-pipe';
 import { PageInfo } from '../../../../core/shared/page-info.model';
+import { XSRFService } from '../../../../core/xsrf/xsrf.service';
 import { MetadataFieldWrapperComponent } from '../../../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
 import { createPaginatedList } from '../../../../shared/testing/utils.test';
 import { NotificationsService } from '../../../../shared/notifications/notifications.service';
@@ -66,6 +67,7 @@ describe('FileSectionComponent', () => {
       }), BrowserAnimationsModule],
       declarations: [FileSectionComponent, VarDirective, FileSizePipe, MetadataFieldWrapperComponent],
       providers: [
+        { provide: XSRFService, useValue: {} },
         { provide: BitstreamDataService, useValue: bitstreamDataService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: APP_CONFIG, useValue: environment }

--- a/src/app/login-page/login-page.component.spec.ts
+++ b/src/app/login-page/login-page.component.spec.ts
@@ -6,6 +6,7 @@ import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { of as observableOf } from 'rxjs';
 
+import { XSRFService } from '../core/xsrf/xsrf.service';
 import { LoginPageComponent } from './login-page.component';
 import { ActivatedRouteStub } from '../shared/testing/active-router.stub';
 
@@ -31,7 +32,8 @@ describe('LoginPageComponent', () => {
       declarations: [LoginPageComponent],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRouteStub },
-        { provide: Store, useValue: store }
+        { provide: Store, useValue: store },
+        { provide: XSRFService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
@@ -14,6 +14,7 @@ import { HostWindowService } from '../host-window.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthTokenInfo } from '../../core/auth/models/auth-token-info.model';
 import { AuthService } from '../../core/auth/auth.service';
+import { XSRFService } from '../../core/xsrf/xsrf.service';
 import { of } from 'rxjs';
 import { BrowserOnlyMockPipe } from '../testing/browser-only-mock.pipe';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
@@ -86,6 +87,7 @@ describe('AuthNavMenuComponent', () => {
         providers: [
           { provide: HostWindowService, useValue: window },
           { provide: AuthService, useValue: authService },
+          { provide: XSRFService, useValue: {} },
         ],
         schemas: [
           CUSTOM_ELEMENTS_SCHEMA

--- a/src/app/shared/auth-nav-menu/user-menu/user-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/user-menu/user-menu.component.spec.ts
@@ -7,6 +7,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { UserMenuComponent } from './user-menu.component';
 import { authReducer, AuthState } from '../../../core/auth/auth.reducer';
 import { AuthTokenInfo } from '../../../core/auth/models/auth-token-info.model';
+import { XSRFService } from '../../../core/xsrf/xsrf.service';
 import { EPersonMock } from '../../testing/eperson.mock';
 import { AppState } from '../../../app.reducer';
 import { TranslateLoaderMock } from '../../mocks/translate-loader.mock';
@@ -69,7 +70,8 @@ describe('UserMenuComponent', () => {
         })
       ],
       providers: [
-        { provide: AuthService, useValue: authService }
+        { provide: AuthService, useValue: authService },
+        { provide: XSRFService, useValue: {} },
       ],
       declarations: [
         UserMenuComponent

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/dynamic-relation-group.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/dynamic-relation-group.component.spec.ts
@@ -25,6 +25,7 @@ import { VocabularyServiceStub } from '../../../../../testing/vocabulary-service
 import { StoreMock } from '../../../../../testing/store.mock';
 import { FormRowModel } from '../../../../../../core/config/models/config-submission-form.model';
 import { storeModuleConfig } from '../../../../../../app.reducer';
+import { XSRFService } from '../../../../../../core/xsrf/xsrf.service';
 
 export let FORM_GROUP_TEST_MODEL_CONFIG;
 
@@ -129,7 +130,8 @@ describe('DsDynamicRelationGroupComponent test suite', () => {
         FormComponent,
         FormService,
         { provide: VocabularyService, useValue: new VocabularyServiceStub() },
-        { provide: Store, useClass: StoreMock }
+        { provide: Store, useClass: StoreMock },
+        { provide: XSRFService, useValue: {} },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -24,6 +24,7 @@ import { RemoteDataBuildService } from '../../../../../core/cache/builders/remot
 import { WorkspaceItem } from '../../../../../core/submission/models/workspaceitem.model';
 import { Collection } from '../../../../../core/shared/collection.model';
 import { By } from '@angular/platform-browser';
+import { XSRFService } from '../../../../../core/xsrf/xsrf.service';
 
 describe('DsDynamicLookupRelationModalComponent', () => {
   let component: DsDynamicLookupRelationModalComponent;
@@ -128,6 +129,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
             }
           }
         },
+        { provide: XSRFService, useValue: {} },
         { provide: NgZone, useValue: new NgZone({}) },
         NgbActiveModal
       ],

--- a/src/app/shared/form/form.component.spec.ts
+++ b/src/app/shared/form/form.component.spec.ts
@@ -24,6 +24,7 @@ import { FormFieldMetadataValueObject } from './builder/models/form-field-metada
 import { createTestComponent } from '../testing/utils.test';
 import { BehaviorSubject } from 'rxjs';
 import { storeModuleConfig } from '../../app.reducer';
+import { XSRFService } from '../../core/xsrf/xsrf.service';
 
 let TEST_FORM_MODEL;
 
@@ -156,7 +157,8 @@ describe('FormComponent test suite', () => {
         FormBuilderService,
         FormComponent,
         FormService,
-        { provide: Store, useClass: StoreMock }
+        { provide: Store, useClass: StoreMock },
+        { provide: XSRFService, useValue: {} },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.spec.ts
+++ b/src/app/shared/object-collection/shared/listable-object/listable-object-component-loader.component.spec.ts
@@ -26,6 +26,7 @@ import { FileService } from '../../../../core/shared/file.service';
 import { TruncatableService } from '../../../truncatable/truncatable.service';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { SearchResultListElementComponent } from '../../../object-list/search-result-list-element/search-result-list-element.component';
+import { XSRFService } from 'src/app/core/xsrf/xsrf.service';
 
 const testType = 'TestType';
 const testContext = Context.Search;
@@ -72,6 +73,7 @@ describe('ListableObjectComponentLoaderComponent', () => {
         { provide: FileService, useValue: fileService },
         { provide: ThemeService, useValue: themeService },
         { provide: TruncatableService, useValue: truncatableService },
+        { provide: XSRFService, useValue: {} },
       ]
     }).overrideComponent(ListableObjectComponentLoaderComponent, {
       set: {

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.spec.ts
@@ -20,6 +20,7 @@ import { FileService } from '../../../../core/shared/file.service';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { Item } from '../../../../core/shared/item.model';
 import { UUIDService } from '../../../../core/shared/uuid.service';
+import { XSRFService } from '../../../../core/xsrf/xsrf.service';
 import { TranslateLoaderMock } from '../../../mocks/translate-loader.mock';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { HALEndpointServiceStub } from '../../../testing/hal-endpoint-service.stub';
@@ -99,6 +100,7 @@ describe('ItemDetailPreviewComponent', () => {
         { provide: HALEndpointService, useValue: new HALEndpointServiceStub('workspaceitems') },
         { provide: ObjectCacheService, useValue: {} },
         { provide: UUIDService, useValue: {} },
+        { provide: XSRFService, useValue: {} },
         { provide: Store, useValue: {} },
         { provide: RemoteDataBuildService, useValue: {} },
         { provide: CommunityDataService, useValue: {} },

--- a/src/app/shared/object-grid/search-result-grid-element/collection-search-result/collection-search-result-grid-element.component.spec.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/collection-search-result/collection-search-result-grid-element.component.spec.ts
@@ -13,6 +13,7 @@ import { DSOChangeAnalyzer } from '../../../../core/data/dso-change-analyzer.ser
 import { Collection } from '../../../../core/shared/collection.model';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { UUIDService } from '../../../../core/shared/uuid.service';
+import { XSRFService } from '../../../../core/xsrf/xsrf.service';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { CollectionSearchResult } from '../../../object-collection/shared/collection-search-result.model';
 import { TruncatableService } from '../../../truncatable/truncatable.service';
@@ -80,6 +81,7 @@ describe('CollectionSearchResultGridElementComponent', () => {
         { provide: DSOChangeAnalyzer, useValue: {} },
         { provide: DefaultChangeAnalyzer, useValue: {} },
         { provide: BitstreamFormatDataService, useValue: {} },
+        { provide: XSRFService, useValue: {} },
         { provide: LinkService, useValue: linkService }
       ],
 

--- a/src/app/shared/object-grid/search-result-grid-element/community-search-result/community-search-result-grid-element.component.spec.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/community-search-result/community-search-result-grid-element.component.spec.ts
@@ -13,6 +13,7 @@ import { DSOChangeAnalyzer } from '../../../../core/data/dso-change-analyzer.ser
 import { Community } from '../../../../core/shared/community.model';
 import { HALEndpointService } from '../../../../core/shared/hal-endpoint.service';
 import { UUIDService } from '../../../../core/shared/uuid.service';
+import { XSRFService } from '../../../../core/xsrf/xsrf.service';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { CommunitySearchResult } from '../../../object-collection/shared/community-search-result.model';
 import { TruncatableService } from '../../../truncatable/truncatable.service';
@@ -80,7 +81,8 @@ describe('CommunitySearchResultGridElementComponent', () => {
         { provide: DSOChangeAnalyzer, useValue: {} },
         { provide: DefaultChangeAnalyzer, useValue: {} },
         { provide: BitstreamFormatDataService, useValue: {} },
-        { provide: LinkService, useValue: linkService }
+        { provide: LinkService, useValue: linkService },
+        { provide: XSRFService, useValue: {} },
       ],
 
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/shared/object-list/item-list-element/item-types/item/item-list-element.component.spec.ts
+++ b/src/app/shared/object-list/item-list-element/item-types/item/item-list-element.component.spec.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { ItemListElementComponent } from './item-list-element.component';
 import { Item } from '../../../../../core/shared/item.model';
+import { XSRFService } from '../../../../../core/xsrf/xsrf.service';
 import { TruncatableService } from '../../../../truncatable/truncatable.service';
 import { of as observableOf } from 'rxjs';
 import { ListableObjectComponentLoaderComponent } from '../../../../object-collection/shared/listable-object/listable-object-component-loader.component';
@@ -91,6 +92,7 @@ describe('ItemListElementComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: XSRFService, useValue: {} },
         { provide: FileService, useValue: fileService },
         { provide: ThemeService, useValue: themeService },
         { provide: TruncatableService, useValue: truncatableService },

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -20,6 +20,7 @@ import { SidebarService } from '../sidebar/sidebar.service';
 import { SearchFilterService } from '../../core/shared/search/search-filter.service';
 import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
 import { SEARCH_CONFIG_SERVICE } from '../../my-dspace-page/my-dspace-page.component';
+import { XSRFService } from '../../core/xsrf/xsrf.service';
 import { RouteService } from '../../core/services/route.service';
 import { createSuccessfulRemoteDataObject, createSuccessfulRemoteDataObject$ } from '../remote-data.utils';
 import { PaginatedSearchOptions } from './models/paginated-search-options.model';
@@ -208,6 +209,7 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
         provide: SearchFilterService,
         useValue: {}
       },
+      { provide: XSRFService, useValue: {} },
       {
         provide: SEARCH_CONFIG_SERVICE,
         useValue: searchConfigurationServiceStub

--- a/src/app/submission/edit/submission-edit.component.spec.ts
+++ b/src/app/submission/edit/submission-edit.component.spec.ts
@@ -18,6 +18,7 @@ import { ActivatedRouteStub } from '../../shared/testing/active-router.stub';
 import { mockSubmissionObject } from '../../shared/mocks/submission.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { ItemDataService } from '../../core/data/item-data.service';
+import { XSRFService } from '../../core/xsrf/xsrf.service';
 import { SubmissionJsonPatchOperationsServiceStub } from '../../shared/testing/submission-json-patch-operations-service.stub';
 import { SubmissionJsonPatchOperationsService } from '../../core/submission/submission-json-patch-operations.service';
 
@@ -54,7 +55,7 @@ describe('SubmissionEditComponent Component', () => {
         { provide: TranslateService, useValue: getMockTranslateService() },
         { provide: Router, useValue: new RouterStub() },
         { provide: ActivatedRoute, useValue: route },
-
+        { provide: XSRFService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/submission/sections/accesses/section-accesses.component.spec.ts
+++ b/src/app/submission/sections/accesses/section-accesses.component.spec.ts
@@ -40,6 +40,7 @@ import { AppState } from '../../../app.reducer';
 import { getMockFormService } from '../../../shared/mocks/form-service.mock';
 import { mockAccessesFormData } from '../../../shared/mocks/submission.mock';
 import { accessConditionChangeEvent, checkboxChangeEvent } from '../../../shared/testing/form-event.stub';
+import { XSRFService } from '../../../core/xsrf/xsrf.service';
 
 describe('SubmissionSectionAccessesComponent', () => {
   let component: SubmissionSectionAccessesComponent;
@@ -96,6 +97,7 @@ describe('SubmissionSectionAccessesComponent', () => {
           { provide: TranslateService, useValue: getMockTranslateService() },
           { provide: FormService, useValue: getMockFormService() },
           { provide: Store, useValue: storeStub },
+          { provide: XSRFService, useValue: {} },
           { provide: SubmissionJsonPatchOperationsService, useValue: SubmissionJsonPatchOperationsServiceStub },
           { provide: 'sectionDataProvider', useValue: sectionData },
           { provide: 'submissionIdProvider', useValue: '1508' },
@@ -188,6 +190,7 @@ describe('SubmissionSectionAccessesComponent', () => {
           { provide: TranslateService, useValue: getMockTranslateService() },
           { provide: FormService, useValue: getMockFormService() },
           { provide: Store, useValue: storeStub },
+          { provide: XSRFService, useValue: {} },
           { provide: SubmissionJsonPatchOperationsService, useValue: SubmissionJsonPatchOperationsServiceStub },
           { provide: 'sectionDataProvider', useValue: sectionData },
           { provide: 'submissionIdProvider', useValue: '1508' },

--- a/src/app/submission/sections/license/section-license.component.spec.ts
+++ b/src/app/submission/sections/license/section-license.component.spec.ts
@@ -38,6 +38,7 @@ import { Collection } from '../../../core/shared/collection.model';
 import { License } from '../../../core/shared/license.model';
 import { FormFieldMetadataValueObject } from '../../../shared/form/builder/models/form-field-metadata-value.model';
 import { cold } from 'jasmine-marbles';
+import { XSRFService } from '../../../core/xsrf/xsrf.service';
 
 const collectionId = mockSubmissionCollectionId;
 const licenseText = 'License text';
@@ -137,6 +138,7 @@ describe('SubmissionSectionLicenseComponent test suite', () => {
         { provide: 'collectionIdProvider', useValue: collectionId },
         { provide: 'sectionDataProvider', useValue: Object.assign({}, sectionObject) },
         { provide: 'submissionIdProvider', useValue: submissionId },
+        { provide: XSRFService, useValue: {} },
         ChangeDetectorRef,
         FormBuilderService,
         SubmissionSectionLicenseComponent

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -47,6 +47,7 @@ import {
 } from '../../../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { dateToISOFormat } from '../../../../../shared/date.util';
 import { of } from 'rxjs';
+import { XSRFService } from '../../../../../core/xsrf/xsrf.service';
 
 const jsonPatchOpBuilder: any = jasmine.createSpyObj('jsonPatchOpBuilder', {
   add: jasmine.createSpy('add'),
@@ -103,6 +104,7 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
         { provide: SubmissionJsonPatchOperationsService, useValue: submissionJsonPatchOperationsServiceStub },
         { provide: JsonPatchOperationsBuilder, useValue: jsonPatchOpBuilder },
         { provide: SectionUploadService, useValue: getMockSectionUploadService() },
+        { provide: XSRFService, useValue: {} },
         FormBuilderService,
         ChangeDetectorRef,
         SubmissionSectionUploadFileEditComponent,

--- a/src/modules/app/browser-app.module.ts
+++ b/src/modules/app/browser-app.module.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule, BrowserTransferStateModule, makeStateKey, TransferState } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { REQUEST } from '@nguniversal/express-engine/tokens';
@@ -32,6 +32,8 @@ import { AuthRequestService } from '../../app/core/auth/auth-request.service';
 import { BrowserAuthRequestService } from '../../app/core/auth/browser-auth-request.service';
 import { BrowserInitService } from './browser-init.service';
 import { ReferrerService } from '../../app/core/services/referrer.service';
+import { BrowserXSRFService } from '../../app/core/xsrf/browser-xsrf.service';
+import { XSRFService } from '../../app/core/xsrf/xsrf.service';
 import { BrowserReferrerService } from '../../app/core/services/browser.referrer.service';
 
 export const REQ_KEY = makeStateKey<string>('req');
@@ -72,6 +74,16 @@ export function getRequest(transferState: TransferState): any {
       provide: REQUEST,
       useFactory: getRequest,
       deps: [TransferState]
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (xsrfService: XSRFService, httpClient: HttpClient) => xsrfService.initXSRFToken(httpClient),
+      deps: [ XSRFService, HttpClient ],
+      multi: true,
+    },
+    {
+      provide: XSRFService,
+      useClass: BrowserXSRFService,
     },
     {
       provide: AuthService,

--- a/src/modules/app/server-app.module.ts
+++ b/src/modules/app/server-app.module.ts
@@ -35,6 +35,8 @@ import { ServerAuthRequestService } from '../../app/core/auth/server-auth-reques
 import { ServerInitService } from './server-init.service';
 import { XhrFactory } from '@angular/common';
 import { ServerXhrService } from '../../app/core/services/server-xhr.service';
+import { ServerXSRFService } from '../../app/core/xsrf/server-xsrf.service';
+import { XSRFService } from '../../app/core/xsrf/xsrf.service';
 import { ReferrerService } from '../../app/core/services/referrer.service';
 import { ServerReferrerService } from '../../app/core/services/server.referrer.service';
 
@@ -93,6 +95,10 @@ export function createTranslateLoader(transferState: TransferState) {
     {
       provide: AuthRequestService,
       useClass: ServerAuthRequestService,
+    },
+    {
+      provide: XSRFService,
+      useClass: ServerXSRFService,
     },
     {
       provide: LocaleService,


### PR DESCRIPTION
## Description
* Manual port of #2886 to `dspace-7_x`
* Also includes commit d2ec558ac24332085d97a1a0ec1b962ac80354e5 of #2897, which refactored that new CSRF token code into a request effect.
* Requires backend port in DSpace/DSpace#9599
* Fixes DSpace/DSpace#9236

## Instructions for Reviewers
* Install this PR and Backend PR DSpace/DSpace#9599
* Verify bug DSpace/DSpace#9236 no longer occurs.  This issue is easily reproducible on https://demo.dspace.org
