### PR TITLE
Provided label for cclicense required error

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1864,6 +1864,8 @@
 
   "error.validation.license.notgranted": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
 
+  "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
+
   "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
 
   "error.validation.filerequired": "The file upload is mandatory",


### PR DESCRIPTION
## References
Supplements: https://github.com/DSpace/DSpace/pull/9639#pullrequestreview-2270236552

## Description
Provided error label for https://github.com/DSpace/DSpace/pull/9639


List of changes in this PR:
Provided error label 


- [x ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- x[ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x ] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [ x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
