### PR TITLE
[Port dspace-7_x] Remove unused dependencies (webfontloader only)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,6 @@
               "lodash",
               "jwt-decode",
               "uuid",
-              "webfontloader",
               "zone.js"
             ],
             "outputPath": "dist/browser",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "sanitize-html": "^2.12.1",
     "sortablejs": "1.15.0",
     "uuid": "^8.3.2",
-    "webfontloader": "1.6.28",
     "zone.js": "~0.11.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12044,11 +12044,6 @@ webdriver-manager@^12.1.8:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
-webfontloader@1.6.28:
-  version "1.6.28"
-  resolved "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz"
-  integrity sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"


### PR DESCRIPTION
## Description
Manual port of #3509 to `dspace-7_x`. 

Because `dspace-7_x` still uses both sortablejs and sanitize-html, this ONLY removes webfontloader.

## Instructions for Reviewers
* Verify tests all still succeed.