### PR TITLE
Enabling navbar links in import section

### DIFF
--- a/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.html
+++ b/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.html
@@ -1,12 +1,12 @@
 <div ng2FileDrop
-     class="ds-document-drop-zone position-fixed h-100 w-100"
+     class="ds-document-drop-zone h-100 w-100"
      [class.ds-document-drop-zone-active]="(isOverDocumentDropZone | async)"
      [uploader]="uploader"
      (onFileDrop)="setFile($event)"
      (fileOver)="fileOverDocument($event)">
 </div>
 <div *ngIf="(isOverDocumentDropZone | async)"
-     class="ds-document-drop-zone-inner position-fixed h-100 w-100 p-2">
+     class="ds-document-drop-zone-inner h-100 w-100 p-2">
   <div
     class="ds-document-drop-zone-inner-content position-relative d-flex flex-column justify-content-center text-center h-100 w-100">
     <p class="text-primary">{{ dropMessageLabel | translate}}</p>

--- a/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.html
+++ b/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.html
@@ -1,12 +1,12 @@
 <div ng2FileDrop
-     class="ds-document-drop-zone h-100 w-100"
+     class="ds-document-drop-zone position-fixed h-100 w-100"
      [class.ds-document-drop-zone-active]="(isOverDocumentDropZone | async)"
      [uploader]="uploader"
      (onFileDrop)="setFile($event)"
      (fileOver)="fileOverDocument($event)">
 </div>
 <div *ngIf="(isOverDocumentDropZone | async)"
-     class="ds-document-drop-zone-inner h-100 w-100 p-2">
+     class="ds-document-drop-zone-inner position-fixed h-100 w-100 p-2">
   <div
     class="ds-document-drop-zone-inner-content position-relative d-flex flex-column justify-content-center text-center h-100 w-100">
     <p class="text-primary">{{ dropMessageLabel | translate}}</p>

--- a/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.scss
+++ b/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.scss
@@ -6,10 +6,16 @@
   top: 0;
   left: 0;
   z-index: -1;
+  display: block;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 
 .ds-document-drop-zone-active {
   z-index: var(--ds-drop-zone-area-z-index) !important;
+  opacity: 1;
+  visibility: visible;
 }
 
 .ds-document-drop-zone-inner {


### PR DESCRIPTION
## References
* Fixes #3189

## Description
The “position-fixed” bootstrap class in the html of the “ds-file-dropzone-no-uploader” component was getting in the way of the navbar links.

## Instructions for Reviewers
List of changes in this PR:
* The bootstrap class “position-fixed” on lines 2 and 9 in the html of the “ds-file-dropzone-no-uploader” component has been removed.

To reproduce:
1. Log in to DSpace as an administrator.
2. Reveal the left-hand sidebar menu, click Import and then click either Metadata or Batch Import (ZIP).
3. See that the navigation links in the header are available again.