### PR TITLE
Add support for non repeatable relationships

### DIFF
--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.spec.ts
@@ -110,7 +110,7 @@ describe('EditRelationshipListComponent', () => {
     },
   };
 
-  function init(leftType: string, rightType: string): void {
+  function init(leftType: string, rightType: string, leftMaxCardinality?: number, rightMaxCardinality?: number): void {
     entityTypeLeft = Object.assign(new ItemType(), {
       id: leftType,
       uuid: leftType,
@@ -130,6 +130,8 @@ describe('EditRelationshipListComponent', () => {
       rightType: createSuccessfulRemoteDataObject$(entityTypeRight),
       leftwardType: `is${rightType}Of${leftType}`,
       rightwardType: `is${leftType}Of${rightType}`,
+      leftMaxCardinality: leftMaxCardinality,
+      rightMaxCardinality: rightMaxCardinality,
     });
 
     paginationOptions = Object.assign(new PaginationComponentOptions(), {
@@ -400,6 +402,33 @@ describe('EditRelationshipListComponent', () => {
       expect(comp.relatedEntityType$).toBeObservable(cold('(a|)', {
         a: entityTypeRight,
       }));
+    });
+  });
+
+  describe('Is repeatable relationship', () => {
+    beforeEach(waitForAsync(() => {
+      currentItemIsLeftItem$ =  new BehaviorSubject<boolean>(true);
+    }));
+    describe('when max cardinality is 1', () => {
+      beforeEach(waitForAsync(() => init('Publication', 'OrgUnit', 1, undefined)));
+      it('should return false', () => {
+        const result = (comp as any).isRepeatable();
+        expect(result).toBeFalse();
+      });
+    });
+    describe('when max cardinality is 2', () => {
+      beforeEach(waitForAsync(() => init('Publication', 'OrgUnit', 2, undefined)));
+      it('should return true', () => {
+        const result = (comp as any).isRepeatable();
+        expect(result).toBeTrue();
+      });
+    });
+    describe('when max cardinality is undefined', () => {
+      beforeEach(waitForAsync(() => init('Publication', 'OrgUnit', undefined, undefined)));
+      it('should return true', () => {
+        const result = (comp as any).isRepeatable();
+        expect(result).toBeTrue();
+      });
     });
   });
 });

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -265,6 +265,22 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Check whether the current entity can have multiple relationships of this type
+   * This is based on the max cardinality of the relationship
+   * @private
+   */
+  private isRepeatable(): boolean {
+    const isLeft = this.currentItemIsLeftItem$.getValue();
+    if (isLeft) {
+      const leftMaxCardinality = this.relationshipType.leftMaxCardinality;
+      return hasNoValue(leftMaxCardinality) || leftMaxCardinality > 1;
+    } else {
+      const rightMaxCardinality = this.relationshipType.rightMaxCardinality;
+      return hasNoValue(rightMaxCardinality) || rightMaxCardinality > 1;
+    }
+  }
+
+  /**
    * Open the dynamic lookup modal to search for items to add as relationships
    */
   openLookup() {
@@ -281,6 +297,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
     modalComp.toAdd = [];
     modalComp.toRemove = [];
     modalComp.isPending = false;
+    modalComp.repeatable = this.isRepeatable();
     modalComp.hiddenQuery = '-search.resourceid:' + this.item.uuid;
 
     this.item.owningCollection.pipe(


### PR DESCRIPTION
## References
DSpace 8 version of #3143 

## Description
This PR fixes an issue in the edit relationship list component where the search modal is always repeatable, regardless of the relationship max cardinality while in the submission forms, you can set it to non-repeatable. 

To make the behaviour more consistent between the submission form modal and the edit relationships modal, the edit relationships modal will now show radio buttons when the max cardinality is set to 1.

## Instructions for Reviewers
- Make sure there is a relationship with max cardinality of one on either the left or the right side and that items are present for both sides of the relationship
- Navigate to an entity that can be linked with the the type with max cardinality 1
- Go to the edit item page > Edit relationships tab and click add on the relevant relationship
- Verify that the modal shows radio buttons and that you can only add one linked item
- Verify that for other relationships you can still add multiple items

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
