### PR TITLE
Configure Dependabot to also attempt minor/patch updates for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,108 @@
 # Enable Dependabot NPM updates for all dependencies on a weekly basis
 version: 2
 updates:
+  ###############
+  ## Main branch
+  ###############
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: main
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together Angular package upgrades
+    groups:
+      # Group together all minor/patch version updates for Angular in a single PR
+      angular:
+        applies-to: version-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for Angular. Only accept minor/patch types.
+      angular-security:
+        applies-to: security-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all minor/patch version updates for NgRx in a single PR
+      ngrx:
+        applies-to: version-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for NgRx. Only accept minor/patch types.
+      ngrx-security:
+        applies-to: security-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+    ignore:
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  #####################
+  ## dspace-8_x branch
+  #####################
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: dspace-8_x
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together Angular package upgrades
+    groups:
+      # Group together all patch version updates for Angular in a single PR
+      angular:
+        applies-to: version-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for Angular. Only accept minor/patch types.
+      angular-security:
+        applies-to: security-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all minor/patch version updates for NgRx in a single PR
+      ngrx:
+        applies-to: version-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for NgRx. Only accept minor/patch types.
+      ngrx-security:
+        applies-to: security-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+    ignore:
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  #####################
+  ## dspace-7_x branch
+  #####################
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: dspace-7_x
     schedule:
       interval: "weekly"
     # Allow up to 10 open PRs for dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,41 +7,41 @@ updates:
       interval: "weekly"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
-# Group together Angular package upgrades
-groups:
-  # Group together all minor/patch version updates for Angular in a single PR
-  angular:
-    applies-to: version-updates
-    patterns:
-    - "@angular*"
-    update-types:
-    - "minor"
-    - "patch"
-  # Group together all security updates for Angular. Only accept minor/patch types.
-  angular-security:
-    applies-to: security-updates
-    patterns:
-    - "@angular*"
-    update-types:
-    - "minor"
-    - "patch"
-  # Group together all minor/patch version updates for NgRx in a single PR
-  ngrx:
-    applies-to: version-updates
-    patterns:
-    - "@ngrx*"
-    update-types:
-    - "minor"
-    - "patch"
-  # Group together all security updates for NgRx. Only accept minor/patch types.
-  ngrx-security:
-    applies-to: security-updates
-    patterns:
-    - "@ngrx*"
-    update-types:
-    - "minor"
-    - "patch"
-ignore:
-  # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major"]
+    # Group together Angular package upgrades
+    groups:
+      # Group together all minor/patch version updates for Angular in a single PR
+      angular:
+        applies-to: version-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for Angular. Only accept minor/patch types.
+      angular-security:
+        applies-to: security-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all minor/patch version updates for NgRx in a single PR
+      ngrx:
+        applies-to: version-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all security updates for NgRx. Only accept minor/patch types.
+      ngrx-security:
+        applies-to: security-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+    ignore:
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Enable Dependabot NPM updates for all dependencies on a weekly basis
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+# Group together Angular package upgrades
+groups:
+  # Group together all minor/patch version updates for Angular in a single PR
+  angular:
+    applies-to: version-updates
+    patterns:
+    - "@angular*"
+    update-types:
+    - "minor"
+    - "patch"
+  # Group together all security updates for Angular. Only accept minor/patch types.
+  angular-security:
+    applies-to: security-updates
+    patterns:
+    - "@angular*"
+    update-types:
+    - "minor"
+    - "patch"
+  # Group together all minor/patch version updates for NgRx in a single PR
+  ngrx:
+    applies-to: version-updates
+    patterns:
+    - "@ngrx*"
+    update-types:
+    - "minor"
+    - "patch"
+  # Group together all security updates for NgRx. Only accept minor/patch types.
+  ngrx-security:
+    applies-to: security-updates
+    patterns:
+    - "@ngrx*"
+    update-types:
+    - "minor"
+    - "patch"
+ignore:
+  # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description
Create dependabot.yml.  Add an initial configuration which does the following:
* Checks for dependency updates weekly.  Automatically creates PRs for non-major updates (i.e. minor and patch only)
* Configures groups for Angular & NgRx updates to ensure these dependencies are updated together in a single PR.  (Otherwise, dependabot will attempt to send a PR per dependency)
* Enables dependabot also on `dspace-8_x` and `dspace-7_x` branches (currently, all branches have identical settings)

References
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates

## Instructions for Reviewers
I don't believe there is any way to test this other than to apply it and see what Dependabot does.