### PR TITLE
Fix advanced workflows throwing 404

### DIFF
--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.html
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.html
@@ -20,24 +20,32 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let eperson of (ePeopleMembersOfGroup | async)?.page">
-          <td class="align-middle">{{eperson.id}}</td>
+        <tr *ngFor="let epersonDTO of (ePeopleMembersOfGroup | async)?.page">
+          <td class="align-middle">{{epersonDTO.eperson.id}}</td>
           <td class="align-middle">
-            <a [routerLink]="getEPersonEditRoute(eperson.id)">
-              {{ dsoNameService.getName(eperson) }}
+            <a [routerLink]="getEPersonEditRoute(epersonDTO.eperson.id)">
+              {{ dsoNameService.getName(epersonDTO.eperson) }}
             </a>
           </td>
           <td class="align-middle">
-            {{messagePrefix + '.table.email' | translate}}: {{ eperson.email ? eperson.email : '-' }}<br/>
-            {{messagePrefix + '.table.netid' | translate}}: {{ eperson.netid ? eperson.netid : '-' }}
+            {{messagePrefix + '.table.email' | translate}}: {{ epersonDTO.eperson.email ? epersonDTO.eperson.email : '-' }}<br/>
+            {{messagePrefix + '.table.netid' | translate}}: {{ epersonDTO.eperson.netid ? epersonDTO.eperson.netid : '-' }}
           </td>
           <td class="align-middle">
             <div class="btn-group edit-field">
-              <button (click)="deleteMemberFromGroup(eperson)"
+              <button (click)="deleteMemberFromGroup(epersonDTO.eperson)"
+                      *ngIf="epersonDTO.ableToDelete"
                       [disabled]="actionConfig.remove.disabled"
                       [ngClass]="['btn btn-sm', actionConfig.remove.css]"
-                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: { name: dsoNameService.getName(eperson) } }}">
+                      title="{{messagePrefix + '.table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDTO.eperson) } }}">
                 <i [ngClass]="actionConfig.remove.icon"></i>
+              </button>
+              <button *ngIf="!epersonDTO.ableToDelete"
+                      (click)="addMemberToGroup(epersonDTO.eperson)"
+                      [disabled]="actionConfig.add.disabled"
+                      [ngClass]="['btn btn-sm', actionConfig.add.css]"
+                      title="{{messagePrefix + '.table.edit.buttons.add' | translate: { name: dsoNameService.getName(epersonDTO.eperson) } }}">
+                <i [ngClass]="actionConfig.add.icon"></i>
               </button>
             </div>
           </td>

