### PR TITLE
Fixed page size change and sorting not working on comcol pages

### DIFF
--- a/src/app/shared/page-size-selector/page-size-selector.component.html
+++ b/src/app/shared/page-size-selector/page-size-selector.component.html
@@ -2,7 +2,7 @@
     <ds-sidebar-dropdown
             [id]="'search-sidebar-rpp'"
             [label]="'search.sidebar.settings.rpp'"
-            (change)="reloadRPP($event)"
+            (changed)="reloadRPP($event)"
     >
         <option *ngFor="let pageSizeOption of (paginationOptions$ | async).pageSizeOptions"
                 [value]="pageSizeOption"

--- a/src/app/shared/search/search-settings/search-settings.component.html
+++ b/src/app/shared/search/search-settings/search-settings.component.html
@@ -4,7 +4,7 @@
     <ds-sidebar-dropdown *ngIf="sortOptionsList"
                          [id]="'search-sidebar-sort'"
                          [label]="'search.sidebar.settings.sort-by'"
-                         (change)="reloadOrder($event)">
+                         (changed)="reloadOrder($event)">
         <option *ngFor="let sortOptionsEntry of sortOptionsList"
                 [value]="sortOptionsEntry.field + ',' + sortOptionsEntry.direction.toString()"
                 [selected]="sortOptionsEntry.field === currentSortOption?.field && sortOptionsEntry.direction === (currentSortOption?.direction)? 'selected': null">

--- a/src/app/shared/sidebar/sidebar-dropdown.component.html
+++ b/src/app/shared/sidebar/sidebar-dropdown.component.html
@@ -1,6 +1,6 @@
 <div class="setting-option mb-3 p-3">
   <h4><label for="{{id}}">{{label | translate}}</label></h4>
-  <select id="{{id}}" class="form-control" (change)="change.emit($event)">
+  <select id="{{id}}" class="form-control" (change)="changed.emit($event)">
     <ng-content></ng-content>
   </select>
 </div>

--- a/src/app/shared/sidebar/sidebar-dropdown.component.ts
+++ b/src/app/shared/sidebar/sidebar-dropdown.component.ts
@@ -20,5 +20,5 @@ import { TranslateModule } from '@ngx-translate/core';
 export class SidebarDropdownComponent {
   @Input() id: string;
   @Input() label: string;
-  @Output() change: EventEmitter<any> = new EventEmitter<number>();
+  @Output() changed: EventEmitter<any> = new EventEmitter<number>();
 }


### PR DESCRIPTION
## References
* Fixes #2996

## Description
This was simply caused because the `EventEmitter` in `SidebarDropdownComponent` used a name that is used as a standard DOM event. This caused the emit to occur multiple times and break the page

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
