### PR TITLE
Improving accessibility on the new user registration page

### DIFF
--- a/src/app/register-email-form/register-email-form.component.html
+++ b/src/app/register-email-form/register-email-form.component.html
@@ -14,13 +14,16 @@
                     <label class="font-weight-bold"
                            for="email">{{MESSAGE_PREFIX + '.email' | translate}}</label>
                     <input [className]="(email.invalid) && (email.dirty || email.touched) ? 'form-control is-invalid' :'form-control'"
-                           type="text" id="email" formControlName="email"/>
+                           type="text" id="email" formControlName="email"
+                           [attr.aria-label]="'register-email.aria.label'|translate"
+                           aria-describedby="email-errors-required email-error-not-valid"
+                           [attr.aria-invalid]="form.get('email')?.invalid"/>
                     <div *ngIf="email.invalid && (email.dirty || email.touched)"
                          class="invalid-feedback show-feedback">
-                    <span *ngIf="email.errors && email.errors.required">
+                    <span *ngIf="email.errors && email.errors.required" id="email-errors-required">
                         {{ MESSAGE_PREFIX + '.email.error.required' | translate }}
                     </span>
-                    <span *ngIf="email.errors && ((email.errors.pattern && this.typeRequest === TYPE_REQUEST_REGISTER) || email.errors.email)">
+                    <span *ngIf="email.errors && ((email.errors.pattern && this.typeRequest === TYPE_REQUEST_REGISTER) || email.errors.email)" id="email-error-not-valid">
                         {{ MESSAGE_PREFIX + '.email.error.not-email-form' | translate }}
                         <ng-container *ngIf="validMailDomains.length > 0">
                           {{ MESSAGE_PREFIX + '.email.error.not-valid-domain' | translate: { domains: validMailDomains.join(', ') } }}

--- a/src/app/register-email-form/register-email-form.component.html
+++ b/src/app/register-email-form/register-email-form.component.html
@@ -15,9 +15,9 @@
                            for="email">{{MESSAGE_PREFIX + '.email' | translate}}</label>
                     <input [className]="(email.invalid) && (email.dirty || email.touched) ? 'form-control is-invalid' :'form-control'"
                            type="text" id="email" formControlName="email"
-                           [attr.aria-label]="'register-email.aria.label'|translate"
+                           [attr.aria-label]="MESSAGE_PREFIX + '.aria.label' | translate"
                            aria-describedby="email-errors-required email-error-not-valid"
-                           [attr.aria-invalid]="form.get('email')?.invalid"/>
+                           [attr.aria-invalid]="email.invalid"/>
                     <div *ngIf="email.invalid && (email.dirty || email.touched)"
                          class="invalid-feedback show-feedback">
                     <span *ngIf="email.errors && email.errors.required" id="email-errors-required">

--- a/src/app/register-email-form/register-email-form.component.html
+++ b/src/app/register-email-form/register-email-form.component.html
@@ -16,7 +16,7 @@
                     <input [className]="(email.invalid) && (email.dirty || email.touched) ? 'form-control is-invalid' :'form-control'"
                            type="text" id="email" formControlName="email"
                            [attr.aria-label]="MESSAGE_PREFIX + '.aria.label' | translate"
-                           [attr.aria-describedby]="ariaDescribedby"
+                           [attr.aria-describedby]="(!email.errors) ? '' : (email.errors.required ? 'email-errors-required' : 'email-error-not-valid')"
                            [attr.aria-invalid]="email.invalid"/>
                     <div *ngIf="email.invalid && (email.dirty || email.touched)"
                          class="invalid-feedback show-feedback">

--- a/src/app/register-email-form/register-email-form.component.html
+++ b/src/app/register-email-form/register-email-form.component.html
@@ -16,7 +16,7 @@
                     <input [className]="(email.invalid) && (email.dirty || email.touched) ? 'form-control is-invalid' :'form-control'"
                            type="text" id="email" formControlName="email"
                            [attr.aria-label]="MESSAGE_PREFIX + '.aria.label' | translate"
-                           aria-describedby="email-errors-required email-error-not-valid"
+                           [attr.aria-describedby]="ariaDescribedby"
                            [attr.aria-invalid]="email.invalid"/>
                     <div *ngIf="email.invalid && (email.dirty || email.touched)"
                          class="invalid-feedback show-feedback">

--- a/src/app/register-email-form/register-email-form.component.spec.ts
+++ b/src/app/register-email-form/register-email-form.component.spec.ts
@@ -210,4 +210,39 @@ describe('RegisterEmailFormComponent', () => {
       expect(router.navigate).not.toHaveBeenCalled();
     }));
   });
