### PR TITLE
Upgrade to Cypress 13.15.0

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  video: true,
   videosFolder: 'cypress/videos',
   screenshotsFolder: 'cypress/screenshots',
   fixturesFolder: 'cypress/fixtures',

--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -20,6 +20,9 @@ describe('Edit Item > Edit Metadata tab', () => {
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="metadata"]').click();
 
+    // Our selected tab should be active
+    cy.get('a[data-test="metadata"]').should('have.class', 'active');
+
     // <ds-edit-item-page> tag must be loaded
     cy.get('ds-edit-item-page').should('be.visible');
 
@@ -38,6 +41,9 @@ describe('Edit Item > Status tab', () => {
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="status"]').click();
 
+    // Our selected tab should be active
+    cy.get('a[data-test="status"]').should('have.class', 'active');
+
     // <ds-item-status> tag must be loaded
     cy.get('ds-item-status').should('be.visible');
 
@@ -50,6 +56,9 @@ describe('Edit Item > Bitstreams tab', () => {
 
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="bitstreams"]').click();
+
+    // Our selected tab should be active
+    cy.get('a[data-test="bitstreams"]').should('have.class', 'active');
 
     // <ds-item-bitstreams> tag must be loaded
     cy.get('ds-item-bitstreams').should('be.visible');
@@ -75,6 +84,9 @@ describe('Edit Item > Curate tab', () => {
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="curate"]').click();
 
+    // Our selected tab should be active
+    cy.get('a[data-test="curate"]').should('have.class', 'active');
+
     // <ds-item-curate> tag must be loaded
     cy.get('ds-item-curate').should('be.visible');
 
@@ -87,6 +99,9 @@ describe('Edit Item > Relationships tab', () => {
 
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="relationships"]').click();
+
+    // Our selected tab should be active
+    cy.get('a[data-test="relationships"]').should('have.class', 'active');
 
     // <ds-item-relationships> tag must be loaded
     cy.get('ds-item-relationships').should('be.visible');
@@ -101,6 +116,9 @@ describe('Edit Item > Version History tab', () => {
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="versionhistory"]').click();
 
+    // Our selected tab should be active
+    cy.get('a[data-test="versionhistory"]').should('have.class', 'active');
+
     // <ds-item-version-history> tag must be loaded
     cy.get('ds-item-version-history').should('be.visible');
 
@@ -114,6 +132,9 @@ describe('Edit Item > Access Control tab', () => {
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="access-control"]').click();
 
+    // Our selected tab should be active
+    cy.get('a[data-test="access-control"]').should('have.class', 'active');
+
     // <ds-item-access-control> tag must be loaded
     cy.get('ds-item-access-control').should('be.visible');
 
@@ -126,6 +147,9 @@ describe('Edit Item > Collection Mapper tab', () => {
 
   it('should pass accessibility tests', () => {
     cy.get('a[data-test="mapper"]').click();
+
+    // Our selected tab should be active
+    cy.get('a[data-test="mapper"]').should('have.class', 'active');
 
     // <ds-item-collection-mapper> tag must be loaded
     cy.get('ds-item-collection-mapper').should('be.visible');

--- a/cypress/e2e/login-modal.cy.ts
+++ b/cypress/e2e/login-modal.cy.ts
@@ -3,31 +3,31 @@ import { testA11y } from 'cypress/support/utils';
 const page = {
   openLoginMenu() {
     // Click the "Log In" dropdown menu in header
-    cy.get('ds-header [data-test="login-menu"]').click();
+    cy.get('[data-test="login-menu"]').click();
   },
   openUserMenu() {
     // Once logged in, click the User menu in header
-    cy.get('ds-header [data-test="user-menu"]').click();
+    cy.get('[data-test="user-menu"]').click();
   },
   submitLoginAndPasswordByPressingButton(email, password) {
     // Enter email
-    cy.get('ds-header [data-test="email"]').type(email);
+    cy.get('[data-test="email"]').type(email);
     // Enter password
-    cy.get('ds-header [data-test="password"]').type(password);
+    cy.get('[data-test="password"]').type(password);
     // Click login button
-    cy.get('ds-header [data-test="login-button"]').click();
+    cy.get('[data-test="login-button"]').click();
   },
   submitLoginAndPasswordByPressingEnter(email, password) {
     // In opened Login modal, fill out email & password, then click Enter
-    cy.get('ds-header [data-test="email"]').type(email);
-    cy.get('ds-header [data-test="password"]').type(password);
-    cy.get('ds-header [data-test="password"]').type('{enter}');
+    cy.get('[data-test="email"]').type(email);
+    cy.get('[data-test="password"]').type(password);
+    cy.get('[data-test="password"]').type('{enter}');
   },
   submitLogoutByPressingButton() {
     // This is the POST command that will actually log us out
     cy.intercept('POST', '/server/api/authn/logout').as('logout');
     // Click logout button
-    cy.get('ds-header [data-test="logout-button"]').click();
+    cy.get('[data-test="logout-button"]').click();
     // Wait until above POST command responds before continuing
     // (This ensures next action waits until logout completes)
     cy.wait('@logout');

--- a/cypress/e2e/login-modal.cy.ts
+++ b/cypress/e2e/login-modal.cy.ts
@@ -67,7 +67,7 @@ describe('Login Modal', () => {
 
     // Login, and the <ds-log-in> tag should no longer exist
     page.submitLoginAndPasswordByPressingEnter(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
-    cy.get('.form-login').should('not.exist');
+    cy.get('ds-log-in').should('not.exist');
 
     // Verify we are still on homepage
     cy.url().should('include', '/home');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -101,11 +101,11 @@ Cypress.Commands.add('login', login);
  */
 function loginViaForm(email: string, password: string): void {
   // Enter email
-  cy.get('ds-log-in [data-test="email"]').type(email);
+  cy.get('[data-test="email"]').type(email);
   // Enter password
-  cy.get('ds-log-in [data-test="password"]').type(password);
+  cy.get('[data-test="password"]').type(password);
   // Click login button
-  cy.get('ds-log-in [data-test="login-button"]').click();
+  cy.get('[data-test="login-button"]').click();
 }
 // Add as a Cypress command (i.e. assign to 'cy.loginViaForm')
 Cypress.Commands.add('loginViaForm', loginViaForm);

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "compression-webpack-plugin": "^9.2.0",
         "copy-webpack-plugin": "^6.4.1",
         "cross-env": "^7.0.3",
-        "cypress": "^13.14.2",
+        "cypress": "^13.15.0",
         "cypress-axe": "^1.5.0",
         "deep-freeze": "0.0.1",
         "eslint": "^8.39.0",
@@ -10075,13 +10075,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.14.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
-      "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.15.0.tgz",
+      "integrity": "sha512-53aO7PwOfi604qzOkCSzNlWquCynLlKE/rmmpSPcziRH6LNfaDUAklQT6WJIsD8ywxlIy+uVZsnTMCCQVd2kTw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^3.0.1",
+        "@cypress/request": "^3.0.4",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "compression-webpack-plugin": "^9.2.0",
         "copy-webpack-plugin": "^6.4.1",
         "cross-env": "^7.0.3",
-        "cypress": "12.17.4",
+        "cypress": "^13.14.2",
         "cypress-axe": "^1.4.0",
         "deep-freeze": "0.0.1",
         "eslint": "^8.39.0",
@@ -3989,9 +3989,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.4.tgz",
+      "integrity": "sha512-eqNHMsxEXuit0sRvvWoGG3/4+Q5qwqjKARWXKM/KoSsKvTNBwWt8pwspg5+TniP3POAZcPPx0O8CiEIQ4e6NWg==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -4000,14 +4000,14 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "http-signature": "~1.3.6",
+        "form-data": "~2.5.0",
+        "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.13.0",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -4018,9 +4018,9 @@
       }
     },
     "node_modules/@cypress/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8200,9 +8200,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true
     },
     "node_modules/axe-core": {
@@ -10075,21 +10075,20 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.14.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
+      "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -10107,7 +10106,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -10121,7 +10120,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -10129,7 +10128,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-axe": {
@@ -10144,12 +10143,6 @@
         "axe-core": "^3 || ^4",
         "cypress": "^10 || ^11 || ^12 || ^13"
       }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.101",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
-      "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA==",
-      "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -10267,6 +10260,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/cypress/node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/cypress/node_modules/universalify": {
@@ -13632,14 +13634,14 @@
       }
     },
     "node_modules/http-signature": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
-        "sshpk": "^1.14.1"
+        "sshpk": "^1.18.0"
       },
       "engines": {
         "node": ">=0.10"
@@ -19673,12 +19675,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "copy-webpack-plugin": "^6.4.1",
         "cross-env": "^7.0.3",
         "cypress": "^13.14.2",
-        "cypress-axe": "^1.4.0",
+        "cypress-axe": "^1.5.0",
         "deep-freeze": "0.0.1",
         "eslint": "^8.39.0",
         "eslint-plugin-deprecation": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
-    "cypress": "^13.14.2",
+    "cypress": "^13.15.0",
     "cypress-axe": "^1.5.0",
     "deep-freeze": "0.0.1",
     "eslint": "^8.39.0",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
-    "cypress": "12.17.4",
+    "cypress": "^13.14.2",
     "cypress-axe": "^1.4.0",
     "deep-freeze": "0.0.1",
     "eslint": "^8.39.0",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "cross-env": "^7.0.3",
     "cypress": "^13.14.2",
-    "cypress-axe": "^1.4.0",
+    "cypress-axe": "^1.5.0",
     "deep-freeze": "0.0.1",
     "eslint": "^8.39.0",
     "eslint-plugin-deprecation": "^1.4.1",


### PR DESCRIPTION
## References
* Replaces #3309 (created by @dependabot)

## Description
Upgrades us to Cypress 13.15.0 which also resolves a security alert related to Cypress v12  (NOTE: This alert doesn't impact production as Cypress is only used to run e2e tests.)

In addition to the Cypress upgrade, the following minor changes were made to ensure better e2e test stability:
* Updates to `item-edit.cy.ts` to check that the proper tab is active.  This solves some random e2e failures which were occurring when an accessibility scan was triggered *before* the tabs were fully loaded on the page.  This check forces Cypress to wait for the tabs to appear before proceeding.
* Updates to `login-modal.cy.ts` to fix a minor bug & to simplify the CSS selectors.
* Updates to `command.ts` to simplify CSS selectors.  (The CSS selector cleanup here & above is just minor cleanup that can be done now that #2676 is merged, because we no longer have duplicate elements in the DOM)

## Instructions for Reviewers
* Verify code changes look reasonable
* Verify all e2e tests pass (as Cypress is just used to run e2e tests)
