### PR TITLE
Make the CC license field component configurable in DSpace 8.0

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -502,7 +502,22 @@ notifyMetrics:
     config: 'NOTIFY.outgoing.delivered'
     description: 'admin-notify-dashboard.NOTIFY.outgoing.delivered.description'
 
-
+# Creative Commons metadata fields
+ccLicense:
+  # Icon variant:
+  # 'full' variant shows image, a disclaimer (optional) and name (always), better for the item page content.
+  # 'small' (default) variant shows image and name (optional), better for the item page sidebar
+  variant: small
+  # Field name containing the CC license URI, as configured in the back-end, in the 'dspace.cfg' file, property 'cc.license.uri'
+  # Defaults to 'dc.rights.uri'
+  uriField: dc.rights.uri
+  # Field name containing the CC license name, as configured in the back-end, in the 'dspace.cfg' file, property 'cc.license'
+  # Defaults to 'dc.rights'
+  nameField: dc.rights
+  # Shows the CC license name with the image. Always show if image fails to load
+  showName: true
+  # Shows the disclaimer in the 'full' variant of the component
+  showDisclaimer: true
 
 
 

--- a/src/app/item-page/simple/field-components/specific-field/cc-license/item-page-cc-license-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/cc-license/item-page-cc-license-field.component.ts
@@ -5,12 +5,17 @@ import {
 } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Item } from 'src/app/core/shared/item.model';
 import { MetadataFieldWrapperComponent } from 'src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from 'src/config/app-config.interface';
 
 @Component({
   selector: 'ds-item-page-cc-license-field',
@@ -31,34 +36,37 @@ export class ItemPageCcLicenseFieldComponent implements OnInit {
    * 'full' variant shows image, a disclaimer (optional) and name (always), better for the item page content.
    * 'small' variant shows image and name (optional), better for the item page sidebar
    */
-  @Input() variant?: 'small' | 'full' = 'small';
+  @Input() variant?: 'small' | 'full' = this.appConfig.ccLicense.variant;
 
   /**
-   * Filed name containing the CC license URI, as configured in the back-end, in the 'dspace.cfg' file, propertie
-   * 'cc.license.uri'
+   * Field name containing the CC license URI
    */
-  @Input() ccLicenseUriField? = 'dc.rights.uri';
+  @Input() ccLicenseUriField? = this.appConfig.ccLicense.uriField;
 
   /**
-   * Filed name containing the CC license name, as configured in the back-end, in the 'dspace.cfg' file, propertie
-   * 'cc.license.name'
+   * Field name containing the CC license name
    */
-  @Input() ccLicenseNameField? = 'dc.rights';
+  @Input() ccLicenseNameField? = this.appConfig.ccLicense.nameField;
 
   /**
    * Shows the CC license name with the image. Always show if image fails to load
    */
-  @Input() showName? = true;
+  @Input() showName? = this.appConfig.ccLicense.showName;
 
   /**
    * Shows the disclaimer in the 'full' variant of the component
    */
-  @Input() showDisclaimer? = true;
+  @Input() showDisclaimer? = this.appConfig.ccLicense.showDisclaimer;
 
   uri: string;
   name: string;
   showImage = true;
   imgSrc: string;
+
+  constructor(
+    @Inject(APP_CONFIG) public appConfig: AppConfig,
+  ) {
+  }
 
   ngOnInit() {
     this.uri = this.item.firstMetadataValue(this.ccLicenseUriField);

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -15,6 +15,7 @@ import { CollectionPageConfig } from './collection-page-config.interface';
 import { CommunityListConfig } from './community-list-config.interface';
 import { CommunityPageConfig } from './community-page-config.interface';
 import { Config } from './config.interface';
+import { CreativeCommonsLicenseConfig } from './creative-commons-license-config.interface';
 import { DiscoverySortConfig } from './discovery-sort.config';
 import { FilterVocabularyConfig } from './filter-vocabulary-config';
 import { FormConfig } from './form-config.interfaces';
@@ -63,6 +64,7 @@ interface AppConfig extends Config {
   qualityAssuranceConfig: QualityAssuranceConfig;
   search: SearchConfig;
   notifyMetrics: AdminNotifyMetricsRow[];
+  ccLicense: CreativeCommonsLicenseConfig;
 }
 
 /**

--- a/src/config/creative-commons-license-config.interface.ts
+++ b/src/config/creative-commons-license-config.interface.ts
@@ -1,0 +1,34 @@
+import { Config } from './config.interface';
+
+export interface CreativeCommonsLicenseConfig extends Config {
+
+    /**
+     * CC icon variant ('small' or 'full')
+     * Used by {@link ItemPageCcLicenseFieldComponent}.
+     */
+    variant: 'small' | 'full';
+
+    /**
+     * Field name containing the CC license URI
+     * Used by {@link ItemPageCcLicenseFieldComponent}.
+     */
+    uriField: string;
+
+    /**
+     * Field name containing the CC license URI
+     * Used by {@link ItemPageCcLicenseFieldComponent}.
+     */
+    nameField: string;
+
+    /**
+     * Shows the CC license name with the image. Always show if image fails to load
+     * Used by {@link ItemPageCcLicenseFieldComponent}.
+     */
+    showName: boolean;
+
+    /**
+     * Show the disclaimer in the 'full' variant of the component
+     * Used by {@link ItemPageCcLicenseFieldComponent}.
+     */
+    showDisclaimer: boolean;
+}

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -10,6 +10,7 @@ import { CacheConfig } from './cache-config.interface';
 import { CollectionPageConfig } from './collection-page-config.interface';
 import { CommunityListConfig } from './community-list-config.interface';
 import { CommunityPageConfig } from './community-page-config.interface';
+import { CreativeCommonsLicenseConfig } from './creative-commons-license-config.interface';
 import { DiscoverySortConfig } from './discovery-sort.config';
 import { FilterVocabularyConfig } from './filter-vocabulary-config';
 import { FormConfig } from './form-config.interfaces';
@@ -591,4 +592,12 @@ export class DefaultAppConfig implements AppConfig {
       ],
     },
   ];
+  // Metadatafields to determine the CC license variant
+  ccLicense: CreativeCommonsLicenseConfig = {
+    variant: 'small',
+    uriField: 'dc.rights.uri',
+    nameField: 'dc.rights',
+    showName: true,
+    showDisclaimer: true,
+  };
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -422,4 +422,11 @@ export const environment: BuildConfig = {
       ],
     },
   ],
