### PR TITLE
[Port dspace-7_x] Fixed bug when declining Google ReCaptcha cookie preferences

### DIFF
--- a/src/app/shared/cookies/klaro-configuration.ts
+++ b/src/app/shared/cookies/klaro-configuration.ts
@@ -183,7 +183,6 @@ export const klaroConfiguration: any = {
       purposes: ['registration-password-recovery'],
       required: false,
       cookies: [
-        [/^klaro-.+$/],
         CAPTCHA_COOKIE
       ],
       onAccept: `window.refreshCaptchaScript?.call()`,


### PR DESCRIPTION
## References
* Fixes #3145 for DSpace 7

## Description
Declining the Google reCaptcha cookies, would also make it impossible to save the Klaro preferences cookies themselves because of an incorrect regex added to its configuration. This would mean that your Klaro cookie preferences were automatically removed when declining the Google reCaptcha cookies. This bug was likely the result of copy-pasting previous configurations.

## Instructions for Reviewers
1. Make sure your Google ReCaptcha key is configured in the backend
2. Open a new window where your cookie preferences aren't saved yet (new incognito/private window)
3. a. Click 'Decline' on the cookie pop-up
OR
b. 'Customize' and then 'Accept selected', and make sure the 'Registration and Password recovery' is disabled on the cookies pop-up
4. Refresh the page 
5. The Klaro cookies pop-up should not show again after declining these cookies, and the klaro-anonymous cookie should be stored in your browser

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
