### PR TITLE
Fix error which prevent submitter to deposit a new item

### DIFF
--- a/src/app/core/json-patch/json-patch-operations.reducer.spec.ts
+++ b/src/app/core/json-patch/json-patch-operations.reducer.spec.ts
@@ -340,4 +340,384 @@ describe('jsonPatchOperationsReducer test suite', () => {
     });
   });
 
+  describe('dedupeOperationEntries', () => {
+    it('should not remove duplicated keys if operations are not sequential', () => {
+      initState = {
+        sections: {
+          children: {
+            publicationStep: {
+              body: [
+                {
+                  operation: {
+                    op: 'add',
+                    path: '/sections/publicationStep/dc.date.issued',
+                    value: [
+                      {
+                        value: '2024-06',
+                        language: null,
+                        authority: null,
+                        display: '2024-06',
+                        confidence: -1,
+                        place: 0,
+                        otherInformation: null,
+                      },
+                    ],
+                  },
+                  timeCompleted: timestampBeforeStart,
+                },
+                {
+                  operation: {
+                    op: 'replace',
+                    path: '/sections/publicationStep/dc.date.issued/0',
+                    value: {
+                      value: '2023-06-19',
+                      language: null,
+                      authority: null,
+                      display: '2023-06-19',
+                      confidence: -1,
+                      place: 0,
+                      otherInformation: null,
+                    },
+                  },
+                  timeCompleted: timestampBeforeStart,
+                },
+              ],
+            } as JsonPatchOperationsEntry,
+          },
+          transactionStartTime: null,
+          commitPending: false,
+        } as JsonPatchOperationsResourceEntry,
+      };
+
+      const value = [
+        {
+          value: '2024-06-19',
+          language: null,
+          authority: null,
+          display: '2024-06-19',
+          confidence: -1,
+          place: 0,
+          otherInformation: null,
+        },
+      ];
+      const action = new NewPatchAddOperationAction(
+        'sections',
+        'publicationStep',
+        '/sections/publicationStep/dc.date.issued',
+        value);
+      const newState = jsonPatchOperationsReducer(initState, action);
+
+      const expectedBody: any =  [
+        {
+          'operation': {
+            'op': 'add',
+            'path': '/sections/publicationStep/dc.date.issued',
+            'value': [
+              {
+                'value': '2024-06',
+                'language': null,
+                'authority': null,
+                'display': '2024-06',
+                'confidence': -1,
+                'place': 0,
+                'otherInformation': null,
+              },
+            ],
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+        {
+          'operation': {
+            'op': 'replace',
+            'path': '/sections/publicationStep/dc.date.issued/0',
+            'value': {
+              'value': '2023-06-19',
+              'language': null,
+              'authority': null,
+              'display': '2023-06-19',
+              'confidence': -1,
+              'place': 0,
+              'otherInformation': null,
+            },
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+        {
+          'operation': {
+            'op': 'add',
+            'path': '/sections/publicationStep/dc.date.issued',
+            'value': [
+              {
+                'value': '2024-06-19',
+                'language': null,
+                'authority': null,
+                'display': '2024-06-19',
+                'confidence': -1,
+                'place': 0,
+                'otherInformation': null,
+              },
+            ],
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+      ];
+
+      expect(newState.sections.children.publicationStep.body).toEqual(expectedBody);
+
+    });
+
+    it('should remove duplicated keys if operations are sequential', () => {
+      initState = {
+        sections: {
+          children: {
+            publicationStep: {
+              body: [
+                {
+                  operation: {
+                    op: 'add',
+                    path: '/sections/publicationStep/dc.date.issued',
+                    value: [
+                      {
+                        value: '2024-06',
+                        language: null,
+                        authority: null,
+                        display: '2024-06',
+                        confidence: -1,
+                        place: 0,
+                        otherInformation: null,
+                      },
+                    ],
+                  },
+                  timeCompleted: timestampBeforeStart,
+                },
+                {
+                  operation: {
+                    op: 'replace',
+                    path: '/sections/publicationStep/dc.date.issued/0',
+                    value: {
+                      value: '2023-06-19',
+                      language: null,
+                      authority: null,
+                      display: '2023-06-19',
+                      confidence: -1,
+                      place: 0,
+                      otherInformation: null,
+                    },
+                  },
+                  timeCompleted: timestampBeforeStart,
+                },
+                {
+                  'operation': {
+                    'op': 'add',
+                    'path': '/sections/publicationStep/dc.date.issued',
+                    'value': [
+                      {
+                        'value': '2024-06-19',
+                        'language': null,
+                        'authority': null,
+                        'display': '2024-06-19',
+                        'confidence': -1,
+                        'place': 0,
+                        'otherInformation': null,
+                      },
+                    ],
+                  },
+                  'timeCompleted': timestampBeforeStart,
+                },
+              ],
+            } as JsonPatchOperationsEntry,
+          },
+          transactionStartTime: null,
+          commitPending: false,
+        } as JsonPatchOperationsResourceEntry,
+      };
+
+      const value = [
+        {
+          value: '2024-06-20',
+          language: null,
+          authority: null,
+          display: '2024-06-20',
+          confidence: -1,
+          place: 0,
+          otherInformation: null,
+        },
+      ];
+      const action = new NewPatchAddOperationAction(
+        'sections',
+        'publicationStep',
+        '/sections/publicationStep/dc.date.issued',
+        value);
+      const newState = jsonPatchOperationsReducer(initState, action);
+
+      const expectedBody: any =  [
+        {
+          'operation': {
+            'op': 'add',
+            'path': '/sections/publicationStep/dc.date.issued',
+            'value': [
+              {
+                'value': '2024-06',
+                'language': null,
+                'authority': null,
+                'display': '2024-06',
+                'confidence': -1,
+                'place': 0,
+                'otherInformation': null,
+              },
+            ],
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+        {
+          'operation': {
+            'op': 'replace',
+            'path': '/sections/publicationStep/dc.date.issued/0',
+            'value': {
+              'value': '2023-06-19',
+              'language': null,
+              'authority': null,
+              'display': '2023-06-19',
+              'confidence': -1,
+              'place': 0,
+              'otherInformation': null,
+            },
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+        {
+          'operation': {
+            'op': 'add',
+            'path': '/sections/publicationStep/dc.date.issued',
+            'value': [
+              {
+                'value': '2024-06-20',
+                'language': null,
+                'authority': null,
+                'display': '2024-06-20',
+                'confidence': -1,
+                'place': 0,
+                'otherInformation': null,
+              },
+            ],
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+      ];
+
+      expect(newState.sections.children.publicationStep.body).toEqual(expectedBody);
+
+    });
+
+    it('should remove duplicated keys if all operations have same key', () => {
+      initState = {
+        sections: {
+          children: {
+            publicationStep: {
+              body: [
+                {
+                  operation: {
+                    op: 'add',
+                    path: '/sections/publicationStep/dc.date.issued',
+                    value: [
+                      {
+                        value: '2024',
+                        language: null,
+                        authority: null,
+                        display: '2024-06',
+                        confidence: -1,
+                        place: 0,
+                        otherInformation: null,
+                      },
+                    ],
+                  },
+                  timeCompleted: timestampBeforeStart,
+                },
+                {
+                  'operation': {
+                    'op': 'add',
+                    'path': '/sections/publicationStep/dc.date.issued',
+                    'value': [
+                      {
+                        'value': '2024-06',
+                        'language': null,
+                        'authority': null,
+                        'display': '2024-06',
+                        'confidence': -1,
+                        'place': 0,
+                        'otherInformation': null,
+                      },
+                    ],
+                  },
+                  'timeCompleted': timestampBeforeStart,
+                },
+                {
+                  'operation': {
+                    'op': 'add',
+                    'path': '/sections/publicationStep/dc.date.issued',
+                    'value': [
+                      {
+                        'value': '2024-06-19',
+                        'language': null,
+                        'authority': null,
+                        'display': '2024-06-19',
+                        'confidence': -1,
+                        'place': 0,
+                        'otherInformation': null,
+                      },
+                    ],
+                  },
+                  'timeCompleted': timestampBeforeStart,
+                },
+              ],
+            } as JsonPatchOperationsEntry,
+          },
+          transactionStartTime: null,
+          commitPending: false,
+        } as JsonPatchOperationsResourceEntry,
+      };
+
+      const value = [
+        {
+          value: '2024-06-20',
+          language: null,
+          authority: null,
+          display: '2024-06-20',
+          confidence: -1,
+          place: 0,
+          otherInformation: null,
+        },
+      ];
+      const action = new NewPatchAddOperationAction(
+        'sections',
+        'publicationStep',
+        '/sections/publicationStep/dc.date.issued',
+        value);
+      const newState = jsonPatchOperationsReducer(initState, action);
+
+      const expectedBody: any =  [
+        {
+          'operation': {
+            'op': 'add',
+            'path': '/sections/publicationStep/dc.date.issued',
+            'value': [
+              {
+                'value': '2024-06-20',
+                'language': null,
+                'authority': null,
+                'display': '2024-06-20',
+                'confidence': -1,
+                'place': 0,
+                'otherInformation': null,
+              },
+            ],
+          },
+          'timeCompleted': timestampBeforeStart,
+        },
+      ];
+
+      expect(newState.sections.children.publicationStep.body).toEqual(expectedBody);
+
+    });
+  });
 });

--- a/src/app/core/json-patch/json-patch-operations.reducer.ts
+++ b/src/app/core/json-patch/json-patch-operations.reducer.ts
@@ -406,14 +406,18 @@ function addOperationToList(body: JsonPatchOperationObject[], actionType, target
  * @returns deduped JSON patch operation object entries
  */
 function dedupeOperationEntries(body: JsonPatchOperationObject[]): JsonPatchOperationObject[] {
-  const ops = new Map<string, any>();
+  const ops = new Map<string, number>();
   for (let i = body.length - 1; i >= 0; i--) {
     const patch = body[i].operation;
     const key = `${patch.op}-${patch.path}`;
     if (!ops.has(key)) {
-      ops.set(key, patch);
+      ops.set(key, i);
     } else {
-      body.splice(i, 1);
+      const entry = ops.get(key);
+      if (entry - 1 === i) {
+        body.splice(i, 1);
+        ops.set(key, i);
+      }
     }
   }
 

--- a/src/app/core/submission/submission-parent-breadcrumb.service.ts
+++ b/src/app/core/submission/submission-parent-breadcrumb.service.ts
@@ -8,7 +8,10 @@ import {
 
 import { getDSORoute } from '../../app-routing-paths';
 import { Breadcrumb } from '../../breadcrumbs/breadcrumb/breadcrumb.model';
-import { hasValue } from '../../shared/empty.util';
+import {
+  hasValue,
+  isEmpty,
+} from '../../shared/empty.util';
 import { SubmissionService } from '../../submission/submission.service';
 import { BreadcrumbsProviderService } from '../breadcrumbs/breadcrumbsProviderService';
 import { DSOBreadcrumbsService } from '../breadcrumbs/dso-breadcrumbs.service';
@@ -46,6 +49,10 @@ export class SubmissionParentBreadcrumbsService implements BreadcrumbsProviderSe
    * @param submissionObject The {@link SubmissionObject} for which the parent breadcrumb structure needs to be created
    */
   getBreadcrumbs(submissionObject: SubmissionObject): Observable<Breadcrumb[]> {
+    if (isEmpty(submissionObject)) {
+      return observableOf([]);
+    }
+
     return combineLatest([
       (submissionObject.collection as Observable<RemoteData<Collection>>).pipe(
         getFirstCompletedRemoteData(),

--- a/src/app/core/submission/submission-rest.service.ts
+++ b/src/app/core/submission/submission-rest.service.ts
@@ -13,6 +13,7 @@ import {
   isNotEmpty,
 } from '../../shared/empty.util';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { ErrorResponse } from '../cache/response.models';
 import { RemoteData } from '../data/remote-data';
 import {
   DeleteRequest,
@@ -23,6 +24,7 @@ import {
   SubmissionRequest,
 } from '../data/request.models';
 import { RequestService } from '../data/request.service';
+import { RequestError } from '../data/request-error.model';
 import { RestRequest } from '../data/rest-request.model';
 import { HttpOptions } from '../dspace-rest/dspace-rest.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
@@ -57,7 +59,7 @@ export class SubmissionRestService {
       getFirstCompletedRemoteData(),
       map((response: RemoteData<SubmissionResponse>) => {
         if (response.hasFailed) {
-          throw new Error(response.errorMessage);
+          throw new ErrorResponse({ statusText: response.errorMessage, statusCode: response.statusCode } as RequestError);
         } else {
           return hasValue(response.payload) ? response.payload.dataDefinition : response.payload;
         }

--- a/src/app/submission/sections/upload/section-upload.component.ts
+++ b/src/app/submission/sections/upload/section-upload.component.ts
@@ -227,20 +227,21 @@ export class SubmissionSectionUploadComponent extends SectionModelComponent {
         this.changeDetectorRef.detectChanges();
       }),
 
-
       // retrieve submission's bitstream data from state
-      combineLatest([this.configMetadataForm$,
-        this.bitstreamService.getUploadedFilesData(this.submissionId, this.sectionData.id)]).pipe(
-        filter(([configMetadataForm, { files }]: [SubmissionFormsModel, WorkspaceitemSectionUploadObject]) => {
-          return isNotEmpty(configMetadataForm) && isNotEmpty(files);
+      combineLatest([
+        this.configMetadataForm$,
+        this.bitstreamService.getUploadedFilesData(this.submissionId, this.sectionData.id),
+      ]).pipe(
+        filter(([configMetadataForm, sectionUploadObject]: [SubmissionFormsModel, WorkspaceitemSectionUploadObject]) => {
+          return isNotEmpty(configMetadataForm) && isNotEmpty(sectionUploadObject);
         }),
-        distinctUntilChanged())
-        .subscribe(([configMetadataForm, { primary, files }]: [SubmissionFormsModel, WorkspaceitemSectionUploadObject]) => {
-          this.primaryBitstreamUUID = primary;
-          this.fileList = files;
-          this.fileNames = Array.from(files, file => this.getFileName(configMetadataForm, file));
-        },
-        ),
+        distinctUntilChanged(),
+      ).subscribe(([configMetadataForm, { primary, files }]: [SubmissionFormsModel, WorkspaceitemSectionUploadObject]) => {
+        this.primaryBitstreamUUID = primary;
+        this.fileList = files;
+        this.fileNames = Array.from(files, file => this.getFileName(configMetadataForm, file));
+        this.changeDetectorRef.detectChanges();
+      }),
     );
   }
 


### PR DESCRIPTION
## References
* Fixes #3050
* Fixes #3136
* Fixes #3137 

## Description
This PR fixes the mentioned issues.
Regarding the #3050 the problem was due a wrong order the replace and add patch operation were sent with the patch request.
It depends on two aspects:
- firstly the date field has a different handling of the patch operation according to the way the field is edited. Indeed when clicking on the arrows button an add operation is always sent regardless a previous value exists for the date. Whereas when the field is edited by entering a value manually a replace operation is sent when the date already have a value
- the other problem found is that recently we introduced an optimization to avoid to send several patch operations of the same type (e.g add, replace, delete etc) all referring to the same metadata in order to send only the latest one (https://github.com/DSpace/dspace-angular/pull/2778).

What i did with this PR is to fix this last point, since the approach used in the mentioned PR didn't take in account whether in the queue of the patch operations there are different type of operation that must be executed in the exact order they have been triggered. So what happened in the buggy case is that a queue of patch operations like : 
```
- Add operation 1
- Replace operation 1
- Add operation 2
```
was optimized in the following queue
```
- Replace operation 1
- Add operation 2
```

To resolve the problem I've change the behaviour in order to optimize the same type of patch operations only if they are sequential. So the queue : 
```
- Add operation 1
- Replace operation 1
- Add operation 2
```
remains as is
```
- Add operation 1
- Replace operation 1
- Add operation 2
```
but the queue
```
- Add operation 1
- Replace operation 1
- Add operation 2
- Add operation 3
- Add operation 4
```
is optimized as
```
- Add operation 1
- Replace operation 1
- Add operation 4
```


## Instructions for Reviewers
To reproduce the error and to check if this PR resolve the bug with the date field please follow the instructions given in this comment https://github.com/DSpace/dspace-angular/issues/3050#issuecomment-2178603047

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
