### PR TITLE
#2923 - Fixed redirect on new Item version creation

### DIFF
--- a/src/app/core/submission/workspaceitem-data.service.spec.ts
+++ b/src/app/core/submission/workspaceitem-data.service.spec.ts
@@ -2,13 +2,18 @@ import {
   HttpClient,
   HttpHeaders,
 } from '@angular/common/http';
+import { waitForAsync } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
 import {
   cold,
   getTestScheduler,
   hot,
 } from 'jasmine-marbles';
-import { of as observableOf } from 'rxjs';
+import {
+  of as observableOf,
+  of,
+} from 'rxjs';
+import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 
 import { getMockHrefOnlyDataService } from '../../shared/mocks/href-only-data.service.mock';
@@ -151,12 +156,17 @@ describe('WorkspaceitemDataService test', () => {
     });
 
     describe('findByItem', () => {
-      it('should proxy the call to UpdateDataServiceImpl.findByHref', () => {
+      it('should proxy the call to UpdateDataServiceImpl.findByHref', waitForAsync(() => {
         scheduler.schedule(() => service.findByItem('1234-1234', true, true, pageInfo));
         scheduler.flush();
-        const searchUrl = service.getIDHref('item', [new RequestParam('uuid', '1234-1234')]);
-        expect((service as any).findByHref).toHaveBeenCalledWith(searchUrl, true, true);
-      });
+        const searchUrl$ =
+          of('https://rest.api/rest/api/submission/workspaceitems/search/item')
+            .pipe(map(href => service.buildHrefFromFindOptions(href, { searchParams: [new RequestParam('uuid', '1234-1234')] }, [])));
+        searchUrl$.subscribe((url) => {
+          expect(url).toEqual('https://rest.api/rest/api/submission/workspaceitems/search/item?uuid=1234-1234');
+        });
+        expect((service as any).findByHref).toHaveBeenCalled();
+      }));
 
       it('should return a RemoteData<WorkspaceItem> for the search', () => {
         const result = service.findByItem('1234-1234', true, true, pageInfo);

--- a/src/app/core/submission/workspaceitem-data.service.ts
+++ b/src/app/core/submission/workspaceitem-data.service.ts
@@ -43,7 +43,7 @@ import { WorkspaceItem } from './models/workspaceitem.model';
 @Injectable({ providedIn: 'root' })
 export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceItem> implements DeleteData<WorkspaceItem>, SearchData<WorkspaceItem>{
   protected linkPath = 'workspaceitems';
-  protected searchByItemLinkPath = 'item';
+  protected searchByItemLinkPath = 'workspaceitems/search/item';
   private deleteData: DeleteData<WorkspaceItem>;
   private searchData: SearchData<WorkspaceItem>;
 
@@ -91,7 +91,8 @@ export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceI
   public findByItem(uuid: string, useCachedVersionIfAvailable = false, reRequestOnStale = true, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<WorkspaceItem>[]): Observable<RemoteData<WorkspaceItem>> {
     const findListOptions = new FindListOptions();
     findListOptions.searchParams = [new RequestParam('uuid', uuid)];
-    const href$ = this.getIDHref(this.searchByItemLinkPath, findListOptions, ...linksToFollow);
+    const href$ = this.halService.getEndpoint(this.searchByItemLinkPath)
+      .pipe(map((href) => this.buildHrefFromFindOptions(href, findListOptions, [], ...linksToFollow)));
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
 

--- a/src/app/core/submission/workspaceitem-data.service.ts
+++ b/src/app/core/submission/workspaceitem-data.service.ts
@@ -43,9 +43,9 @@ import { WorkspaceItem } from './models/workspaceitem.model';
 @Injectable({ providedIn: 'root' })
 export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceItem> implements DeleteData<WorkspaceItem>, SearchData<WorkspaceItem>{
   protected linkPath = 'workspaceitems';
-  protected searchByItemLinkPath = 'workspaceitems/search/item';
+  protected searchByItemLinkPath = 'item';
   private deleteData: DeleteData<WorkspaceItem>;
-  private searchData: SearchData<WorkspaceItem>;
+  private searchData: SearchDataImpl<WorkspaceItem>;
 
   constructor(
     protected comparator: DSOChangeAnalyzer<WorkspaceItem>,
@@ -91,8 +91,7 @@ export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceI
   public findByItem(uuid: string, useCachedVersionIfAvailable = false, reRequestOnStale = true, options: FindListOptions = {}, ...linksToFollow: FollowLinkConfig<WorkspaceItem>[]): Observable<RemoteData<WorkspaceItem>> {
     const findListOptions = new FindListOptions();
     findListOptions.searchParams = [new RequestParam('uuid', uuid)];
-    const href$ = this.halService.getEndpoint(this.searchByItemLinkPath)
-      .pipe(map((href) => this.buildHrefFromFindOptions(href, findListOptions, [], ...linksToFollow)));
+    const href$ = this.searchData.getSearchByHref(this.searchByItemLinkPath, findListOptions, ...linksToFollow);
     return this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
 


### PR DESCRIPTION
## References

* Fixes #2923

## Description
Fixed user redirect after creating a new version of an item. Replaced the old method `this.getIDHref()` with `this.searchData.getSearchByHref()`.

## Instructions for Reviewers

List of changes in this PR:
* Implemented new solution inside method `findByItem()`;
* Changed tests.

**To Test**:

- Connect as administrator;
- Find and open an item in the repository;
- Click on the new version button in the upper left of the page;
- Add text to describe the version and then click on Create;
- Want a few seconds, a confirmation message appears: New version has been created with version number 2;
- The new version submission form is displayed.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [X] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [X] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
