### PR TITLE
robots.txt: add /server/* and /app/health to list of disallowed paths

### DIFF
--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -18,6 +18,8 @@ Disallow: /profile
 Disallow: /workflowitems
 # Crawlers should be able to access entity pages, but not the facet search links present on entity pages
 Disallow: /entities/*?f
+# do not crawl REST API endpoints and HAL browser
+Disallow: /server/*
 
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -18,7 +18,8 @@ Disallow: /profile
 Disallow: /workflowitems
 # Crawlers should be able to access entity pages, but not the facet search links present on entity pages
 Disallow: /entities/*?f
-# do not crawl REST API endpoints and HAL browser
+# do not crawl REST API endpoints and HAL browser (with the exception of the bitstream download endpoint)
+Allow: /server/api/core/bitstreams/*
 Disallow: /server/*
 # do not crawl health status
 Disallow: /app/health

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -20,6 +20,8 @@ Disallow: /workflowitems
 Disallow: /entities/*?f
 # do not crawl REST API endpoints and HAL browser
 Disallow: /server/*
+# do not crawl health status
+Disallow: /app/health
 
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.


### PR DESCRIPTION
## Description

This minor PR extends `robots.txt` by additional `Disallow` rules.