### PR TITLE
Various browse link rendering fixes (value vs startsWith, authority checks)

### DIFF
--- a/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.ts
+++ b/src/app/core/shared/metadata-representation/item/item-metadata-representation.model.ts
@@ -41,4 +41,11 @@ export class ItemMetadataRepresentation extends Item implements MetadataRepresen
     return this.virtualMetadata.value;
   }
 
+  /**
+   * Get the authority key of the virtual metadata value (which should have virtual:: prefix itself)
+   */
+  getAuthority(): string {
+    return this.virtualMetadata.authority;
+  }
+
 }

--- a/src/app/core/shared/metadata-representation/metadata-representation.model.ts
+++ b/src/app/core/shared/metadata-representation/metadata-representation.model.ts
@@ -37,4 +37,9 @@ export interface MetadataRepresentation {
    */
   getValue(): string;
 
+  /**
+   * Fetches the authority key which may also be needed for display
+   */
+  getAuthority(): string;
+
 }

--- a/src/app/core/shared/metadata-representation/metadatum/metadatum-representation.model.ts
+++ b/src/app/core/shared/metadata-representation/metadatum/metadatum-representation.model.ts
@@ -47,4 +47,10 @@ export class MetadatumRepresentation extends MetadataValue implements MetadataRe
     return this.value;
   }
 
+  /**
+   * Get the authority key
+   */
+  getAuthority(): string {
+    return this.authority;
+  }
 }

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -4,44 +4,44 @@
       Choose a template. Priority: markdown, link, browse link.
       -->
       <ng-container *ngTemplateOutlet="(renderMarkdown ? markdown : (hasLink(mdValue) ? (hasValue(img) ? linkImg : link) : (hasBrowseDefinition() ? browselink : simple)));
-        context: {value: mdValue.value, img}">
+        context: {mdValue: mdValue, img}">
       </ng-container>
       <span class="separator" *ngIf="!last" [innerHTML]="separator"></span>
     </ng-container>
 </ds-metadata-field-wrapper>
 
 <!-- Render value as markdown -->
-<ng-template #markdown let-value="value">
-  <span class="dont-break-out" [dsMarkdown]="value">
+<ng-template #markdown let-mdValue="mdValue">
+  <span class="dont-break-out" [dsMarkdown]="mdValue.value">
   </span>
 </ng-template>
 
 <!-- Render value as a link (href and label) -->
-<ng-template #link let-value="value">
-    <a class="dont-break-out ds-simple-metadata-link" target="_blank" [href]="value">
-      {{value}}
+<ng-template #link let-mdValue="mdValue">
+    <a class="dont-break-out ds-simple-metadata-link" target="_blank" [href]="mdValue.value">
+      {{mdValue.value}}
     </a>
 </ng-template>
 
 <!-- Render value as a link with icon -->
-<ng-template #linkImg let-img="img" let-value="value">
-  <a [href]="value" class="link-anchor dont-break-out ds-simple-metadata-link" target="_blank">
+<ng-template #linkImg let-img="img" let-mdValue="mdValue">
+  <a [href]="mdValue.value" class="link-anchor dont-break-out ds-simple-metadata-link" target="_blank">
     <img class="link-logo"
       [alt]="img.alt | translate"
       [style.height]="'var(' + img.heightVar + ', --ds-item-page-img-field-default-inline-height)'"
       [src]="img.URI"/>
-    {{value}}
+    {{mdValue.value}}
   </a>
 </ng-template>
 
 <!-- Render simple value in a span  -->
-<ng-template #simple let-value="value">
-  <span class="dont-break-out preserve-line-breaks">{{value}}</span>
+<ng-template #simple let-mdValue="mdValue">
+  <span class="dont-break-out preserve-line-breaks">{{mdValue.value}}</span>
 </ng-template>
 
 <!-- Render value as a link to browse index -->
-<ng-template #browselink let-value="value">
+<ng-template #browselink let-mdValue="mdValue">
   <a class="dont-break-out preserve-line-breaks ds-browse-link"
      [routerLink]="['/browse', browseDefinition.id]"
-     [queryParams]="getQueryParams(value)">{{value}}</a>
+     [queryParams]="getQueryParams(mdValue)">{{mdValue.value}}</a>
 </ng-template>

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -19,10 +19,14 @@ import {
   AppConfig,
 } from '../../../../config/app-config.interface';
 import { environment } from '../../../../environments/environment';
+import { BrowseByDataType } from '../../../browse-by/browse-by-switcher/browse-by-data-type';
+import { MetadataService } from '../../../core/metadata/metadata.service';
 import { BrowseDefinition } from '../../../core/shared/browse-definition.model';
 import { MetadataValue } from '../../../core/shared/metadata.models';
