### PR TITLE
fix #3241: Configuring the URI link target

### DIFF
--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -18,7 +18,10 @@
 
 <!-- Render value as a link (href and label) -->
 <ng-template #link let-value="value">
-    <a class="dont-break-out ds-simple-metadata-link" target="_blank" [href]="value">
+    <a class="dont-break-out ds-simple-metadata-link"
+      [href]="value"
+      [attr.target]="getLinkAttributes(value).target"
+      [attr.rel]="getLinkAttributes(value).rel">
       {{value}}
     </a>
 </ng-template>

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -134,4 +134,16 @@ export class MetadataValuesComponent implements OnChanges {
   hasInternalLink(linkValue: string): boolean {
     return linkValue.startsWith(environment.ui.baseUrl);
   }
+
+  /**
+   * This method performs a validation and determines the target of the url.
+   * @returns - Returns the target url.
+   */
+ getLinkAttributes(urlValue: string): { target: string, rel: string } {
+    if (this.hasInternalLink(urlValue)) {
+      return { target: '_self', rel: '' };
+    } else {
+      return { target: '_blank', rel: 'noopener noreferrer' };
+    }
+  }
 }


### PR DESCRIPTION
## References
* Fixes [#3241](https://github.com/dspace/dspace-angular/issues/3241)
Note: To reproduce the error, use DSpace version 8.

## Description
Creation of a new method in the “metadata-uri-values” component to identify when the url link on the item's simplified page is internal or external and where it will open.

## Instructions for Reviewers
A getLinkAttributes method has been created which receives the value of the item's url and compares this value with the repository's base url; if the values of the urls are the same, the method returns the following attributes {target: '_self', rel:' '} and the link is opened in the same browser tab. Otherwise, the method returns the attributes {target: '_blank', rel: 'noopener noreferrer'} and the link is opened in a new browser tab. In the end, this conditional was dynamically added to the template via [attr.target] and [attr.rel].

List of changes in this PR:
* Creation of the “getLinkAttributes” method. 
* Removal of the static target=“_blank” attribute from the anchor that forms the url on the item's simplified page.
* And adding the attributes “[attr.target]” and “[attr.rel]” to the same anchor.  

To reproduce:
1. Go to the simplified page for any item.
2. Inside the page, click on the item's URI and see how the link behaves. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
