### PR TITLE
Always sanitize HTML passed to dsMarkdown even if markdown rendering is disabled

### DIFF
--- a/src/app/shared/utils/markdown.directive.spec.ts
+++ b/src/app/shared/utils/markdown.directive.spec.ts
@@ -8,21 +8,20 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { environment } from '../../../environments/environment.test';
 import { MathService } from '../../core/shared/math.service';
 import { MockMathService } from '../../core/shared/math.service.spec';
 import { MarkdownDirective } from './markdown.directive';
 
 @Component({
-  template: `<div dsMarkdown="test"></div>`,
+  template: `<div [dsMarkdown]="'test<script>alert(1);</script>'"></div>`,
   standalone: true,
   imports: [ MarkdownDirective ],
 })
 class TestComponent {}
 
 describe('MarkdownDirective', () => {
-  let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
-  let divEl: DebugElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -32,12 +31,61 @@ describe('MarkdownDirective', () => {
     }).compileComponents();
     spyOn(MarkdownDirective.prototype, 'render');
     fixture = TestBed.createComponent(TestComponent);
-    component = fixture.componentInstance;
-    divEl = fixture.debugElement.query(By.css('div'));
   });
 
   it('should call render method', () => {
     fixture.detectChanges();
     expect(MarkdownDirective.prototype.render).toHaveBeenCalled();
   });
+
+});
+
+describe('MarkdownDirective sanitization with markdown disabled', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let divEl: DebugElement;
+  // Disable markdown
+  environment.markdown.enabled = false;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: MathService, useClass: MockMathService },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestComponent);
+    divEl = fixture.debugElement.query(By.css('div'));
+
+  });
+
+  it('should sanitize the script element out of innerHTML (markdown disabled)',() => {
+    fixture.detectChanges();
+    divEl = fixture.debugElement.query(By.css('div'));
+    expect(divEl.nativeElement.innerHTML).toEqual('test');
+  });
+
+});
+
+describe('MarkdownDirective sanitization with markdown enabled', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let divEl: DebugElement;
+  // Enable markdown
+  environment.markdown.enabled = true;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: MathService, useClass: MockMathService },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestComponent);
+    divEl = fixture.debugElement.query(By.css('div'));
+
+  });
+
+  it('should sanitize the script element out of innerHTML (markdown enabled)',() => {
+    fixture.detectChanges();
+    divEl = fixture.debugElement.query(By.css('div'));
+    expect(divEl.nativeElement.innerHTML).toEqual('test');
+  });
+
 });

--- a/src/app/shared/utils/markdown.directive.ts
+++ b/src/app/shared/utils/markdown.directive.ts
@@ -55,7 +55,7 @@ export class MarkdownDirective implements OnInit, OnDestroy {
 
   async render(value: string, forcePreview = false): Promise<SafeHtml> {
     if (isEmpty(value) || (!environment.markdown.enabled && !forcePreview)) {
-      this.el.innerHTML = value;
+      this.el.innerHTML = this.sanitizer.sanitize(SecurityContext.HTML, value);
       return;
     } else {
       if (environment.markdown.mathjax) {


### PR DESCRIPTION
## Description
The markdown directive currently sets `this.el.innerHTML` directly to `value` if markdown is disabled in config and forcePreview is not set. This means unsanitized HTML can end up making its way into the `innerHTML` of an element when somebody uses the `[dsMarkdown]=....` directive.

This small pull request ensures the `innerHTML` is always sanitized.

New tests are included to prove this behaviour (the template is initialised with `test<script>alert(1)</script>` and we check that in all cases, the div innerHTML is equal only to `test`.

## Instructions for Reviewers

* Try to inject unsafe HTML in a `[dsMarkdown]` directive (you can do this via metadata value, or as a raw string), with both `environment.markdown.enabled` true, and false. In both cases HTML should be correctly sanitized.
* You should notice that in main branch, disabling markdown allows HTML through unsanitized, and enabling it does sanitize the HTML correctly
* In this PR, the HTML should be sanitized in both cases
* Quick review of `markdown.directive.spec.ts` test coverage is appreciated

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.