### PR TITLE
[#3111] fix markdown rendering applying before mathjax rendering

### DIFF
--- a/src/app/core/shared/client-math.service.ts
+++ b/src/app/core/shared/client-math.service.ts
@@ -31,7 +31,7 @@ export class ClientMathService extends MathService {
 
   protected mathJaxOptions = {
     tex: {
-      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      inlineMath: [['$', '$'], ['$$', '$$'], ['\\(', '\\)']],
     },
     svg: {
       fontCache: 'global',
@@ -108,7 +108,7 @@ export class ClientMathService extends MathService {
    */
   render(element: HTMLElement) {
     if (environment.markdown.mathjax) {
-      this._window.nativeWindow.MathJax.typesetPromise([element]);
+      return (window as any).MathJax.typesetPromise([element]) as Promise<any>;
     }
   }
 }

--- a/src/app/core/shared/math.service.spec.ts
+++ b/src/app/core/shared/math.service.spec.ts
@@ -22,8 +22,8 @@ export class MockMathService extends MathService {
     return of(true);
   }
 
-  render(element: HTMLElement): void {
-    return;
+  render(element: HTMLElement): Promise<any> {
+    return Promise.resolve();
   }
 }
 

--- a/src/app/core/shared/math.service.ts
+++ b/src/app/core/shared/math.service.ts
@@ -15,5 +15,5 @@ export abstract class MathService {
 
   protected abstract registerMathJaxAsync(config: MathJaxConfig): Promise<any>;
   abstract ready(): Observable<boolean>;
-  abstract render(element: HTMLElement): void;
+  abstract render(element: HTMLElement): Promise<any>;
 }

--- a/src/app/core/shared/server-math.service.ts
+++ b/src/app/core/shared/server-math.service.ts
@@ -47,6 +47,6 @@ export class ServerMathService extends MathService {
   }
 
   render(element: HTMLElement) {
-    return;
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
## References
* Fixes #3111

## Description
With this PR, LaTeX formulas are rendered with mathjax before any markdown rendering is applied. This fixes unwanted behaviors described on the linked issue.

## Instructions for Reviewers

List of changes in this PR:
* Applied mathjax rendering before markdown rendering (if mathjax is enabled);
* Removed `nativeWindow` injection in `client-math.service` (since it's a Client-Side-Rendering service, there is no need to use the injection);
* Included the popular LaTeX `$$` delimiter in the list of approved delimiters.

To test this PR, try to use this text in any place where the markdown rendering is enabled:
`...measurements in (EDT-TTF-CONH$_2$)$_2^{+}$[BABCO$^{-}$] (EDT-BCO) confirmed the absence...`.
It should render fine, instead of showing a broken formula and some italic text.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
