### PR TITLE
Fix truncatable-part keyboard accessibility

### DIFF
--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.html
@@ -2,12 +2,16 @@
   <div #content class="content dont-break-out preserve-line-breaks">
     <ng-content></ng-content>
   </div>
-  <button class="btn btn-link p-0 expandButton" dsDragClick (actualClick)="toggle()">
-    <i class="fas fa-angle-down"></i>
-    <span class="ml-1">{{ 'item.truncatable-part.show-more' | translate }}</span>
-  </button>
-  <button class="btn btn-link p-0 collapseButton" dsDragClick (actualClick)="toggle()" *ngIf="expand && expandable">
-    <i class="fas fa-angle-up"></i>
-    <span class="ml-1">{{ 'item.truncatable-part.show-less' | translate }}</span>
+  <button
+    class="btn btn-link p-0 {{isExpanded ? 'collapseButton' : 'expandButton'}}"
+    dsDragClick
+    (actualClick)="toggle()"
+    (keyup.Enter)="toggle()"
+    (keyup.Space)="toggle()"
+    role="button"
+    [attr.aria-expanded]="isExpanded"
+  >
+    <i class="fas {{isExpanded ? 'fa-angle-up' : 'fa-angle-down'}}"></i>
+    <span class="ml-1">{{ 'item.truncatable-part.show-' + (isExpanded ? 'less' : 'more') | translate }}</span>
   </button>
 </div>

--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.spec.ts
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.spec.ts
@@ -87,6 +87,11 @@ describe('TruncatablePartComponent', () => {
       const a = fixture.debugElement.query(By.css('.collapseButton'));
       expect(a).toBeNull();
     });
+
+    it('expandButton aria-expanded should be false', () => {
+      const btn = fixture.debugElement.query(By.css('.expandButton'));
+      expect(btn.nativeElement.getAttribute('aria-expanded')).toEqual('false');
+    });
   });
 
   describe('When the item is expanded', () => {
@@ -114,6 +119,14 @@ describe('TruncatablePartComponent', () => {
       fixture.detectChanges();
       const a = fixture.debugElement.query(By.css('.collapseButton'));
       expect(a).not.toBeNull();
+    });
+
+    it('collapseButton aria-expanded should be true', () => {
+      (comp as any).setLines();
+      (comp as any).expandable = true;
+      fixture.detectChanges();
+      const btn = fixture.debugElement.query(By.css('.collapseButton'));
+      expect(btn.nativeElement.getAttribute('aria-expanded')).toEqual('true');
     });
   });
 });

--- a/src/app/shared/truncatable/truncatable-part/truncatable-part.component.ts
+++ b/src/app/shared/truncatable/truncatable-part/truncatable-part.component.ts
@@ -151,6 +151,13 @@ export class TruncatablePartComponent implements AfterViewChecked, OnInit, OnDes
   }
 
   /**
+   * Indicates if the content is expanded, button state is 'Collapse'
+   */
+  public get isExpanded() {
+    return this.expand && this.expandable;
+  }
+
+  /**
    * Unsubscribe from the subscription
    */
   ngOnDestroy(): void {


### PR DESCRIPTION
## References

Fixes #3073

## Description
Fixes keyboard shortcuts of the truncatable-part component, used in the 'Show more' button.

## Instructions for Reviewers

- Go to a page that lists items, such as the home page or a search, with at least one of the items having content long enough for the "Show More" button to be displayed. 
- Click anywhere in a blank area near the item list. Cycle through the DOM elements using the TAB key.
- When the 'Show More'/'Collapse' button is highlighted, you can toggle it using the Enter key or the spacebar.
- Button still works using the mouse

List of changes in this PR:

* truncatable-part.component.html:    
  - Refactored/simplified the 'Show more' and 'Collapse' buttons into a single button element
  - Added event bindings for the enter key and the spacebar
  - Added [aria-expanded](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
