### PR TITLE
Fixed Edit Item's Version History crashing

### DIFF
--- a/src/app/item-page/versions/item-versions.component.html
+++ b/src/app/item-page/versions/item-versions.component.html
@@ -49,35 +49,31 @@
                 </ng-template>
               </div>
 
-              <div class="float-right btn-group edit-field space-children-mr" *ngIf="displayActions">
-                <!--DISCARD EDIT -->
-                <ng-container *ngIf="versionDTO.canEditVersion && isThisBeingEdited(versionDTO.version)">
-                  <button class="btn btn-sm"
-                          [ngClass]="isThisBeingEdited(versionDTO.version) ? 'btn-outline-warning' : 'btn-outline-primary'"
+              <div class="float-right btn-group edit-field space-children-mr" *ngIf="displayActions && versionDTO.canEditVersion | async">
+                <ng-container *ngIf="isThisBeingEdited(versionDTO.version); else notThisBeingEdited">
+                  <!--DISCARD EDIT-->
+                  <button class="btn btn-sm btn-outline-warning"
                           (click)="disableVersionEditing()"
                           title="{{'item.version.history.table.action.discardSummary' | translate}}">
                     <i class="fas fa-undo-alt fa-fw"></i>
                   </button>
-                </ng-container>
-                <!--EDIT / SAVE-->
-                <ng-container *ngIf="versionDTO.canEditVersion">
-                  <button class="btn btn-outline-primary btn-sm version-row-element-edit"
-                          *ngIf="!isThisBeingEdited(versionDTO.version)"
-                          [disabled]="isAnyBeingEdited()"
-                          (click)="enableVersionEditing(versionDTO.version)"
-                          title="{{'item.version.history.table.action.editSummary' | translate}}">
-                    <i class="fas fa-edit fa-fw"></i>
-                  </button>
+                  <!--SAVE-->
                   <button class="btn btn-outline-success btn-sm"
-                          *ngIf="isThisBeingEdited(versionDTO.version)"
                           (click)="onSummarySubmit()"
                           title="{{'item.version.history.table.action.saveSummary' | translate}}">
                     <i class="fas fa-check fa-fw"></i>
                   </button>
                 </ng-container>
+                <ng-template #notThisBeingEdited>
+                  <!--EDIT-->
+                  <button class="btn btn-outline-primary btn-sm version-row-element-edit"
+                          [disabled]="isAnyBeingEdited()"
+                          (click)="enableVersionEditing(versionDTO.version)"
+                          title="{{'item.version.history.table.action.editSummary' | translate}}">
+                    <i class="fas fa-edit fa-fw"></i>
+                  </button>
+                </ng-template>
               </div>
-
-
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
## References
* Fixes #3252

## Description
This PR removes the method calls from the template that return Observables causing an infinite rerendering of the page.

## Instructions for Reviewers
List of changes in this PR:
* Created a `VersionsDTO` containg all the data that is required to render the template in order to prevent the infinite recreation of the `canEditVersion` `Observable`.

**Guidance for how to test or review this PR:**
Test that everything still work correctly on the item page & the edit item version history tab both for items with and without any versions.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
