### PR TITLE
Fixed caching & same entity type relationship with different left/rightwardtype bugs on edit item relationships

### DIFF
--- a/src/app/core/data/relationship-data.service.spec.ts
+++ b/src/app/core/data/relationship-data.service.spec.ts
@@ -128,6 +128,7 @@ describe('RelationshipDataService', () => {
   const itemService = jasmine.createSpyObj('itemService', {
     findById: (uuid) => createSuccessfulRemoteDataObject(relatedItems.find((relatedItem) => relatedItem.id === uuid)),
     findByHref: createSuccessfulRemoteDataObject$(relatedItems[0]),
+    getIDHrefObs: (uuid: string) => observableOf(`https://demo.dspace.org/server/api/core/items/${uuid}`),
   });
 
   const getRequestEntry$ = (successful: boolean) => {
@@ -241,6 +242,16 @@ describe('RelationshipDataService', () => {
         expect((service as any).paginatedRelationsToItems).toHaveBeenCalledWith(mockItem.uuid);
         done();
       });
+    });
+  });
+
+  describe('searchByItemsAndType', () => {
+    it('should call addDependency for each item to invalidate the request when one of the items is update', () => {
+      spyOn(service as any, 'addDependency');
+
+      service.searchByItemsAndType(relationshipType.id, item.id, relationshipType.leftwardType, ['item-id-1', 'item-id-2']);
+
+      expect((service as any).addDependency).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/app/core/data/relationship-data.service.ts
+++ b/src/app/core/data/relationship-data.service.ts
@@ -574,13 +574,18 @@ export class RelationshipDataService extends IdentifiableDataService<Relationshi
       );
     });
 
-    return this.searchBy(
+    const searchRD$: Observable<RemoteData<PaginatedList<Relationship>>> = this.searchBy(
       'byItemsAndType',
       {
         searchParams: searchParams,
       },
     ) as Observable<RemoteData<PaginatedList<Relationship>>>;
 
+    arrayOfItemIds.forEach((itemId: string) => {
+      this.addDependency(searchRD$, this.itemService.getIDHrefObs(encodeURIComponent(itemId)));
+    });
+
+    return searchRD$;
   }
 
   /**

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
@@ -316,14 +316,31 @@ describe('EditItemRelationshipsService', () => {
   describe('relationshipMatchesBothSameTypes', () => {
     it('should return true if both left and right type of the relationship type are the same and match the provided itemtype', (done) => {
       const relationshipType = Object.assign(new RelationshipType(), {
-        leftType: createSuccessfulRemoteDataObject$({ id:  'sameType' }),
+        leftType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
         rightType: createSuccessfulRemoteDataObject$({ id:'sameType' }),
+        leftwardType: 'isDepartmentOfDivision',
+        rightwardType: 'isDivisionOfDepartment',
       });
       const itemType = Object.assign(new ItemType(), { id: 'sameType' } );
 
-      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      const result = service.shouldDisplayBothRelationshipSides(relationshipType, itemType);
       result.subscribe((resultValue) => {
         expect(resultValue).toBeTrue();
+        done();
+      });
+    });
+    it('should return false if both left and right type of the relationship type are the same and match the provided itemtype but the leftwardType & rightwardType is identical', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
+        leftwardType: 'isOrgUnitOfOrgUnit',
+        rightwardType: 'isOrgUnitOfOrgUnit',
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'sameType' });
+
+      const result = service.shouldDisplayBothRelationshipSides(relationshipType, itemType);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeFalse();
         done();
       });
     });
@@ -331,10 +348,12 @@ describe('EditItemRelationshipsService', () => {
       const relationshipType = Object.assign(new RelationshipType(), {
         leftType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
         rightType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
+        leftwardType: 'isDepartmentOfDivision',
+        rightwardType: 'isDivisionOfDepartment',
       });
       const itemType = Object.assign(new ItemType(), { id: 'something-else' } );
 
-      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      const result = service.shouldDisplayBothRelationshipSides(relationshipType, itemType);
       result.subscribe((resultValue) => {
         expect(resultValue).toBeFalse();
         done();
@@ -344,10 +363,12 @@ describe('EditItemRelationshipsService', () => {
       const relationshipType = Object.assign(new RelationshipType(), {
         leftType: createSuccessfulRemoteDataObject$({ id: 'leftType' }),
         rightType: createSuccessfulRemoteDataObject$({ id: 'rightType' }),
+        leftwardType: 'isAuthorOfPublication',
+        rightwardType: 'isPublicationOfAuthor',
       });
       const itemType = Object.assign(new ItemType(), { id: 'leftType' } );
 
-      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      const result = service.shouldDisplayBothRelationshipSides(relationshipType, itemType);
       result.subscribe((resultValue) => {
         expect(resultValue).toBeFalse();
         done();

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
@@ -265,6 +265,95 @@ describe('EditItemRelationshipsService', () => {
     });
   });
 
+  describe('isProvidedItemTypeLeftType', () => {
+    it('should return true if the provided item corresponds to the left type of the relationship', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'leftType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'rightType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'leftType' } );
+      const item = Object.assign(new Item(), { uuid: 'item-uuid' });
+
+      const result = service.isProvidedItemTypeLeftType(relationshipType, itemType, item);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeTrue();
+        done();
+      });
+    });
+
+    it('should return false if the provided item corresponds to the right type of the relationship', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'leftType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'rightType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'rightType' } );
+      const item = Object.assign(new Item(), { uuid: 'item-uuid' });
+
+      const result = service.isProvidedItemTypeLeftType(relationshipType, itemType, item);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeFalse();
+        done();
+      });
+    });
+
+    it('should return undefined if the provided item corresponds does not match any of the relationship types', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'leftType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'rightType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'something-else' } );
+      const item = Object.assign(new Item(), { uuid: 'item-uuid' });
+
+      const result = service.isProvidedItemTypeLeftType(relationshipType, itemType, item);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeUndefined();
+        done();
+      });
+    });
+  });
+
+  describe('relationshipMatchesBothSameTypes', () => {
+    it('should return true if both left and right type of the relationship type are the same and match the provided itemtype', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id:  'sameType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id:'sameType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'sameType' } );
+
+      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeTrue();
+        done();
+      });
+    });
+    it('should return false if both left and right type of the relationship type are the same and do not match the provided itemtype', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'sameType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'something-else' } );
+
+      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeFalse();
+        done();
+      });
+    });
+    it('should return false if both left and right type of the relationship type are different', (done) => {
+      const relationshipType = Object.assign(new RelationshipType(), {
+        leftType: createSuccessfulRemoteDataObject$({ id: 'leftType' }),
+        rightType: createSuccessfulRemoteDataObject$({ id: 'rightType' }),
+      });
+      const itemType = Object.assign(new ItemType(), { id: 'leftType' } );
+
+      const result = service.relationshipMatchesBothSameTypes(relationshipType, itemType);
+      result.subscribe((resultValue) => {
+        expect(resultValue).toBeFalse();
+        done();
+      });
+    });
+  });
+
   describe('displayNotifications', () => {
     it('should show one success notification when multiple requests succeeded', () => {
       service.displayNotifications([

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.spec.ts
@@ -185,6 +185,7 @@ describe('EditItemRelationshipsService', () => {
 
       expect(itemService.invalidateByHref).toHaveBeenCalledWith(currentItem.self);
       expect(itemService.invalidateByHref).toHaveBeenCalledWith(relationshipItem1.self);
+      expect(itemService.invalidateByHref).toHaveBeenCalledWith(relationshipItem2.self);
 
       expect(notificationsService.success).toHaveBeenCalledTimes(1);
     });

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
@@ -216,10 +216,16 @@ export class EditItemRelationshipsService {
     );
   }
 
-  relationshipMatchesBothSameTypes(relationshipType: RelationshipType, itemType: ItemType): Observable<boolean> {
+  /**
+   * Whether both side of the relationship need to be displayed on the edit relationship page or not.
+   *
+   * @param relationshipType The relationship type
+   * @param itemType         The item type
+   */
+  shouldDisplayBothRelationshipSides(relationshipType: RelationshipType, itemType: ItemType): Observable<boolean> {
     return this.getRelationshipLeftAndRightType(relationshipType).pipe(
       map(([leftType, rightType]: [ItemType, ItemType]) => {
-        return leftType.id === itemType.id && rightType.id === itemType.id;
+        return leftType.id === itemType.id && rightType.id === itemType.id && relationshipType.leftwardType !== relationshipType.rightwardType;
       }),
     );
   }

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
@@ -3,6 +3,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateService } from '@ngx-translate/core';
 import {
   BehaviorSubject,
+  combineLatest as observableCombineLatest,
   EMPTY,
   Observable,
   Subscription,
@@ -28,8 +29,14 @@ import { ObjectUpdatesService } from '../../../core/data/object-updates/object-u
 import { RelationshipDataService } from '../../../core/data/relationship-data.service';
 import { RemoteData } from '../../../core/data/remote-data';
 import { Item } from '../../../core/shared/item.model';
+import { ItemType } from '../../../core/shared/item-relationships/item-type.model';
 import { Relationship } from '../../../core/shared/item-relationships/relationship.model';
+import { RelationshipType } from '../../../core/shared/item-relationships/relationship-type.model';
 import { NoContent } from '../../../core/shared/NoContent.model';
+import {
+  getFirstSucceededRemoteData,
+  getRemoteDataPayload,
+} from '../../../core/shared/operators';
 import { hasValue } from '../../../shared/empty.util';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 
@@ -181,6 +188,49 @@ export class EditItemRelationshipsService {
     }
   }
 
