### PR TITLE
Docker build: fix FromAsCasing warning

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -4,7 +4,7 @@
 # Test build:
 # docker build -f Dockerfile.dist -t dspace/dspace-angular:latest-dist .
 
-FROM node:18-alpine as build
+FROM node:18-alpine AS build
 
 # Ensure Python and other build tools are available
 # These are needed to install some node modules, especially on linux/arm64


### PR DESCRIPTION
## Description

This PR fixes a warn message that occurs when the Docker image is being built:

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```