### PR TITLE
Fix infinite loading on item pages and optimize menu resolver usage

### DIFF
--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -9,11 +9,6 @@ beforeEach(() => {
 
   // This page is restricted, so we will be shown the login form. Fill it out & submit.
   cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
-
-  // We need to wait for the correction types allowed for the item to be loaded to be sure that each tab is fully loaded.
-  // This because the edit item page causes often tests to fails due to timeout.
-  cy.intercept('GET', 'server/api/config/correctiontypes/search/findByItem*').as('correctionTypes');
-  cy.wait('@correctionTypes');
 });
 
 describe('Edit Item > Edit Metadata tab', () => {

--- a/src/app/browse-by/browse-by-page-routes.ts
+++ b/src/app/browse-by/browse-by-page-routes.ts
@@ -1,6 +1,5 @@
 import { Route } from '@angular/router';
 
-import { dsoEditMenuResolver } from '../shared/dso-page/dso-edit-menu.resolver';
 import { browseByDSOBreadcrumbResolver } from './browse-by-dso-breadcrumb.resolver';
 import { browseByGuard } from './browse-by-guard';
 import { browseByI18nBreadcrumbResolver } from './browse-by-i18n-breadcrumb.resolver';
@@ -11,7 +10,6 @@ export const ROUTES: Route[] = [
     path: '',
     resolve: {
       breadcrumb: browseByDSOBreadcrumbResolver,
-      menu: dsoEditMenuResolver,
     },
     children: [
       {

--- a/src/app/collection-page/collection-page-routes.ts
+++ b/src/app/collection-page/collection-page-routes.ts
@@ -54,7 +54,6 @@ export const ROUTES: Route[] = [
     resolve: {
       dso: collectionPageResolver,
       breadcrumb: collectionBreadcrumbResolver,
-      menu: dsoEditMenuResolver,
     },
     runGuardsAndResolvers: 'always',
     children: [
@@ -83,6 +82,9 @@ export const ROUTES: Route[] = [
       {
         path: '',
         component: ThemedCollectionPageComponent,
+        resolve: {
+          menu: dsoEditMenuResolver,
+        },
         children: [
           {
             path: '',

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -51,7 +51,6 @@ export const ROUTES: Route[] = [
     resolve: {
       dso: communityPageResolver,
       breadcrumb: communityBreadcrumbResolver,
-      menu: dsoEditMenuResolver,
     },
     runGuardsAndResolvers: 'always',
     children: [
@@ -70,6 +69,9 @@ export const ROUTES: Route[] = [
       {
         path: '',
         component: ThemedCommunityPageComponent,
+        resolve: {
+          menu: dsoEditMenuResolver,
+        },
         children: [
           {
             path: '',

--- a/src/app/core/data/base/base-data.service.spec.ts
+++ b/src/app/core/data/base/base-data.service.spec.ts
@@ -65,6 +65,7 @@ describe('BaseDataService', () => {
   let selfLink;
   let linksToFollow;
   let testScheduler;
+  let remoteDataTimestamp: number;
   let remoteDataMocks: { [responseType: string]: RemoteData<any> };
   let remoteDataPageMocks: { [responseType: string]: RemoteData<any> };
 
@@ -85,7 +86,9 @@ describe('BaseDataService', () => {
       expect(actual).toEqual(expected);
     });
 
-    const timeStamp = new Date().getTime();
+    // The response's lastUpdated equals the time of 60 seconds after the test started, ensuring they are not perceived
+    // as cached values.
+    remoteDataTimestamp = new Date().getTime() + 60 * 1000;
     const msToLive = 15 * 60 * 1000;
     const payload = {
       foo: 'bar',
@@ -112,22 +115,22 @@ describe('BaseDataService', () => {
     const statusCodeError = 404;
     const errorMessage = 'not found';
     remoteDataMocks = {
-      RequestPending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.RequestPending, undefined, undefined, undefined),
-      ResponsePending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.ResponsePending, undefined, undefined, undefined),
-      ResponsePendingStale: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.ResponsePendingStale, undefined, undefined, undefined),
-      Success: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Success, undefined, payload, statusCodeSuccess),
-      SuccessStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.SuccessStale, undefined, payload, statusCodeSuccess),
-      Error: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Error, errorMessage, undefined, statusCodeError),
-      ErrorStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.ErrorStale, errorMessage, undefined, statusCodeError),
+      RequestPending: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.RequestPending, undefined, undefined, undefined),
+      ResponsePending: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.ResponsePending, undefined, undefined, undefined),
+      ResponsePendingStale: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.ResponsePendingStale, undefined, undefined, undefined),
+      Success: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.Success, undefined, payload, statusCodeSuccess),
+      SuccessStale: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.SuccessStale, undefined, payload, statusCodeSuccess),
+      Error: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.Error, errorMessage, undefined, statusCodeError),
+      ErrorStale: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.ErrorStale, errorMessage, undefined, statusCodeError),
     };
     remoteDataPageMocks = {
-      RequestPending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.RequestPending, undefined, undefined, undefined),
-      ResponsePending: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.ResponsePending, undefined, undefined, undefined),
-      ResponsePendingStale: new RemoteData(undefined, msToLive, timeStamp, RequestEntryState.ResponsePendingStale, undefined, undefined, undefined),
-      Success: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Success, undefined, createPaginatedList([payload]), statusCodeSuccess),
-      SuccessStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.SuccessStale, undefined, createPaginatedList([payload]), statusCodeSuccess),
-      Error: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.Error, errorMessage, undefined, statusCodeError),
-      ErrorStale: new RemoteData(timeStamp, msToLive, timeStamp, RequestEntryState.ErrorStale, errorMessage, undefined, statusCodeError),
+      RequestPending: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.RequestPending, undefined, undefined, undefined),
+      ResponsePending: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.ResponsePending, undefined, undefined, undefined),
+      ResponsePendingStale: new RemoteData(undefined, msToLive, remoteDataTimestamp, RequestEntryState.ResponsePendingStale, undefined, undefined, undefined),
+      Success: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.Success, undefined, createPaginatedList([payload]), statusCodeSuccess),
+      SuccessStale: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.SuccessStale, undefined, createPaginatedList([payload]), statusCodeSuccess),
+      Error: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.Error, errorMessage, undefined, statusCodeError),
+      ErrorStale: new RemoteData(remoteDataTimestamp, msToLive, remoteDataTimestamp, RequestEntryState.ErrorStale, errorMessage, undefined, statusCodeError),
     };
 
     return new TestService(
@@ -361,11 +364,15 @@ describe('BaseDataService', () => {
         spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
       });
 
-
-      it(`should not emit a cached completed RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+      it('should not emit a cached completed RemoteData', () => {
+        // Old cached value from 1 minute before the test started
+        const oldCachedSucceededData: RemoteData<any> = Object.assign({}, remoteDataPageMocks.Success, {
+          timeCompleted: remoteDataTimestamp - 2 * 60 * 1000,
+          lastUpdated: remoteDataTimestamp - 2 * 60 * 1000,
+        } as RemoteData<any>);
         testScheduler.run(({ cold, expectObservable }) => {
           spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d-e', {
-            a: remoteDataMocks.Success,
+            a: oldCachedSucceededData,
             b: remoteDataMocks.RequestPending,
             c: remoteDataMocks.ResponsePending,
             d: remoteDataMocks.Success,
@@ -377,6 +384,22 @@ describe('BaseDataService', () => {
             c: remoteDataMocks.ResponsePending,
             d: remoteDataMocks.Success,
             e: remoteDataMocks.SuccessStale,
+          };
+
+          expectObservable(service.findByHref(selfLink, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it('should emit the first completed RemoteData since the request was made', () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b', {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.SuccessStale,
+          }));
+          const expected = 'a-b';
+          const values = {
+            a: remoteDataMocks.Success,
+            b: remoteDataMocks.SuccessStale,
           };
 
           expectObservable(service.findByHref(selfLink, false, true, ...linksToFollow)).toBe(expected, values);
@@ -411,17 +434,12 @@ describe('BaseDataService', () => {
     it('should link all the followLinks of a cached object by calling addDependency', () => {
       spyOn(objectCache, 'addDependency').and.callThrough();
       testScheduler.run(({ cold, expectObservable, flush }) => {
-        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a-b-c-d', {
+        spyOn(rdbService, 'buildSingle').and.returnValue(cold('a', {
           a: remoteDataMocks.Success,
-          b: remoteDataMocks.RequestPending,
-          c: remoteDataMocks.ResponsePending,
-          d: remoteDataMocks.Success,
         }));
-        const expected = '--b-c-d';
+        const expected = 'a';
         const values = {
-          b: remoteDataMocks.RequestPending,
-          c: remoteDataMocks.ResponsePending,
-          d: remoteDataMocks.Success,
+          a: remoteDataMocks.Success,
         };
 
         expectObservable(service.findByHref(selfLink, false, false, ...linksToFollow)).toBe(expected, values);
@@ -570,11 +588,15 @@ describe('BaseDataService', () => {
         spyOn(service as any, 'reRequestStaleRemoteData').and.callFake(() => (source) => source);
       });
 
-
-      it(`should not emit a cached completed RemoteData, but only start emitting after the state first changes to RequestPending`, () => {
+      it('should not emit a cached completed RemoteData', () => {
         testScheduler.run(({ cold, expectObservable }) => {
+          // Old cached value from 1 minute before the test started
+          const oldCachedSucceededData: RemoteData<any> = Object.assign({}, remoteDataPageMocks.Success, {
+            timeCompleted: remoteDataTimestamp - 2 * 60 * 1000,
+            lastUpdated: remoteDataTimestamp - 2 * 60 * 1000,
+          } as RemoteData<any>);
           spyOn(rdbService, 'buildList').and.returnValue(cold('a-b-c-d-e', {
-            a: remoteDataPageMocks.Success,
+            a: oldCachedSucceededData,
             b: remoteDataPageMocks.RequestPending,
             c: remoteDataPageMocks.ResponsePending,
             d: remoteDataPageMocks.Success,
@@ -586,6 +608,22 @@ describe('BaseDataService', () => {
             c: remoteDataPageMocks.ResponsePending,
             d: remoteDataPageMocks.Success,
             e: remoteDataPageMocks.SuccessStale,
+          };
+
+          expectObservable(service.findListByHref(selfLink, findListOptions, false, true, ...linksToFollow)).toBe(expected, values);
+        });
+      });
+
+      it('should emit the first completed RemoteData since the request was made', () => {
+        testScheduler.run(({ cold, expectObservable }) => {
+          spyOn(rdbService, 'buildList').and.returnValue(cold('a-b', {
+            a: remoteDataPageMocks.Success,
+            b: remoteDataPageMocks.SuccessStale,
+          }));
+          const expected = 'a-b';
+          const values = {
+            a: remoteDataPageMocks.Success,
+            b: remoteDataPageMocks.SuccessStale,
           };
 
           expectObservable(service.findListByHref(selfLink, findListOptions, false, true, ...linksToFollow)).toBe(expected, values);

--- a/src/app/core/data/base/base-data.service.ts
+++ b/src/app/core/data/base/base-data.service.ts
@@ -285,6 +285,7 @@ export class BaseDataService<T extends CacheableObject> implements HALDataServic
       map((href: string) => this.buildHrefFromFindOptions(href, {}, [], ...linksToFollow)),
     );
 
+    const startTime: number = new Date().getTime();
     this.createAndSendGetRequest(requestHref$, useCachedVersionIfAvailable);
 
     const response$: Observable<RemoteData<T>> = this.rdbService.buildSingle<T>(requestHref$, ...linksToFollow).pipe(
@@ -292,7 +293,7 @@ export class BaseDataService<T extends CacheableObject> implements HALDataServic
       // call it isn't immediately returned, but we wait until the remote data for the new request
       // is created. If useCachedVersionIfAvailable is false it also ensures you don't get a
       // cached completed object
-      skipWhile((rd: RemoteData<T>) => rd.isStale || (!useCachedVersionIfAvailable && rd.hasCompleted)),
+      skipWhile((rd: RemoteData<T>) => rd.isStale || (!useCachedVersionIfAvailable && rd.lastUpdated < startTime)),
       this.reRequestStaleRemoteData(reRequestOnStale, () =>
         this.findByHref(href$, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow)),
     );
@@ -338,6 +339,7 @@ export class BaseDataService<T extends CacheableObject> implements HALDataServic
       map((href: string) => this.buildHrefFromFindOptions(href, options, [], ...linksToFollow)),
     );
 
+    const startTime: number = new Date().getTime();
     this.createAndSendGetRequest(requestHref$, useCachedVersionIfAvailable);
 
     const response$: Observable<RemoteData<PaginatedList<T>>> = this.rdbService.buildList<T>(requestHref$, ...linksToFollow).pipe(
@@ -345,7 +347,7 @@ export class BaseDataService<T extends CacheableObject> implements HALDataServic
       // call it isn't immediately returned, but we wait until the remote data for the new request
       // is created. If useCachedVersionIfAvailable is false it also ensures you don't get a
       // cached completed object
-      skipWhile((rd: RemoteData<PaginatedList<T>>) => rd.isStale || (!useCachedVersionIfAvailable && rd.hasCompleted)),
+      skipWhile((rd: RemoteData<PaginatedList<T>>) => rd.isStale || (!useCachedVersionIfAvailable && rd.lastUpdated < startTime)),
       this.reRequestStaleRemoteData(reRequestOnStale, () =>
         this.findListByHref(href$, options, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow)),
     );

--- a/src/app/item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
+++ b/src/app/item-page/edit-item-page/abstract-item-update/abstract-item-update.component.ts
@@ -16,9 +16,9 @@ import {
   Subscription,
 } from 'rxjs';
 import {
-  first,
   map,
   switchMap,
+  take,
   tap,
 } from 'rxjs/operators';
 
@@ -102,7 +102,7 @@ export class AbstractItemUpdateComponent extends AbstractTrackableComponent impl
     super.ngOnInit();
 
     this.discardTimeOut = environment.item.edit.undoTimeout;
-    this.hasChanges().pipe(first()).subscribe((hasChanges) => {
+    this.hasChanges().pipe(take(1)).subscribe((hasChanges) => {
       if (!hasChanges) {
         this.initializeOriginalFields();
       } else {
@@ -187,7 +187,7 @@ export class AbstractItemUpdateComponent extends AbstractTrackableComponent impl
    */
   private checkLastModified() {
     const currentVersion = this.item.lastModified;
-    this.objectUpdatesService.getLastModified(this.url).pipe(first()).subscribe(
+    this.objectUpdatesService.getLastModified(this.url).pipe(take(1)).subscribe(
       (updateVersion: Date) => {
         if (updateVersion.getDate() !== currentVersion.getDate()) {
           this.notificationsService.warning(this.getNotificationTitle('outdated'), this.getNotificationContent('outdated'));

--- a/src/app/item-page/item-page-routes.ts
+++ b/src/app/item-page/item-page-routes.ts
@@ -27,7 +27,6 @@ export const ROUTES: Route[] = [
     resolve: {
       dso: itemPageResolver,
       breadcrumb: itemBreadcrumbResolver,
-      menu: dsoEditMenuResolver,
     },
     runGuardsAndResolvers: 'always',
     children: [
@@ -35,10 +34,16 @@ export const ROUTES: Route[] = [
         path: '',
         component: ThemedItemPageComponent,
         pathMatch: 'full',
+        resolve: {
+          menu: dsoEditMenuResolver,
+        },
       },
       {
         path: 'full',
         component: ThemedFullItemPageComponent,
+        resolve: {
+          menu: dsoEditMenuResolver,
+        },
       },
       {
         path: ITEM_EDIT_PATH,

--- a/src/app/shared/dso-page/dso-edit-menu-resolver.service.ts
+++ b/src/app/shared/dso-page/dso-edit-menu-resolver.service.ts
@@ -155,7 +155,7 @@ export class DSOEditMenuResolverService  {
         this.dsoVersioningModalService.getVersioningTooltipMessage(dso, 'item.page.version.hasDraft', 'item.page.version.create'),
         this.authorizationService.isAuthorized(FeatureID.CanSynchronizeWithORCID, dso.self),
         this.authorizationService.isAuthorized(FeatureID.CanClaimItem, dso.self),
-        this.correctionTypeDataService.findByItem(dso.uuid, false).pipe(
+        this.correctionTypeDataService.findByItem(dso.uuid, true).pipe(
           getFirstCompletedRemoteData(),
           getRemoteDataPayload()),
       ]).pipe(


### PR DESCRIPTION
## References
* Fixes #3584
* Fixes #3425

## Description
Fixed the issue where switching between item pages could cause an infinite loading screen. This issue was caused by requests made in `dsoEditMenuResolver` that set the `useCachedVersionIfAvailable` to `false`. The problem arose due to a change in the timing of when a request is actually sent to the backend. Since Angular 16, an [`asapScheduler`](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/request.service.ts#L450) causes requests to sometimes happen sooner. This broke [this logic](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/base/base-data.service.ts#L344-L348), which prevents cached data (when the cache is disabled) and stale data from being returned immediately when the service call is made.

The bitstream and relationship pages also had an additional issue that could cause an infinite loading screen. When navigating to these pages, you could sometimes see the error `no elements in sequence` in the console. This occurred when taking the first value of an observable that does not emit. This issue has been fixed.

Finally, the menu resolver was being resolved in too many places. It should only be resolved on pages that use the `DsoEditMenuComponent`. Therefore, it has been restricted to resolve only for the simple item page, the full item page, and the community and collection pages. All other places, such as the edit item/collection/community tabs and the browse tab, no longer need to resolve it. As a result, the edit item metadata tab, for example, now requires five fewer requests.

## Instructions for Reviewers
List of changes in this PR:
- **Fixed the edge case where sending a request with `useCachedVersionIfAvailable === false` could cause an infinite loading screen:**
  Previously, when a cached version was already present in the store, the [`RemoteDataBuildService#buildList`](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/base/base-data.service.ts#L343) would always first emit the cached value. This was then followed by a `ResponsePending`, which in turn was followed by the new response.
  Because we don't want to return the old cached value when `useCachedVersionIfAvailable` is `false`, a `skipWhile` was added to filter out all completed responses until a non-completed response was emitted.

  Due to recent changes, requests are sent earlier, which can cause the [`RemoteDataBuildService#buildList`](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/base/base-data.service.ts#L343) to already have the new completed response ready. The issue is that the [`skipWhile`](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/base/base-data.service.ts#L348) mistakenly interprets this as the old cached value (because no non-completed response was emitted), causing the observable to never emit.

  The fix is to update the `skipWhile` logic to not rely on the `RemoteData`'s `state` to skip responses. Instead, it should compare the `lastUpdated` timestamp with the time before the request was sent. This ensures that all responses emitted by the [`RemoteDataBuildService#buildList`](https://github.com/DSpace/dspace-angular/blob/757d23e74d0cc731b2e64ad093ce0e3a80f6ff68/src/app/core/data/base/base-data.service.ts#L343) are skipped unless they are new.
- Fixed the `no elements in sequence` issue for the `ItemBitstreamsComponent` and `ItemRelationshipsComponent`. This was resolved by replacing the `first()` operators with `take(1)` to prevent such an error from being thrown.
- Removed the `dsoEditMenuResolver` from the browse routes since the browse pages were separated from the community and collection pages in #2722, making the menu no longer necessary.
- Moved the `dsoEditMenuResolver` to resolve only for simple/full item pages rather than for every item, collection, or community route. This prevents routes like edit metadata from resolving the menu.
- Updated the correction types call in `DSOEditMenuResolverService` to always use the cache when such a request is present. However, if this was done to ensure it is re-fetched in certain situations, we should refactor it to mark the data as stale instead.

**Guidance for how to test or review this PR:**
- Verify that switching between tabs does not accidentally cause an infinite load. The speed of switching between tabs should have no impact, as this bug is caused by how quickly a response is processed.
- Verify that the DSO edit menus still work correctly and that tabs that don't use them no longer resolve them.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
