### PR TITLE
Ignore some paths from file watcher

### DIFF
--- a/webpack/webpack.browser.ts
+++ b/webpack/webpack.browser.ts
@@ -35,5 +35,12 @@ module.exports = Object.assign({}, commonExports, {
       buildAppConfig(join(process.cwd(), 'src/assets/config.json'));
       return middlewares;
     }
-  }
+  },
+  watchOptions: {
+    // Ignore directories that should not be watched for recompiling angular
+    ignored: [
+      '**/node_modules', '**/_build', '**/.git', '**/docker',
+      '**/.angular', '**/.idea', '**/.vscode', '**/.history', '**/.vsix'
+    ]
+  },
 });


### PR DESCRIPTION
Watching all these directories can cause systems to exceed maximum watched files / inotify limits, especially in dev mode with IDEs etc also watching files.

I've included node_modules, and some basic vcs and project dirs that should be excluded.

```
  watchOptions: {
    // Ignore directories that should not be watched for recompiling angular
    ignored: [
      '**/node_modules', '**/_build', '**/.git', '**/docker',
      '**/.angular', '**/.idea', '**/.vscode', '**/.history', '**/.vsix'
    ]
  },
```

### Testing

It's actually not super trivial to 'see' watched files, but if you can reproduce the underlying issue (get your system into a state where inotify limit is exceeded), then you can run with and without this change, and review any errors listed, to see whether the file watcher is _attempting_ to watch e.g. node_modules

(if anyone has any better test procedures please let me know!)

### Notes

Documentation: https://webpack.js.org/configuration/watch/#watchoptions

Note, there is also a way to do this in tsconfig.json but in my practical testing it wasn't taking effect (see: https://www.typescriptlang.org/tsconfig/#watchOptions)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
