### PR TITLE
Fixed bug when declining Google ReCaptcha cookie preferences

### DIFF
--- a/src/app/info/feedback/feedback-form/feedback-form.component.html
+++ b/src/app/info/feedback/feedback-form/feedback-form.component.html
@@ -3,7 +3,7 @@
     <h1>{{ 'info.feedback.head' | translate }}</h1>
     <p>{{ 'info.feedback.info' | translate }}</p>
     <form [formGroup]="feedbackForm" (ngSubmit)="createFeedback()" class="col p-0">
-      <div class="row">
+      <div class="row mt-3">
         <div class="control-group col-sm-12">
           <label class="control-label" for="email">{{ 'info.feedback.email-label' | translate }}&nbsp;</label>
           <input id="email" class="form-control" name="email" type="text" value="" formControlName="email" autofocus="autofocus" title="{{ 'info.feedback.email_help' | translate }}">
@@ -11,29 +11,35 @@
         </div>
       </div>
 
-      <ng-container *ngIf="feedbackForm.controls.email.invalid && (feedbackForm.controls.email.dirty || feedbackForm.controls.email.touched)"
-        class="alert">
-        <ds-error *ngIf="feedbackForm.controls.email.errors?.required" message="{{'info.feedback.error.email.required' | translate}}"></ds-error>
-        <ds-error *ngIf="feedbackForm.controls.email.errors?.pattern" message="{{'info.feedback.error.email.required' | translate}}"></ds-error>
-      </ng-container>
-      <div class="row">
+      <div *ngIf="feedbackForm.controls.email.invalid && (feedbackForm.controls.email.dirty || feedbackForm.controls.email.touched)" class="row">
+        <div class="col-sm-12 alert">
+          <ds-error *ngIf="feedbackForm.controls.email.errors?.required" message="{{'info.feedback.error.email.required' | translate}}"></ds-error>
+          <ds-error *ngIf="feedbackForm.controls.email.errors?.pattern" message="{{'info.feedback.error.email.required' | translate}}"></ds-error>
+        </div>
+      </div>
+
+      <div class="row mt-3">
         <div class="control-group col-sm-12">
           <label class="control-label" for="comments">{{ 'info.feedback.comments' | translate }}:&nbsp;</label>
           <textarea id="comments" formControlName="message" class="form-control" name="message" cols="20" rows="5"> </textarea>
         </div>
       </div>
-      <ng-container *ngIf="feedbackForm.controls.message.invalid && (feedbackForm.controls.message.dirty || feedbackForm.controls.message.touched)"
-        class="alert">
-        <ds-error *ngIf="feedbackForm.controls.message.errors?.required" message="{{'info.feedback.error.message.required' | translate}}"></ds-error>
-      </ng-container>
-      <div class="row">
+
+      <div *ngIf="feedbackForm.controls.message.invalid && (feedbackForm.controls.message.dirty || feedbackForm.controls.message.touched)" class="row">
+        <div class="col-sm-12 alert">
+          <ds-error *ngIf="feedbackForm.controls.message.errors?.required" message="{{'info.feedback.error.message.required' | translate}}"></ds-error>
+        </div>
+      </div>
+
+      <div class="row mt-3">
         <div class="control-group col-sm-12">
           <label class="control-label" for="page">{{ 'info.feedback.page-label' | translate }}&nbsp;</label>
           <input id="page" readonly class="form-control" name="page" type="text" value="" formControlName="page" autofocus="autofocus" title="{{ 'info.feedback.page_help' | translate }}">
           <small class="text-muted">{{ 'info.feedback.page_help' | translate }}</small>
         </div>
       </div>
-      <div class="row py-2">
+
+      <div class="row mt-3">
         <div class="control-group col-sm-12 text-right">
           <button [disabled]="!feedbackForm.valid" class="btn btn-primary" name="submit" type="submit">{{ 'info.feedback.send' | translate }}</button>
         </div>

--- a/src/app/shared/cookies/klaro-configuration.ts
+++ b/src/app/shared/cookies/klaro-configuration.ts
@@ -189,7 +189,6 @@ export const klaroConfiguration: any = {
       purposes: ['registration-password-recovery'],
       required: false,
       cookies: [
-        [/^klaro-.+$/],
         CAPTCHA_COOKIE,
       ],
       onAccept: `window.refreshCaptchaScript?.call()`,


### PR DESCRIPTION
## References
* Fixes #3145
* Port for 7.x: #3147

## Description
Declining the Google reCaptcha cookies, would also make it impossible to save the Klaro preferences cookies themselves because of an incorrect regex added to its configuration. This would mean that your Klaro cookie preferences were automatically removed when declining the Google reCaptcha cookies. This bug was likely the result of copy-pasting previous configurations.

## Instructions for Reviewers
1. Make sure your Google ReCaptcha key is configured in the backend
2. Open a new window where your cookie preferences aren't saved yet (new incognito/private window)
3. a. Click 'Decline' on the cookie pop-up
OR
b. 'Customize' and then 'Accept selected', and make sure the 'Registration and Password recovery' is disabled on the cookies pop-up
4. Refresh the page 
5. The Klaro cookies pop-up should not show again after declining these cookies, and the klaro-anonymous cookie should be stored in your browser

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
