### PR TITLE
Update isbot dependency to newest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "filesize": "^6.1.0",
         "http-proxy-middleware": "^1.0.5",
         "http-terminator": "^3.2.0",
-        "isbot": "^3.6.10",
+        "isbot": "^5.1.17",
         "js-cookie": "2.2.1",
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
@@ -14436,11 +14436,11 @@
       }
     },
     "node_modules/isbot": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.8.0.tgz",
-      "integrity": "sha512-vne1mzQUTR+qsMLeCBL9+/tgnDXRyc2pygLGl/WsgA+EZKIiB5Ehu0CiVTHIIk30zhJ24uGz4M5Ppse37aR0Hg==",
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.17.tgz",
+      "integrity": "sha512-/wch8pRKZE+aoVhRX/hYPY1C7dMCeeMyhkQLNLNlYAbGQn9bkvMB8fOUXNnk5I0m4vDYbBJ9ciVtkr9zfBJ7qA==",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/isexe": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "filesize": "^6.1.0",
     "http-proxy-middleware": "^1.0.5",
     "http-terminator": "^3.2.0",
-    "isbot": "^3.6.10",
+    "isbot": "^5.1.17",
     "js-cookie": "2.2.1",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",

--- a/server.ts
+++ b/server.ts
@@ -27,7 +27,7 @@ import * as expressStaticGzip from 'express-static-gzip';
 /* eslint-enable import/no-namespace */
 import axios from 'axios';
 import LRU from 'lru-cache';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import { createCertificate } from 'pem';
 import { createServer } from 'https';
 import { json } from 'body-parser';


### PR DESCRIPTION
## References
While investigating the impacts of https://github.com/DSpace/dspace-angular/pull/2033 on views/downloads statistics in the DSpace backend I noticed that the `isbot` Javascript dependency is several versions behind. 

## Description
This is a drop-in replacement that doesn't require any changes to the code. It should work the exact same, except for catching more bots.

## Instructions for Reviewers
I used the steps in "Instructions for Reviewers" in https://github.com/DSpace/dspace-angular/pull/2033 to test this dependency update. I observed the same cache hits for bots when SSR is enabled.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
