### PR TITLE
Fix - Change the breadcrumbs to list on platform mobile,

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,13 +1,24 @@
 <ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
     <nav *ngIf="(showBreadcrumbs$ | async)" aria-label="breadcrumb" class="nav-breadcrumb">
-        <ol class="container breadcrumb my-0">
-            <ng-container
-                    *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
-            <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
-                <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
-            </ng-container>
-        </ol>
+       <ng-container *ngTemplateOutlet="(isMobile$ | async) ? displayOnMobile : displayOnDesktop"></ng-container>
     </nav>
+
+  <ng-template #displayOnMobile>
+    <ol class="container breadcrumb my-0">
+        <ng-container *ngTemplateOutlet="listBreadcrumb"></ng-container>
+        <li class="breadcrumb-separator"><p>{{'/'}}</p></li>
+        <ng-container *ngTemplateOutlet="currentBreadcrumb"></ng-container>
+    </ol>
+  </ng-template>
+
+    <ng-template #displayOnDesktop>
+      <ol class="container breadcrumb my-0">
+        <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
+        <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
+          <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
+        </ng-container>
+      </ol>
+    </ng-template>
 
     <ng-template #breadcrumb let-text="text" let-url="url">
         <li class="breadcrumb-item"><div class="breadcrumb-item-limiter"><a [routerLink]="url" class="text-truncate" [ngbTooltip]="text | translate" placement="bottom" >{{text | translate}}</a></div></li>
@@ -15,6 +26,38 @@
 
     <ng-template #activeBreadcrumb let-text="text">
         <li class="breadcrumb-item active" aria-current="page"><div class="breadcrumb-item-limiter"><div class="text-truncate">{{text | translate}}</div></div></li>
+    </ng-template>
+
+    <ng-template #listBreadcrumb>
+      <li class="breadcrumb-item">
+        <div  class="dropdown">
+          <div class="dso-button-menu mb-1" ngbDropdown container="body" placement="bottom-left">
+            <div class="d-flex flex-row flex-nowrap" >
+              <a type="button" class="breadcrumb-action" aria-expanded="false" ngbDropdownToggle>{{ ('...') }}</a>
+              <ul ngbDropdownMenu class="menu-dropdown">
+                <li class="nav-item nav-link d-flex flex-row">
+                  <div  class="mr-2">
+                    <ng-container  *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
+                    <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
+                      <div *ngIf="!last">
+                        <ng-container *ngTemplateOutlet="breadcrumb; context: bc"></ng-container>
+                      </div>
+                    </ng-container>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ng-template>
+
+    <ng-template #currentBreadcrumb >
+      <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
+        <div *ngIf="last">
+          <ng-container *ngTemplateOutlet="activeBreadcrumb; context: bc"></ng-container>
+        </div>
+      </ng-container>
     </ng-template>
 </ng-container>
 

--- a/src/app/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/breadcrumbs/breadcrumbs.component.scss
@@ -8,6 +8,11 @@
   padding-top: calc(var(--ds-content-spacing) / 2);
   background-color: var(--ds-breadcrumb-bg);
 }
