### PR TITLE
Remove unused PostCSS plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
         "postcss-import": "^14.0.0",
         "postcss-loader": "^4.0.3",
         "postcss-preset-env": "^7.4.2",
-        "postcss-responsive-type": "1.0.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "rimraf": "^3.0.2",
@@ -19031,38 +19030,6 @@
       "dev": true,
       "peerDependencies": {
         "postcss": "^8.0.3"
-      }
-    },
-    "node_modules/postcss-responsive-type": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-responsive-type/-/postcss-responsive-type-1.0.0.tgz",
-      "integrity": "sha512-O4kAKbc4RLnSkzcguJ6ojW67uOfeILaj+8xjsO0quLU94d8BKCqYwwFEUVRNbj0YcXA6d3uF/byhbaEATMRVig==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^6.0.6"
-      }
-    },
-    "node_modules/postcss-responsive-type/node_modules/postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-responsive-type/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-selector-not": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,6 @@
         "ngx-mask": "14.2.4",
         "nodemon": "^2.0.22",
         "postcss": "^8.4",
-        "postcss-apply": "0.12.0",
         "postcss-import": "^14.0.0",
         "postcss-loader": "^4.0.3",
         "postcss-preset-env": "^7.4.2",
@@ -18351,48 +18350,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-apply": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.12.0.tgz",
-      "integrity": "sha512-u8qZLyA9P86cD08IhqjSVV8tf1eGiKQ4fPvjcG3Ic/eOU65EAkDQClp8We7d15TG+RIWRVPSy9v7cJ2D9OReqw==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^7.0.14"
-      }
-    },
-    "node_modules/postcss-apply/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true
-    },
-    "node_modules/postcss-apply/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-apply/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {

--- a/package.json
+++ b/package.json
@@ -227,7 +227,6 @@
     "ngx-mask": "14.2.4",
     "nodemon": "^2.0.22",
     "postcss": "^8.4",
-    "postcss-apply": "0.12.0",
     "postcss-import": "^14.0.0",
     "postcss-loader": "^4.0.3",
     "postcss-preset-env": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,6 @@
     "postcss-import": "^14.0.0",
     "postcss-loader": "^4.0.3",
     "postcss-preset-env": "^7.4.2",
-    "postcss-responsive-type": "1.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "rimraf": "^3.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   plugins: [
     require('postcss-import')(),
-    require('postcss-preset-env')(),
-    require('postcss-responsive-type')()
+    require('postcss-preset-env')()
   ]
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,6 @@ module.exports = {
   plugins: [
     require('postcss-import')(),
     require('postcss-preset-env')(),
-    require('postcss-apply')(),
     require('postcss-responsive-type')()
   ]
 };


### PR DESCRIPTION
## Description
Several [PostCSS](https://postcss.org/) plugins are installed in DSpace but are unused.  Specifically:
* [`postcss-apply`](https://www.npmjs.com/package/postcss-apply)  (used via `@apply`...which is never used in our SCSS files)
* [`postcss-responsive-type`](https://www.npmjs.com/package/postcss-responsive-type) (used via `responsive`...which is never used in our SCSS files)

Because these are unused, I'm removing them completely.  Both of these plugins also rely on outdated versions of PostCSS.  So, removing them makes it much easier to upgrade PostCSS in the future.

## Instructions for Reviewers
* Ensure UI still compiles and passes tests
* Ensure themes still work.  I've already tested this manually and found no changes in behavior.