### PR TITLE
[dspace-7_x] Fix Collection Page e2e test. Wait on Recent Submissions

### DIFF
--- a/cypress/e2e/collection-page.cy.ts
+++ b/cypress/e2e/collection-page.cy.ts
@@ -3,7 +3,14 @@ import { testA11y } from 'cypress/support/utils';
 describe('Collection Page', () => {
 
   it('should pass accessibility tests', () => {
+    cy.intercept('POST', '/server/api/statistics/viewevents').as('viewevent');
+
+    // Visit Collections page
     cy.visit('/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')));
+
+    // Wait for the "viewevent" to trigger on the Collection page.
+    // This ensures our <ds-collection-page> tag  is fully loaded, as the <ds-view-event> tag is contained within it.
+    cy.wait('@viewevent');
 
     // <ds-collection-page> tag must be loaded
     cy.get('ds-collection-page').should('be.visible');


### PR DESCRIPTION
## Description
Frequently, the `collection-page.cy.ts` is failing because the e2e test times out before the Collection Page fully loads.  This simply updates the test to wait on the list of Recent Submissions before performing any other tests.

## Instructions for Reviewers
* If e2e tests succeed, I'll merge this immediately.  This failure is occurring frequently on the 7.x branch (only)