+  describe('ariaDescribedby', () => {
+    it('should have required error message when email is empty', () => {
+      comp.form.patchValue({ email: '' });
+      comp.checkEmailValidity();
+
+      expect(comp.ariaDescribedby).toContain('email-errors-required');
+    });
+
+    it('should have invalid email error message when email is invalid', () => {
+      comp.form.patchValue({ email: 'invalid-email' });
+      comp.checkEmailValidity();
+
+      expect(comp.ariaDescribedby).toContain('email-error-not-valid');
+    });
+
+    it('should clear ariaDescribedby when email is valid', () => {
+      comp.form.patchValue({ email: 'valid@email.com' });
+      comp.checkEmailValidity();
+
+      expect(comp.ariaDescribedby).toBe('');
+    });
+
+    it('should update ariaDescribedby on value changes', () => {
+      spyOn(comp, 'checkEmailValidity').and.callThrough();
+
+      comp.form.patchValue({ email: '' });
+      expect(comp.ariaDescribedby).toContain('email-errors-required');
+
+      comp.form.patchValue({ email: 'invalid-email' });
+      expect(comp.ariaDescribedby).toContain('email-error-not-valid');
+
+      comp.form.patchValue({ email: 'valid@email.com' });
+      expect(comp.ariaDescribedby).toBe('');
+    });
+  });
 });

--- a/src/app/register-email-form/register-email-form.component.spec.ts
+++ b/src/app/register-email-form/register-email-form.component.spec.ts
@@ -210,39 +210,4 @@ describe('RegisterEmailFormComponent', () => {
       expect(router.navigate).not.toHaveBeenCalled();
     }));
   });
-  describe('ariaDescribedby', () => {
-    it('should have required error message when email is empty', () => {
-      comp.form.patchValue({ email: '' });
-      comp.checkEmailValidity();
-
-      expect(comp.ariaDescribedby).toContain('email-errors-required');
-    });
-
-    it('should have invalid email error message when email is invalid', () => {
-      comp.form.patchValue({ email: 'invalid-email' });
-      comp.checkEmailValidity();
-
-      expect(comp.ariaDescribedby).toContain('email-error-not-valid');
-    });
-
-    it('should clear ariaDescribedby when email is valid', () => {
-      comp.form.patchValue({ email: 'valid@email.com' });
-      comp.checkEmailValidity();
-
-      expect(comp.ariaDescribedby).toBe('');
-    });
-
-    it('should update ariaDescribedby on value changes', () => {
-      spyOn(comp, 'checkEmailValidity').and.callThrough();
-
-      comp.form.patchValue({ email: '' });
-      expect(comp.ariaDescribedby).toContain('email-errors-required');
-
-      comp.form.patchValue({ email: 'invalid-email' });
-      expect(comp.ariaDescribedby).toContain('email-error-not-valid');
-
-      comp.form.patchValue({ email: 'valid@email.com' });
-      expect(comp.ariaDescribedby).toBe('');
-    });
-  });
 });

--- a/src/app/register-email-form/register-email-form.component.ts
+++ b/src/app/register-email-form/register-email-form.component.ts
@@ -290,5 +290,4 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
         console.warn(`Unimplemented notification '${key}' from reCaptcha service`);
     }
   }
-  
 }

--- a/src/app/register-email-form/register-email-form.component.ts
+++ b/src/app/register-email-form/register-email-form.component.ts
@@ -109,6 +109,11 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
 
   subscriptions: Subscription[] = [];
 
+  /**
+   * Stores error messages related to the email field
+   */
+  ariaDescribedby: string = '';
+
   captchaVersion(): Observable<string> {
     return this.googleRecaptchaService.captchaVersion();
   }
@@ -177,6 +182,13 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
     this.subscriptions.push(this.disableUntilCheckedFcn().subscribe((res) => {
       this.disableUntilChecked = res;
       this.changeDetectorRef.detectChanges();
+    }));
+
+    /**
+     * Subscription to email field value changes
+     */
+    this.subscriptions.push(this.email.valueChanges.subscribe(() => {
+      this.checkEmailValidity();
     }));
   }
 
@@ -289,6 +301,20 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
       default:
         console.warn(`Unimplemented notification '${key}' from reCaptcha service`);
     }
+  }
+
+  checkEmailValidity() {
+    const descriptions = [];
+
+    if (this.email.errors?.required) {
+      descriptions.push('email-errors-required');
+    }
+
+    if (this.email.errors?.pattern || this.email.errors?.email) {
+      descriptions.push('email-error-not-valid');
+    }
+
+    this.ariaDescribedby = descriptions.join(' ');
   }
 
 }

--- a/src/app/register-email-form/register-email-form.component.ts
+++ b/src/app/register-email-form/register-email-form.component.ts
@@ -109,11 +109,6 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
 
   subscriptions: Subscription[] = [];
 
