### PR TITLE
Made expandable navbar section more keyboard accessible

### DIFF
--- a/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.ts
+++ b/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.ts
@@ -84,7 +84,7 @@ export class ExpandableAdminSidebarSectionComponent extends AdminSidebarSectionC
     this.sidebarActiveBg$ = this.variableService.getVariable('--ds-admin-sidebar-active-bg');
     this.isSidebarCollapsed$ = this.menuService.isMenuCollapsed(this.menuID);
     this.isSidebarPreviewCollapsed$ = this.menuService.isMenuPreviewCollapsed(this.menuID);
-    this.isExpanded$ = combineLatestObservable([this.active, this.isSidebarCollapsed$, this.isSidebarPreviewCollapsed$]).pipe(
+    this.isExpanded$ = combineLatestObservable([this.active$, this.isSidebarCollapsed$, this.isSidebarPreviewCollapsed$]).pipe(
       map(([active, sidebarCollapsed, sidebarPreviewCollapsed]) => (active && (!sidebarCollapsed || !sidebarPreviewCollapsed))),
     );
   }

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,36 +1,37 @@
-<div class="ds-menu-item-wrapper text-md-center"
-    [id]="'expandable-navbar-section-' + section.id"
-    (mouseenter)="onMouseEnter($event)"
-    (mouseleave)="onMouseLeave($event)"
-    data-test="navbar-section-wrapper">
-    <a href="javascript:void(0);" routerLinkActive="active"
-       role="menuitem"
-       (keyup.enter)="toggleSection($event)"
-       (keyup.space)="toggleSection($event)"
-       (click)="toggleSection($event)"
-       (keydown.space)="$event.preventDefault()"
-       (keydown.tab)="deactivateSection($event, false)"
-       aria-haspopup="menu"
-       data-test="navbar-section-toggler"
-       [attr.aria-expanded]="(active$ | async).valueOf()"
-       [attr.aria-controls]="expandableNavbarSectionId(section.id)"
-       class="d-flex flex-row flex-nowrap align-items-center gapx-1 ds-menu-toggler-wrapper"
-       [class.disabled]="section.model?.disabled">
+<div #expandableNavbarSectionContainer class="ds-menu-item-wrapper text-md-center"
+     [id]="'expandable-navbar-section-' + section.id"
+     (mouseenter)="onMouseEnter($event)"
+     (mouseleave)="onMouseLeave($event)"
+     data-test="navbar-section-wrapper">
+  <a href="javascript:void(0);" routerLinkActive="active"
+     role="menuitem"
+     (keyup.enter)="toggleSection($event)"
+     (keyup.space)="toggleSection($event)"
+     (click)="toggleSection($event)"
+     (keydown)="keyDown($event)"
+     aria-haspopup="menu"
+     data-test="navbar-section-toggler"
+     [attr.aria-expanded]="(active$ | async).valueOf()"
+     [attr.aria-controls]="expandableNavbarSectionId()"
+     class="d-flex flex-row flex-nowrap align-items-center gapx-1 ds-menu-toggler-wrapper"
+     [class.disabled]="section.model?.disabled">
       <span class="flex-fill">
         <ng-container
           *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
       </span>
-      <i class="fas fa-caret-down fa-xs toggle-menu-icon" aria-hidden="true"></i>
-    </a>
-    <div *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
-        [id]="expandableNavbarSectionId(section.id)"
-        role="menu"
-        class="dropdown-menu show nav-dropdown-menu m-0 shadow-none border-top-0 px-3 px-md-0 pt-0 pt-md-1">
-      <div @slide role="presentation">
-        <div *ngFor="let subSection of (subSections$ | async)" class="text-nowrap" role="presentation">
-              <ng-container
-                      *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
-          </div>
+    <i class="fas fa-caret-down fa-xs toggle-menu-icon" aria-hidden="true"></i>
+  </a>
+  <div *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
+       [id]="expandableNavbarSectionId()"
+       [dsHoverOutsideOfElement]="expandableNavbarSection"
+       (dsHoverOutside)="deactivateSection($event, false)"
+       role="menu"
+       class="dropdown-menu show nav-dropdown-menu m-0 shadow-none border-top-0 px-3 px-md-0 pt-0 pt-md-1">
+    <div @slide role="presentation">
+      <div *ngFor="let subSection of (subSections$ | async)" class="text-nowrap" role="presentation">
+        <ng-container
+          *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
       </div>
     </div>
