### PR TITLE
Fix lint error regarding missing interface

### DIFF
--- a/src/app/notifications/suggestion-targets/publication-claim/publication-claim.component.ts
+++ b/src/app/notifications/suggestion-targets/publication-claim/publication-claim.component.ts
@@ -4,6 +4,7 @@ import {
   NgIf,
 } from '@angular/common';
 import {
+  AfterViewInit,
   Component,
   Input,
   OnDestroy,
@@ -51,7 +52,7 @@ import { SuggestionTargetsStateService } from '../suggestion-targets.state.servi
   ],
   standalone: true,
 })
-export class PublicationClaimComponent implements OnDestroy, OnInit {
+export class PublicationClaimComponent implements AfterViewInit, OnDestroy, OnInit {
 
   /**
    * The source for which to list targets


### PR DESCRIPTION
## References
* Follow up to #3048

## Description

After merging #3048, `main` is now throwing this lint error:
```
/home/runner/work/dspace-angular/dspace-angular/src/app/notifications/suggestion-targets/publication-claim/publication-claim.component.ts
Lint errors found in the listed files.
Error:   110:3  error  Lifecycle interface 'AfterViewInit' should be implemented for method 'ngAfterViewInit'. (https://angular.io/styleguide#style-09-01)  @angular-eslint/use-lifecycle-interface
```

This small PR fixes that error