### PR TITLE
Fixed delete item page freezing when having relationships

### DIFF
--- a/src/app/core/data/base/delete-data.spec.ts
+++ b/src/app/core/data/base/delete-data.spec.ts
@@ -209,6 +209,11 @@ describe('DeleteDataImpl', () => {
             method: RestRequestMethod.DELETE,
             href: 'some-href?copyVirtualMetadata=a&copyVirtualMetadata=b&copyVirtualMetadata=c',
           }));
+
+          const callback = (rdbService.buildFromRequestUUIDAndAwait as jasmine.Spy).calls.argsFor(0)[1];
+          callback();
+          expect(service.invalidateByHref).toHaveBeenCalledWith('some-href');
+
           done();
         });
       });

--- a/src/app/core/data/base/delete-data.ts
+++ b/src/app/core/data/base/delete-data.ts
@@ -75,15 +75,16 @@ export class DeleteDataImpl<T extends CacheableObject> extends IdentifiableDataS
   deleteByHref(href: string, copyVirtualMetadata?: string[]): Observable<RemoteData<NoContent>> {
     const requestId = this.requestService.generateRequestId();
 
+    let deleteHref: string = href;
     if (copyVirtualMetadata) {
       copyVirtualMetadata.forEach((id) =>
-        href += (href.includes('?') ? '&' : '?')
+        deleteHref += (deleteHref.includes('?') ? '&' : '?')
           + 'copyVirtualMetadata='
           + id,
       );
     }
 
-    const request = new DeleteRequest(requestId, href);
+    const request = new DeleteRequest(requestId, deleteHref);
     if (hasValue(this.responseMsToLive)) {
       request.responseMsToLive = this.responseMsToLive;
     }

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
@@ -6,30 +6,29 @@
             <p>{{descriptionMessage | translate}}</p>
             <ds-modify-item-overview [item]="item"></ds-modify-item-overview>
 
-            <ng-container *ngVar="(types$ | async) as types">
+            <ng-container *ngVar="(typeDTOs$ | async) as types">
 
                 <div *ngIf="types && types.length > 0" class="mb-4">
 
                     {{'virtual-metadata.delete-item.info' | translate}}
 
-                    <div *ngFor="let type of types" class="mb-4">
-
-                        <div *ngVar="(isSelected(type) | async) as selected"
+                    <div *ngFor="let typeDto of types" class="mb-4">
+                        <div *ngVar="(typeDto.isSelected$ | async) as selected"
                              class="d-flex flex-row">
 
-                            <div class="m-2" (click)="setSelected(type, !selected)">
+                            <div class="m-2" (click)="setSelected(typeDto.relationshipType, !selected)">
                                 <label>
-                                    <input type="checkbox" [checked]="selected">
+                                    <input type="checkbox" [checked]="selected" [disabled]="isDeleting$ | async">
                                 </label>
                             </div>
 
                             <div class="flex-column flex-grow-1">
-                                <h5 (click)="setSelected(type, !selected)">
-                                    {{getRelationshipMessageKey(getLabel(type) | async) | translate}}
+                                <h5 (click)="setSelected(typeDto.relationshipType, !selected)">
+                                    {{getRelationshipMessageKey(typeDto.label$ | async) | translate}}
                                 </h5>
-                                <div *ngFor="let relationship of (getRelationships(type) | async)"
+                                <div *ngFor="let relationshipDto of (typeDto.relationshipDTOs$ | async)"
                                      class="d-flex flex-row">
-                                    <ng-container *ngVar="(getRelatedItem(relationship) | async) as relatedItem">
+                                    <ng-container *ngVar="(relationshipDto.relatedItem$ | async) as relatedItem">
 
                                         <ds-listable-object-component-loader
                                                 *ngIf="relatedItem"
@@ -46,7 +45,7 @@
                                         </div>
 
                                         <ng-template #virtualMetadataModal>
-                                            <div>
+                                            <div class="thumb-font-1">
                                                 <div class="modal-header">
                                                     {{'virtual-metadata.delete-item.modal-head' | translate}}
                                                     <button type="button" class="close"
@@ -60,7 +59,7 @@
                                                             [object]="relatedItem"
                                                             [viewMode]="viewMode">
                                                     </ds-listable-object-component-loader>
-                                                    <div *ngFor="let metadata of (getVirtualMetadata(relationship) | async)">
+                                                    <div *ngFor="let metadata of (relationshipDto.virtualMetadata$ | async)">
                                                         <div>
                                                             <div class="font-weight-bold">
                                                                 {{metadata.metadataField}}
@@ -87,10 +86,11 @@
             </ng-container>
 
             <div class="space-children-mr">
-              <button (click)="performAction()"
+              <button [disabled]="isDeleting$ | async" (click)="performAction()"
                       class="btn btn-outline-secondary perform-action">{{confirmMessage | translate}}
               </button>
-              <button [routerLink]="[itemPageRoute, 'edit']" class="btn btn-outline-secondary cancel">
+              <button [disabled]="isDeleting$ | async" [routerLink]="[itemPageRoute, 'edit']"
+                      class="btn btn-outline-secondary cancel">
                 {{cancelMessage| translate}}
               </button>
             </div>

--- a/src/app/item-page/full/full-item-page.component.spec.ts
+++ b/src/app/item-page/full/full-item-page.component.spec.ts
@@ -22,7 +22,6 @@ import {
   of as observableOf,
 } from 'rxjs';
 
-import { AuthService } from '../../core/auth/auth.service';
 import { NotifyInfoService } from '../../core/coar-notify/notify-info/notify-info.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { ItemDataService } from '../../core/data/item-data.service';
@@ -79,7 +78,6 @@ describe('FullItemPageComponent', () => {
   let comp: FullItemPageComponent;
   let fixture: ComponentFixture<FullItemPageComponent>;
 
-  let authService: AuthService;
   let routeStub: ActivatedRouteStub;
   let routeData;
   let authorizationDataService: AuthorizationDataService;
@@ -102,11 +100,6 @@ describe('FullItemPageComponent', () => {
   };
 
   beforeEach(waitForAsync(() => {
-    authService = jasmine.createSpyObj('authService', {
-      isAuthenticated: observableOf(true),
-      setRedirectUrl: {},
-    });
-
     routeData = {
       dso: createSuccessfulRemoteDataObject(mockItem),
     };
@@ -151,7 +144,6 @@ describe('FullItemPageComponent', () => {
         { provide: ActivatedRoute, useValue: routeStub },
         { provide: ItemDataService, useValue: {} },
         { provide: HeadTagService, useValue: headTagService },
-        { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationDataService },
         { provide: ServerResponseService, useValue: serverResponseService },
         { provide: SignpostingDataService, useValue: signpostingDataService },

--- a/src/app/item-page/full/full-item-page.component.ts
+++ b/src/app/item-page/full/full-item-page.component.ts
@@ -29,7 +29,6 @@ import {
   map,
 } from 'rxjs/operators';
 
-import { AuthService } from '../../core/auth/auth.service';
 import { NotifyInfoService } from '../../core/coar-notify/notify-info/notify-info.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { ItemDataService } from '../../core/data/item-data.service';
@@ -103,7 +102,6 @@ export class FullItemPageComponent extends ItemPageComponent implements OnInit, 
     protected route: ActivatedRoute,
     protected router: Router,
     protected items: ItemDataService,
-    protected authService: AuthService,
     protected authorizationService: AuthorizationDataService,
     protected _location: Location,
     protected responseService: ServerResponseService,
@@ -112,7 +110,7 @@ export class FullItemPageComponent extends ItemPageComponent implements OnInit, 
     protected notifyInfoService: NotifyInfoService,
     @Inject(PLATFORM_ID) protected platformId: string,
   ) {
-    super(route, router, items, authService, authorizationService, responseService, signpostingDataService, linkHeadService, notifyInfoService, platformId);
+    super(route, router, items, authorizationService, responseService, signpostingDataService, linkHeadService, notifyInfoService, platformId);
   }
 
   /*** AoT inheritance fix, will hopefully be resolved in the near future **/

--- a/src/app/item-page/item-page.resolver.spec.ts
+++ b/src/app/item-page/item-page.resolver.spec.ts
@@ -1,17 +1,20 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import {
+  Router,
+  RouterModule,
+} from '@angular/router';
 import { first } from 'rxjs/operators';
 
 import { DSpaceObject } from '../core/shared/dspace-object.model';
 import { MetadataValueFilter } from '../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
+import { AuthServiceStub } from '../shared/testing/auth-service.stub';
 import { itemPageResolver } from './item-page.resolver';
 
 describe('itemPageResolver', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([{
+      imports: [RouterModule.forRoot([{
         path: 'entities/:entity-type/:id',
         component: {} as any,
       }])],
@@ -22,7 +25,8 @@ describe('itemPageResolver', () => {
     let resolver: any;
     let itemService: any;
     let store: any;
-    let router: any;
+    let router: Router;
+    let authService: AuthServiceStub;
 
     const uuid = '1234-65487-12354-1235';
     let item: DSpaceObject;
@@ -42,6 +46,7 @@ describe('itemPageResolver', () => {
         store = jasmine.createSpyObj('store', {
           dispatch: {},
         });
+        authService = new AuthServiceStub();
         resolver = itemPageResolver;
       });
 
@@ -54,6 +59,7 @@ describe('itemPageResolver', () => {
           router,
           itemService,
           store,
+          authService,
         ).pipe(first())
           .subscribe(
             () => {
@@ -73,6 +79,7 @@ describe('itemPageResolver', () => {
           router,
           itemService,
           store,
+          authService,
         ).pipe(first())
           .subscribe(
             () => {

--- a/src/app/item-page/simple/item-page.component.spec.ts
+++ b/src/app/item-page/simple/item-page.component.spec.ts
@@ -20,7 +20,6 @@ import {
 } from '@ngx-translate/core';
 import { of as observableOf } from 'rxjs';
 
-import { AuthService } from '../../core/auth/auth.service';
 import { NotifyInfoService } from '../../core/coar-notify/notify-info/notify-info.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { ItemDataService } from '../../core/data/item-data.service';
@@ -84,7 +83,6 @@ const mockSignpostingLinks: SignpostingLink[] = [mocklink, mocklink2];
 describe('ItemPageComponent', () => {
   let comp: ItemPageComponent;
   let fixture: ComponentFixture<ItemPageComponent>;
-  let authService: AuthService;
   let authorizationDataService: AuthorizationDataService;
   let serverResponseService: jasmine.SpyObj<ServerResponseService>;
   let signpostingDataService: jasmine.SpyObj<SignpostingDataService>;
@@ -98,10 +96,6 @@ describe('ItemPageComponent', () => {
   const getCoarLdnLocalInboxUrls = ['http://InboxUrls.org', 'http://InboxUrls2.org'];
 
   beforeEach(waitForAsync(() => {
-    authService = jasmine.createSpyObj('authService', {
-      isAuthenticated: observableOf(true),
-      setRedirectUrl: {},
-    });
     authorizationDataService = jasmine.createSpyObj('authorizationDataService', {
       isAuthorized: observableOf(false),
     });
@@ -135,7 +129,6 @@ describe('ItemPageComponent', () => {
         { provide: ActivatedRoute, useValue: mockRoute },
         { provide: ItemDataService, useValue: {} },
         { provide: Router, useValue: {} },
-        { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationDataService },
         { provide: ServerResponseService, useValue: serverResponseService },
         { provide: SignpostingDataService, useValue: signpostingDataService },

--- a/src/app/item-page/simple/item-page.component.ts
+++ b/src/app/item-page/simple/item-page.component.ts
@@ -28,7 +28,6 @@ import {
 } from 'rxjs/operators';
 import { NotifyInfoService } from 'src/app/core/coar-notify/notify-info/notify-info.service';
 
-import { AuthService } from '../../core/auth/auth.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '../../core/data/feature-authorization/feature-id';
 import { ItemDataService } from '../../core/data/item-data.service';
@@ -40,7 +39,6 @@ import {
   LinkHeadService,
 } from '../../core/services/link-head.service';
 import { ServerResponseService } from '../../core/services/server-response.service';
-import { redirectOn4xx } from '../../core/shared/authorized.operators';
 import { Item } from '../../core/shared/item.model';
 import { getAllSucceededRemoteDataPayload } from '../../core/shared/operators';
 import { ViewMode } from '../../core/shared/view-mode.model';
@@ -131,7 +129,6 @@ export class ItemPageComponent implements OnInit, OnDestroy {
     protected route: ActivatedRoute,
     protected router: Router,
     protected items: ItemDataService,
-    protected authService: AuthService,
     protected authorizationService: AuthorizationDataService,
     protected responseService: ServerResponseService,
     protected signpostingDataService: SignpostingDataService,
@@ -148,7 +145,6 @@ export class ItemPageComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.itemRD$ = this.route.data.pipe(
       map((data) => data.dso as RemoteData<Item>),
-      redirectOn4xx(this.router, this.authService),
     );
     this.itemPageRoute$ = this.itemRD$.pipe(
       getAllSucceededRemoteDataPayload(),


### PR DESCRIPTION
## References
* Fixes #3068

## Description
Fixed performance issues that cause the delete item page to completely break when it has relationships. This was because it subscribed to functions returning Observables. While fixing this bug I also saw that accessing an edit item page with an invalid ID would not redirect you to the 404 page so I also fixed this. Also fixed the issue that prevented the user from being redirected when selecting some virtual metadata to copy

## Instructions for Reviewers
List of changes in this PR:
* Fixed the delete item page completely freezing by creating two new DTO classes: `RelationshipTypeDTO` & `RelationshipDTO`. Theses classes will contain all the `Observable`s that are needed in the HTML template. By saving this in one object we prevent resubscribing to all those observables every time change detection is triggered
* Fixed issue where a white page would be shown when accessing the edit item pages from a deleted item (also happens for community & collection pages, I'll add a fix for this later as well)
* Disabled the cancel & delete button when deleting an item to prevent double submissions
* Fixed issue where the user wasn't redirected after selecting some virtual metadata that should persist after the item deletion. This was caused because the `DeleteDataImpl#deleteByHref` method invalidated the delete item URL instead of the get item URL. This caused the method to never emit when `copyVirtualMetadata` had values.

**Guidance for how to test & review this PR:** 
- Create 2 items and create a relationship between them
- Select the entity type for which the virtual metadata should be kept as plaintext metadata
- Copy the URL in you browser & click on delete at the bottom
- Verify That you were now automatically redirect to the home page & that the URL that you copied automatically redirect you to the 404 page

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