-import { VALUE_LIST_BROWSE_DEFINITION } from '../../../core/shared/value-list-browse-definition.resource-type';
-import { hasValue } from '../../../shared/empty.util';
+import {
+  hasValue,
+  isNotEmpty,
+} from '../../../shared/empty.util';
 import { MetadataFieldWrapperComponent } from '../../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
 import { MarkdownDirective } from '../../../shared/utils/markdown.directive';
 import { ImageField } from '../../simple/field-components/specific-field/image-field';
@@ -42,6 +46,7 @@ export class MetadataValuesComponent implements OnChanges {
 
   constructor(
     @Inject(APP_CONFIG) private appConfig: AppConfig,
+    private metadataService: MetadataService,
   ) {
   }
 
@@ -112,17 +117,18 @@ export class MetadataValuesComponent implements OnChanges {
 
   /**
    * Return a queryparams object for use in a link, with the key dependent on whether this browse
-   * definition is metadata browse, or item browse
-   * @param value the specific metadata value being linked
+   * definition is metadata browse, or item browse, and whether or not an authority key is included
+   * @param mdValue the specific metadata value being linked
    */
-  getQueryParams(value) {
-    const queryParams = { startsWith: value };
-    // todo: should compare with type instead?
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    if (this.browseDefinition.getRenderType() === VALUE_LIST_BROWSE_DEFINITION.value) {
-      return { value: value };
+  getQueryParams(mdValue: MetadataValue) {
+    if (this.browseDefinition.getRenderType() === BrowseByDataType.Metadata) {
+      if (isNotEmpty(mdValue.authority) && !this.metadataService.isVirtual(mdValue)) {
+        return { value: mdValue.value, authority: mdValue.authority };
+      } else {
+        return { value: mdValue.value };
+      }
     }
-    return queryParams;
+    return { startsWith: mdValue.value };
   }
 
 

--- a/src/app/shared/object-list/metadata-representation-list-element/browse-link/browse-link-metadata-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/browse-link/browse-link-metadata-list-element.component.ts
@@ -2,7 +2,6 @@ import { NgIf } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { VALUE_LIST_BROWSE_DEFINITION } from '../../../../core/shared/value-list-browse-definition.resource-type';
 import { MetadataRepresentationListElementComponent } from '../metadata-representation-list-element.component';
 
 @Component({
@@ -16,17 +15,5 @@ import { MetadataRepresentationListElementComponent } from '../metadata-represen
  * It will simply use the value retrieved from MetadataRepresentation.getValue() to display as plain text
  */
 export class BrowseLinkMetadataListElementComponent extends MetadataRepresentationListElementComponent {
-  /**
-   * Get the appropriate query parameters for this browse link, depending on whether the browse definition
-   * expects 'startsWith' (eg browse by date) or 'value' (eg browse by title)
-   */
-  getQueryParams() {
-    const queryParams = { startsWith: this.mdRepresentation.getValue() };
-    // todo: should compare with type instead?
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    if (this.mdRepresentation.browseDefinition.getRenderType() === VALUE_LIST_BROWSE_DEFINITION.value) {
-      return { value: this.mdRepresentation.getValue() };
-    }
-    return queryParams;
-  }
+
 }

--- a/src/app/shared/object-list/metadata-representation-list-element/metadata-representation-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/metadata-representation-list-element.component.ts
@@ -3,8 +3,11 @@ import {
   Input,
 } from '@angular/core';
 
+import { BrowseByDataType } from '../../../browse-by/browse-by-switcher/browse-by-data-type';
 import { Context } from '../../../core/shared/context.model';
+import { VIRTUAL_METADATA_PREFIX } from '../../../core/shared/metadata.models';
 import { MetadataRepresentation } from '../../../core/shared/metadata-representation/metadata-representation.model';
+import { hasValue } from '../../empty.util';
 
 @Component({
   selector: 'ds-metadata-representation-list-element',
@@ -15,6 +18,7 @@ import { MetadataRepresentation } from '../../../core/shared/metadata-representa
  * An abstract class for displaying a single MetadataRepresentation
  */
 export class MetadataRepresentationListElementComponent {
+
   /**
    * The optional context
    */
@@ -32,6 +36,29 @@ export class MetadataRepresentationListElementComponent {
     // Match any string that begins with http:// or https://
     const linkPattern = new RegExp(/^https?:\/\/.*/);
     return linkPattern.test(this.mdRepresentation.getValue());
+  }
+
+  /**
+   * Get the appropriate query parameters for this browse link, depending on whether the browse definition
+   * expects 'startsWith' (eg browse by date) or 'value' (eg browse by title)
+   */
+  getQueryParams() {
+    const queryParams = { startsWith: this.mdRepresentation.getValue() };
+    // todo: should compare with type instead?
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    if (this.mdRepresentation.browseDefinition.getRenderType() === BrowseByDataType.Metadata) {
+      if (hasValue(this.mdRepresentation.getAuthority()) && !this.isVirtual(this.mdRepresentation)) {
+        return { value: this.mdRepresentation.getValue(), authority: this.mdRepresentation.getAuthority() };
+      } else {
+        return { value: this.mdRepresentation.getValue() };
+      }
+    }
+    return queryParams;
+  }
+
+  private isVirtual(metadataRepresentation: MetadataRepresentation | undefined): boolean {
+    return hasValue(metadataRepresentation?.getAuthority()) && metadataRepresentation.getAuthority()
+      .startsWith(VIRTUAL_METADATA_PREFIX);
   }
 
 }

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
@@ -16,17 +16,5 @@ import { MetadataRepresentationListElementComponent } from '../metadata-represen
  * It will simply use the value retrieved from MetadataRepresentation.getValue() to display as plain text
  */
 export class PlainTextMetadataListElementComponent extends MetadataRepresentationListElementComponent {
-  /**
-   * Get the appropriate query parameters for this browse link, depending on whether the browse definition
-   * expects 'startsWith' (eg browse by date) or 'value' (eg browse by title)
-   */
-  getQueryParams() {
-    const queryParams = { startsWith: this.mdRepresentation.getValue() };
-    // todo: should compare with type instead?
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-    if (this.mdRepresentation.browseDefinition.getRenderType() === VALUE_LIST_BROWSE_DEFINITION.value) {
-      return { value: this.mdRepresentation.getValue() };
-    }
-    return queryParams;
-  }
+
 }


### PR DESCRIPTION
Various browse link rendering fixes (value vs startsWith, authority checks)

## References
* Fixes #2955 
* This is an alternate fix of PR #2949. @wwelling , we had different approaches to this so I'm interested to hear any feedback you have. This PR can be backported to 7.x fairly easily (my first dev version was for 7.x).

## Description
Browse links for metadata representations and plain values were incorrectly (or confusingly?) comparing the `getRenderType()` of the browse definition (e.g. text, date, item) to e.g. `VALUE_LIST_BROWSE_DEFINITION.value` (e.g. valueList, flatBrowse, etc.).

Since browse links were not supported in early 7.x, I think there was some mismatch of render hints and configuration when they did get introduced. I think  using BrowseDataType enums makes the most sense for matching our configuration and expected behaviour:
```
export enum BrowseByDataType {
  Title = 'title',
  Metadata = 'text',
  Date = 'date',
  Hierarchy = 'hierarchy',
}
```

These are the browse by pages we want our links to route to, based on the last segment of the configuration as below:
```
webui.browse.index.1 = dateissued:item:dateissued
webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text
webui.browse.index.3 = title:item:title
webui.browse.index.4 = subject:metadata:dc.subject.*:text
```

In addition, I extended the MetadataRepresentation model to allow a `getAuthority` getter: this is necessary as it's not enough to say "is authority controlled" when passing a value to be rendered as a browse link -- we also need the key.

I shifted `getQueryParams()` to the parent MetadataRepresentationListElement component and changed its behaviour, along with the same method for MetadataValues component:

* If the the browse definition render type (data type) is `BrowseByDataType.Metadata`, then:
  * If the metadata value or representation has non-virtual authority key (does not start with virtual::) then return value and authority as query params
  * Otherwise just return value in query params
* Otherwise, just return startsWith in query params 
 
## Instructions for Reviewers
Compare the behaviour of dspace-8.0 / main branch with this PR. The default dspace.cfg is enough to run with but I recommend adding some additional `webui.browse.link.<n>` configs like subject, and testing different data type config in the last segment, and compare results when using both `<ds-generic-item-page-field>` components (metadata value lists) and `<ds-metadata-representation-list>` components (reps of related items _or_ values, with different components responsible for actual value display)

## Other notes

As I noted, this might need discussion. I think some of the way we have separated representations from item page fields -> values leads to a bit of duplicate handling and confusion in some areas... I also might have fixed this the 'wrong' way around, if browse definition `getRenderType()` is not actually suppose to return the data type from configuration (which is what @wwelling 's PR #2949 seems to suggest?)

## Needs tests

If this PR looks good conceptually, it needs tests to handle extension of metadata rep model, and changes in query param methods.

- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