-  /**
-   * Stores error messages related to the email field
-   */
-  ariaDescribedby = '';
-
   captchaVersion(): Observable<string> {
     return this.googleRecaptchaService.captchaVersion();
   }
@@ -182,13 +177,6 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
     this.subscriptions.push(this.disableUntilCheckedFcn().subscribe((res) => {
       this.disableUntilChecked = res;
       this.changeDetectorRef.detectChanges();
-    }));
-
-    /**
-     * Subscription to email field value changes
-     */
-    this.subscriptions.push(this.email.valueChanges.subscribe(() => {
-      this.checkEmailValidity();
     }));
   }
 
@@ -302,19 +290,5 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
         console.warn(`Unimplemented notification '${key}' from reCaptcha service`);
     }
   }
-
-  checkEmailValidity() {
-    const descriptions = [];
-
-    if (this.email.errors?.required) {
-      descriptions.push('email-errors-required');
-    }
-
-    if (this.email.errors?.pattern || this.email.errors?.email) {
-      descriptions.push('email-error-not-valid');
-    }
-
-    this.ariaDescribedby = descriptions.join(' ');
-  }
-
+  
 }

--- a/src/app/register-email-form/register-email-form.component.ts
+++ b/src/app/register-email-form/register-email-form.component.ts
@@ -112,7 +112,7 @@ export class RegisterEmailFormComponent implements OnDestroy, OnInit {
   /**
    * Stores error messages related to the email field
    */
-  ariaDescribedby: string = '';
+  ariaDescribedby = '';
 
   captchaVersion(): Observable<string> {
     return this.googleRecaptchaService.captchaVersion();

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6740,5 +6740,7 @@
 
   "browse.search-form.placeholder": "Search the repository",
 
-  "register-email.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "Enter your e-mail address",
+
+  "forgot-email.form.aria.label": "Enter your e-mail address",
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6739,4 +6739,6 @@
   "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
 
   "browse.search-form.placeholder": "Search the repository",
+
+  "register-email.aria.label": "Enter your e-mail address",
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -8152,8 +8152,11 @@
   //"browse.search-form.placeholder": "Search the repository",
   "browse.search-form.placeholder": "Buscar en el repositorio",
 
-  // "register-email.aria.label": "Enter your e-mail address",
-  "register-email.aria.label": "Introduzca su dirección de correo electrónico",
+  // "register-page.registration.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "Introduzca su dirección de correo electrónico",
+
+  // "forgot-email.form.aria.label": "Enter your e-mail address",
+  "forgot-email.form.aria.label": "Introduzca su dirección de correo electrónico",
 
 
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -8152,5 +8152,8 @@
   //"browse.search-form.placeholder": "Search the repository",
   "browse.search-form.placeholder": "Buscar en el repositorio",
 
+  // "register-email.aria.label": "Enter your e-mail address",
+  "register-email.aria.label": "Introduzca su dirección de correo electrónico",
+
 
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10250,6 +10250,9 @@
   //"browse.search-form.placeholder": "Search the repository",
   "browse.search-form.placeholder": "Buscar no repositório",
 
-  // "register-email.aria.label": "Enter your e-mail address",
-  "register-email.aria.label": "Digite seu e-mail",
+  // "register-page.registration.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "Digite seu e-mail",
+
+  // "forgot-email.form.aria.label": "Enter your e-mail address",
+  "forgot-email.form.aria.label": "Digite seu e-mail",
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10249,4 +10249,7 @@
 
   //"browse.search-form.placeholder": "Search the repository",
   "browse.search-form.placeholder": "Buscar no repositório",
+
+  // "register-email.aria.label": "Enter your e-mail address",
+  "register-email.aria.label": "Digite seu e-mail",
 }


### PR DESCRIPTION
## References
* Fixes ##3271

## Description
Use of the attributes “attr.aria-label”, “aria-describedby” and “attr.aria-invalid” to improve the user experience when browsing DSpace using a screen reader.

## Instructions for reviewers
Use of the “attr.aria-label” attribute which provides a clear description of what the user needs to do in the email field. Use of the “aria-describedby” attribute which describes error messages and use of the “attr.aria-invalid” attribute which informs when a field is invalid.

List of changes in this PR:
* In the html the attributes attr.aria-label, aria-describedby and attr.aria-invalid have been added.
* Creation of ids in the spans that announce error messages to be used in the aria-describedby attribute.

Note: This PR does not deal with the accessibility of the “Register” button as there is already a PR dealing with this issue.
https://github.com/DSpace/dspace-angular/pull/3268

To reproduce:
1. Using a screen reader, go to the login area.
2. click on “register new user”.
3. Navigate through the page and notice that there is a better accessibility experience.