--- a/src/app/access-control/group-registry/group-form/members-list/members-list.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/members-list/members-list.component.spec.ts
@@ -222,13 +222,13 @@ describe('MembersListComponent', () => {
 
     describe('if first delete button is pressed', () => {
       beforeEach(() => {
+        spyOn(component, 'search').and.callThrough();
         const deleteButton: DebugElement = fixture.debugElement.query(By.css('#ePeopleMembersOfGroup tbody .fa-trash-alt'));
         deleteButton.nativeElement.click();
         fixture.detectChanges();
       });
-      it('then no ePerson remains as a member of the active group.', () => {
-        const epersonsFound = fixture.debugElement.queryAll(By.css('#ePeopleMembersOfGroup tbody tr'));
-        expect(epersonsFound.length).toEqual(0);
+      it('should trigger the search to add the user back to the search table', () => {
+        expect(component.search).toHaveBeenCalled();
       });
     });
   });
@@ -264,13 +264,13 @@ describe('MembersListComponent', () => {
 
       describe('if first add button is pressed', () => {
         beforeEach(() => {
+          spyOn(component, 'search').and.callThrough();
           const addButton: DebugElement = fixture.debugElement.query(By.css('#epersonsSearch tbody .fa-plus'));
           addButton.nativeElement.click();
           fixture.detectChanges();
         });
-        it('then all (two) ePersons are member of the active group. No non-members left', () => {
-          epersonsFound = fixture.debugElement.queryAll(By.css('#epersonsSearch tbody tr'));
-          expect(epersonsFound.length).toEqual(0);
+        it('should trigger the search to remove the user from the search table', () => {
+          expect(component.search).toHaveBeenCalled();
         });
       });
     });

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -107,13 +107,17 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
    * @param scope   Scope of the EPeople search, default byMetadata
    * @param query   Query of search
    * @param options Options of search request
+   * @param useCachedVersionIfAvailable If this is true, the request will only be sent if there's
+   *                                    no valid cached version. Defaults to true
+   * @param reRequestOnStale            Whether or not the request should automatically be re-
+   *                                    requested after the response becomes stale
    */
-  public searchByScope(scope: string, query: string, options: FindListOptions = {}, useCachedVersionIfAvailable?: boolean): Observable<RemoteData<PaginatedList<EPerson>>> {
+  public searchByScope(scope: string, query: string, options: FindListOptions = {}, useCachedVersionIfAvailable?: boolean, reRequestOnStale = true): Observable<RemoteData<PaginatedList<EPerson>>> {
     switch (scope) {
       case 'metadata':
-        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable);
+        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable, reRequestOnStale);
       case 'email':
-        return this.getEPersonByEmail(query.trim()).pipe(
+        return this.getEPersonByEmail(query.trim(), useCachedVersionIfAvailable, reRequestOnStale).pipe(
           map((rd: RemoteData<EPerson | NoContent>) => {
             if (rd.hasSucceeded) {
               // Turn the single EPerson or NoContent in to a PaginatedList<EPerson>
@@ -145,7 +149,7 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
           }),
         );
       default:
-        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable);
+        return this.getEpeopleByMetadata(query.trim(), options, useCachedVersionIfAvailable, reRequestOnStale);
     }
   }
 

--- a/src/app/item-page/edit-item-page/modify-item-overview/modify-item-overview.component.spec.ts
+++ b/src/app/item-page/edit-item-page/modify-item-overview/modify-item-overview.component.spec.ts
@@ -37,6 +37,7 @@ describe('ModifyItemOverviewComponent', () => {
     fixture = TestBed.createComponent(ModifyItemOverviewComponent);
     comp = fixture.componentInstance;
     comp.item = mockItem;
+    comp.ngOnChanges();
 
     fixture.detectChanges();
   });

--- a/src/app/item-page/edit-item-page/modify-item-overview/modify-item-overview.component.ts
+++ b/src/app/item-page/edit-item-page/modify-item-overview/modify-item-overview.component.ts
@@ -5,7 +5,7 @@ import {
 import {
   Component,
   Input,
-  OnInit,
+  OnChanges,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -21,12 +21,12 @@ import { MetadataMap } from '../../../core/shared/metadata.models';
 /**
  * Component responsible for rendering a table containing the metadatavalues from the to be edited item
  */
-export class ModifyItemOverviewComponent implements OnInit {
+export class ModifyItemOverviewComponent implements OnChanges  {
 
   @Input() item: Item;
   metadata: MetadataMap;
 
-  ngOnInit(): void {
-    this.metadata = this.item.metadata;
+  ngOnChanges(): void {
+    this.metadata = this.item?.metadata;
   }
 }

--- a/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
@@ -38,7 +38,7 @@ export abstract class ClaimedTaskActionsAbstractComponent extends MyDSpaceReload
   /**
    * The workflow task option the child component represents
    */
-  abstract option: string;
+  @Input() option: string;
 
   object: ClaimedTask;
 

--- a/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   Injector,
+  Input,
   OnDestroy,
 } from '@angular/core';
 import { Router } from '@angular/router';
@@ -44,7 +45,7 @@ export abstract class ClaimedTaskActionsAbstractComponent extends MyDSpaceReload
   /**
    * The item object that belonging to the ClaimedTask object
    */
-  item: Item;
+  @Input() item: Item;
 
   /**
    * Anchor used to reload the pool task.
@@ -56,7 +57,7 @@ export abstract class ClaimedTaskActionsAbstractComponent extends MyDSpaceReload
   /**
    * The workflowitem object that belonging to the ClaimedTask object
    */
-  workflowitem: WorkflowItem;
+  @Input() workflowitem: WorkflowItem;
 
   protected constructor(protected injector: Injector,
                         protected router: Router,

--- a/src/app/shared/mydspace-actions/claimed-task/approve/claimed-task-actions-approve.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/approve/claimed-task-actions-approve.component.ts
@@ -38,10 +38,6 @@ export const WORKFLOW_TASK_OPTION_APPROVE = 'submit_approve';
  * Component for displaying and processing the approve action on a workflow task item
  */
 export class ClaimedTaskActionsApproveComponent extends ClaimedTaskActionsAbstractComponent {
-  /**
-   * This component represents the approve option
-   */
-  option = WORKFLOW_TASK_OPTION_APPROVE;
 
   constructor(protected injector: Injector,
               protected router: Router,

--- a/src/app/shared/mydspace-actions/claimed-task/decline-task/claimed-task-actions-decline-task.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/decline-task/claimed-task-actions-decline-task.component.ts
@@ -39,8 +39,6 @@ export const WORKFLOW_TASK_OPTION_DECLINE_TASK = 'submit_decline_task';
  */
 export class ClaimedTaskActionsDeclineTaskComponent extends ClaimedTaskActionsAbstractComponent {
 
-  option = WORKFLOW_TASK_OPTION_DECLINE_TASK;
-
   constructor(protected injector: Injector,
               protected router: Router,
               protected notificationsService: NotificationsService,

--- a/src/app/shared/mydspace-actions/claimed-task/edit-metadata/claimed-task-actions-edit-metadata.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/edit-metadata/claimed-task-actions-edit-metadata.component.ts
@@ -34,10 +34,6 @@ export const WORKFLOW_TASK_OPTION_EDIT_METADATA = 'submit_edit_metadata';
  * Component for displaying the edit metadata action on a workflow task item
  */
 export class ClaimedTaskActionsEditMetadataComponent extends ClaimedTaskActionsAbstractComponent {
-  /**
-   * This component represents the edit metadata option
-   */
-  option = WORKFLOW_TASK_OPTION_EDIT_METADATA;
 
   constructor(protected injector: Injector,
               protected router: Router,

--- a/src/app/shared/mydspace-actions/claimed-task/rating/advanced-claimed-task-action-rating.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/rating/advanced-claimed-task-action-rating.component.ts
@@ -14,10 +14,7 @@ import {
 
 import { RequestService } from '../../../../core/data/request.service';
 import { SearchService } from '../../../../core/shared/search/search.service';
-import {
-  ADVANCED_WORKFLOW_ACTION_RATING,
-  ADVANCED_WORKFLOW_TASK_OPTION_RATING,
-} from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-rating/advanced-workflow-action-rating.component';
+import { ADVANCED_WORKFLOW_ACTION_RATING } from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-rating/advanced-workflow-action-rating.component';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { AdvancedClaimedTaskActionsAbstractComponent } from '../abstract/advanced-claimed-task-actions-abstract.component';
 
@@ -32,11 +29,6 @@ import { AdvancedClaimedTaskActionsAbstractComponent } from '../abstract/advance
   imports: [NgbTooltipModule, TranslateModule],
 })
 export class AdvancedClaimedTaskActionRatingComponent extends AdvancedClaimedTaskActionsAbstractComponent {
-
-  /**
-   * This component represents the advanced select option
-   */
-  option = ADVANCED_WORKFLOW_TASK_OPTION_RATING;
 
   workflowType = ADVANCED_WORKFLOW_ACTION_RATING;
 

--- a/src/app/shared/mydspace-actions/claimed-task/reject/claimed-task-actions-reject.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/reject/claimed-task-actions-reject.component.ts
@@ -50,10 +50,6 @@ export const WORKFLOW_TASK_OPTION_REJECT = 'submit_reject';
  * Component for displaying and processing the reject action on a workflow task item
  */
 export class ClaimedTaskActionsRejectComponent extends ClaimedTaskActionsAbstractComponent implements OnInit {
-  /**
-   * This component represents the reject option
-   */
-  option = WORKFLOW_TASK_OPTION_REJECT;
 
   /**
    * The reject form group

--- a/src/app/shared/mydspace-actions/claimed-task/return-to-pool/claimed-task-actions-return-to-pool.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/return-to-pool/claimed-task-actions-return-to-pool.component.ts
@@ -36,10 +36,6 @@ export const WORKFLOW_TASK_OPTION_RETURN_TO_POOL = 'return_to_pool';
  * Component for displaying and processing the return to pool action on a workflow task item
  */
 export class ClaimedTaskActionsReturnToPoolComponent extends ClaimedTaskActionsAbstractComponent {
-  /**
-   * This component represents the return to pool option
-   */
-  option = WORKFLOW_TASK_OPTION_RETURN_TO_POOL;
 
   constructor(protected injector: Injector,
               protected router: Router,

--- a/src/app/shared/mydspace-actions/claimed-task/select-reviewer/advanced-claimed-task-action-select-reviewer.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/select-reviewer/advanced-claimed-task-action-select-reviewer.component.ts
@@ -14,10 +14,7 @@ import {
 
 import { RequestService } from '../../../../core/data/request.service';
 import { SearchService } from '../../../../core/shared/search/search.service';
-import {
-  ADVANCED_WORKFLOW_ACTION_SELECT_REVIEWER,
-  ADVANCED_WORKFLOW_TASK_OPTION_SELECT_REVIEWER,
-} from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/advanced-workflow-action-select-reviewer.component';
+import { ADVANCED_WORKFLOW_ACTION_SELECT_REVIEWER } from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/advanced-workflow-action-select-reviewer.component';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { AdvancedClaimedTaskActionsAbstractComponent } from '../abstract/advanced-claimed-task-actions-abstract.component';
 
@@ -32,11 +29,6 @@ import { AdvancedClaimedTaskActionsAbstractComponent } from '../abstract/advance
   imports: [NgbTooltipModule, TranslateModule],
 })
 export class AdvancedClaimedTaskActionSelectReviewerComponent extends AdvancedClaimedTaskActionsAbstractComponent {
-
-  /**
-   * This component represents the advanced select option
-   */
-  option = ADVANCED_WORKFLOW_TASK_OPTION_SELECT_REVIEWER;
 
   workflowType = ADVANCED_WORKFLOW_ACTION_SELECT_REVIEWER;
 

--- a/src/app/shared/mydspace-actions/claimed-task/switcher/claimed-task-actions-decorator.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/switcher/claimed-task-actions-decorator.ts
@@ -1,8 +1,10 @@
 import {
+  ADVANCED_WORKFLOW_ACTION_RATING,
   ADVANCED_WORKFLOW_TASK_OPTION_RATING,
   AdvancedWorkflowActionRatingComponent,
 } from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-rating/advanced-workflow-action-rating.component';
 import {
+  ADVANCED_WORKFLOW_ACTION_SELECT_REVIEWER,
   ADVANCED_WORKFLOW_TASK_OPTION_SELECT_REVIEWER,
   AdvancedWorkflowActionSelectReviewerComponent,
 } from '../../../../workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/advanced-workflow-action-select-reviewer.component';
@@ -54,8 +56,8 @@ export const WORKFLOW_TASK_OPTION_DECORATOR_MAP = new Map<string, WorkflowTaskOp
 ]);
 
 export const ADVANCED_WORKFLOW_TASK_OPTION_DECORATOR_MAP = new Map<string, AdvancedWorkflowTaskOptionComponent>([
-  [ADVANCED_WORKFLOW_TASK_OPTION_RATING, AdvancedWorkflowActionRatingComponent],
-  [ADVANCED_WORKFLOW_TASK_OPTION_SELECT_REVIEWER, AdvancedWorkflowActionSelectReviewerComponent],
+  [ADVANCED_WORKFLOW_ACTION_RATING, AdvancedWorkflowActionRatingComponent],
+  [ADVANCED_WORKFLOW_ACTION_SELECT_REVIEWER, AdvancedWorkflowActionSelectReviewerComponent],
 ]);
 
 /**

--- a/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.spec.ts
+++ b/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.spec.ts
@@ -224,6 +224,38 @@ describe('ReviewersListComponent', () => {
         })).not.toBeTruthy();
       });
     });
+
+    it('should replace the value when a new member is added when multipleReviewers is false', () => {
+      spyOn(component.selectedReviewersUpdated, 'emit');
+      component.multipleReviewers = false;
+      component.selectedReviewers = [EPersonMock];
+
+      component.addMemberToGroup(EPersonMock2);
+
+      expect(component.selectedReviewers).toEqual([EPersonMock2]);
+      expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([EPersonMock2]);
+    });
+
+    it('should add the value when a new member is added when multipleReviewers is true', () => {
+      spyOn(component.selectedReviewersUpdated, 'emit');
+      component.multipleReviewers = true;
+      component.selectedReviewers = [EPersonMock];
+
+      component.addMemberToGroup(EPersonMock2);
+
+      expect(component.selectedReviewers).toEqual([EPersonMock, EPersonMock2]);
+      expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([EPersonMock, EPersonMock2]);
+    });
+
+    it('should delete the member when present', () => {
+      spyOn(component.selectedReviewersUpdated, 'emit');
+      component.selectedReviewers = [EPersonMock];
+
+      component.deleteMemberFromGroup(EPersonMock);
+
+      expect(component.selectedReviewers).toEqual([]);
+      expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([]);
+    });
   });
 
   describe('when a group is selected', () => {
@@ -243,39 +275,6 @@ describe('ReviewersListComponent', () => {
         })).toBeTruthy();
       });
     });
-  });
-
-
-  it('should replace the value when a new member is added when multipleReviewers is false', () => {
-    spyOn(component.selectedReviewersUpdated, 'emit');
-    component.multipleReviewers = false;
-    component.selectedReviewers = [EPersonMock];
-
-    component.addMemberToGroup(EPersonMock2);
-
-    expect(component.selectedReviewers).toEqual([EPersonMock2]);
-    expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([EPersonMock2]);
-  });
-
-  it('should add the value when a new member is added when multipleReviewers is true', () => {
-    spyOn(component.selectedReviewersUpdated, 'emit');
-    component.multipleReviewers = true;
-    component.selectedReviewers = [EPersonMock];
-
-    component.addMemberToGroup(EPersonMock2);
-
-    expect(component.selectedReviewers).toEqual([EPersonMock, EPersonMock2]);
-    expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([EPersonMock, EPersonMock2]);
-  });
-
-  it('should delete the member when present', () => {
-    spyOn(component.selectedReviewersUpdated, 'emit');
-    component.selectedReviewers = [EPersonMock];
-
-    component.deleteMemberFromGroup(EPersonMock);
-
-    expect(component.selectedReviewers).toEqual([]);
-    expect(component.selectedReviewersUpdated.emit).toHaveBeenCalledWith([]);
   });
 
 });

--- a/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.ts
+++ b/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action-select-reviewer/reviewers-list/reviewers-list.component.ts
@@ -26,6 +26,10 @@ import {
   TranslateModule,
   TranslateService,
 } from '@ngx-translate/core';
+import {
+  Observable,
+  of as observableOf,
+} from 'rxjs';
 
 import {
   EPersonListActionConfig,
@@ -36,10 +40,12 @@ import { PaginatedList } from '../../../../core/data/paginated-list.model';
 import { EPersonDataService } from '../../../../core/eperson/eperson-data.service';
 import { GroupDataService } from '../../../../core/eperson/group-data.service';
 import { EPerson } from '../../../../core/eperson/models/eperson.model';
+import { EpersonDtoModel } from '../../../../core/eperson/models/eperson-dto.model';
 import { Group } from '../../../../core/eperson/models/group.model';
 import { PaginationService } from '../../../../core/pagination/pagination.service';
 import { getFirstSucceededRemoteDataPayload } from '../../../../core/shared/operators';
 import { ContextHelpDirective } from '../../../../shared/context-help.directive';
+import { hasValue } from '../../../../shared/empty.util';
 import { NotificationsService } from '../../../../shared/notifications/notifications.service';
 import { PaginationComponent } from '../../../../shared/pagination/pagination.component';
 
@@ -101,7 +107,7 @@ export class ReviewersListComponent extends MembersListComponent implements OnIn
     super(groupService, ePersonDataService, translateService, notificationsService, formBuilder, paginationService, router, dsoNameService);
   }
 
-  ngOnInit() {
+  override ngOnInit(): void {
     this.searchForm = this.formBuilder.group(({
       scope: 'metadata',
       query: '',
@@ -114,6 +120,7 @@ export class ReviewersListComponent extends MembersListComponent implements OnIn
       if (this.groupId === null) {
         this.retrieveMembers(this.config.currentPage);
       } else {
+        this.unsubFrom(SubKey.ActiveGroup);
         this.subs.set(SubKey.ActiveGroup, this.groupService.findById(this.groupId).pipe(
           getFirstSucceededRemoteDataPayload(),
         ).subscribe((activeGroup: Group) => {
@@ -136,13 +143,24 @@ export class ReviewersListComponent extends MembersListComponent implements OnIn
   retrieveMembers(page: number): void {
     this.config.currentPage = page;
     if (this.groupId === null) {
-      this.unsubFrom(SubKey.Members);
-      const paginatedListOfEPersons: PaginatedList<EPerson> = new PaginatedList();
-      paginatedListOfEPersons.page = this.selectedReviewers;
+      const paginatedListOfEPersons: PaginatedList<EpersonDtoModel> = new PaginatedList();
+      paginatedListOfEPersons.page = this.selectedReviewers.map((ePerson: EPerson) => Object.assign(new EpersonDtoModel(), {
+        eperson: ePerson,
+        ableToDelete: this.isMemberOfGroup(ePerson),
+      }));
       this.ePeopleMembersOfGroup.next(paginatedListOfEPersons);
     } else {
       super.retrieveMembers(page);
     }
+  }
+
+  /**
+   * Checks whether the given {@link possibleMember} is part of the {@link selectedReviewers}.
+   *
+   * @param possibleMember The {@link EPerson} that needs to be checked
+   */
+  isMemberOfGroup(possibleMember: EPerson): Observable<boolean> {
+    return observableOf(hasValue(this.selectedReviewers.find((reviewer: EPerson) => reviewer.id === possibleMember.id)));
   }
 
   /**
@@ -151,10 +169,11 @@ export class ReviewersListComponent extends MembersListComponent implements OnIn
    * @param eperson The {@link EPerson} to remove
    */
   deleteMemberFromGroup(eperson: EPerson) {
-    const index = this.selectedReviewers.indexOf(eperson);
+    const index = this.selectedReviewers.findIndex((reviewer: EPerson) => reviewer.id === eperson.id);
     if (index !== -1) {
       this.selectedReviewers.splice(index, 1);
     }
+    this.retrieveMembers(this.config.currentPage);
     this.selectedReviewersUpdated.emit(this.selectedReviewers);
   }
 
@@ -169,6 +188,7 @@ export class ReviewersListComponent extends MembersListComponent implements OnIn
       this.selectedReviewers = [];
     }
     this.selectedReviewers.push(eperson);
+    this.retrieveMembers(this.config.currentPage);
     this.selectedReviewersUpdated.emit(this.selectedReviewers);
   }
 

--- a/src/app/workflowitems-edit-page/workflow-item-action-page.component.ts
+++ b/src/app/workflowitems-edit-page/workflow-item-action-page.component.ts
@@ -1,6 +1,7 @@
 import { Location } from '@angular/common';
 import {
   Directive,
+  Input,
   OnInit,
 } from '@angular/core';
 import {
@@ -42,7 +43,9 @@ import { NotificationsService } from '../shared/notifications/notifications.serv
   standalone: true,
 })
 export abstract class WorkflowItemActionPageDirective implements OnInit {
-  public type;
+
+  @Input() type: string;
+
   public wfi$: Observable<WorkflowItem>;
   public item$: Observable<Item>;
   protected previousQueryParameters?: Params;


### PR DESCRIPTION
## References
* Fixes #3031

## Description
Fixed issue causing advanced workflow actions returning in a 404 page and fixed issues with `ReviewersListComponent` not working correctly anymore after the `MembersListComponent` page [refactor](https://github.com/DSpace/dspace-angular/commit/1f15b21ba969dafb5a86f264e33044b36d0a3138).

## Instructions for Reviewers
List of changes in this PR:
- Fixed `ADVANCED_WORKFLOW_TASK_OPTION_DECORATOR_MAP` having incorrect option key (this caused the 404 issue)
- Changed the `ePeopleMembersOfGroup` back to `BehaviorSubject<PaginatedList<EpersonDtoModel>>` because the first `<table>` of `members-list.component.html` is used to display all the users of the `Reviewers` group so the option to select & unselect a member should exist there. In the future it would maybe be better to add support to provide the `group` parameter that would limit the search to EPerson of a certain Group like this: `/server/api/eperson/epersons/search/byMetadata?page=0&size=5&query=&group={uuid}`. This would be handy because then we would be able to separate the selected reviewers from all the members of the `Reviewers` group, and then it would also be possible to search through the members of the `Reviewers` group. Now when the `Reviewers` group is very large it there is no user friendly way to easily find the correct EPerson. This current fix restored the functionality to how it worked on 7.6, but this might be a nice improvement.
- Replaced the hardcoded abstract `option` variable from `ClaimedTaskActionsAbstractComponent` with an `@Input`, since the `ClaimedTaskActionsLoaderComponent` already has that information and it can simply be passed down instead

**Guidance for how to test/review this PR:**
See #2039 for how to properly test those advanced workflows

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
