### PR TITLE
Added support for caching embedded objects without a self link & null responses

### DIFF
--- a/src/app/core/breadcrumbs/item-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/item-breadcrumb.resolver.ts
@@ -7,7 +7,7 @@ import {
 import { Observable } from 'rxjs';
 
 import { BreadcrumbConfig } from '../../breadcrumbs/breadcrumb/breadcrumb-config.model';
-import { ITEM_PAGE_LINKS_TO_FOLLOW } from '../../item-page/item.resolver';
+import { getItemPageLinksToFollow } from '../../item-page/item.resolver';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { ItemDataService } from '../data/item-data.service';
 import { DSpaceObject } from '../shared/dspace-object.model';
@@ -24,7 +24,7 @@ export const itemBreadcrumbResolver: ResolveFn<BreadcrumbConfig<Item>> = (
   breadcrumbService: DSOBreadcrumbsService = inject(DSOBreadcrumbsService),
   dataService: ItemDataService = inject(ItemDataService),
 ): Observable<BreadcrumbConfig<Item>> => {
-  const linksToFollow: FollowLinkConfig<DSpaceObject>[] = ITEM_PAGE_LINKS_TO_FOLLOW as FollowLinkConfig<DSpaceObject>[];
+  const linksToFollow: FollowLinkConfig<DSpaceObject>[] = getItemPageLinksToFollow() as FollowLinkConfig<DSpaceObject>[];
   return DSOBreadcrumbResolver(
     route,
     state,

--- a/src/app/core/browse/browse.service.spec.ts
+++ b/src/app/core/browse/browse.service.spec.ts
@@ -7,7 +7,6 @@ import { of as observableOf } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { getMockHrefOnlyDataService } from '../../shared/mocks/href-only-data.service.mock';
-import { getMockRemoteDataBuildService } from '../../shared/mocks/remote-data-build.service.mock';
 import { getMockRequestService } from '../../shared/mocks/request.service.mock';
 import {
   createSuccessfulRemoteDataObject,
@@ -18,7 +17,6 @@ import {
   createPaginatedList,
   getFirstUsedArgumentOfSpyMethod,
 } from '../../shared/testing/utils.test';
-import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { RequestService } from '../data/request.service';
 import { RequestEntry } from '../data/request-entry.model';
 import { FlatBrowseDefinition } from '../shared/flat-browse-definition.model';
@@ -31,7 +29,6 @@ describe('BrowseService', () => {
   let scheduler: TestScheduler;
   let service: BrowseService;
   let requestService: RequestService;
-  let rdbService: RemoteDataBuildService;
 
   const browsesEndpointURL = 'https://rest.api/browses';
   const halService: any = new HALEndpointServiceStub(browsesEndpointURL);
@@ -129,7 +126,6 @@ describe('BrowseService', () => {
       halService,
       browseDefinitionDataService,
       hrefOnlyDataService,
-      rdbService,
     );
   }
 
@@ -141,11 +137,9 @@ describe('BrowseService', () => {
 
     beforeEach(() => {
       requestService = getMockRequestService(getRequestEntry$(true));
-      rdbService = getMockRemoteDataBuildService();
       service = initTestService();
       spyOn(halService, 'getEndpoint').and
         .returnValue(hot('--a-', { a: browsesEndpointURL }));
-      spyOn(rdbService, 'buildList').and.callThrough();
     });
 
     it('should call BrowseDefinitionDataService to create the RemoteData Observable', () => {
@@ -162,9 +156,7 @@ describe('BrowseService', () => {
 
     beforeEach(() => {
       requestService = getMockRequestService(getRequestEntry$(true));
-      rdbService = getMockRemoteDataBuildService();
       service = initTestService();
-      spyOn(rdbService, 'buildList').and.callThrough();
     });
 
     describe('when getBrowseEntriesFor is called with a valid browse definition id', () => {
@@ -215,7 +207,6 @@ describe('BrowseService', () => {
     describe('if getBrowseDefinitions fires', () => {
       beforeEach(() => {
         requestService = getMockRequestService(getRequestEntry$(true));
-        rdbService = getMockRemoteDataBuildService();
         service = initTestService();
         spyOn(service, 'getBrowseDefinitions').and
           .returnValue(hot('--a-', {
@@ -270,7 +261,6 @@ describe('BrowseService', () => {
     describe('if getBrowseDefinitions doesn\'t fire', () => {
       it('should return undefined', () => {
         requestService = getMockRequestService(getRequestEntry$(true));
-        rdbService = getMockRemoteDataBuildService();
         service = initTestService();
         spyOn(service, 'getBrowseDefinitions').and
           .returnValue(hot('----'));
@@ -288,9 +278,7 @@ describe('BrowseService', () => {
   describe('getFirstItemFor', () => {
     beforeEach(() => {
       requestService = getMockRequestService();
-      rdbService = getMockRemoteDataBuildService();
       service = initTestService();
-      spyOn(rdbService, 'buildList').and.callThrough();
     });
 
     describe('when getFirstItemFor is called with a valid browse definition id', () => {

--- a/src/app/core/browse/browse.service.ts
+++ b/src/app/core/browse/browse.service.ts
@@ -6,6 +6,7 @@ import {
   startWith,
 } from 'rxjs/operators';
 
+import { environment } from '../../../environments/environment';
 import {
   hasValue,
   hasValueOperator,
@@ -16,7 +17,6 @@ import {
   followLink,
   FollowLinkConfig,
 } from '../../shared/utils/follow-link-config.model';
-import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { SortDirection } from '../cache/models/sort-options.model';
 import { HrefOnlyDataService } from '../data/href-only-data.service';
 import { PaginatedList } from '../data/paginated-list.model';
@@ -38,9 +38,15 @@ import { URLCombiner } from '../url-combiner/url-combiner';
 import { BrowseDefinitionDataService } from './browse-definition-data.service';
 import { BrowseEntrySearchOptions } from './browse-entry-search-options.model';
 
-export const BROWSE_LINKS_TO_FOLLOW: FollowLinkConfig<BrowseEntry | Item>[] = [
-  followLink('thumbnail'),
-];
+export function getBrowseLinksToFollow(): FollowLinkConfig<BrowseEntry | Item>[] {
+  const followLinks = [
+    followLink('thumbnail'),
+  ];
+  if (environment.item.showAccessStatuses) {
+    followLinks.push(followLink('accessStatus'));
+  }
+  return followLinks;
+}
 
 /**
  * The service handling all browse requests
@@ -67,7 +73,6 @@ export class BrowseService {
     protected halService: HALEndpointService,
     private browseDefinitionDataService: BrowseDefinitionDataService,
     private hrefOnlyDataService: HrefOnlyDataService,
-    private rdb: RemoteDataBuildService,
   ) {
   }
 
@@ -117,7 +122,7 @@ export class BrowseService {
       }),
     );
     if (options.fetchThumbnail ) {
-      return this.hrefOnlyDataService.findListByHref<BrowseEntry>(href$, {}, undefined, undefined, ...BROWSE_LINKS_TO_FOLLOW);
+      return this.hrefOnlyDataService.findListByHref<BrowseEntry>(href$, {}, undefined, undefined, ...getBrowseLinksToFollow());
     }
     return this.hrefOnlyDataService.findListByHref<BrowseEntry>(href$);
   }
@@ -165,7 +170,7 @@ export class BrowseService {
       }),
     );
     if (options.fetchThumbnail) {
-      return this.hrefOnlyDataService.findListByHref<Item>(href$, {}, undefined, undefined, ...BROWSE_LINKS_TO_FOLLOW);
+      return this.hrefOnlyDataService.findListByHref<Item>(href$, {}, undefined, undefined, ...getBrowseLinksToFollow());
     }
     return this.hrefOnlyDataService.findListByHref<Item>(href$);
   }

--- a/src/app/core/cache/object-cache.reducer.ts
+++ b/src/app/core/cache/object-cache.reducer.ts
@@ -174,20 +174,25 @@ export function objectCacheReducer(state = initialState, action: ObjectCacheActi
  *    the new state, with the object added, or overwritten.
  */
 function addToObjectCache(state: ObjectCacheState, action: AddToObjectCacheAction): ObjectCacheState {
-  const existing = state[action.payload.objectToCache._links.self.href] || {} as any;
+  const cacheLink = hasValue(action.payload.objectToCache?._links?.self) ? action.payload.objectToCache._links.self.href : action.payload.alternativeLink;
+  const existing = state[cacheLink] || {} as any;
   const newAltLinks = hasValue(action.payload.alternativeLink) ? [action.payload.alternativeLink] : [];
-  return Object.assign({}, state, {
-    [action.payload.objectToCache._links.self.href]: {
-      data: action.payload.objectToCache,
-      timeCompleted: action.payload.timeCompleted,
-      msToLive: action.payload.msToLive,
-      requestUUIDs: [action.payload.requestUUID, ...(existing.requestUUIDs || [])],
-      dependentRequestUUIDs: existing.dependentRequestUUIDs || [],
-      isDirty: isNotEmpty(existing.patches),
-      patches: existing.patches || [],
-      alternativeLinks: [...(existing.alternativeLinks || []), ...newAltLinks],
-    } as ObjectCacheEntry,
-  });
+  if (hasValue(cacheLink)) {
+    return Object.assign({}, state, {
+      [cacheLink]: {
+        data: action.payload.objectToCache,
+        timeCompleted: action.payload.timeCompleted,
+        msToLive: action.payload.msToLive,
+        requestUUIDs: [action.payload.requestUUID, ...(existing.requestUUIDs || [])],
+        dependentRequestUUIDs: existing.dependentRequestUUIDs || [],
+        isDirty: isNotEmpty(existing.patches),
+        patches: existing.patches || [],
+        alternativeLinks: [...(existing.alternativeLinks || []), ...newAltLinks],
+      } as ObjectCacheEntry,
+    });
+  } else {
+    return state;
+  }
 }
 
 /**

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -120,6 +120,13 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
               if (hasValue(match)) {
                 embedAltUrl = new URLCombiner(embedAltUrl, `?size=${match.size}`).toString();
               }
+              if (data._embedded[property] == null) {
+                // Embedded object is null, meaning it exists (not undefined), but had an empty response (204) -> cache it as null
+                this.addToObjectCache(null, request, data, embedAltUrl);
+              } else if (!isCacheableObject(data._embedded[property])) {
+                // Embedded object exists, but doesn't contain a self link -> cache it using the alternative link instead
+                this.objectCache.add(data._embedded[property], hasValue(request.responseMsToLive) ? request.responseMsToLive : environment.cache.msToLive.default, request.uuid, embedAltUrl);
+              }
               this.process<ObjectDomain>(data._embedded[property], request, embedAltUrl);
             });
         }
@@ -237,7 +244,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
    * @param alternativeURL  an alternative url that can be used to retrieve the object
    */
   addToObjectCache(co: CacheableObject, request: RestRequest, data: any, alternativeURL?: string): void {
-    if (!isCacheableObject(co)) {
+    if (hasValue(co) && !isCacheableObject(co)) {
       const type = hasValue(data) && hasValue(data.type) ? data.type : 'object';
       let dataJSON: string;
       if (hasValue(data._embedded)) {
@@ -251,7 +258,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
       return;
     }
 
-    if (alternativeURL === co._links.self.href) {
+    if (hasValue(co) && alternativeURL === co._links.self.href) {
       alternativeURL = undefined;
     }
 

--- a/src/app/core/data/relationship-data.service.spec.ts
+++ b/src/app/core/data/relationship-data.service.spec.ts
@@ -3,6 +3,8 @@ import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of as observableOf } from 'rxjs';
 
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from '../../../environments/environment.test';
 import { PAGINATED_RELATIONS_TO_ITEMS_OPERATOR } from '../../item-page/simple/item-types/shared/item-relationships-utils';
 import { getMockRemoteDataBuildServiceHrefMap } from '../../shared/mocks/remote-data-build.service.mock';
 import { getMockRequestService } from '../../shared/mocks/request.service.mock';
@@ -150,6 +152,7 @@ describe('RelationshipDataService', () => {
         { provide: RequestService, useValue: requestService },
         { provide: PAGINATED_RELATIONS_TO_ITEMS_OPERATOR, useValue: jasmine.createSpy('paginatedRelationsToItems').and.returnValue((v) => v) },
         { provide: Store, useValue: provideMockStore() },
+        { provide: APP_CONFIG, useValue: environment },
         RelationshipDataService,
       ],
     });
@@ -157,7 +160,7 @@ describe('RelationshipDataService', () => {
   });
 
   describe('composition', () => {
-    const initService = () => new RelationshipDataService(null, null, null, null, null, null, null, null);
+    const initService = () => new RelationshipDataService(null, null, null, null, null, null, null, null, environment);
 
     testSearchDataImplementation(initService);
   });

--- a/src/app/core/data/relationship-data.service.ts
+++ b/src/app/core/data/relationship-data.service.ts
@@ -25,6 +25,10 @@ import {
 } from 'rxjs/operators';
 
 import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../config/app-config.interface';
+import {
   AppState,
   keySelector,
 } from '../../app.reducer';
@@ -133,6 +137,7 @@ export class RelationshipDataService extends IdentifiableDataService<Relationshi
     protected itemService: ItemDataService,
     protected appStore: Store<AppState>,
     @Inject(PAGINATED_RELATIONS_TO_ITEMS_OPERATOR) private paginatedRelationsToItems: (thisId: string) => (source: Observable<RemoteData<PaginatedList<Relationship>>>) => Observable<RemoteData<PaginatedList<Item>>>,
+    @Inject(APP_CONFIG) private appConfig: AppConfig,
   ) {
     super('relationships', requestService, rdbService, objectCache, halService, 15 * 60 * 1000);
 
@@ -319,7 +324,7 @@ export class RelationshipDataService extends IdentifiableDataService<Relationshi
    * @param options
    */
   getRelatedItemsByLabel(item: Item, label: string, options?: FindListOptions): Observable<RemoteData<PaginatedList<Item>>> {
-    const linksToFollow: FollowLinkConfig<Relationship>[] = itemLinksToFollow(options.fetchThumbnail);
+    const linksToFollow: FollowLinkConfig<Relationship>[] = itemLinksToFollow(options.fetchThumbnail, this.appConfig.item.showAccessStatuses);
     linksToFollow.push(followLink('relationshipType'));
 
     return this.getItemRelationshipsByLabel(item, label, options, true, true, ...linksToFollow).pipe(this.paginatedRelationsToItems(item.uuid));

--- a/src/app/core/data/version-history-data.service.ts
+++ b/src/app/core/data/version-history-data.service.ts
@@ -190,7 +190,7 @@ export class VersionHistoryDataService extends IdentifiableDataService<VersionHi
     return this.versionDataService.findByHref(versionHref, false, true, followLink('versionhistory')).pipe(
       getFirstCompletedRemoteData(),
       switchMap((versionRD: RemoteData<Version>) => {
-        if (versionRD.hasSucceeded && !versionRD.hasNoContent) {
+        if (versionRD.hasSucceeded && !versionRD.hasNoContent && hasValue(versionRD.payload)) {
           return versionRD.payload.versionhistory.pipe(
             getFirstCompletedRemoteData(),
             map((versionHistoryRD: RemoteData<VersionHistory>) => {

--- a/src/app/core/index/index.effects.ts
+++ b/src/app/core/index/index.effects.ts
@@ -45,7 +45,7 @@ export class UUIDIndexEffects {
   addObject$ = createEffect(() => this.actions$
     .pipe(
       ofType(ObjectCacheActionTypes.ADD),
-      filter((action: AddToObjectCacheAction) => hasValue(action.payload.objectToCache.uuid)),
+      filter((action: AddToObjectCacheAction) => hasValue(action.payload.objectToCache) && hasValue(action.payload.objectToCache.uuid)),
       map((action: AddToObjectCacheAction) => {
         return new AddToIndexAction(
           IndexName.OBJECT,
@@ -64,7 +64,7 @@ export class UUIDIndexEffects {
       ofType(ObjectCacheActionTypes.ADD),
       map((action: AddToObjectCacheAction) => {
         const alternativeLink = action.payload.alternativeLink;
-        const selfLink = action.payload.objectToCache._links.self.href;
+        const selfLink = hasValue(action.payload.objectToCache?._links?.self) ? action.payload.objectToCache._links.self.href : alternativeLink;
         if (hasValue(alternativeLink) && alternativeLink !== selfLink) {
           return new AddToIndexAction(
             IndexName.ALTERNATIVE_OBJECT_LINK,

--- a/src/app/home-page/recent-item-list/recent-item-list.component.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.ts
@@ -98,6 +98,9 @@ export class RecentItemListComponent implements OnInit, OnDestroy {
     if (this.appConfig.browseBy.showThumbnails) {
       linksToFollow.push(followLink('thumbnail'));
     }
+    if (this.appConfig.item.showAccessStatuses) {
+      linksToFollow.push(followLink('accessStatus'));
+    }
 
     this.itemRD$ = this.searchService.search(
       new PaginatedSearchOptions({

--- a/src/app/item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
+++ b/src/app/item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
@@ -33,7 +33,7 @@ import { getAllSucceededRemoteData } from '../../../core/shared/operators';
 import { hasValue } from '../../../shared/empty.util';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { AbstractTrackableComponent } from '../../../shared/trackable/abstract-trackable.component';
-import { ITEM_PAGE_LINKS_TO_FOLLOW } from '../../item.resolver';
+import { getItemPageLinksToFollow } from '../../item.resolver';
 import { getItemPageRoute } from '../../item-page-routing-paths';
 
 @Component({
@@ -92,7 +92,7 @@ export class AbstractItemUpdateComponent extends AbstractTrackableComponent impl
           this.item = rd.payload;
         }),
         switchMap((rd: RemoteData<Item>) => {
-          return this.itemService.findByHref(rd.payload._links.self.href, true, true, ...ITEM_PAGE_LINKS_TO_FOLLOW);
+          return this.itemService.findByHref(rd.payload._links.self.href, true, true, ...getItemPageLinksToFollow());
         }),
         getAllSucceededRemoteData(),
       ).subscribe((rd: RemoteData<Item>) => {

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
@@ -320,8 +320,8 @@ export class ItemDeleteComponent
     this.linkService.resolveLinks(
       relationship,
       followLink('relationshipType'),
-      followLink('leftItem'),
-      followLink('rightItem'),
+      followLink('leftItem', undefined, followLink<Item>('accessStatus')),
+      followLink('rightItem', undefined, followLink<Item>('accessStatus')),
     );
     return relationship.relationshipType.pipe(
       getFirstSucceededRemoteData(),

--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -478,7 +478,7 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
     );
 
     // this adds thumbnail images when required by configuration
-    const linksToFollow: FollowLinkConfig<Relationship>[] = itemLinksToFollow(this.fetchThumbnail);
+    const linksToFollow: FollowLinkConfig<Relationship>[] = itemLinksToFollow(this.fetchThumbnail, this.appConfig.item.showAccessStatuses);
 
     this.subs.push(
       observableCombineLatest([

--- a/src/app/item-page/item-page.resolver.ts
+++ b/src/app/item-page/item-page.resolver.ts
@@ -18,7 +18,7 @@ import { redirectOn4xx } from '../core/shared/authorized.operators';
 import { Item } from '../core/shared/item.model';
 import { getFirstCompletedRemoteData } from '../core/shared/operators';
 import { hasValue } from '../shared/empty.util';
-import { ITEM_PAGE_LINKS_TO_FOLLOW } from './item.resolver';
+import { getItemPageLinksToFollow } from './item.resolver';
 import { getItemPageRoute } from './item-page-routing-paths';
 
 /**
@@ -44,7 +44,7 @@ export const itemPageResolver: ResolveFn<RemoteData<Item>> = (
     route.params.id,
     true,
     false,
-    ...ITEM_PAGE_LINKS_TO_FOLLOW,
+    ...getItemPageLinksToFollow(),
   ).pipe(
     getFirstCompletedRemoteData(),
     redirectOn4xx(router, authService),

--- a/src/app/item-page/item.resolver.ts
+++ b/src/app/item-page/item.resolver.ts
@@ -7,6 +7,7 @@ import {
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
+import { environment } from '../../environments/environment';
 import { AppState } from '../app.reducer';
 import { ItemDataService } from '../core/data/item-data.service';
 import { RemoteData } from '../core/data/remote-data';
@@ -22,15 +23,21 @@ import {
  * The self links defined in this list are expected to be requested somewhere in the near future
  * Requesting them as embeds will limit the number of requests
  */
-export const ITEM_PAGE_LINKS_TO_FOLLOW: FollowLinkConfig<Item>[] = [
-  followLink('owningCollection', {},
-    followLink('parentCommunity', {},
-      followLink('parentCommunity')),
-  ),
-  followLink('relationships'),
-  followLink('version', {}, followLink('versionhistory')),
-  followLink('thumbnail'),
-];
+export function getItemPageLinksToFollow(): FollowLinkConfig<Item>[] {
+  const followLinks: FollowLinkConfig<Item>[] = [
+    followLink('owningCollection', {},
+      followLink('parentCommunity', {},
+        followLink('parentCommunity')),
+    ),
+    followLink('relationships'),
+    followLink('version', {}, followLink('versionhistory')),
+    followLink('thumbnail'),
+  ];
+  if (environment.item.showAccessStatuses) {
+    followLinks.push(followLink('accessStatus'));
+  }
+  return followLinks;
+}
 
 export const itemResolver: ResolveFn<RemoteData<Item>> = (
   route: ActivatedRouteSnapshot,
@@ -42,7 +49,7 @@ export const itemResolver: ResolveFn<RemoteData<Item>> = (
     route.params.id,
     true,
     false,
-    ...ITEM_PAGE_LINKS_TO_FOLLOW,
+    ...getItemPageLinksToFollow(),
   ).pipe(
     getFirstCompletedRemoteData(),
   );

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -280,7 +280,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
         const relationship$ = this.relationshipService.findById(this.metadataService.virtualValue(this.value),
           true,
           true,
-          ... itemLinksToFollow(this.fetchThumbnail)).pipe(
+          ... itemLinksToFollow(this.fetchThumbnail, this.appConfig.item.showAccessStatuses)).pipe(
           getAllSucceededRemoteData(),
           getRemoteDataPayload());
         this.relationshipValue$ = observableCombineLatest([this.item$.pipe(take(1)), relationship$]).pipe(

--- a/src/app/shared/utils/relation-query.utils.ts
+++ b/src/app/shared/utils/relation-query.utils.ts
@@ -1,3 +1,4 @@
+import { Item } from '../../core/shared/item.model';
 import { Relationship } from '../../core/shared/item-relationships/relationship.model';
 import {
   followLink,
@@ -24,19 +25,22 @@ export function getFilterByRelation(relationType: string, itemUUID: string): str
 }
 
 /**
- * Creates links to follow for the leftItem and rightItem. Links will include
- * @param showThumbnail thumbnail image configuration
- * @returns followLink array
+ * Creates links to follow for the leftItem and rightItem. Optionally additional links for `thumbnail` & `accessStatus`
+ * can be embedded as well.
+ *
+ * @param showThumbnail    Whether the `thumbnail` needs to be embedded on the {@link Item}
+ * @param showAccessStatus Whether the `accessStatus` needs to be embedded on the {@link Item}
  */
-export function itemLinksToFollow(showThumbnail: boolean):  FollowLinkConfig<Relationship>[] {
-  let linksToFollow: FollowLinkConfig<Relationship>[];
+export function itemLinksToFollow(showThumbnail: boolean, showAccessStatus: boolean):  FollowLinkConfig<Relationship>[] {
+  const conditionalLinksToFollow: FollowLinkConfig<Item>[] = [];
   if (showThumbnail) {
-    linksToFollow = [
-      followLink('leftItem',{}, followLink('thumbnail')),
-      followLink('rightItem',{}, followLink('thumbnail')),
-    ];
-  } else {
-    linksToFollow = [followLink('leftItem'), followLink('rightItem')];
+    conditionalLinksToFollow.push(followLink<Item>('thumbnail'));
   }
-  return linksToFollow;
+  if (showAccessStatus) {
+    conditionalLinksToFollow.push(followLink<Item>('accessStatus'));
+  }
+  return [
+    followLink('leftItem', undefined, ...conditionalLinksToFollow),
+    followLink('rightItem', undefined, ...conditionalLinksToFollow),
+  ];
 }


### PR DESCRIPTION
## References
* Fixes DSpace/DSpace#9316
* Partially solves #3163
* Fixes #2833

## Description
Reduced the number of requests sent to the backend by caching embedded null objects (this will prevent unnecessary thumbnail requests). Also added support for caching embedded objects without a self-link. (Credit for this PR goes to @Atmire-Kristof)

## Instructions for Reviewers
List of changes in this PR:
* Added support to cache `null` responses.
* Added support to cache embedded objects without `self` links.
* Embedded the `accessStatus` in places where a separate request was made.

**Guidance for how to test/review this PR:**
- On [demo](https://demo.dspace.org/), go to your network tab and select Item Type Publication. Verify that a lot of `thumbnail` and `accessStatus` requests are made.
- Perform the same action with this fix and verify that both the `thumbnail` and `accessStatus` requests are now cached.
- These changes also apply to the browse page, the item page's related items section, the delete item tab, and the recent submissions section on the home page.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