+  ccLicense: {
+    variant: 'small',
+    uriField: 'dc.rights.uri',
+    nameField: 'dc.rights',
+    showName: true,
+    showDisclaimer: true,
+  },
 };


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
This PR does not directly address an open issue, but improves PR #3010 that addressed #3002.

## Description
The `ItemPageCcLicenseFieldComponent`implemented in #3010 has some configuration properties that, however, are hardcoded in the component itself and require manual modifications of the typescript code.

Since at least two configuration properties are indeed easily configurable in the back end (license URI field and license name field), makes sense that the front-end allows to tweak them.

This PR adds these configuration options (and some others) to the application config, so that no more modifications are required at the code level.

## Instructions for Reviewers

1. Run the front-end with the default DSpace 8.0 configuration.
2. Create an item, and set its `dc.rights.uri` and `dc.rights` to a valid value (e.g., `https://creativecommons.org/licenses/by-nc-nd/4.0/` and `CC BY-NC-ND 4.0` respectively) and see the Creative Commons badge to appear.
3. Delete the `dc.rights` metadata value and refresh the item. The CC badge will not show (the `ItemPageCcLicenseFieldComponent` requires both the CC uri and CC name to be set).
4. Create a new `dc.rights.license` metadata value with the value `CC BY-NC-ND 4.0`. Refresh the item, and the badge will still not be shown (since only `dc.right.uri` will be found with the default configuration).
5. Shutdown the front-end, and add the following configuration to your app config:
```
ccLicense:
  # Field name containing the CC license name, as configured in the back-end, in the 'dspace.cfg' file, property 'cc.license'
  # Defaults to 'dc.rights'
  nameField: dc.rights.license
```
6. Start the front-end, and the CC badge will now appear in the item.

Other properties that ca be configured are:

```
# Creative Commons metadata fields
ccLicense:
  # Icon variant:
  # 'full' variant shows image, a disclaimer (optional) and name (always), better for the item page content.
  # 'small' (default) variant shows image and name (optional), better for the item page sidebar
  variant: small
  # Field name containing the CC license URI, as configured in the back-end, in the 'dspace.cfg' file, property 'cc.license.uri'
  # Defaults to 'dc.rights.uri'
  uriField: dc.rights.uri
  # Field name containing the CC license name, as configured in the back-end, in the 'dspace.cfg' file, property 'cc.license'
  # Defaults to 'dc.rights'
  nameField: dc.rights
  # Shows the CC license name with the image. Always show if image fails to load
  showName: true
  # Shows the disclaimer in the 'full' variant of the component
  showDisclaimer: true
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
