### PR TITLE
Forward client's user-agent instead of Node's

### DIFF
--- a/src/app/core/forward-client-ip/forward-client-ip.interceptor.ts
+++ b/src/app/core/forward-client-ip/forward-client-ip.interceptor.ts
@@ -18,6 +18,14 @@ export class ForwardClientIpInterceptor implements HttpInterceptor {
    */
   intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const clientIp = this.req.get('x-forwarded-for') || this.req.connection.remoteAddress;
-    return next.handle(httpRequest.clone({ setHeaders: { 'X-Forwarded-For': clientIp } }));
+    const headers = { 'X-Forwarded-For': clientIp };
+
+    // if the request has a user-agent retain it
+    const userAgent = this.req.get('user-agent');
+    if (userAgent) {
+      headers['User-Agent'] = userAgent;
+    }
+
+    return next.handle(httpRequest.clone({ setHeaders: headers }));
   }
 }


### PR DESCRIPTION
## References
* Fixes #2902

## Description
Forward the client's user-agent instead of Node's. Code by @mark-cooper in https://github.com/DSpace/dspace-angular/issues/2902#issuecomment-2067342387.

## Instructions for Reviewers

List of changes in this PR:
* Adjust `forward-client-ip` component to also forward the client's user-agent along with the client's IP

*Note: there was a small discussion about whether to rename the `forward-client-ip` component to `forward-client-headers` and the consensus seemed to be that it was not important for 7.x and 8.x, but maybe we can do that for 9.0.*

**Include guidance for how to test or review your PR.**

To see the client headers you must look in the web server logs, which mean you must run the modified code on a server which has a full set up like Apache HTTPD or Nginx etc. Where before you would see Node.js's user-agent header, you should now see the actual user-agent of the client.

For example, when loading the home page in a web browser, the backend server / API logs used to show:

```console
41.18.204.190 - - [25/Jun/2024:08:55:52 +0200] "GET /server/api HTTP/1.1" 200 7180 "-" "Mozilla/5.0 (Linux x64) node.js/18.17.1 v8/10.2.154.26-node.26"
41.18.204.190 - - [25/Jun/2024:08:55:52 +0200] "GET /server/api/authn/status HTTP/1.1" 200 447 "-" "Mozilla/5.0 (Linux x64) node.js/18.17.1 v8/10.2.154.26-node.26"
```

With this patch they should show:

```console
41.18.204.190 - - [25/Jun/2024:08:55:55 +0200] "GET /server/api HTTP/1.1" 200 7381 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"        
41.18.204.190 - - [25/Jun/2024:08:55:55 +0200] "GET /server/api/authn/status HTTP/1.1" 200 456 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
