### PR TITLE
[Port dspace-7_x] Add orcid icon with tooltip

### DIFF
--- a/src/app/entity-groups/research-entities/metadata-representations/person/person-item-metadata-list-element.component.html
+++ b/src/app/entity-groups/research-entities/metadata-representations/person/person-item-metadata-list-element.component.html
@@ -12,4 +12,9 @@
   <a [routerLink]="[itemPageRoute]"
      [innerHTML]="mdRepresentation.getValue()"
      [ngbTooltip]="mdRepresentation.allMetadata(['person.jobTitle']).length > 0 ? descTemplate : null"></a>
+  <ds-orcid-badge-and-tooltip class="ml-1"
+                              *ngIf="mdRepresentation.firstMetadata('person.identifier.orcid')"
+                              [orcid]="mdRepresentation.firstMetadata('person.identifier.orcid')"
+                              [authenticatedTimestamp]="mdRepresentation.firstMetadata('dspace.orcid.authenticated')">
+  </ds-orcid-badge-and-tooltip>
 </ds-truncatable>

--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.html
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.html
@@ -2,7 +2,7 @@
      [ngbTooltip]="orcidTooltipTemplate"
      class="orcid-icon"
      [ngClass]="{'not-authenticated': !authenticatedTimestamp}"
-     alt="orcid-logo"
+     alt="ORCID {{ orcidTooltip }}"
      src="assets/images/orcid.logo.icon.svg"
      data-test="orcidIcon"/>
 

--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.html
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.html
@@ -1,0 +1,11 @@
+<img placement="top"
+     [ngbTooltip]="orcidTooltipTemplate"
+     class="orcid-icon"
+     [ngClass]="{'not-authenticated': !authenticatedTimestamp}"
+     alt="orcid-logo"
+     src="assets/images/orcid.logo.icon.svg"
+     data-test="orcidIcon"/>
+
+<ng-template #orcidTooltipTemplate>
+    <span class="text-muted">{{ orcidTooltip }}</span>
+</ng-template>

--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.scss
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.scss
@@ -1,0 +1,11 @@
+:host {
+  display: inline-block;
+}
+
+.orcid-icon {
+  height: 1.2rem;
+
+  &.not-authenticated {
+    filter: grayscale(100%);
+  }
+}

--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.spec.ts
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.spec.ts
@@ -1,0 +1,71 @@
+import {
+  NgClass,
+  NgIf,
+} from '@angular/common';
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateService } from '@ngx-translate/core';
+
+import { MetadataValue } from '../../core/shared/metadata.models';
+import { OrcidBadgeAndTooltipComponent } from './orcid-badge-and-tooltip.component';
+
+describe('OrcidBadgeAndTooltipComponent', () => {
+  let component: OrcidBadgeAndTooltipComponent;
+  let fixture: ComponentFixture<OrcidBadgeAndTooltipComponent>;
+  let translateService: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OrcidBadgeAndTooltipComponent],
+      imports: [
+        NgbTooltipModule,
+        NgClass,
+        NgIf,
+      ],
+      providers: [
+        { provide: TranslateService, useValue: { instant: (key: string) => key } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrcidBadgeAndTooltipComponent);
+    component = fixture.componentInstance;
+    translateService = TestBed.inject(TranslateService);
+
+    component.orcid = { value: '0000-0002-1825-0097' } as MetadataValue;
+    component.authenticatedTimestamp = { value: '2023-10-01' } as MetadataValue;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set orcidTooltip when authenticatedTimestamp is provided', () => {
+    component.ngOnInit();
+    expect(component.orcidTooltip).toBe('person.orcid-tooltip.authenticated');
+  });
+
+  it('should set orcidTooltip when authenticatedTimestamp is not provided', () => {
+    component.authenticatedTimestamp = null;
+    component.ngOnInit();
+    expect(component.orcidTooltip).toBe('person.orcid-tooltip.not-authenticated');
+  });
+
+  it('should display the ORCID icon', () => {
+    const badgeIcon = fixture.debugElement.query(By.css('img[data-test="orcidIcon"]'));
+    expect(badgeIcon).toBeTruthy();
+  });
+
+  it('should display the ORCID icon in greyscale if there is no authenticated timestamp', () => {
+    component.authenticatedTimestamp = null;
+    fixture.detectChanges();
+    const badgeIcon = fixture.debugElement.query(By.css('img[data-test="orcidIcon"]'));
+    expect(badgeIcon.nativeElement.classList).toContain('not-authenticated');
+  });
+
+});

