### PR TITLE
[8.x] Accessibility cookie settings

### DIFF
--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -146,7 +146,8 @@
   --ds-process-overview-table-user-column-width: 200px;
   --ds-process-overview-table-info-column-width: 250px;
   --ds-process-overview-table-actions-column-width: 80px;
-  
+
   --green1: #1FB300;  // This variable represents the success color for the Klaro cookie banner
   --button-text-color-cookie: #333; // This variable represents the text color for buttons in the Klaro cookie banner
+  --very-dark-cyan: #215E50; // This variable represents the background color of the save cookies button
 }

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -43,17 +43,39 @@ body {
     .cm-btn.cm-btn-success {
       color: var(--button-text-color-cookie);
       background-color: var(--green1);
-    }
-    .cm-btn.cm-btn-success.cm-btn-accept-all {
-      color: var(--button-text-color-cookie);
-      background-color: var(--green1);
+      font-weight: 600;
     }
   }
 }
 
-.klaro .cookie-modal a, .klaro .context-notice a, .klaro .cookie-notice a
-{
+.klaro .cookie-modal .cm-btn.cm-btn-success.cm-btn-accept-all {
+  color: var(--button-text-color-cookie);
+  background-color: var(--green1);
+  font-weight: 600;
+}
+
+.klaro .cookie-modal a,
+.klaro .context-notice a,
+.klaro .cookie-notice a {
   color: var(--green1);
+  text-decoration: underline !important;
+}
+
+.klaro .cookie-modal .cm-modal .cm-body span,
+.klaro
+  .cookie-modal
+  .cm-modal
+  .cm-body
+  ul.cm-purposes
+  li.cm-purpose
+  span.cm-required,
+p.purposes,
+.klaro .cookie-modal .cm-modal .cm-footer .cm-powered-by a {
+  color: var(--bs-light) !important;
+}
+
+.klaro .cookie-modal .cm-btn.cm-btn-info {
+  background-color: var(--very-dark-cyan) !important;
 }
 
 .media-viewer


### PR DESCRIPTION
## References
* Fixes #2668

## Description
Adding and changing some classes in the global scss to make the cookie settings more accessible.

## Instructions for Reviewers

List of changes in this PR:
* Added the variable "--very-dark-cyan" in _custom_variables.scss.
* Removed the variable ".cm-btn.cm-btn-success.cm-btn-accept-all" and its styling as it was no longer needed.
* Styled the "Accept all" button by overwriting the style of the ".klaro .cookie-modal .cm-btn.cm-btn-success.cm-btn-accept-all" variables.
* Added "text-decoration: underline;" to the anchors.
* Changed the color of some informational texts, which were previously gray and are now lighter to improve contrast.
* Changed the color of the "Save" button by overwriting the styling of the variables: .klaro .cookie-modal .cm-btn.cm-btn-info.

To reproduce:
1. Visit a DSpace repository in an anonymous browser.
2. Klaro cookie popup should appear. Click on "Customize" to bring up the screen above
3. Expand all sections on that screen.
4. Run an accessibility scanner (WAVE or "axe DevTools) and check that the accessibility test is positive.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