+  </div>
 </div>

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -9,6 +9,7 @@
        (keyup.space)="toggleSection($event)"
        (click)="toggleSection($event)"
        (keydown.space)="$event.preventDefault()"
+       (keydown.tab)="deactivateSection($event, false)"
        aria-haspopup="menu"
        data-test="navbar-section-toggler"
        [attr.aria-expanded]="(active$ | async).valueOf()"
@@ -21,13 +22,15 @@
       </span>
       <i class="fas fa-caret-down fa-xs toggle-menu-icon" aria-hidden="true"></i>
     </a>
-    <div @slide *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
+    <div *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
         [id]="expandableNavbarSectionId(section.id)"
         role="menu"
         class="dropdown-menu show nav-dropdown-menu m-0 shadow-none border-top-0 px-3 px-md-0 pt-0 pt-md-1">
+      <div @slide role="presentation">
         <div *ngFor="let subSection of (subSections$ | async)" class="text-nowrap" role="presentation">
-            <ng-container
-                    *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
-        </div>
+              <ng-container
+                      *ngComponentOutlet="(sectionMap$ | async).get(subSection.id).component; injector: (sectionMap$ | async).get(subSection.id).injector;"></ng-container>
+          </div>
+      </div>
     </div>
 </div>

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,9 +1,8 @@
 <div class="ds-menu-item-wrapper text-md-center"
     [id]="'expandable-navbar-section-' + section.id"
-    (mouseenter)="onMouseEnter($event, isActive)"
-    (mouseleave)="onMouseLeave($event, isActive)"
-    data-test="navbar-section-wrapper"
-    *ngVar="(active | async) as isActive">
+    (mouseenter)="onMouseEnter($event)"
+    (mouseleave)="onMouseLeave($event)"
+    data-test="navbar-section-wrapper">
     <a href="javascript:void(0);" routerLinkActive="active"
        role="menuitem"
        (keyup.enter)="toggleSection($event)"
@@ -12,18 +11,17 @@
        (keydown.space)="$event.preventDefault()"
        aria-haspopup="menu"
        data-test="navbar-section-toggler"
-       [attr.aria-expanded]="isActive"
+       [attr.aria-expanded]="(active$ | async).valueOf()"
        [attr.aria-controls]="expandableNavbarSectionId(section.id)"
        class="d-flex flex-row flex-nowrap align-items-center gapx-1 ds-menu-toggler-wrapper"
        [class.disabled]="section.model?.disabled">
       <span class="flex-fill">
         <ng-container
           *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
-<!--        <span class="sr-only">{{'nav.expandable-navbar-section-suffix' | translate}}</span>-->
       </span>
       <i class="fas fa-caret-down fa-xs toggle-menu-icon" aria-hidden="true"></i>
     </a>
-    <div @slide *ngIf="isActive" (click)="deactivateSection($event)"
+    <div @slide *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
         [id]="expandableNavbarSectionId(section.id)"
         role="menu"
         class="dropdown-menu show nav-dropdown-menu m-0 shadow-none border-top-0 px-3 px-md-0 pt-0 pt-md-1">

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -1,4 +1,4 @@
-<div #expandableNavbarSectionContainer class="ds-menu-item-wrapper text-md-center"
+<div class="ds-menu-item-wrapper text-md-center"
      [id]="'expandable-navbar-section-' + section.id"
      (mouseenter)="onMouseEnter($event)"
      (mouseleave)="onMouseLeave($event)"
@@ -23,7 +23,7 @@
   </a>
   <div *ngIf="(active$ | async).valueOf() === true" (click)="deactivateSection($event)"
        [id]="expandableNavbarSectionId()"
-       [dsHoverOutsideOfElement]="expandableNavbarSection"
+       [dsHoverOutsideOfParentSelector]="'#expandable-navbar-section-' + section.id"
        (dsHoverOutside)="deactivateSection($event, false)"
        role="menu"
        class="dropdown-menu show nav-dropdown-menu m-0 shadow-none border-top-0 px-3 px-md-0 pt-0 pt-md-1">

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -12,7 +12,7 @@ import { HostWindowService } from '../../shared/host-window.service';
 import { MenuService } from '../../shared/menu/menu.service';
 import { HostWindowServiceStub } from '../../shared/testing/host-window-service.stub';
 import { MenuServiceStub } from '../../shared/testing/menu-service.stub';
