### PR TITLE
Typo in German translation

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -3450,7 +3450,7 @@
   "journalissue.listelement.badge": "Zeitschriftenheft",
 
   // "journalissue.page.description": "Description",
-  "journalissue.page.description": "Beschreibeung",
+  "journalissue.page.description": "Beschreibung",
 
   // "journalissue.page.edit": "Edit this item",
   "journalissue.page.edit": "Dieses Item bearbeiten",


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/3259

## Description
A Typo has been fixed  in the German translation