### PR TITLE
#3624 - Fix Multi-Row Drag-and-Drop Issue for Chips in Item Submission Form

### DIFF
--- a/src/app/shared/form/chips/chips.component.html
+++ b/src/app/shared/form/chips/chips.component.html
@@ -1,14 +1,18 @@
 <div [className]="'float-left w-100 ' + wrapperClass">
-  <div role="list" class="nav nav-pills d-flex flex-column flex-sm-row" cdkDropList cdkDropListOrientation="horizontal" (cdkDropListDropped)="onDrop($event)">
+  <div role="list" class="nav nav-pills d-flex flex-column flex-sm-row" cdkDropListGroup>
     <ng-template #tipContent>
       <p class="text-left p-0 m-0" *ngFor="let tip of tipText">
         {{tip}}
       </p>
     </ng-template>
-    <div role="listitem" class="nav-item mr-2 mb-1"
+    <div role="listitem" class="nav-item mr-2 mb-1 d-flex flex-row"
            *ngFor="let c of chips.getChips(); let i = index"
            #t="ngbTooltip"
            triggers="manual"
+           cdkDropList
+           [cdkDropListData]="{ index: i }"
+           cdkDropListOrientation="horizontal"
+           (cdkDropListDropped)="onDrop($event)"
            [ngbTooltip]="tipContent"
            (mouseover)="showTooltip(t, i)"
            (mouseout)="t.close()">

--- a/src/app/shared/form/chips/chips.component.scss
+++ b/src/app/shared/form/chips/chips.component.scss
@@ -1,7 +1,8 @@
 .cdk-drag-placeholder {
   filter: grayscale(100%);
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+  margin: 0 0.25rem;
 }
+
 .cdk-drag-preview {
   color: white;
   box-sizing: border-box;

--- a/src/app/shared/form/chips/chips.component.spec.ts
+++ b/src/app/shared/form/chips/chips.component.spec.ts
@@ -143,9 +143,9 @@ describe('ChipsComponent test suite', () => {
 
     it('should update chips item order when drag and drop end', fakeAsync(() => {
       spyOn(chipsComp.chips, 'updateOrder');
-      const de = chipsFixture.debugElement.query(By.css('div[role="list"]'));
+      const de = chipsFixture.debugElement.query(By.css('div[role="listitem"]'));
 
-      de.triggerEventHandler('cdkDropListDropped', { previousIndex: 0, currentIndex: 1 });
+      de.triggerEventHandler('cdkDropListDropped', { previousIndex: 0, currentIndex: 1, previousContainer: { data: { index: 0 } }, container: { data: { index: 1 } } });
 
       expect(chipsComp.dragged).toBe(-1);
       expect(chipsComp.chips.updateOrder).toHaveBeenCalled();

--- a/src/app/shared/form/chips/chips.component.ts
+++ b/src/app/shared/form/chips/chips.component.ts
@@ -2,6 +2,7 @@ import {
   CdkDrag,
   CdkDragDrop,
   CdkDropList,
+  CdkDropListGroup,
   moveItemInArray,
 } from '@angular/cdk/drag-drop';
 import {
@@ -48,6 +49,7 @@ import { ChipsItem } from './models/chips-item.model';
     TranslateModule,
     CdkDrag,
     CdkDropList,
+    CdkDropListGroup,
   ],
   standalone: true,
 })
@@ -105,8 +107,17 @@ export class ChipsComponent implements OnChanges {
     this.dragged = index;
   }
 
-  onDrop(event: CdkDragDrop<ChipsItem[]>) {
-    moveItemInArray(this.chips.chipsItems.getValue(), event.previousIndex, event.currentIndex);
+  onDrop(event: CdkDragDrop<{ index: number }>) {
+    const previousContainerIndex = event.previousContainer.data.index;
+    const currentContainerIndex = event.container.data.index;
+
+    const currentPositionInCurrentContainer = event.currentIndex;
+
+    const directionAdjuster = currentContainerIndex > previousContainerIndex ? -1 : 0;
+
+    moveItemInArray(this.chips.chipsItems.getValue(),
+      previousContainerIndex,
+      currentContainerIndex + currentPositionInCurrentContainer + directionAdjuster);
     this.dragged = -1;
     this.chips.updateOrder();
     this.isDragging.next(false);


### PR DESCRIPTION
## References
* Fixes #3624 

## Description
This PR addresses an issue with multi-row drag-and-drop functionality in DSpace’s item submission form. When chips are distributed across multiple rows, drag-and-drop operations fail due to limitations in the current Angular CDK version (17.3.10). This update ensures correct functionality for dragging and swapping items across rows in DSpace 8.

## Instructions for Reviewers
The changes in this PR ensure that items can be individually dragged between rows without affecting other items in adjacent rows.

List of changes in this PR:

- Defined cdkDropListGroup to connect all drag-and-drop items, allowing them to act independently within their respective rows.
- Assigned unique cdkDropList instances to each item to prevent unintended reordering of the entire list.
- Set cdkDropListOrientation to horizontal to control the drag direction, restricting movements along a single row.
- Updated the onDrop method to capture and handle item swaps within the chipsItems array, using indices for precise item placement.
- Adjusted CSS layout for visual consistency, aligning chips horizontally with appropriate spacing to enhance usability.

**Testing Instructions**

1. Go to the DSpace instance and initiate a new item submission in the "Articles" collection.
2. In the "Describe" section, under "Subject Keyword," add multiple keywords to create multiple rows.
3. Try dragging items within a row and between rows, observing that only the dragged item moves, and adjacent rows remain unaffected.

This fix ensures that the drag-and-drop functionality aligns with the expected user experience, allowing seamless interactions within and across rows.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
