### PR TITLE
Changing the bitstream title in the submission form to use the view c…

### DIFF
--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -18,7 +18,7 @@
     </div>
     <div class="col-md-10">
       <div class="float-left w-75">
-        <h3>{{fileName}} <span class="text-muted">({{fileData?.sizeBytes | dsFileSize}})</span></h3>
+        <ds-submission-section-upload-file-view [fileData]="fileData"></ds-submission-section-upload-file-view>
       </div>
       <div class="float-right w-15">
         <ng-container>
@@ -43,7 +43,6 @@
         </ng-container>
       </div>
       <div class="clearfix"></div>
-      <ds-submission-section-upload-file-view [fileData]="fileData"></ds-submission-section-upload-file-view>
     </div>
   </div>
 </ng-container>

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.html
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.html
@@ -2,9 +2,10 @@
   <ng-container *ngIf="metadata">
     <ng-container *ngFor="let entry of getAllMetadataValue(fileTitleKey)">
       <ng-container *ngIf="entry.value !== ''">
-        <h5>
+        <h3>
           {{entry.value}}
-        </h5>
+          <span class="text-muted">({{fileData?.sizeBytes | dsFileSize}})</span>
+        </h3>
       </ng-container>
       <ng-container *ngIf="entry.value === ''">
         <h5 *ngIf="metadata[fileTitleKey].indexOf(entry) === 0">

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -17,8 +17,8 @@ import { Metadata } from '../../../../../core/shared/metadata.utils';
 import { WorkspaceitemSectionUploadFileObject } from '../../../../../core/submission/models/workspaceitem-section-upload-file.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
 import { TruncatePipe } from '../../../../../shared/utils/truncate.pipe';
-import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessConditions/submission-section-upload-access-conditions.component';
 import { FileSizePipe } from '../../../../../shared/utils/file-size-pipe';
+import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessConditions/submission-section-upload-access-conditions.component';
 
 /**
  * This component allow to show bitstream's metadata

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -18,7 +18,7 @@ import { WorkspaceitemSectionUploadFileObject } from '../../../../../core/submis
 import { isNotEmpty } from '../../../../../shared/empty.util';
 import { TruncatePipe } from '../../../../../shared/utils/truncate.pipe';
 import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessConditions/submission-section-upload-access-conditions.component';
-import { FileSizePipe } from "../../../../../shared/utils/file-size-pipe";
+import { FileSizePipe } from '../../../../../shared/utils/file-size-pipe';
 
 /**
  * This component allow to show bitstream's metadata
@@ -32,8 +32,8 @@ import { FileSizePipe } from "../../../../../shared/utils/file-size-pipe";
     TruncatePipe,
     NgIf,
     NgForOf,
-    FileSizePipe
-],
+    FileSizePipe,
+  ],
   standalone: true,
 })
 export class SubmissionSectionUploadFileViewComponent implements OnInit {

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -16,8 +16,8 @@ import {
 import { Metadata } from '../../../../../core/shared/metadata.utils';
 import { WorkspaceitemSectionUploadFileObject } from '../../../../../core/submission/models/workspaceitem-section-upload-file.model';
 import { isNotEmpty } from '../../../../../shared/empty.util';
-import { TruncatePipe } from '../../../../../shared/utils/truncate.pipe';
 import { FileSizePipe } from '../../../../../shared/utils/file-size-pipe';
+import { TruncatePipe } from '../../../../../shared/utils/truncate.pipe';
 import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessConditions/submission-section-upload-access-conditions.component';
 
 /**

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -18,6 +18,7 @@ import { WorkspaceitemSectionUploadFileObject } from '../../../../../core/submis
 import { isNotEmpty } from '../../../../../shared/empty.util';
 import { TruncatePipe } from '../../../../../shared/utils/truncate.pipe';
 import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessConditions/submission-section-upload-access-conditions.component';
+import { FileSizePipe } from "../../../../../shared/utils/file-size-pipe";
 
 /**
  * This component allow to show bitstream's metadata
@@ -31,7 +32,8 @@ import { SubmissionSectionUploadAccessConditionsComponent } from '../../accessCo
     TruncatePipe,
     NgIf,
     NgForOf,
-  ],
+    FileSizePipe
+],
   standalone: true,
 })
 export class SubmissionSectionUploadFileViewComponent implements OnInit {

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -54,13 +54,13 @@ export class SubmissionSectionUploadFileViewComponent implements OnInit {
    * The bitstream's title key
    * @type {string}
    */
-  public fileTitleKey = 'Title';
+  public fileTitleKey: string = 'Title';
 
   /**
    * The bitstream's description key
    * @type {string}
    */
-  public fileDescrKey = 'Description';
+  public fileDescrKey: string = 'Description';
 
   public fileFormat!: string;
 

--- a/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
+++ b/src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts
@@ -54,13 +54,13 @@ export class SubmissionSectionUploadFileViewComponent implements OnInit {
    * The bitstream's title key
    * @type {string}
    */
-  public fileTitleKey: string = 'Title';
+  public fileTitleKey = 'Title';
 
   /**
    * The bitstream's description key
    * @type {string}
    */
-  public fileDescrKey: string = 'Description';
+  public fileDescrKey = 'Description';
 
   public fileFormat!: string;
 


### PR DESCRIPTION
…omponent title, avoiding disappearance with changes to the form

## References
* Fixes #3291 

## Description
The "fileName" variable was removed from the upload "step" and the bitstream visualization component was used to display the title and thus prevent it from disappearing when the form is changed.

## Instructions for Reviewers

Install this frontend connected to the demo backend or a clean backend and test the submission in a publishing entity that has a form that links metadata to another entity with the search modal active (different from the "suggest" mode). In this submission, you must initially upload the file, check if the file title appears correctly and then open the modal and select the entity to be linked (whether author, advisor, journal...). Note that after this the bistream title remains intact, correcting the problem reported where the title disappeared.

List of changes in this PR:

* Removing original line 21 from the file "src/app/submission/sections/upload/file/section-upload-file.component.html" and replacing it with the import of the "ds-submission-section-upload-file-view" view component; removing this same call from line 46 of the same file.

* In the "src/app/submission/sections/upload/file/view/section-upload-file-view.component.html" view component, the title size was changed from "h5" to "h3" as it was in the previous title and the "span" was included, taking into account the size of the file being processed.

* Inserting the "FileSizePipe" call in the "src/app/submission/sections/upload/file/view/section-upload-file-view.component.ts" component so that it is possible to process the viewing of the submitted file.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
