### PR TITLE
WorkspaceitemsEditPageModule: remove duplicated delete route

### DIFF
--- a/src/app/workspaceitems-edit-page/workspaceitems-edit-page-routes.ts
+++ b/src/app/workspaceitems-edit-page/workspaceitems-edit-page-routes.ts
@@ -50,16 +50,6 @@ export const ROUTES: Route[] = [
         },
         data: { title: 'workspace-item.delete', breadcrumbKey: 'workspace-item.delete' },
       },
-      {
-        canActivate: [authenticatedGuard],
-        path: 'delete',
-        component: ThemedWorkspaceItemsDeletePageComponent,
-        resolve: {
-          dso: itemFromWorkspaceResolver,
-          breadcrumb: i18nBreadcrumbResolver,
-        },
-        data: { title: 'workspace-item.delete', breadcrumbKey: 'workspace-item.delete' },
-      },
     ],
   },
 ];


### PR DESCRIPTION
## Description

This PR removes a duplicated `/delete` route in `WorkspaceitemsEditPageModule`.