--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.ts
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.ts
@@ -1,0 +1,56 @@
+
+
+import {
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+import { MetadataValue } from '../../core/shared/metadata.models';
+
+/**
+ * Component to display an ORCID badge with a tooltip.
+ * The tooltip text changes based on whether the ORCID is authenticated.
+ */
+@Component({
+  selector: 'ds-orcid-badge-and-tooltip',
+  templateUrl: './orcid-badge-and-tooltip.component.html',
+  styleUrls: ['./orcid-badge-and-tooltip.component.scss'],
+})
+export class OrcidBadgeAndTooltipComponent implements OnInit {
+
+  /**
+   * The ORCID value to be displayed.
+   */
+  @Input() orcid: MetadataValue;
+
+  /**
+   * The timestamp indicating when the ORCID was authenticated.
+   */
+  @Input() authenticatedTimestamp: MetadataValue;
+
+  /**
+   * The tooltip text to be displayed.
+   */
+  orcidTooltip: string;
+
+  /**
+   * Constructor to inject the TranslateService.
+   * @param translateService - Service for translation.
+   */
+  constructor(
+    private translateService: TranslateService,
+  ) { }
+
+  /**
+   * Initializes the component.
+   * Sets the tooltip text based on the presence of the authenticated timestamp.
+   */
+  ngOnInit() {
+    this.orcidTooltip = this.authenticatedTimestamp ?
+      this.translateService.instant('person.orcid-tooltip.authenticated', { orcid: this.orcid.value }) :
+      this.translateService.instant('person.orcid-tooltip.not-authenticated', { orcid: this.orcid.value });
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -284,6 +284,7 @@ import { BitstreamListItemComponent } from './object-list/bitstream-list-item/bi
 import { NgxPaginationModule } from 'ngx-pagination';
 import { ThemedLangSwitchComponent } from './lang-switch/themed-lang-switch.component';
 import {ThemedUserMenuComponent} from './auth-nav-menu/user-menu/themed-user-menu.component';
+import { OrcidBadgeAndTooltipComponent } from './orcid-badge-and-tooltip/orcid-badge-and-tooltip.component';
 
 const MODULES = [
   CommonModule,
@@ -404,6 +405,7 @@ const COMPONENTS = [
   EpersonSearchBoxComponent,
   GroupSearchBoxComponent,
   ThemedItemPageTitleFieldComponent,
+  OrcidBadgeAndTooltipComponent,
 ];
 
 const ENTRY_COMPONENTS = [

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5248,6 +5248,10 @@
 
   "person.orcid.registry.auth": "ORCID Authorizations",
 
+  "person.orcid-tooltip.authenticated": "{{orcid}}",
+
+  "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
+
   "home.recent-submissions.head": "Recent Submissions",
 
   "listable-notification-object.default-message": "This object couldn't be retrieved",


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/9086

## Description
A new component has been created and added to the `ds-person-item-metadata-list-element` component template. This component shows the ORCID logo and a tooltip on hovering shows the ORCID of the person.

## Instructions for Reviewers
You can see the ORCID logo in a Publication page with authors listed.

In order to show the ORCID logo, an author should have at least the `person.identifier.orcid` metadata set. In this case, the logo is shown with a greyscale filter and a tooltip shows the ORCID with an `(unconfirmed)` clause.

![image](https://github.com/user-attachments/assets/c5d59c1b-36ce-4d6a-ac5c-9b456d647e3b)

If the author also has the `dspace.orcid.authenticated` metadata value, the logo is shown in full color and the tooltip has no `(unconfirmed)`  clause.

![image](https://github.com/user-attachments/assets/9d8f05a3-1d36-4b4f-88fa-d6fabf820008)


List of changes in this PR:
* Created `orcid-badge-and-tooltip` component;
* Included said component in the `ds-person-item-metadata-list-element` component template;

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
