### PR TITLE
[DURACOM-301] fix facets search bar appearing if last page was full

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-authority-filter/search-authority-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-authority-filter/search-authority-filter.component.html
@@ -17,7 +17,9 @@
             </a>
         </div>
     </div>
-    <ds-filter-input-suggestions [suggestions]="(filterSearchResults$ | async)"
+    <ds-filter-input-suggestions
+                          *ngIf="(isLastPage$ | async) === false"
+                          [suggestions]="(filterSearchResults$ | async)"
                           [placeholder]="'search.filters.filter.' + filterConfig.name + '.placeholder' | translate"
                           [label]="'search.filters.filter.' + filterConfig.name + '.label' | translate"
                           [action]="currentUrl"
@@ -26,6 +28,5 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
-                          *ngIf="(isAvailableForShowSearchText | async) === false"
                           ngDefaultControl></ds-filter-input-suggestions>
 </div>

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter/search-facet-filter.component.ts
@@ -105,10 +105,6 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
   isLastPage$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   /**
-   * Emits true if show the search text
-   */
-  isAvailableForShowSearchText: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  /**
    * The value of the input field that is used to query for possible values for this filter
    */
   filter: string;
@@ -293,8 +289,6 @@ export class SearchFacetFilterComponent implements OnInit, OnDestroy {
         getFirstSucceededRemoteDataPayload(),
         tap((facetValues: FacetValues) => {
           this.isLastPage$.next(hasNoValue(facetValues?.next));
-          const hasLimitFacets =  facetValues?.page?.length < facetValues?.facetLimit;
-          this.isAvailableForShowSearchText.next(hasLimitFacets && hasNoValue(facetValues?.next));
         }),
       )),
       map((newFacetValues: FacetValues) => {

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.html
@@ -17,7 +17,9 @@
             </a>
         </div>
     </div>
-    <ds-filter-input-suggestions [suggestions]="(filterSearchResults$ | async)"
+    <ds-filter-input-suggestions
+                          *ngIf="(isLastPage$ | async) === false"
+                          [suggestions]="(filterSearchResults$ | async)"
                           [placeholder]="'search.filters.filter.' + filterConfig.name + '.placeholder' | translate"
                           [label]="'search.filters.filter.' + filterConfig.name + '.label' | translate"
                           [action]="currentUrl"
@@ -26,7 +28,6 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
-                          *ngIf="(isAvailableForShowSearchText | async) === false"
                           ngDefaultControl
     ></ds-filter-input-suggestions>
 </div>

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.spec.ts
@@ -104,6 +104,22 @@ describe('SearchHierarchyFilterComponent', () => {
     showVocabularyTreeLink = fixture.debugElement.query(By.css(`a#show-${testSearchFilter}-tree`));
   }
 
+  describe('if the last page of facet values has been reached', () => {
+    beforeEach(() => {
+      spyOn(vocabularyService, 'searchTopEntries').and.returnValue(observableOf(new RemoteData(
+        undefined, 0, 0, RequestEntryState.Success, undefined, buildPaginatedList(new PageInfo(), []), 200,
+      )));
+      init();
+    });
+
+    it('should not show the search bar', () => {
+      comp.isLastPage$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      const textSearchBar = fixture.debugElement.query(By.css('ds-filter-input-suggestions'));
+      expect(textSearchBar).toBeNull();
+    });
+  });
+
   describe('if the vocabulary doesn\'t exist', () => {
 
     beforeEach(() => {

--- a/src/app/shared/search/search-filters/search-filter/search-text-filter/search-text-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-text-filter/search-text-filter.component.html
@@ -17,7 +17,9 @@
             </a>
         </div>
     </div>
-    <ds-filter-input-suggestions [suggestions]="(filterSearchResults$ | async)"
+    <ds-filter-input-suggestions
+                          *ngIf="(isLastPage$ | async) === false"
+                          [suggestions]="(filterSearchResults$ | async)"
                           [placeholder]="'search.filters.filter.' + filterConfig.name + '.placeholder' | translate"
                           [label]="'search.filters.filter.' + filterConfig.name + '.label' | translate"
                           [action]="currentUrl"
@@ -26,6 +28,5 @@
                           (submitSuggestion)="onSubmit($event)"
                           (clickSuggestion)="onClick($event)"
                           (findSuggestions)="findSuggestions($event)"
-                          *ngIf="(isAvailableForShowSearchText | async) === false"
                           ngDefaultControl></ds-filter-input-suggestions>
 </div>


### PR DESCRIPTION
## References
* Fixes #3611 

## Description
Removed the `isAvailableForShowSearchText` property in favor of using `isLastPage$` only. Used the latter as a condition in order to show or hide the search bar.

## Instructions for Reviewers

List of changes in this PR:
* Removed the `isAvailableForShowText` and replaced its use with a check for `(isLastPage$ | async) === false`;
* Added a test.

To reproduce the bug and its fix, as said in the linked issue:
1. Go to any search page and do a search that retrieves, for a single facet, a number of values multiple of 5;
2. Continue clicking on the "show more" button until it disappears. Now the search bar disappears.

![image](https://github.com/user-attachments/assets/d3d3578e-9a80-44d4-be21-02261657fe19)

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
