### PR TITLE
#3288 - Enabled 'admin-div' only for Site Administrator

### DIFF
--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -5,6 +5,7 @@
         </button>
     </div>
     <div class="modal-body">
+      <div data-test="admin-div" *ngIf="(isAdmin$ | async)">
         <button class="btn btn-outline-primary btn-lg btn-block" (click)="selectObject(undefined)">{{'dso-selector.create.community.top-level' | translate}}</button>
         <div class="h3 position-relative py-1 my-3 font-weight-normal">
             <hr>
@@ -12,7 +13,7 @@
                 <span class="px-4 bg-white">{{'dso-selector.create.community.or-divider' | translate}}</span>
             </div>
         </div>
-
+      </div>
         <span class="h5 px-2">{{'dso-selector.create.community.sub-level' | translate}}</span>
         <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="selectorTypes" [sort]="defaultSort" (onSelect)="selectObject($event)"></ds-dso-selector>
     </div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
@@ -7,13 +7,16 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import {
   ActivatedRoute,
   Router,
 } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
+import { of as observableOf } from 'rxjs';
 
+import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
 import { Community } from '../../../../core/shared/community.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject } from '../../../remote-data.utils';
@@ -38,7 +41,9 @@ describe('CreateCommunityParentSelectorComponent', () => {
   const communityRD = createSuccessfulRemoteDataObject(community);
   const modalStub = jasmine.createSpyObj('modalStub', ['close']);
   const createPath = '/communities/create';
-
+  const mockAuthorizationDataService = jasmine.createSpyObj('authorizationService', {
+    isAuthorized: observableOf(true),
+  });
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), CreateCommunityParentSelectorComponent],
@@ -59,6 +64,7 @@ describe('CreateCommunityParentSelectorComponent', () => {
         {
           provide: Router, useValue: router,
         },
+        { provide: AuthorizationDataService, useValue: mockAuthorizationDataService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
@@ -84,5 +90,21 @@ describe('CreateCommunityParentSelectorComponent', () => {
     component.navigate(community);
     expect(router.navigate).toHaveBeenCalledWith([createPath], { queryParams: { parent: community.uuid } });
   });
+
+  it('should show the div when user is an admin', (waitForAsync(() => {
+    component.isAdmin$ = observableOf(true);
+    fixture.detectChanges();
+
+    const divElement = fixture.debugElement.query(By.css('div[data-test="admin-div"]'));
+    expect(divElement).toBeTruthy();
+  })));
+
+  it('should hide the div when user is not an admin', (waitForAsync(() => {
+    component.isAdmin$ = observableOf(false);
+    fixture.detectChanges();
+
+    const divElement = fixture.debugElement.query(By.css('div[data-test="admin-div"]'));
+    expect(divElement).toBeFalsy();
+  })));
 
 });

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
@@ -1,4 +1,8 @@
 import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
+import {
   Component,
   OnInit,
 } from '@angular/core';
@@ -9,6 +13,7 @@ import {
 } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 
 import { environment } from '../../../../../environments/environment';
 import {
@@ -19,6 +24,8 @@ import {
   SortDirection,
   SortOptions,
 } from '../../../../core/cache/models/sort-options.model';
+import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../../core/data/feature-authorization/feature-id';
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
 import { hasValue } from '../../../empty.util';
@@ -40,16 +47,21 @@ import {
   styleUrls: ['./create-community-parent-selector.component.scss'],
   templateUrl: './create-community-parent-selector.component.html',
   standalone: true,
-  imports: [DSOSelectorComponent, TranslateModule],
+  imports: [DSOSelectorComponent, TranslateModule, NgIf, AsyncPipe],
 })
 export class CreateCommunityParentSelectorComponent extends DSOSelectorModalWrapperComponent implements OnInit {
   objectType = DSpaceObjectType.COMMUNITY;
   selectorTypes = [DSpaceObjectType.COMMUNITY];
   action = SelectorActionType.CREATE;
   defaultSort = new SortOptions(environment.comcolSelectionSort.sortField, environment.comcolSelectionSort.sortDirection as SortDirection);
+  isAdmin$: Observable<boolean>;
 
-  constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router) {
+  constructor(protected activeModal: NgbActiveModal, protected route: ActivatedRoute, private router: Router, protected authorizationService: AuthorizationDataService) {
     super(activeModal, route);
+  }
+
+  ngOnInit() {
+    this.isAdmin$ = this.authorizationService.isAuthorized(FeatureID.AdministratorOf);
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #3288 

## Description
This PR introduces a change to the CreateCommunityParentSelectorComponent to display the admin-div section only to users with Site Administrator privileges.

## Instructions for Reviewers
The key changes include:

- **New** `isAdmin$` **Observable:** Added an isAdmin$ observable to the CreateCommunityParentSelectorComponent to track admin status.

- **Conditional Rendering**: Added a `<div>` with `data-test="admin-div"` in the component's template, which is displayed only if `isAdmin$ `emits `true`.

- **Updated Tests**: Adjusted the unit tests to check for the presence of the `admin-div` based on the admin status.

**How to test:**

1. Log in as Community admin on https://demo.dspace.org/home
2. On the admin bar, click on New -> Community
3. Verify that the admin-div is not visible.

![Screenshot from 2024-09-06 18-05-31](https://github.com/user-attachments/assets/1213cfb2-3d76-4b97-80dd-7a289c1306c6)

This will confirm that the `admin-div` is correctly shown or hidden based on the user's admin status.
## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `yarn lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `yarn check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
