### PR TITLE
Fix Klaro translations by forcing Klaro to use a zy language code that DSpace will translate

### DIFF
--- a/src/app/shared/cookies/browser-klaro.service.spec.ts
+++ b/src/app/shared/cookies/browser-klaro.service.spec.ts
@@ -108,7 +108,7 @@ describe('BrowserKlaroService', () => {
 
     mockConfig = {
       translations: {
-        zz: {
+        zy: {
           purposes: {},
           test: {
             testeritis: testKey,
@@ -166,8 +166,8 @@ describe('BrowserKlaroService', () => {
 
   it('addAppMessages', () => {
     service.addAppMessages();
-    expect(mockConfig.translations.zz[appName]).toBeDefined();
-    expect(mockConfig.translations.zz.purposes[purpose]).toBeDefined();
+    expect(mockConfig.translations.zy[appName]).toBeDefined();
+    expect(mockConfig.translations.zy.purposes[purpose]).toBeDefined();
   });
 
   it('translateConfiguration', () => {

--- a/src/app/shared/cookies/browser-klaro.service.ts
+++ b/src/app/shared/cookies/browser-klaro.service.ts
@@ -111,7 +111,7 @@ export class BrowserKlaroService extends KlaroService {
   initialize() {
     if (!environment.info.enablePrivacyStatement) {
       delete this.klaroConfig.privacyPolicy;
-      this.klaroConfig.translations.zz.consentNotice.description = 'cookies.consent.content-notice.description.no-privacy';
+      this.klaroConfig.translations.zy.consentNotice.description = 'cookies.consent.content-notice.description.no-privacy';
     }
 
     const hideGoogleAnalytics$ = this.configService.findByPropertyName(this.GOOGLE_ANALYTICS_KEY).pipe(
@@ -258,12 +258,12 @@ export class BrowserKlaroService extends KlaroService {
    */
   addAppMessages() {
     this.klaroConfig.services.forEach((app) => {
-      this.klaroConfig.translations.zz[app.name] = {
+      this.klaroConfig.translations.zy[app.name] = {
         title: this.getTitleTranslation(app.name),
         description: this.getDescriptionTranslation(app.name),
       };
       app.purposes.forEach((purpose) => {
-        this.klaroConfig.translations.zz.purposes[purpose] = this.getPurposeTranslation(purpose);
+        this.klaroConfig.translations.zy.purposes[purpose] = this.getPurposeTranslation(purpose);
       });
     });
   }
@@ -277,7 +277,7 @@ export class BrowserKlaroService extends KlaroService {
      */
     this.translateService.setDefaultLang(environment.defaultLanguage);
 
-    this.translate(this.klaroConfig.translations.zz);
+    this.translate(this.klaroConfig.translations.zy);
   }
 
   /**

--- a/src/app/shared/cookies/klaro-configuration.ts
+++ b/src/app/shared/cookies/klaro-configuration.ts
@@ -23,7 +23,7 @@ export const GOOGLE_ANALYTICS_KLARO_KEY = 'google-analytics';
 
 /**
  * Klaro configuration
- * For more information see https://kiprotect.com/docs/klaro/annotated-config
+ * For more information see https://klaro.org/docs/integration/annotated-configuration
  */
 export const klaroConfiguration: any = {
   storageName: ANONYMOUS_STORAGE_NAME_KLARO,
@@ -54,20 +54,29 @@ export const klaroConfiguration: any = {
   htmlTexts: true,
 
   /*
+  Force Klaro to use our custom "zy" lang configs defined below.
+  */
+  lang: 'zy',
+
+  /*
   You can overwrite existing translations and add translations for your app
   descriptions and purposes. See `src/translations/` for a full list of
   translations that can be overwritten:
-  https://github.com/KIProtect/klaro/tree/master/src/translations
+  https://github.com/klaro-org/klaro-js/tree/master/src/translations
   */
   translations: {
     /*
-      The `zz` key contains default translations that will be used as fallback values.
-      This can e.g. be useful for defining a fallback privacy policy URL.
-      FOR DSPACE: We use 'zz' to map to our own i18n translations for klaro, see
+      For DSpace we use this custom 'zy' key to map to our own i18n translations for klaro, see
       translateConfiguration() in browser-klaro.service.ts. All the below i18n keys are specified
       in your /src/assets/i18n/*.json5 translation pack.
+      This 'zy' key has no special meaning to Klaro & is not a valid language code. It just
+      allows DSpace to override Klaro's own translations in favor of DSpace's i18n keys.
+      NOTE: we do not use 'zz' as that has special meaning to Klaro and is ONLY used as a "fallback"
+      if no other translations can be found within Klaro. Currently, a bug in Klaro means that
+      'zz' is never used as there's no way to exclude translations:
+      https://github.com/klaro-org/klaro-js/issues/515
     */
-    zz: {
+    zy: {
       acceptAll: 'cookies.consent.accept-all',
       acceptSelected: 'cookies.consent.accept-selected',
       close: 'cookies.consent.close',


### PR DESCRIPTION
## References
* Related to #2027 
* Broken since upgrade to Klaro 0.7.19. See https://github.com/klaro-org/klaro-js/issues/515
* Fixes #3618

## Description
After upgrading to Klaro 0.7.19 (or later), our custom message translations are no longer loading into Klaro.  This can be seen on both https://sandbox.dspace.org and https://demo.dspace.org because the Klaro Cookie pop-up shows the default Klaro text like this:
![klaro-text](https://github.com/user-attachments/assets/cc73b7af-6e25-4f0f-a4d8-753230d90afa)

The main issue is that the Klaro `'zz'` "default translations" no longer seem to work.  The reason is because Klaro only uses the `zz` translations if no other languages can be found, and (as of 0.7.19) the `klaro-no-translations` package is wrongly including all the translations (see https://github.com/klaro-org/klaro-js/issues/515).  So, there's no longer a way to tell Klaro to not include translations and therefore to _only_ use the `zz` language code.

This PR fixes the issue by changing our Klaro configuration to **force** Klaro to always use a (different, fake) language code of `zy`.  In our Klaro configuration, we then use our i18n keys for the `zy` language, and translate it to the user's language as we did before.

## Instructions for Reviewers
* Verify the Klaro cookie popup works as before.  It's easiest to verify by opening the homepage in an Incognito window.

This bug does NOT impact 7.6.2 or 8.0 (as they both used Klaro 0.7.18).  However, it does impact `main`, `dspace-8_x` and `dspace-7_x` as they all now use Klaro 0.7.21 (and this Klaro bug began with 0.7.19).