-import { VarDirective } from '../../shared/utils/var.directive';
+import { HoverOutsideDirective } from '../../shared/utils/hover-outside.directive';
 import { ExpandableNavbarSectionComponent } from './expandable-navbar-section.component';
 
 describe('ExpandableNavbarSectionComponent', () => {
@@ -23,7 +23,12 @@ describe('ExpandableNavbarSectionComponent', () => {
   describe('on larger screens', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, ExpandableNavbarSectionComponent, TestComponent, VarDirective],
+        imports: [
+          ExpandableNavbarSectionComponent,
+          HoverOutsideDirective,
+          NoopAnimationsModule,
+          TestComponent,
+        ],
         providers: [
           { provide: 'sectionDataProvider', useValue: {} },
           { provide: MenuService, useValue: menuService },
@@ -39,10 +44,6 @@ describe('ExpandableNavbarSectionComponent', () => {
       component = fixture.componentInstance;
       spyOn(component as any, 'getMenuItemComponent').and.returnValue(TestComponent);
       fixture.detectChanges();
-    });
-
-    it('should create', () => {
-      expect(component).toBeTruthy();
     });
 
     describe('when the mouse enters the section header (while inactive)', () => {
@@ -184,7 +185,12 @@ describe('ExpandableNavbarSectionComponent', () => {
   describe('on smaller, mobile screens', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, ExpandableNavbarSectionComponent, TestComponent, VarDirective],
+        imports: [
+          ExpandableNavbarSectionComponent,
+          HoverOutsideDirective,
+          NoopAnimationsModule,
+          TestComponent,
+        ],
         providers: [
           { provide: 'sectionDataProvider', useValue: {} },
           { provide: MenuService, useValue: menuService },

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -112,10 +112,13 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
 
   ngAfterViewChecked(): void {
     if (this.addArrowEventListeners) {
-      const dropdownItems = document.querySelectorAll(`#${this.expandableNavbarSectionId()} *[role="menuitem"]`);
-      dropdownItems.forEach(item => {
+      const dropdownItems: NodeListOf<HTMLElement> = document.querySelectorAll(`#${this.expandableNavbarSectionId()} *[role="menuitem"]`);
+      dropdownItems.forEach((item: HTMLElement) => {
         item.addEventListener('keydown', this.navigateDropdown.bind(this));
       });
+      if (dropdownItems.length > 0) {
+        dropdownItems.item(0).focus();
+      }
       this.addArrowEventListeners = false;
     }
   }
@@ -195,7 +198,7 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
         this.deactivateSection(event, false);
         break;
       case 'ArrowDown':
-        this.navigateDropdown(event);
+        this.activateSection(event);
         break;
       case 'Space':
         event.preventDefault();

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -166,8 +166,12 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
    * @param event
    */
   navigateDropdown(event: KeyboardEvent): void {
-    if (event.key === 'Tab') {
+    if (event.code === 'Tab') {
       this.deactivateSection(event, false);
+      return;
+    } else if (event.code === 'Escape') {
+      this.deactivateSection(event, false);
+      (document.querySelector(`a[aria-controls="${this.expandableNavbarSectionId()}"]`) as HTMLElement)?.focus();
       return;
     }
     event.preventDefault();

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -84,13 +84,12 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
   /**
    * When the mouse enters the section toggler activate the menu section
    * @param $event
-   * @param isActive
    */
-  onMouseEnter($event: Event, isActive: boolean) {
+  onMouseEnter($event: Event): void {
     this.isMobile$.pipe(
       first(),
     ).subscribe((isMobile) => {
-      if (!isMobile && !isActive && !this.mouseEntered) {
+      if (!isMobile && !this.active$.value && !this.mouseEntered) {
         this.activateSection($event);
       }
       this.mouseEntered = true;
@@ -100,13 +99,12 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
   /**
    * When the mouse leaves the section toggler deactivate the menu section
    * @param $event
-   * @param isActive
    */
-  onMouseLeave($event: Event, isActive: boolean) {
+  onMouseLeave($event: Event): void {
     this.isMobile$.pipe(
       first(),
     ).subscribe((isMobile) => {
-      if (!isMobile && isActive && this.mouseEntered) {
+      if (!isMobile && this.active$.value && this.mouseEntered) {
         this.deactivateSection($event);
       }
       this.mouseEntered = false;

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -56,6 +56,11 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
   mouseEntered = false;
 
   /**
+   * Whether the section was expanded
+   */
+  focusOnFirstChildSection = false;
+
+  /**
    * True if screen size was small before a resize event
    */
   wasMobile = undefined;
@@ -107,6 +112,7 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
       if (active === true) {
         this.addArrowEventListeners = true;
       } else {
+        this.focusOnFirstChildSection = undefined;
         this.unsubscribeFromEventListeners();
       }
     }));
@@ -118,7 +124,7 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
       this.dropdownItems.forEach((item: HTMLElement) => {
         item.addEventListener('keydown', this.navigateDropdown.bind(this));
       });
-      if (this.dropdownItems.length > 0) {
+      if (this.focusOnFirstChildSection && this.dropdownItems.length > 0) {
         this.dropdownItems.item(0).focus();
       }
       this.addArrowEventListeners = false;
@@ -128,6 +134,18 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
   ngOnDestroy(): void {
     super.ngOnDestroy();
     this.unsubscribeFromEventListeners();
+  }
+
+  /**
+   * Activate this section if it's currently inactive, deactivate it when it's currently active.
+   * Also saves whether this toggle was performed by a keyboard event (non-click event) in order to know if thi first
+   * item should be focussed when activating a section.
+   *
+   *  @param {Event} event The user event that triggered this method
+   */
+  override toggleSection(event: Event): void {
+    this.focusOnFirstChildSection = event.type !== 'click';
+    super.toggleSection(event);
   }
 
   /**
@@ -222,9 +240,11 @@ export class ExpandableNavbarSectionComponent extends NavbarSectionComponent imp
         this.deactivateSection(event, false);
         break;
       case 'ArrowDown':
+        this.focusOnFirstChildSection = true;
         this.activateSection(event);
         break;
       case 'Space':
+      case 'Enter':
         event.preventDefault();
         break;
     }

--- a/src/app/shared/menu/menu-section/menu-section.component.ts
+++ b/src/app/shared/menu/menu-section/menu-section.component.ts
@@ -37,9 +37,9 @@ import { MenuSection } from '../menu-section.model';
 export class MenuSectionComponent implements OnInit, OnDestroy {
 
   /**
-   * Observable that emits whether or not this section is currently active
+   * {@link BehaviorSubject} containing the current state to whether this section is currently active
    */
-  active: Observable<boolean>;
+  active$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   /**
    * The ID of the menu this section resides in
@@ -72,7 +72,9 @@ export class MenuSectionComponent implements OnInit, OnDestroy {
    * Set initial values for instance variables
    */
   ngOnInit(): void {
-    this.active = this.menuService.isSectionActive(this.menuID, this.section.id).pipe(distinctUntilChanged());
+    this.menuService.isSectionActive(this.menuID, this.section.id).pipe(distinctUntilChanged()).subscribe((isActive: boolean) => {
+      this.active$.next(isActive);
+    });
     this.initializeInjectorData();
   }
 

--- a/src/app/shared/menu/menu-section/menu-section.component.ts
+++ b/src/app/shared/menu/menu-section/menu-section.component.ts
@@ -102,10 +102,14 @@ export class MenuSectionComponent implements OnInit, OnDestroy {
 
   /**
    * Deactivate this section
+   *
    * @param {Event} event The user event that triggered this method
+   * @param skipEvent Weather the event should still be triggered after deactivating the section or not
    */
-  deactivateSection(event: Event) {
-    event.preventDefault();
+  deactivateSection(event: Event, skipEvent = true): void {
+    if (skipEvent) {
+      event.preventDefault();
+    }
     this.menuService.deactivateSection(this.menuID, this.section.id);
   }
 

--- a/src/app/shared/menu/menu-section/menu-section.component.ts
+++ b/src/app/shared/menu/menu-section/menu-section.component.ts
@@ -92,9 +92,12 @@ export class MenuSectionComponent implements OnInit, OnDestroy {
   /**
    * Activate this section
    * @param {Event} event The user event that triggered this method
+   * @param skipEvent Weather the event should still be triggered after deactivating the section or not
    */
-  activateSection(event: Event) {
-    event.preventDefault();
+  activateSection(event: Event, skipEvent = true): void {
+    if (skipEvent) {
+      event.preventDefault();
+    }
     if (!this.section.model?.disabled) {
       this.menuService.activateSection(this.menuID, this.section.id);
     }

--- a/src/app/shared/menu/menu-section/menu-section.component.ts
+++ b/src/app/shared/menu/menu-section/menu-section.component.ts
@@ -72,9 +72,11 @@ export class MenuSectionComponent implements OnInit, OnDestroy {
    * Set initial values for instance variables
    */
   ngOnInit(): void {
-    this.menuService.isSectionActive(this.menuID, this.section.id).pipe(distinctUntilChanged()).subscribe((isActive: boolean) => {
-      this.active$.next(isActive);
-    });
+    this.subs.push(this.menuService.isSectionActive(this.menuID, this.section.id).pipe(distinctUntilChanged()).subscribe((isActive: boolean) => {
+      if (this.active$.value !== isActive) {
+        this.active$.next(isActive);
+      }
+    }));
     this.initializeInjectorData();
   }
 

--- a/src/app/shared/utils/hover-outside.directive.ts
+++ b/src/app/shared/utils/hover-outside.directive.ts
@@ -1,0 +1,51 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+
+/**
+ * Directive to detect when the user hovers outside of the element the directive was put on
+ *
+ * BEWARE: it's probably not good for performance to use this excessively (on {@link ExpandableNavbarSectionComponent}
+ * for example, a workaround for this problem was to add an `*ngIf` to prevent this Directive from always being active)
+ */
+@Directive({
+  selector: '[dsHoverOutside]',
+  standalone: true,
+})
+export class HoverOutsideDirective {
+
+  /**
+   * Emits null when the user hovers outside of the element
+   */
+  @Output()
+  public dsHoverOutside = new EventEmitter();
+
+  /**
+   * The {@link ElementRef} for which this directive should emit when the mouse leaves it. By default this will be the
+   * element the directive was put on.
+   */
+  @Input()
+  public dsHoverOutsideOfElement: ElementRef;
+
+  constructor(
+    private elementRef: ElementRef,
+  ) {
+    this.dsHoverOutsideOfElement = this.elementRef;
+  }
+
+  @HostListener('document:mouseover', ['$event'])
+  public onMouseOver(event: MouseEvent): void {
+    const targetElement: HTMLElement = event.target as HTMLElement;
+    const hoveredInside = this.dsHoverOutsideOfElement.nativeElement.contains(targetElement);
+
+    if (!hoveredInside) {
+      this.dsHoverOutside.emit(null);
+    }
+  }
+
+}

--- a/src/app/shared/utils/hover-outside.directive.ts
+++ b/src/app/shared/utils/hover-outside.directive.ts
@@ -8,10 +8,11 @@ import {
 } from '@angular/core';
 
 /**
- * Directive to detect when the user hovers outside of the element the directive was put on
+ * Directive to detect when the user hovers outside the element the directive was put on
  *
- * BEWARE: it's probably not good for performance to use this excessively (on {@link ExpandableNavbarSectionComponent}
- * for example, a workaround for this problem was to add an `*ngIf` to prevent this Directive from always being active)
+ * **Performance Consideration**: it's probably not good for performance to use this excessively (on
+ * {@link ExpandableNavbarSectionComponent} for example, a workaround for this problem was to add an `*ngIf` to prevent
+ * this Directive from always being active)
  */
 @Directive({
   selector: '[dsHoverOutside]',
@@ -26,22 +27,23 @@ export class HoverOutsideDirective {
   public dsHoverOutside = new EventEmitter();
 
   /**
-   * The {@link ElementRef} for which this directive should emit when the mouse leaves it. By default this will be the
-   * element the directive was put on.
+   * CSS selector for the parent element to monitor. If set, the directive will use this
+   * selector to determine if the hover event originated within the selected parent element.
+   * If left unset, the directive will monitor mouseover hover events for the element it is applied to.
    */
   @Input()
-  public dsHoverOutsideOfElement: ElementRef;
+  public dsHoverOutsideOfParentSelector: string;
 
   constructor(
     private elementRef: ElementRef,
   ) {
-    this.dsHoverOutsideOfElement = this.elementRef;
   }
 
   @HostListener('document:mouseover', ['$event'])
   public onMouseOver(event: MouseEvent): void {
     const targetElement: HTMLElement = event.target as HTMLElement;
-    const hoveredInside = this.dsHoverOutsideOfElement.nativeElement.contains(targetElement);
+    const element: Element = document.querySelector(this.dsHoverOutsideOfParentSelector);
+    const hoveredInside = (element ? new ElementRef(element) : this.elementRef).nativeElement.contains(targetElement);
 
     if (!hoveredInside) {
       this.dsHoverOutside.emit(null);

--- a/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -9,11 +9,9 @@ import { RouterLinkActive } from '@angular/router';
 
 import { ExpandableNavbarSectionComponent as BaseComponent } from '../../../../../app/navbar/expandable-navbar-section/expandable-navbar-section.component';
 import { slide } from '../../../../../app/shared/animations/slide';
+import { HoverOutsideDirective } from '../../../../../app/shared/utils/hover-outside.directive';
 import { VarDirective } from '../../../../../app/shared/utils/var.directive';
 
-/**
- * Represents an expandable section in the navbar
- */
 @Component({
   selector: 'ds-themed-expandable-navbar-section',
   // templateUrl: './expandable-navbar-section.component.html',
@@ -22,7 +20,15 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
   styleUrls: ['../../../../../app/navbar/expandable-navbar-section/expandable-navbar-section.component.scss'],
   animations: [slide],
   standalone: true,
-  imports: [VarDirective, RouterLinkActive, NgComponentOutlet, NgIf, NgFor, AsyncPipe],
+  imports: [
+    AsyncPipe,
+    HoverOutsideDirective,
+    NgComponentOutlet,
+    NgFor,
+    NgIf,
+    RouterLinkActive,
+    VarDirective,
+  ],
 })
 export class ExpandableNavbarSectionComponent extends BaseComponent {
 }

--- a/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
+++ b/src/themes/custom/app/navbar/expandable-navbar-section/expandable-navbar-section.component.ts
@@ -10,7 +10,6 @@ import { RouterLinkActive } from '@angular/router';
 import { ExpandableNavbarSectionComponent as BaseComponent } from '../../../../../app/navbar/expandable-navbar-section/expandable-navbar-section.component';
 import { slide } from '../../../../../app/shared/animations/slide';
 import { HoverOutsideDirective } from '../../../../../app/shared/utils/hover-outside.directive';
-import { VarDirective } from '../../../../../app/shared/utils/var.directive';
 
 @Component({
   selector: 'ds-themed-expandable-navbar-section',
@@ -27,7 +26,6 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
     NgFor,
     NgIf,
     RouterLinkActive,
-    VarDirective,
   ],
 })
 export class ExpandableNavbarSectionComponent extends BaseComponent {


### PR DESCRIPTION
## References
* Fixes #3085

## Description
Improved the accessibility of the expandable navbar menu section. For all the keyboard interactions, I based them on the [W3C guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/). The only behaviors I haven't implemented are the `Left Arrow` & `Right Arrow`.

## Instructions for Reviewers
List of changes in this PR:
* Created new `HoverOutsideDirective` to detect when you hover outside a specific element to close the expandable modal. This also works when you open it using your keyboard and hover outside the expandable navbar afterwards
* Added multiple new keyboard interaction behaviors:
  * Set focus on the first item when expanding the expandable navbar (with `space` & `enter`)
  * Added `Up Arrow` & `Down Arrow` support to navigate through the expandable navbar options
  * Close the expandable navbar with `esc` & `shift` + `tab`
  * Close the expandable navbar on `tab` and navigate to the next item

The only two keyboard interactions I didn't implement are `Left Arrow` & `Right Arrow`. To achieve these, we would need to know what the next & previous top-level items are. The cleanest approach would have been to trigger a `tab`/`shift` + `tab` event; however, doing this doesn't automatically set the focus on the next/previous top-level item, as this is controlled by the browser. Calculating these items using CSS selectors also didn't seem like a clean solution, which is why I didn't implement this.

**Guidance for how to test and review this PR:**
- Verify that all the keyboard interactions from the [W3C guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) now work (except for `Left Arrow` & `Right Arrow`).
- Some screen readers, like [NVDA](https://www.nvaccess.org/download/), block certain keys, causing specific keydown events to not work properly. If you have any screen readers, try enabling them to verify that this still works.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
