### PR TITLE
Fixes incorrect operation of the keyword selection field with < and , on the Submission page

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.spec.ts
@@ -45,10 +45,12 @@ import { FormFieldMetadataValueObject } from '../../../models/form-field-metadat
 import { DsDynamicTagComponent } from './dynamic-tag.component';
 import { DynamicTagModel } from './dynamic-tag.model';
 
-function createKeyUpEvent(key: number) {
+function createKeyUpEvent(key: number, keyName: string) {
   /* eslint-disable no-empty,@typescript-eslint/no-empty-function */
   const event = {
-    keyCode: key, preventDefault: () => {
+    keyCode: key,
+    key: keyName,
+    preventDefault: () => {
     }, stopPropagation: () => {
     },
   };
@@ -279,7 +281,7 @@ describe('DsDynamicTagComponent test suite', () => {
       });
 
       it('should add an item on ENTER or key press is \',\' or \';\'', fakeAsync(() => {
-        let event = createKeyUpEvent(13);
+        let event = createKeyUpEvent(188,',');
         tagComp.currentValue = 'test value';
 
         tagFixture.detectChanges();
@@ -290,7 +292,7 @@ describe('DsDynamicTagComponent test suite', () => {
         expect(tagComp.model.value).toEqual(['test value']);
         expect(tagComp.currentValue).toBeNull();
 
-        event = createKeyUpEvent(188);
+        event = createKeyUpEvent(13,'Enter');
         tagComp.currentValue = 'test value';
 
         tagFixture.detectChanges();

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
@@ -224,7 +224,7 @@ export class DsDynamicTagComponent extends DsDynamicVocabularyComponent implemen
    * @param event the keyUp event
    */
   onKeyUp(event) {
-    if (event.keyCode === 13 || event.keyCode === 188) {
+    if (event.keyCode === 13 || (event.key.includes(',') && event.keyCode === 188)  || ((event.key as string).includes(';') && event.keyCode === 186) ) {
       event.preventDefault();
       // Key: 'Enter' or ',' or ';'
       this.addTagsToChips();


### PR DESCRIPTION
Hi @tdonohue , I'm @jtimal partner, I like to share this PR with you,  the above pull request (https://github.com/DSpace/dspace-angular/pull/3108) has a bug in the local project, so I created a new pull request from branch 8 to avoid the bug.

## References
* Fixes #2679

## Description
I changed the current validation for tag component in on keyup function for validate the keys "ENTER", "," and ";" for add the tags to Chips template.

## Instructions for Reviewers
I added validation for the keys "," and ";" add the labels to the chip template because the current functionality splits the value using the keys mentioned above so I think it is the correct way to validate as it causes an error if we don't validate by those keys incorrectly separating those values, i attach an example:

https://github.com/DSpace/dspace-angular/assets/25066032/46a8b86d-aac2-40a0-839e-c9dced1451ad

With validation I simplified the separation of values.

List of changes in this PR:
* Change the validation considering the keys "," and ";"  using the properties keyCode and key of the keyup event

To review and check:
Create a new item or edit item
Enter a keyword with the symbol , or <

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