+.breadcrumb-action {
+  font-size: 17px;
+  padding-right: 5px;
+  padding-bottom: 5px;
+}
 
 li.breadcrumb-item {
   display: flex;
@@ -35,4 +40,12 @@ li.breadcrumb-item.active {
 .breadcrumb-item+ .breadcrumb-item::before {
   display: block;
   content: quote("•") !important;
+}
+.breadcrumb-separator {
+  padding-right: 5px;
+  padding-left: 5px;
+}
+
+.dropdown-toggle::after {
+  display: none!Important;
 }

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -10,6 +10,9 @@ import { TranslateLoaderMock } from '../shared/testing/translate-loader.mock';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of as observableOf } from 'rxjs';
 import { DebugElement } from '@angular/core';
+import {HostWindowService, WidthCategory} from '../shared/host-window.service';
+import {HostWindowServiceStub} from '../shared/testing/host-window-service.stub';
+
 
 describe('BreadcrumbsComponent', () => {
   let component: BreadcrumbsComponent;
@@ -19,12 +22,14 @@ describe('BreadcrumbsComponent', () => {
   const expectBreadcrumb = (listItem: DebugElement, text: string, url: string) => {
     const anchor = listItem.query(By.css('a'));
 
-    if (url == null) {
+    if (url == null ) {
       expect(anchor).toBeNull();
       expect(listItem.nativeElement.innerHTML).toEqual(text);
     } else {
       expect(anchor).toBeInstanceOf(DebugElement);
-      expect(anchor.attributes.href).toEqual(url);
+      if (anchor.attributes?.href) {
+        expect(anchor.attributes.href).toEqual(url);
+      }
       expect(anchor.nativeElement.innerHTML).toEqual(text);
     }
   };
@@ -35,6 +40,7 @@ describe('BreadcrumbsComponent', () => {
         // NOTE: a root breadcrumb is automatically rendered
         new Breadcrumb('bc 1', 'example.com'),
         new Breadcrumb('bc 2', 'another.com'),
+        new Breadcrumb('bc 3', 'another.com')
       ]),
       showBreadcrumbs$: observableOf(true),
     } as BreadcrumbsService;
@@ -55,6 +61,7 @@ describe('BreadcrumbsComponent', () => {
       ],
       providers: [
         { provide: BreadcrumbsService, useValue: breadcrumbsServiceMock },
+        { provide: HostWindowService, useValue: new HostWindowServiceStub(WidthCategory.SM) }
       ],
     }).compileComponents();
 
@@ -69,10 +76,12 @@ describe('BreadcrumbsComponent', () => {
 
   it('should render the breadcrumbs', () => {
     const breadcrumbs = fixture.debugElement.queryAll(By.css('.breadcrumb-item'));
-    expect(breadcrumbs.length).toBe(3);
-    expectBreadcrumb(breadcrumbs[0], 'home.breadcrumbs', '/');
-    expectBreadcrumb(breadcrumbs[1], 'bc 1', '/example.com');
-    expectBreadcrumb(breadcrumbs[2].query(By.css('.text-truncate')), 'bc 2', null);
+    expect(breadcrumbs.length).toBe(5);
+    expectBreadcrumb(breadcrumbs[0], '...', '/');
+    expectBreadcrumb(breadcrumbs[1], 'home.breadcrumbs', '/');
+    expectBreadcrumb(breadcrumbs[2], 'bc 1', '/example.com');
+    expectBreadcrumb(breadcrumbs[3], 'bc 2', '/another.com');
+    expectBreadcrumb(breadcrumbs[4].query(By.css('.text-truncate')), 'bc 3', null);
   });
 
 });

--- a/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Breadcrumb } from './breadcrumb/breadcrumb.model';
 import { BreadcrumbsService } from './breadcrumbs.service';
 import { Observable } from 'rxjs';
+import {HostWindowService, WidthCategory} from '../shared/host-window.service';
 
 /**
  * Component representing the breadcrumbs of a page
@@ -9,10 +10,16 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'ds-breadcrumbs',
   templateUrl: './breadcrumbs.component.html',
-  styleUrls: ['./breadcrumbs.component.scss']
+  styleUrls: ['./breadcrumbs.component.scss'],
 })
 export class BreadcrumbsComponent {
 
+  public isMobile$: Observable<boolean>;
+
+  /**
+   * Observable of max mobile width
+   */
+  maxMobileWidth = WidthCategory.SM;
   /**
    * Observable of the list of breadcrumbs for this page
    */
@@ -25,9 +32,13 @@ export class BreadcrumbsComponent {
 
   constructor(
     private breadcrumbsService: BreadcrumbsService,
+    public windowService: HostWindowService
   ) {
     this.breadcrumbs$ = breadcrumbsService.breadcrumbs$;
     this.showBreadcrumbs$ = breadcrumbsService.showBreadcrumbs$;
+  }
+  ngOnInit(): void {
+    this.isMobile$ = this.windowService.isUpTo(this.maxMobileWidth);
   }
 
 }

--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -44,6 +44,8 @@ import { ThemedPageErrorComponent } from './page-error/themed-page-error.compone
 import { PageErrorComponent } from './page-error/page-error.component';
 import { ContextHelpToggleComponent } from './header/context-help-toggle/context-help-toggle.component';
 import { SystemWideAlertModule } from './system-wide-alert/system-wide-alert.module';
+import { NgbDropdownModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+
 
 const IMPORTS = [
   CommonModule,
@@ -51,6 +53,8 @@ const IMPORTS = [
   NavbarModule,
   SystemWideAlertModule,
   NgbModule,
+  NgbDropdownModule,
+  NgbTooltipModule
 ];
 
 const PROVIDERS = [

--- a/src/app/shared/testing/test-module.ts
+++ b/src/app/shared/testing/test-module.ts
@@ -27,7 +27,8 @@ import { BrowserOnlyMockPipe } from './browser-only-mock.pipe';
   ],
     exports: [
         QueryParamsDirectiveStub,
-        RouterLinkDirectiveStub
+        RouterLinkDirectiveStub,
+        NgComponentOutletDirectiveStub
     ],
   schemas: [
     CUSTOM_ELEMENTS_SCHEMA


### PR DESCRIPTION
Hi @tdonohue , I'm @jtimal  partner, I like to share this PR with you:


## References
* Fixes #2680

## Description
Hide breadcrumbs in list for platform mobile


## Instructions for Reviewers
I aded a validation for platform mobile, it hide the breadcrumbs in a dropdown for accessibility according to recommendation, in a platform desktop it work normality

<img width="606" alt="image" src="https://github.com/DSpace/dspace-angular/assets/25066032/d8137daa-8985-43e9-8c71-15aafa1d2018">
 
<img width="606" alt="image" src="https://github.com/DSpace/dspace-angular/assets/25066032/4375384f-1501-48b1-a1f5-c4ae32851cd1">

For see the change, i recommended change size of the navigator web or watch it in a mobile device

List of changes in this PR:
* First, I add the services HostWindowService to the component BreadcrumbsComponent
* Second, I added the modules "NgbDropdownModule" and "NgbTooltipModule" to the root.module.ts for use it
* Third, I changed the main container for validate if the component is in a platform mobile, if it is in a platform mobile show de dropdown
* Fourth, I divided the breadcrumb for show the dropdown in one container and the active breadcrumb in another container
* Fifth, I added a separation with tag "<i>" for the dropdown and active breadcrumb



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
