### PR TITLE
Removed unnecessary *ngVars from ThumbnailComponent

### DIFF
--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -1,4 +1,4 @@
-<div class="thumbnail" [class.limit-width]="limitWidth" *ngVar="(isLoading$ | async) as isLoading">
+<div class="thumbnail" [class.limit-width]="limitWidth">
   <div *ngIf="isLoading" class="thumbnail-content outer">
     <div class="inner">
       <div class="centered">
@@ -6,16 +6,14 @@
       </div>
     </div>
   </div>
-  <ng-container *ngVar="(src$ | async) as src">
-    <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-    <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
-         [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
-    <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
-      <div class="inner">
-        <div class="thumbnail-placeholder centered lead">
-          {{ placeholder | translate }}
-        </div>
+  <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
+  <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+       [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
+  <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
+    <div class="inner">
+      <div class="thumbnail-placeholder centered lead">
+        {{ placeholder | translate }}
       </div>
     </div>
-  </ng-container>
+  </div>
 </div>

--- a/src/app/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/thumbnail/thumbnail.component.spec.ts
@@ -96,31 +96,31 @@ describe('ThumbnailComponent', () => {
 
   describe('loading', () => {
     it('should start out with isLoading$ true', () => {
-      expect(comp.isLoading$.getValue()).toBeTrue();
+      expect(comp.isLoading).toBeTrue();
     });
 
     it('should set isLoading$ to false once an image is successfully loaded', () => {
       comp.setSrc('http://bit.stream');
       fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
-      expect(comp.isLoading$.getValue()).toBeFalse();
+      expect(comp.isLoading).toBeFalse();
     });
 
     it('should set isLoading$ to false once the src is set to null', () => {
       comp.setSrc(null);
-      expect(comp.isLoading$.getValue()).toBeFalse();
+      expect(comp.isLoading).toBeFalse();
     });
 
     it('should show a loading animation while isLoading$ is true', () => {
       expect(de.query(By.css('ds-loading'))).toBeTruthy();
 
-      comp.isLoading$.next(false);
+      comp.isLoading = false;
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('ds-loading'))).toBeFalsy();
     });
 
     describe('with a thumbnail image', () => {
       beforeEach(() => {
-        comp.src$.next('https://bit.stream');
+        comp.src = 'https://bit.stream';
         fixture.detectChanges();
       });
 
@@ -129,7 +129,7 @@ describe('ThumbnailComponent', () => {
         expect(img).toBeTruthy();
         expect(img.classes['d-none']).toBeTrue();
 
-        comp.isLoading$.next(false);
+        comp.isLoading = false;
         fixture.detectChanges();
         img = fixture.debugElement.query(By.css('img.thumbnail-content'));
         expect(img).toBeTruthy();
@@ -140,14 +140,14 @@ describe('ThumbnailComponent', () => {
 
     describe('without a thumbnail image', () => {
       beforeEach(() => {
-        comp.src$.next(null);
+        comp.src = null;
         fixture.detectChanges();
       });
 
       it('should only show the HTML placeholder once done loading', () => {
         expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
 
-        comp.isLoading$.next(false);
+        comp.isLoading = false;
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
       });
@@ -243,14 +243,14 @@ describe('ThumbnailComponent', () => {
   describe('fallback', () => {
     describe('if there is a default image', () => {
       it('should display the default image', () => {
-        comp.src$.next('http://bit.stream');
+        comp.src = 'http://bit.stream';
         comp.defaultImage = 'http://default.img';
         comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(comp.defaultImage);
+        expect(comp.src).toBe(comp.defaultImage);
       });
 
       it('should include the alt text', () => {
-        comp.src$.next('http://bit.stream');
+        comp.src = 'http://bit.stream';
         comp.defaultImage = 'http://default.img';
         comp.errorHandler();
 
@@ -262,10 +262,10 @@ describe('ThumbnailComponent', () => {
 
     describe('if there is no default image', () => {
       it('should display the HTML placeholder', () => {
-        comp.src$.next('http://default.img');
+        comp.src = 'http://default.img';
         comp.defaultImage = null;
         comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(null);
+        expect(comp.src).toBe(null);
 
         fixture.detectChanges();
         const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
@@ -357,7 +357,7 @@ describe('ThumbnailComponent', () => {
       it('should show the default image', () => {
         comp.defaultImage = 'default/image.jpg';
         comp.ngOnChanges({});
-        expect(comp.src$.getValue()).toBe('default/image.jpg');
+        expect(comp.src).toBe('default/image.jpg');
       });
     });
   });

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -6,10 +6,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  BehaviorSubject,
-  of as observableOf,
-} from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { AuthService } from '../core/auth/auth.service';
@@ -53,7 +50,7 @@ export class ThumbnailComponent implements OnChanges {
   /**
    * The src attribute used in the template to render the image.
    */
-  src$ = new BehaviorSubject<string>(undefined);
+  src: string = undefined;
 
   retriedWithToken = false;
 
@@ -76,7 +73,7 @@ export class ThumbnailComponent implements OnChanges {
    * Whether the thumbnail is currently loading
    * Start out as true to avoid flashing the alt text while a thumbnail is being loaded.
    */
-  isLoading$ = new BehaviorSubject(true);
+  isLoading = true;
 
   constructor(
     protected auth: AuthService,
@@ -129,7 +126,7 @@ export class ThumbnailComponent implements OnChanges {
    * Otherwise, fall back to the default image or a HTML placeholder
    */
   errorHandler() {
-    const src = this.src$.getValue();
+    const src = this.src;
     const thumbnail = this.bitstream;
     const thumbnailSrc = thumbnail?._links?.content?.href;
 
@@ -181,9 +178,9 @@ export class ThumbnailComponent implements OnChanges {
    * @param src
    */
   setSrc(src: string): void {
-    this.src$.next(src);
+    this.src = src;
     if (src === null) {
-      this.isLoading$.next(false);
+      this.isLoading = false;
     }
   }
 
@@ -191,6 +188,6 @@ export class ThumbnailComponent implements OnChanges {
    * Stop the loading animation once the thumbnail is successfully loaded
    */
   successHandler() {
-    this.isLoading$.next(false);
+    this.isLoading = false;
   }
 }


### PR DESCRIPTION
## References
* Fixes #3134

## Description
This PR removes the unnecessary `*ngVar`s in the `ThumbnailComponent`. When you disable caching and you run dspace in prod mode you will still be able to see that the content is retrieved twice, but this can't be avoided. The first time it is triggered by the SSR and the second time by CSR. We can't change that, but we should still remove the `*ngVar`s since they are actually not necessary and `*ngVar`s also trigger `fixture.detectChanges()` every time there is interaction with the template so that's not really good for performance.

## Instructions for Reviewers
We actually don't need those `BehaviourSubject`s because we don't subscribe to them except in the template, so I just converted them back to regular string/boolean fields. Everything should still work like they did before.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