+  isProvidedItemTypeLeftType(relationshipType: RelationshipType, itemType: ItemType, item: Item): Observable<boolean> {
+    return this.getRelationshipLeftAndRightType(relationshipType).pipe(
+      map(([leftType, rightType]: [ItemType, ItemType]) => {
+        if (leftType.id === itemType.id) {
+          return true;
+        }
+
+        if (rightType.id === itemType.id) {
+          return false;
+        }
+
+        // should never happen...
+        console.warn(`The item ${item.uuid} is not on the right or the left side of relationship type ${relationshipType.uuid}`);
+        return undefined;
+      }),
+    );
+  }
+
+  relationshipMatchesBothSameTypes(relationshipType: RelationshipType, itemType: ItemType): Observable<boolean> {
+    return this.getRelationshipLeftAndRightType(relationshipType).pipe(
+      map(([leftType, rightType]: [ItemType, ItemType]) => {
+        return leftType.id === itemType.id && rightType.id === itemType.id;
+      }),
+    );
+  }
+
+  protected getRelationshipLeftAndRightType(relationshipType: RelationshipType): Observable<[ItemType, ItemType]> {
+    const leftType$: Observable<ItemType> = relationshipType.leftType.pipe(
+      getFirstSucceededRemoteData(),
+      getRemoteDataPayload(),
+    );
+
+    const rightType$: Observable<ItemType> = relationshipType.rightType.pipe(
+      getFirstSucceededRemoteData(),
+      getRemoteDataPayload(),
+    );
+
+    return observableCombineLatest([
+      leftType$,
+      rightType$,
+    ]);
+  }
+
 
 
   /**
@@ -197,6 +247,5 @@ export class EditItemRelationshipsService {
    */
   getNotificationContent(key: string): string {
     return this.translateService.instant(this.notificationsPrefix + key + '.content');
-
   }
 }

