### PR TITLE
#3678, #3217 - Fix ordering and changing values of repeatable inputs in submission form

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
@@ -7,9 +7,9 @@
       <!-- Draggable Container -->
       <div cdkDropList cdkDropListLockAxis="y" (cdkDropListDropped)="moveSelection($event)">
         <!-- Draggable Items -->
-        <div *ngFor="let groupModel of model.groups; let idx = index"
+        <div *ngFor="let groupModel of model.groups"
              role="group"
-             [formGroupName]="idx"
+             [formGroupName]="groupModel.index"
              [ngClass]="[getClass('element', 'group'), getClass('grid', 'group')]"
              cdkDrag
              [cdkDragDisabled]="dragDisabled"
@@ -25,7 +25,7 @@
                                              [formGroup]="group"
                                              [formModel]="formModel"
                                              [context]="groupModel"
-                                             [group]="control.get([idx])"
+                                             [group]="getControlOfGroup(groupModel)"
                                              [hidden]="_model.hidden"
                                              [class.d-none]="_model.hidden"
                                              [layout]="formLayout"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.ts
@@ -114,4 +114,17 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
   get dragDisabled(): boolean {
     return this.model.groups.length === 1 || !this.model.isDraggable;
   }
+
+  /**
+   * Gets the control of the specified group model. It adds the startingIndex property to the group model if it does not
+   * already have it. This ensures that the controls are always linked to the correct group model.
+   * @param groupModel The group model to get the control for.
+   * @returns The form control of the specified group model.
+   */
+  getControlOfGroup(groupModel: any) {
+    if (!groupModel.hasOwnProperty('startingIndex')) {
+      groupModel.startingIndex = groupModel.index;
+    }
+    return this.control.get([groupModel.startingIndex]);
+  }
 }


### PR DESCRIPTION
## References
* Fixes #3678 
* Fixes #3217

## Description
Wrapped the `control.get` method call in order to maintain a consistent link between Models and Controls.

## Instructions for Reviewers
Please, try to reproduce the bug described in #3678 following the same steps included in that issue. 
Here is a video showcasing the bugfix.

https://github.com/user-attachments/assets/f7500905-182a-4306-8dcf-496099142e38



List of changes in this PR:
* Wrapped the `control.get` method in a custom method that adds the `startingIndex` property to the `groupModel` and uses that value as the key to get the relative `control`. Since controls are never updated, but elements change their index when they are being reordered, this fixes issues regarding value changes and consequential reordering of items.
* Set up the `formGroupName` as the index stored in the `groupModel` object. This way we can avoid using the `ngFor` index, since the `groupModel.index` property is being updated after reordering items.


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- ~My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).~ Tests are not available for the `DynamicFormArray` component.
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
