### PR TITLE
[dspace-7_x] Fix flakey Item page accessibility tests by waiting for pages to fuly load

### DIFF
--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -18,6 +18,11 @@ describe('Edit Item > Edit Metadata tab', () => {
     // <ds-edit-item-page> tag must be loaded
     cy.get('ds-edit-item-page').should('be.visible');
 
+    // wait for all the Edit Item tabs to be rendered
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLDivElement) => {
+      cy.wrap($row).find('li[role="presentation"]').should('be.visible');
+    });
+
     // wait for all the ds-dso-edit-metadata-value components to be rendered
     cy.get('ds-dso-edit-metadata-value div[role="row"]').each(($row: HTMLDivElement) => {
       cy.wrap($row).find('div[role="cell"]').should('be.visible');

--- a/cypress/e2e/item-page.cy.ts
+++ b/cypress/e2e/item-page.cy.ts
@@ -12,7 +12,13 @@ describe('Item  Page', () => {
     });
 
     it('should pass accessibility tests', () => {
+        cy.intercept('POST', '/server/api/statistics/viewevents').as('viewevent');
+
         cy.visit(ENTITYPAGE);
+
+        // Wait for the "viewevent" to trigger on the Item page.
+        // This ensures our <ds-item-page> tag  is fully loaded, as the <ds-view-event> tag is contained within it.
+        cy.wait('@viewevent');
 
         // <ds-item-page> tag must be loaded
         cy.get('ds-item-page').should('be.visible');
@@ -22,7 +28,13 @@ describe('Item  Page', () => {
     });
 
     it('should pass accessibility tests on full item page', () => {
+        cy.intercept('POST', '/server/api/statistics/viewevents').as('viewevent');
+
         cy.visit(ENTITYPAGE + '/full');
+
+        // Wait for the "viewevent" to trigger on the Item page.
+        // This ensures our <ds-item-page> tag  is fully loaded, as the <ds-view-event> tag is contained within it.
+        cy.wait('@viewevent');
 
         // <ds-full-item-page> tag must be loaded
         cy.get('ds-full-item-page').should('be.visible');


### PR DESCRIPTION
## Description
After merging #3432 , the Item page e2e accessibility tests have gotten a bit more flakey.

This small PR attempts to fix them by forcing the e2e tests to wait for the Item page to fully load **before** running an accessibility scan on the page.

## Instructions for Reviewers
* If the e2e tests now fully pass, this was successful.  Otherwise this needs more work