--- a/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-item-relationships.service.ts
@@ -77,7 +77,17 @@ export class EditItemRelationshipsService {
       // process each update one by one, while waiting for the previous to finish
       concatMap((update: FieldUpdate) => {
         if (update.changeType === FieldChangeType.REMOVE) {
-          return this.deleteRelationship(update.field as DeleteRelationship).pipe(take(1));
+          return this.deleteRelationship(update.field as DeleteRelationship).pipe(
+            take(1),
+            switchMap((deleteRD: RemoteData<NoContent>) => {
+              if (deleteRD.hasSucceeded) {
+                return this.itemService.invalidateByHref((update.field as DeleteRelationship).relatedItem._links.self.href).pipe(
+                  map(() => deleteRD),
+                );
+              }
+              return [deleteRD];
+            }),
+          );
         } else if (update.changeType === FieldChangeType.ADD) {
           return this.addRelationship(update.field as RelationshipIdentifiable).pipe(
             take(1),

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.html
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.html
@@ -1,0 +1,30 @@
+<ng-container *ngIf="bothItemsMatchType$ | async">
+    <ds-edit-relationship-list
+            [url]="url"
+            [item]="item"
+            [itemType]="itemType"
+            [relationshipType]="relationshipType"
+            [hasChanges]="hasChanges"
+            [currentItemIsLeftItem$]="isLeftItem$"
+    ></ds-edit-relationship-list>
+    <ds-edit-relationship-list
+            [url]="url"
+            [item]="item"
+            [itemType]="itemType"
+            [relationshipType]="relationshipType"
+            [hasChanges]="hasChanges"
+            [currentItemIsLeftItem$]="isRightItem$"
+    ></ds-edit-relationship-list>
+</ng-container>
+
+<ng-container *ngIf="(bothItemsMatchType$ | async) === false">
+    <ds-edit-relationship-list
+            [url]="url"
+            [item]="item"
+            [itemType]="itemType"
+            [relationshipType]="relationshipType"
+            [hasChanges]="hasChanges"
+            [currentItemIsLeftItem$]="currentItemIsLeftItem$"
+    ></ds-edit-relationship-list>
+</ng-container>
+

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.html
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="bothItemsMatchType$ | async">
+<ng-container *ngIf="shouldDisplayBothRelationshipSides$ | async">
     <ds-edit-relationship-list
             [url]="url"
             [item]="item"
@@ -6,6 +6,7 @@
             [relationshipType]="relationshipType"
             [hasChanges]="hasChanges"
             [currentItemIsLeftItem$]="isLeftItem$"
+            class="d-block mb-4"
     ></ds-edit-relationship-list>
     <ds-edit-relationship-list
             [url]="url"
@@ -17,7 +18,7 @@
     ></ds-edit-relationship-list>
 </ng-container>
 
-<ng-container *ngIf="(bothItemsMatchType$ | async) === false">
+<ng-container *ngIf="(shouldDisplayBothRelationshipSides$ | async) === false">
     <ds-edit-relationship-list
             [url]="url"
             [item]="item"

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.spec.ts
@@ -5,6 +5,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { cold } from 'jasmine-marbles';
 import { of as observableOf } from 'rxjs';
 
 import { Item } from '../../../../core/shared/item.model';
@@ -42,7 +43,7 @@ describe('EditRelationshipListWrapperComponent', () => {
 
     editItemRelationshipsService = jasmine.createSpyObj('editItemRelationshipsService', {
       isProvidedItemTypeLeftType: observableOf(true),
-      relationshipMatchesBothSameTypes: observableOf(false),
+      shouldDisplayBothRelationshipSides: observableOf(false),
     });
 
 
@@ -82,10 +83,10 @@ describe('EditRelationshipListWrapperComponent', () => {
     });
     it('should set currentItemIsLeftItem$ and bothItemsMatchType$  based on the provided relationshipType, itemType and item', () => {
       expect(editItemRelationshipsService.isProvidedItemTypeLeftType).toHaveBeenCalledWith(relationshipType, leftType, item);
-      expect(editItemRelationshipsService.relationshipMatchesBothSameTypes).toHaveBeenCalledWith(relationshipType, leftType);
+      expect(editItemRelationshipsService.shouldDisplayBothRelationshipSides).toHaveBeenCalledWith(relationshipType, leftType);
 
       expect(comp.currentItemIsLeftItem$.getValue()).toEqual(true);
-      expect(comp.bothItemsMatchType$.getValue()).toEqual(false);
+      expect(comp.shouldDisplayBothRelationshipSides$).toBeObservable(cold('(a|)', { a: false }));
     });
   });
 
@@ -109,7 +110,7 @@ describe('EditRelationshipListWrapperComponent', () => {
 
   describe('when the current item is both left and right', () => {
     it('should render two relationship list sections', () => {
-      (editItemRelationshipsService.relationshipMatchesBothSameTypes as jasmine.Spy).and.returnValue(observableOf(true));
+      (editItemRelationshipsService.shouldDisplayBothRelationshipSides as jasmine.Spy).and.returnValue(observableOf(true));
       comp.ngOnInit();
       fixture.detectChanges();
 

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.spec.ts
@@ -1,0 +1,121 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of as observableOf } from 'rxjs';
+
+import { Item } from '../../../../core/shared/item.model';
+import { ItemType } from '../../../../core/shared/item-relationships/item-type.model';
+import { RelationshipType } from '../../../../core/shared/item-relationships/relationship-type.model';
+import { createSuccessfulRemoteDataObject$ } from '../../../../shared/remote-data.utils';
+import { EditItemRelationshipsService } from '../edit-item-relationships.service';
+import { EditRelationshipListComponent } from '../edit-relationship-list/edit-relationship-list.component';
+import { EditRelationshipListWrapperComponent } from './edit-relationship-list-wrapper.component';
+
+describe('EditRelationshipListWrapperComponent', () => {
+  let editItemRelationshipsService: EditItemRelationshipsService;
+  let comp: EditRelationshipListWrapperComponent;
+  let fixture: ComponentFixture<EditRelationshipListWrapperComponent>;
+
+  const leftType = Object.assign(new ItemType(), { id: 'leftType', label: 'leftTypeString' });
+  const rightType = Object.assign(new ItemType(), { id: 'rightType', label: 'rightTypeString' });
+
+  const relationshipType = Object.assign(new RelationshipType(), {
+    id: '1',
+    leftMaxCardinality: null,
+    leftMinCardinality: 0,
+    leftType: createSuccessfulRemoteDataObject$(leftType),
+    leftwardType: 'isOrgUnitOfOrgUnit',
+    rightMaxCardinality: null,
+    rightMinCardinality: 0,
+    rightType: createSuccessfulRemoteDataObject$(rightType),
+    rightwardType: 'isOrgUnitOfOrgUnit',
+    uuid: 'relationshiptype-1',
+  });
+
+  const item = Object.assign(new Item(), { uuid: 'item-uuid' });
+
+  beforeEach(waitForAsync(() => {
+
+    editItemRelationshipsService = jasmine.createSpyObj('editItemRelationshipsService', {
+      isProvidedItemTypeLeftType: observableOf(true),
+      relationshipMatchesBothSameTypes: observableOf(false),
+    });
+
+
+    TestBed.configureTestingModule({
+      imports: [
+        EditRelationshipListWrapperComponent,
+      ],
+      providers: [
+        { provide: EditItemRelationshipsService, useValue: editItemRelationshipsService },
+      ],
+      schemas: [
+        CUSTOM_ELEMENTS_SCHEMA,
+      ],
+    }).overrideComponent(EditRelationshipListWrapperComponent, {
+      remove: {
+        imports: [
+          EditRelationshipListComponent,
+        ],
+      },
+    }).compileComponents();
+
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditRelationshipListWrapperComponent);
+    comp = fixture.componentInstance;
+    comp.relationshipType = relationshipType;
+    comp.itemType = leftType;
+    comp.item = item;
+
+    fixture.detectChanges();
+  });
+
+  describe('onInit', () => {
+    it('should render the component', () => {
+      expect(comp).toBeTruthy();
+    });
+    it('should set currentItemIsLeftItem$ and bothItemsMatchType$  based on the provided relationshipType, itemType and item', () => {
+      expect(editItemRelationshipsService.isProvidedItemTypeLeftType).toHaveBeenCalledWith(relationshipType, leftType, item);
+      expect(editItemRelationshipsService.relationshipMatchesBothSameTypes).toHaveBeenCalledWith(relationshipType, leftType);
+
+      expect(comp.currentItemIsLeftItem$.getValue()).toEqual(true);
+      expect(comp.bothItemsMatchType$.getValue()).toEqual(false);
+    });
+  });
+
+  describe('when the current item is left', () => {
+    it('should render one relationship list section', () => {
+      const relationshipLists = fixture.debugElement.queryAll(By.css('ds-edit-relationship-list'));
+      expect(relationshipLists.length).toEqual(1);
+    });
+  });
+
+  describe('when the current item is right', () => {
+    it('should render one relationship list section', () => {
+      (editItemRelationshipsService.isProvidedItemTypeLeftType as jasmine.Spy).and.returnValue(observableOf(false));
+      comp.ngOnInit();
+      fixture.detectChanges();
+
+      const relationshipLists = fixture.debugElement.queryAll(By.css('ds-edit-relationship-list'));
+      expect(relationshipLists.length).toEqual(1);
+    });
+  });
+
+  describe('when the current item is both left and right', () => {
+    it('should render two relationship list sections', () => {
+      (editItemRelationshipsService.relationshipMatchesBothSameTypes as jasmine.Spy).and.returnValue(observableOf(true));
+      comp.ngOnInit();
+      fixture.detectChanges();
+
+      const relationshipLists = fixture.debugElement.queryAll(By.css('ds-edit-relationship-list'));
+      expect(relationshipLists.length).toEqual(2);
+    });
+  });
+
+});

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.ts
@@ -1,0 +1,114 @@
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+import {
+  BehaviorSubject,
+  Observable,
+  Subscription,
+} from 'rxjs';
+
+import { Item } from '../../../../core/shared/item.model';
+import { ItemType } from '../../../../core/shared/item-relationships/item-type.model';
+import { RelationshipType } from '../../../../core/shared/item-relationships/relationship-type.model';
+import { hasValue } from '../../../../shared/empty.util';
+import { EditItemRelationshipsService } from '../edit-item-relationships.service';
+import { EditRelationshipListComponent } from '../edit-relationship-list/edit-relationship-list.component';
+
+@Component({
+  selector: 'ds-edit-relationship-list-wrapper',
+  styleUrls: ['./edit-relationship-list-wrapper.component.scss'],
+  templateUrl: './edit-relationship-list-wrapper.component.html',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    EditRelationshipListComponent,
+    NgIf,
+  ],
+})
+/**
+ * A component creating a list of editable relationships of a certain type
+ * The relationships are rendered as a list of related items
+ */
+export class EditRelationshipListWrapperComponent implements OnInit, OnDestroy {
+
+  /**
+   * The item to display related items for
+   */
+  @Input() item: Item;
+
+  @Input() itemType: ItemType;
+
+  /**
+   * The URL to the current page
+   * Used to fetch updates for the current item from the store
+   */
+  @Input() url: string;
+
+  /**
+   * The label of the relationship-type we're rendering a list for
+   */
+  @Input() relationshipType: RelationshipType;
+
+  /**
+   * If updated information has changed
+   */
+  @Input() hasChanges!: Observable<boolean>;
+
+  /**
+   * The event emmiter to submit the new information
+   */
+  @Output() submitModal: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * Observable that emits true if {@link itemType} is on the left-hand side of {@link relationshipType},
+   * false if it is on the right-hand side and undefined in the rare case that it is on neither side.
+   */
+  currentItemIsLeftItem$: BehaviorSubject<boolean> = new BehaviorSubject(undefined);
+
+
+  isLeftItem$ = new BehaviorSubject(true);
+
+  isRightItem$ = new BehaviorSubject(false);
+
+  bothItemsMatchType$: BehaviorSubject<boolean> = new BehaviorSubject(undefined);
+
+  /**
+   * Array to track all subscriptions and unsubscribe them onDestroy
+   * @type {Array}
+   */
+  private subs: Subscription[] = [];
+
+  constructor(
+    protected editItemRelationshipsService: EditItemRelationshipsService,
+  ) {
+  }
+
+
+  ngOnInit(): void {
+    this.subs.push(this.editItemRelationshipsService.isProvidedItemTypeLeftType(this.relationshipType, this.itemType, this.item)
+      .subscribe((nextValue: boolean) => {
+        this.currentItemIsLeftItem$.next(nextValue);
+      }));
+
+    this.subs.push(this.editItemRelationshipsService.relationshipMatchesBothSameTypes(this.relationshipType, this.itemType)
+      .subscribe((nextValue: boolean) => {
+        this.bothItemsMatchType$.next(nextValue);
+      }));
+  }
+
+
+  ngOnDestroy(): void {
+    this.subs
+      .filter((subscription) => hasValue(subscription))
+      .forEach((subscription) => subscription.unsubscribe());
+  }
+}

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list-wrapper/edit-relationship-list-wrapper.component.ts
@@ -79,7 +79,7 @@ export class EditRelationshipListWrapperComponent implements OnInit, OnDestroy {
 
   isRightItem$ = new BehaviorSubject(false);
 
-  bothItemsMatchType$: BehaviorSubject<boolean> = new BehaviorSubject(undefined);
+  shouldDisplayBothRelationshipSides$: Observable<boolean>;
 
   /**
    * Array to track all subscriptions and unsubscribe them onDestroy
@@ -99,10 +99,7 @@ export class EditRelationshipListWrapperComponent implements OnInit, OnDestroy {
         this.currentItemIsLeftItem$.next(nextValue);
       }));
 
-    this.subs.push(this.editItemRelationshipsService.relationshipMatchesBothSameTypes(this.relationshipType, this.itemType)
-      .subscribe((nextValue: boolean) => {
-        this.bothItemsMatchType$.next(nextValue);
-      }));
+    this.shouldDisplayBothRelationshipSides$ = this.editItemRelationshipsService.shouldDisplayBothRelationshipSides(this.relationshipType, this.itemType);
   }
 
 

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
@@ -15,7 +15,10 @@ import {
 import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { cold } from 'jasmine-marbles';
-import { of as observableOf } from 'rxjs';
+import {
+  BehaviorSubject,
+  of as observableOf,
+} from 'rxjs';
 
 import { APP_CONFIG } from '../../../../../config/app-config.interface';
 import { environment } from '../../../../../environments/environment.test';
@@ -82,6 +85,7 @@ describe('EditRelationshipListComponent', () => {
   let relationships: Relationship[];
   let relationshipType: RelationshipType;
   let paginationOptions: PaginationComponentOptions;
+  let currentItemIsLeftItem$ =  new BehaviorSubject<boolean>(true);
 
   const resetComponent = () => {
     fixture = TestBed.createComponent(EditRelationshipListComponent);
@@ -92,6 +96,7 @@ describe('EditRelationshipListComponent', () => {
     comp.url = url;
     comp.relationshipType = relationshipType;
     comp.hasChanges = observableOf(false);
+    comp.currentItemIsLeftItem$ = currentItemIsLeftItem$;
     fixture.detectChanges();
   };
 
@@ -328,6 +333,7 @@ describe('EditRelationshipListComponent', () => {
             leftwardType: 'isAuthorOfPublication',
             rightwardType: 'isPublicationOfAuthor',
           });
+          currentItemIsLeftItem$ =  new BehaviorSubject<boolean>(true);
           relationshipService.getItemRelationshipsByLabel.calls.reset();
           resetComponent();
         });
@@ -352,6 +358,7 @@ describe('EditRelationshipListComponent', () => {
             leftwardType: 'isPublicationOfAuthor',
             rightwardType: 'isAuthorOfPublication',
           });
+          currentItemIsLeftItem$ =  new BehaviorSubject<boolean>(false);
           relationshipService.getItemRelationshipsByLabel.calls.reset();
           resetComponent();
         });

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -68,6 +68,7 @@ import {
   hasNoValue,
   hasValue,
   hasValueOperator,
+  isNotEmpty,
 } from '../../../../shared/empty.util';
 import { DsDynamicLookupRelationModalComponent } from '../../../../shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
 import { RelationshipOptions } from '../../../../shared/form/builder/models/relationship-options.model';
@@ -308,7 +309,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
                 }
               }
 
-              this.loading$.next(true);
+              this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
               // emit the last page again to trigger a fieldupdates refresh
               this.relationshipsRd$.next(this.relationshipsRd$.getValue());
             });
@@ -326,6 +327,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
         } else {
           modalComp.toRemove.push(searchResult);
         }
+        this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
       });
     };
 
@@ -399,6 +401,11 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
 
       modalComp.toAdd = [];
       modalComp.toRemove = [];
+      this.loading$.next(false);
+    };
+
+    modalComp.closeEv = () => {
+      this.loading$.next(false);
     };
 
     this.relatedEntityType$

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -59,6 +59,7 @@ import { Relationship } from '../../../../core/shared/item-relationships/relatio
 import { RelationshipType } from '../../../../core/shared/item-relationships/relationship-type.model';
 import {
   getAllSucceededRemoteData,
+  getFirstCompletedRemoteData,
   getFirstSucceededRemoteData,
   getFirstSucceededRemoteDataPayload,
   getRemoteDataPayload,
@@ -364,6 +365,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
                       type: this.relationshipType,
                       originalIsLeft: isLeft,
                       originalItem: this.item,
+                      relatedItem,
                       relationship,
                     } as RelationshipIdentifiable;
                     return this.objectUpdatesService.saveRemoveFieldUpdate(this.url,update);
@@ -518,10 +520,24 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
             this.relationshipService.isLeftItem(relationship, this.item).pipe(
               // emit an array containing both the relationship and whether it's the left item,
               // as we'll need both
-              map((isLeftItem: boolean) => [relationship, isLeftItem]),
+              switchMap((isLeftItem: boolean) => {
+                if (isLeftItem) {
+                  return relationship.rightItem.pipe(
+                    getFirstCompletedRemoteData(),
+                    getRemoteDataPayload(),
+                    map((relatedItem: Item) => [relationship, isLeftItem, relatedItem]),
+                  );
+                } else {
+                  return relationship.leftItem.pipe(
+                    getFirstCompletedRemoteData(),
+                    getRemoteDataPayload(),
+                    map((relatedItem: Item) => [relationship, isLeftItem, relatedItem]),
+                  );
+                }
+              }),
             ),
           ),
-          map(([relationship, isLeftItem]: [Relationship, boolean]) => {
+          map(([relationship, isLeftItem, relatedItem]: [Relationship, boolean, Item]) => {
             // turn it into a RelationshipIdentifiable, an
             const nameVariant =
               isLeftItem ? relationship.rightwardValue : relationship.leftwardValue;
@@ -531,6 +547,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
               relationship,
               originalIsLeft: isLeftItem,
               originalItem: this.item,
+              relatedItem: relatedItem,
               nameVariant,
             } as RelationshipIdentifiable;
           }),

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -143,7 +143,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
    * Observable that emits true if {@link itemType} is on the left-hand side of {@link relationshipType},
    * false if it is on the right-hand side and undefined in the rare case that it is on neither side.
    */
-  private currentItemIsLeftItem$: BehaviorSubject<boolean> = new BehaviorSubject(undefined);
+  @Input() currentItemIsLeftItem$: BehaviorSubject<boolean> = new BehaviorSubject(undefined);
 
   relatedEntityType$: Observable<ItemType>;
 
@@ -243,17 +243,14 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
    * Get the relevant label for this relationship type
    */
   private getLabel(): Observable<string> {
-    return observableCombineLatest([
-      this.relationshipType.leftType,
-      this.relationshipType.rightType,
-    ].map((itemTypeRD) => itemTypeRD.pipe(
-      getFirstSucceededRemoteData(),
-      getRemoteDataPayload(),
-    ))).pipe(
-      map((itemTypes: ItemType[]) => [
-        this.relationshipType.leftwardType,
-        this.relationshipType.rightwardType,
-      ][itemTypes.findIndex((itemType) => itemType.id === this.itemType.id)]),
+    return this.currentItemIsLeftItem$.pipe(
+      map((currentItemIsLeftItem) => {
+        if (currentItemIsLeftItem) {
+          return this.relationshipType.leftwardType;
+        } else {
+          return this.relationshipType.rightwardType;
+        }
+      }),
     );
   }
 
@@ -281,6 +278,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
     modalComp.toAdd = [];
     modalComp.toRemove = [];
     modalComp.isPending = false;
+    modalComp.hiddenQuery = '-search.resourceid:' + this.item.uuid;
 
     this.item.owningCollection.pipe(
       getFirstSucceededRemoteDataPayload(),
@@ -453,24 +451,6 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
     );
 
     this.relationshipMessageKey$ = this.getRelationshipMessageKey();
-
-    this.subs.push(this.relationshipLeftAndRightType$.pipe(
-      map(([leftType, rightType]: [ItemType, ItemType]) => {
-        if (leftType.id === this.itemType.id) {
-          return true;
-        }
-
-        if (rightType.id === this.itemType.id) {
-          return false;
-        }
-
-        // should never happen...
-        console.warn(`The item ${this.item.uuid} is not on the right or the left side of relationship type ${this.relationshipType.uuid}`);
-        return undefined;
-      }),
-    ).subscribe((nextValue: boolean) => {
-      this.currentItemIsLeftItem$.next(nextValue);
-    }));
 
 
     // initialize the pagination options

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship/edit-relationship.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship/edit-relationship.component.ts
@@ -131,9 +131,7 @@ export class EditRelationshipComponent implements OnChanges {
         this.leftItem$,
         this.rightItem$,
       ]).pipe(
-        map((items: Item[]) =>
-          items.find((item) => item.uuid !== this.editItem.uuid),
-        ),
+        map(([leftItem, rightItem]: [Item, Item]) => leftItem.uuid === this.editItem.uuid ? rightItem : leftItem),
         take(1),
       ).subscribe((relatedItem) => {
         this.relatedItem$.next(relatedItem);

--- a/src/app/item-page/edit-item-page/item-relationships/item-relationships.component.html
+++ b/src/app/item-page/edit-item-page/item-relationships/item-relationships.component.html
@@ -5,13 +5,13 @@
     </div>
     <div *ngIf="relationshipTypes$ | async as relationshipTypes; else loading" class="mb-4">
       <div *ngFor="let relationshipType of relationshipTypes; trackBy: trackById" class="mb-4">
-        <ds-edit-relationship-list
+        <ds-edit-relationship-list-wrapper
           [url]="url"
           [item]="item"
           [itemType]="entityType"
           [relationshipType]="relationshipType"
           [hasChanges]="hasChanges$"
-        ></ds-edit-relationship-list>
+        ></ds-edit-relationship-list-wrapper>
       </div>
     </div>
     <div class="button-row bottom">

--- a/src/app/item-page/edit-item-page/item-relationships/item-relationships.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/item-relationships.component.ts
@@ -50,6 +50,7 @@ import { compareArraysUsingIds } from '../../simple/item-types/shared/item-relat
 import { AbstractItemUpdateComponent } from '../abstract-item-update/abstract-item-update.component';
 import { EditItemRelationshipsService } from './edit-item-relationships.service';
 import { EditRelationshipListComponent } from './edit-relationship-list/edit-relationship-list.component';
+import { EditRelationshipListWrapperComponent } from './edit-relationship-list-wrapper/edit-relationship-list-wrapper.component';
 
 @Component({
   selector: 'ds-item-relationships',
@@ -65,6 +66,7 @@ import { EditRelationshipListComponent } from './edit-relationship-list/edit-rel
     ThemedLoadingComponent,
     TranslateModule,
     VarDirective,
+    EditRelationshipListWrapperComponent,
   ],
   standalone: true,
 })

--- a/src/app/item-page/simple/item-types/shared/item-relationships-utils.ts
+++ b/src/app/item-page/simple/item-types/shared/item-relationships-utils.ts
@@ -2,6 +2,7 @@ import { InjectionToken } from '@angular/core';
 import {
   combineLatest as observableCombineLatest,
   Observable,
+  of as observableOf,
   zip as observableZip,
 } from 'rxjs';
 import {
@@ -53,17 +54,19 @@ export const compareArraysUsingIds = <T extends { id: string }>() =>
 /**
  * Operator for turning a list of relationships into a list of the relevant items
  * @param {string} thisId       The item's id of which the relations belong to
- * @returns {(source: Observable<Relationship[]>) => Observable<Item[]>}
  */
-export const relationsToItems = (thisId: string) =>
+export const relationsToItems = (thisId: string): (source: Observable<Relationship[]>) => Observable<Item[]> =>
   (source: Observable<Relationship[]>): Observable<Item[]> =>
     source.pipe(
-      mergeMap((rels: Relationship[]) =>
-        observableZip(
-          ...rels.map((rel: Relationship) => observableCombineLatest(rel.leftItem, rel.rightItem)),
-        ),
-      ),
-      map((arr) =>
+      mergeMap((relationships: Relationship[]) => {
+        if (relationships.length === 0) {
+          return observableOf([]);
+        }
+        return observableZip(
+          ...relationships.map((rel: Relationship) => observableCombineLatest([rel.leftItem, rel.rightItem])),
+        );
+      }),
+      map((arr: [RemoteData<Item>, RemoteData<Item>][]) =>
         arr
           .filter(([leftItem, rightItem]) => leftItem.hasSucceeded && rightItem.hasSucceeded)
           .map(([leftItem, rightItem]) => {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
@@ -19,6 +19,7 @@
                             [repeatable]="repeatable"
                             [context]="context"
                             [query]="query"
+                            [hiddenQuery]="hiddenQuery"
                             [relationshipType]="relationshipType"
                             [isLeft]="isLeft"
                             [item]="item"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -27,7 +27,6 @@ import { RemoteDataBuildService } from '../../../../../core/cache/builders/remot
 import { ExternalSourceDataService } from '../../../../../core/data/external-source-data.service';
 import { LookupRelationService } from '../../../../../core/data/lookup-relation.service';
 import { RelationshipDataService } from '../../../../../core/data/relationship-data.service';
-import { RelationshipTypeDataService } from '../../../../../core/data/relationship-type-data.service';
 import { Collection } from '../../../../../core/shared/collection.model';
 import { ExternalSource } from '../../../../../core/shared/external-source.model';
 import { Item } from '../../../../../core/shared/item.model';
@@ -139,7 +138,6 @@ describe('DsDynamicLookupRelationModalComponent', () => {
         {
           provide: RelationshipDataService, useValue: { getNameVariant: () => observableOf(nameVariant) },
         },
-        { provide: RelationshipTypeDataService, useValue: {} },
         { provide: RemoteDataBuildService, useValue: rdbService },
         {
           provide: Store, useValue: {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -150,6 +150,11 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   query: string;
 
   /**
+   * A hidden query that will be used but not displayed in the url/searchbar
+   */
+  hiddenQuery: string;
+
+  /**
    * A map of subscriptions within this component
    */
   subMap: {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -39,7 +39,6 @@ import { FindListOptions } from '../../../../../core/data/find-list-options.mode
 import { LookupRelationService } from '../../../../../core/data/lookup-relation.service';
 import { PaginatedList } from '../../../../../core/data/paginated-list.model';
 import { RelationshipDataService } from '../../../../../core/data/relationship-data.service';
-import { RelationshipTypeDataService } from '../../../../../core/data/relationship-type-data.service';
 import { Context } from '../../../../../core/shared/context.model';
 import { DSpaceObject } from '../../../../../core/shared/dspace-object.model';
 import { ExternalSource } from '../../../../../core/shared/external-source.model';
@@ -216,7 +215,6 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     public modal: NgbActiveModal,
     private selectableListService: SelectableListService,
     private relationshipService: RelationshipDataService,
-    private relationshipTypeService: RelationshipTypeDataService,
     private externalSourceService: ExternalSourceDataService,
     private lookupRelationService: LookupRelationService,
     private searchConfigService: SearchConfigurationService,
@@ -283,6 +281,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     this.toAdd = [];
     this.toRemove = [];
     this.modal.close();
+    this.closeEv();
   }
 
   /**
@@ -377,13 +376,19 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
 
   /* eslint-disable no-empty,@typescript-eslint/no-empty-function */
   /**
-   * Called when discard button is clicked, emit discard event to parent to conclude functionality
+   * Called when close button is clicked
+   */
+  closeEv(): void {
+  }
+
+  /**
+   * Called when discard button is clicked
    */
   discardEv(): void {
   }
 
   /**
-   * Called when submit button is clicked, emit submit event to parent to conclude functionality
+   * Called when submit button is clicked
    */
   submitEv(): void {
   }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.html
@@ -2,6 +2,7 @@
            [configuration]="this.relationship.searchConfiguration"
            [context]="context"
            [fixedFilterQuery]="this.relationship.filter"
+           [hiddenQuery]="hiddenQuery"
            [inPlaceSearch]="true"
            [linkType]="linkTypes.ExternalLink"
            [searchFormPlaceholder]="'submission.sections.describe.relationship-lookup.search-tab.search-form.placeholder'"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
@@ -130,6 +130,11 @@ export class DsDynamicLookupRelationSearchTabComponent implements OnInit, OnDest
   @Input() isEditRelationship: boolean;
 
   /**
+   * A hidden query that will be used but not displayed in the url/searchbar
+   */
+  @Input() hiddenQuery: string;
+
+  /**
    * Send an event to deselect an object from the list
    */
   @Output() deselectObject: EventEmitter<SearchResult<DSpaceObject>> = new EventEmitter();

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/themed-dynamic-lookup-relation-search-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/themed-dynamic-lookup-relation-search-tab.component.ts
@@ -26,7 +26,7 @@ import { DsDynamicLookupRelationSearchTabComponent } from './dynamic-lookup-rela
 })
 export class ThemedDynamicLookupRelationSearchTabComponent extends ThemedComponent<DsDynamicLookupRelationSearchTabComponent> {
   protected inAndOutputNames: (keyof DsDynamicLookupRelationSearchTabComponent & keyof this)[] = ['relationship', 'listId',
-    'query', 'repeatable', 'selection$', 'context', 'relationshipType', 'item', 'isLeft', 'toRemove', 'isEditRelationship',
+    'query', 'hiddenQuery', 'repeatable', 'selection$', 'context', 'relationshipType', 'item', 'isLeft', 'toRemove', 'isEditRelationship',
     'deselectObject', 'selectObject', 'resultFound'];
 
   @Input() relationship: RelationshipOptions;
@@ -34,6 +34,8 @@ export class ThemedDynamicLookupRelationSearchTabComponent extends ThemedCompone
   @Input() listId: string;
 
   @Input() query: string;
+
+  @Input() hiddenQuery: string;
 
   @Input() repeatable: boolean;
 

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -138,6 +138,7 @@ const searchServiceStub = jasmine.createSpyObj('SearchService', {
   trackSearch: {},
 }) as SearchService;
 const queryParam = 'test query';
+const hiddenQuery = 'hidden query';
 const scopeParam = '7669c72a-3f2a-451f-a3b9-9210e7a4c02f';
 
 const defaultSearchOptions = new PaginatedSearchOptions({ pagination });
@@ -279,6 +280,7 @@ describe('SearchComponent', () => {
     comp = fixture.componentInstance; // SearchComponent test instance
     comp.inPlaceSearch = false;
     comp.paginationId = paginationId;
+    comp.hiddenQuery = hiddenQuery;
 
     spyOn((comp as any), 'getSearchOptions').and.returnValue(paginatedSearchOptions$.asObservable());
   });

--- a/src/app/shared/search/themed-search.component.ts
+++ b/src/app/shared/search/themed-search.component.ts
@@ -32,6 +32,7 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
     'context',
     'configuration',
     'fixedFilterQuery',
+    'hiddenQuery',
     'useCachedVersionIfAvailable',
     'inPlaceSearch',
     'linkType',
@@ -64,6 +65,8 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
   @Input() configuration: string;
 
   @Input() fixedFilterQuery: string;
+
+  @Input() hiddenQuery: string;
 
   @Input() useCachedVersionIfAvailable: boolean;
 


### PR DESCRIPTION
## References
* Fixes last remaining bugs noticed during #3060
* Backport PR #3109

## Description
This PR fixes 2 remaining bugs. A caching issue where the selected status of the relationship popup modal would stay cached even after deleting a relationship. And also an issue where only one side of the same entity type relationship would be shown on the edit item relationship page (for example both `isDepartmentOfDivision` & `isDivisionOfDepartment` should be shown). It also hides the item you are currently on in the search results of the popup modal.

## Instructions for Reviewers
List of changes in this PR:
* When removing a relationship the item you are on is invalidated, but the item on the other side of the relationship wasn't, so this has now been fixed in `EditItemRelationshipsService#submit`
* Every search request in the relationship popup modal stayed cached even when it contained an item which was just invalidated. By using `addDependency` this search request is now linked to every item that is returned in the results, this way when one of the items is invalidated the request is also invalidated.
* The current item won't be displayed in the search results in the popup modal anymore (because making a relationship with yourself doesn't really make sense). This was only visible for same entity relationships
* When you have a relationship with the same entity type on both sides it would only show one side. To fix this a new component was created (`EditRelationshipListWrapperComponent`), which will display both sides of the relationship when a relationship has the same entity type on both sides and has different `leftwardType` & `rightwardType`

**Guidance for how to test or review this PR:**
Caching issues:
- On the edit relationships tab open click copy the uuid of one of the objects with whom you can create a relationship and use this a query to find results (normally only one results should be displayed).
- Select the item and save it
- Open the modal again and search for the same uuid, the checkbox should be selected

Display both side of the relationship:
- Add the following relationship config to your `relationship-types.xml`:
   ```xml
   <type>
        <leftType>OrgUnit</leftType>
        <rightType>OrgUnit</rightType>
        <leftwardType>isDepartmentOfDivision</leftwardType>
        <rightwardType>isDivisionOfDepartment</rightwardType>
        <leftCardinality>
            <min>0</min>
        </leftCardinality>
        <rightCardinality>
            <min>0</min>
        </rightCardinality>
        <copyToLeft>true</copyToLeft>
    </type>
    <type>
        <leftType>OrgUnit</leftType>
        <rightType>OrgUnit</rightType>
        <leftwardType>isOrgUnitOfOrgUnit</leftwardType>
        <rightwardType>isOrgUnitOfOrgUnit</rightwardType>
        <leftCardinality>
            <min>0</min>
        </leftCardinality>
        <rightCardinality>
            <min>0</min>
        </rightCardinality>
        <copyToLeft>true</copyToLeft>
    </type>
   ```
- Create the following metadata fields in `relationship-formats.xml` (can also be done though the UI):
   ```xml
    <dc-type>
        <schema>relation</schema>
        <element>isDepartmentOfDivision</element>
    </dc-type>
    <dc-type>
        <schema>relation</schema>
        <element>isDivisionOfDepartment</element>
    </dc-type>
    <dc-type>
        <schema>relation</schema>
        <element>isOrgUnitOfOrgUnit</element>
    </dc-type>
   ```
- Verify that there are 2 separate sections for the first relationship type: a `isDepartmentOfDivision` section & `isDivisionOfDepartment` section
- Verify that for the `isOrgUnitOfOrgUnit` only one section is shown
- Verify that you can't see the item you are on anymore in the list of suggested items

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
