### PR TITLE
#3094 - Update date slider to prevent automatic page reloads

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.html
@@ -8,7 +8,7 @@
                     {{'search.filters.filter.' + filterConfig.name + '.min.label' | translate}}
                   </span>
                   <input type="text" [(ngModel)]="range[0]" [name]="filterConfig.paramName + '.min'"
-                         class="form-control" (blur)="onSubmit()"
+                         class="form-control"
                          [attr.aria-label]="minLabel"
                          [placeholder]="minLabel"
                   />
@@ -20,7 +20,7 @@
                       {{'search.filters.filter.' + filterConfig.name + '.max.label' | translate}}
                     </span>
                     <input type="text" [(ngModel)]="range[1]" [name]="filterConfig.paramName + '.max'"
-                           class="form-control" (blur)="onSubmit()"
+                           class="form-control"
                            [attr.aria-label]="maxLabel"
                            [placeholder]="maxLabel"
                     />
@@ -33,7 +33,8 @@
 
         <ng-container *ngIf="shouldShowSlider()">
             <nouislider [connect]="true" [config]="config" [min]="min" [max]="max" [step]="1"
-                        [dsDebounce]="250" (onDebounce)="onSubmit()"
+                        [dsDebounce]="250"
+                        (change)="onSliderChange($event)"
                         (keydown)="startKeyboardControl()" (keyup)="stopKeyboardControl()"
                         [(ngModel)]="range" ngDefaultControl>
             </nouislider>
@@ -43,5 +44,8 @@
           <ds-search-facet-range-option *ngFor="let value of page.page; trackBy: trackUpdate" [filterConfig]="filterConfig" [filterValue]="value" [inPlaceSearch]="inPlaceSearch"></ds-search-facet-range-option>
           </div>
         </ng-container>
+        <button (click)="onSubmit()" class="btn btn-primary">
+          {{'search.filters.search.submit' | translate}}
+        </button>
     </div>
 </div>

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
@@ -92,6 +92,11 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   range: [number | undefined, number | undefined];
 
   /**
+   * The range currently selected by the slider
+   */
+  sliderRange: [number | undefined, number | undefined];
+
+  /**
    * Whether the sider is being controlled by the keyboard.
    * Supresses any changes until the key is released.
    */
@@ -146,6 +151,15 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   }
 
   /**
+   * Updates the sliderRange property with the current slider range.
+   * This method is called whenever the slider value changes, but it does not immediately apply the changes.
+   * @param range - The current range selected by the slider
+   */
+  onSliderChange(range: [number | undefined, number | undefined]): void {
+    this.sliderRange = range;
+  }
+
+  /**
    * Submits new custom range values to the range filter from the widget
    */
   onSubmit() {
@@ -182,5 +196,4 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   shouldShowSlider(): boolean {
     return isPlatformBrowser(this.platformId);
   }
-
 }


### PR DESCRIPTION
## References
* #3094 

## Description
* Updated the slider implementation in `SearchRangeFilterComponent` to comply with WCAG 2.1 Success Criterion 3.2.2 (On Input). This improvement ensures that slider value changes no longer trigger automatic page reloads, enhancing user control over when context changes occur.

## Instructions for Reviewers
List of changes in this PR:
* **Updated Slider Event Handling**: Replaced `(onDebounce)="onSubmit()"` with `(change)="onSliderChange($event)"` to prevent automatic page reloads when slider values change. This ensures users have control over when the page context updates.
* **Refactored Form Submission**: Decoupled slider value updates from form submission, allowing users to submit changes only when they choose, thus preventing unintended context changes.
* **Enhanced User Control**: By separating slider changes from form submission, users can manage when and how context changes occur, aligning with WCAG 2.1 guidelines for user control and context management.

**To Reproduce**
Steps to reproduce the behavior:

1. Visit the search page on the sandbox, demo, or localhost (e.g., .../search?query=).
2. Expand the date filter to reveal the date slider.
3. Adjust the date slider to filter search results.

* **Expected Behavior**: The page should not reload automatically when the date slider is adjusted. The page should only reload when the submit button is clicked after adjusting the slider.
* **Actual Behavior (before changes)**: The page would reload automatically each time the date slider was adjusted, which interfered with the user's ability to refine search results smoothly.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
