### PR TITLE
[Port dspace-7_x] Avoid metadata representation element is rendered twice when checking the browse configuration

### DIFF
--- a/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
@@ -4,7 +4,7 @@ import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { BrowseDefinition } from '../../../../core/shared/browse-definition.model';
 import { BrowseDefinitionDataService } from '../../../../core/browse/browse-definition-data.service';
-import { getRemoteDataPayload } from '../../../../core/shared/operators';
+import { getFirstCompletedRemoteData } from '../../../../core/shared/operators';
 
 /**
  * This component can be used to represent metadata on a simple item page.
@@ -57,8 +57,8 @@ export class ItemPageFieldComponent {
      */
     get browseDefinition(): Observable<BrowseDefinition> {
       return this.browseDefinitionDataService.findByFields(this.fields).pipe(
-        getRemoteDataPayload(),
-        map((def) => def)
+        getFirstCompletedRemoteData(),
+        map((def) => def.payload)
       );
     }
 }

--- a/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
+++ b/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
@@ -9,7 +9,7 @@ import { MetadataValue } from '../../../core/shared/metadata.models';
 import { Item } from '../../../core/shared/item.model';
 import { AbstractIncrementalListComponent } from '../abstract-incremental-list/abstract-incremental-list.component';
 import { map } from 'rxjs/operators';
-import { getRemoteDataPayload } from '../../../core/shared/operators';
+import { getFirstCompletedRemoteData } from '../../../core/shared/operators';
 import {
   MetadatumRepresentation
 } from '../../../core/shared/metadata-representation/metadatum/metadatum-representation.model';
@@ -96,8 +96,8 @@ export class MetadataRepresentationListComponent extends AbstractIncrementalList
               searchKeyArray = searchKeyArray.concat(BrowseService.toSearchKeyArray(field));
             });
             return this.browseDefinitionDataService.findByFields(this.metadataFields).pipe(
-              getRemoteDataPayload(),
-              map((def) => Object.assign(new MetadatumRepresentation(this.itemType, def), metadatum))
+              getFirstCompletedRemoteData(),
+              map((def) => Object.assign(new MetadatumRepresentation(this.itemType, def.payload), metadatum))
             );
           }
         }),


### PR DESCRIPTION
Manual port of #2953 by @atarix83 to `dspace-7_x`