### PR TITLE
Remove unused `@types/sanitize-html` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
         "@types/js-cookie": "2.2.6",
         "@types/lodash": "^4.17.12",
         "@types/node": "^14.14.9",
-        "@types/sanitize-html": "^2.9.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@typescript-eslint/rule-tester": "^7.18.0",
@@ -7052,15 +7051,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/sanitize-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.11.0.tgz",
-      "integrity": "sha512-7oxPGNQHXLHE48r/r/qjn7q0hlrs3kL7oZnGj0Wf/h9tj/6ibFyRkNbsDxaBBZ4XUZ0Dx5LGCyDJ04ytSofacQ==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^8.0.0"
-      }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
     "@types/js-cookie": "2.2.6",
     "@types/lodash": "^4.17.12",
     "@types/node": "^14.14.9",
-    "@types/sanitize-html": "^2.9.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@typescript-eslint/rule-tester": "^7.18.0",


### PR DESCRIPTION
## Description
Follow-up to #3511, which accidentally forgot to remove `@types/sanitize-html`.  

See also #3509 (the 8.x version) which removes `@types/sanitize-html` from `dspace-8_x`.  This change was supposed to be ported to `main` in #3511, but was accidently forgotten.

## Instructions for Reviewers
* This `@types/sanitize-html` dependency is only used in the dev environment for compilation, etc.  So, if this compiles & passes all tests, then it can be merged.