### PR TITLE
Fix browse by date's year dropdown being empty on DSpace 7.6.2+

### DIFF
--- a/src/app/shared/browse-by/browse-by.component.spec.ts
+++ b/src/app/shared/browse-by/browse-by.component.spec.ts
@@ -142,6 +142,8 @@ describe('BrowseByComponent', () => {
         { provide: RouteService, useValue: routeServiceStub},
         { provide: SelectableListService, useValue: {} },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(800) },
+        { provide: 'startsWithOptions', useValue: [] },
+        { provide: 'paginationId', useValue: 'bbm' },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();

--- a/src/app/shared/browse-by/browse-by.component.ts
+++ b/src/app/shared/browse-by/browse-by.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Injector, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, SimpleChanges, OnChanges } from '@angular/core';
 import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { PaginationComponentOptions } from '../pagination/pagination-component-options.model';
@@ -26,7 +26,7 @@ import { TranslateService } from '@ngx-translate/core';
 /**
  * Component to display a browse-by page for any ListableObject
  */
-export class BrowseByComponent implements OnInit, OnDestroy {
+export class BrowseByComponent implements OnInit, OnDestroy, OnChanges {
 
   /**
    * ViewMode that should be passed to {@link ListableObjectComponentLoaderComponent}.
@@ -182,14 +182,7 @@ export class BrowseByComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.objectInjector = Injector.create({
-      providers: [
-        { provide: 'startsWithOptions', useFactory: () => (this.startsWithOptions), deps:[] },
-        { provide: 'paginationId', useFactory: () => (this.paginationConfig?.id), deps:[] }
-      ],
-      parent: this.injector
-    });
-
+    this.generateInjector();
     const startsWith$ = this.routeService.getQueryParameterValue('startsWith');
     const value$ = this.routeService.getQueryParameterValue('value');
 
@@ -199,9 +192,26 @@ export class BrowseByComponent implements OnInit, OnDestroy {
     this.sub = this.routeService.getQueryParameterValue(this.paginationConfig.id + '.return').subscribe(this.previousPage$);
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.startsWithOptions || changes.paginationId) {
+      this.generateInjector();
+    }
+  }
+
   ngOnDestroy(): void {
     if (this.sub) {
       this.sub.unsubscribe();
     }
   }
+
+  generateInjector(): void {
+    this.objectInjector = Injector.create({
+      providers: [
+        { provide: 'startsWithOptions', useFactory: () => (this.startsWithOptions), deps:[] },
+        { provide: 'paginationId', useFactory: () => (this.paginationConfig?.id), deps:[] }
+      ],
+      parent: this.injector
+    });
+  }
+
 }


### PR DESCRIPTION
## References
* Fixes #3408
* Related #2832

## Description
Fixes the browse by date's year dropdown not always showing the available years. This bug was caused by #2832 since it was only a partial port #2722 to `dspace-7_x`. This fix is not required for DSpace 8.0+ since it has already been fixed there during the refactor with a more appropriate fix (https://github.com/DSpace/dspace-angular/commit/6e29f306a75fd04dd5bdb5086eafd264f3259692) that can't be backported since it would require PR #2339 to be backported as well.

## Instructions for Reviewers
List of changes in this PR:
* Moved the initialization of the `objectInjector` to `ngOnChanges`, in order to assure that the `StartsWithDateComponent` is re-rendered when one of the injector parameters is updated.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
