### PR TITLE
Fix incorrect example in `config.example.yml`

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,7 +1,7 @@
 # NOTE: will log all redux actions and transfers in console
 debug: false
 
-# Angular Universal server settings
+# Angular User Inteface settings
 # NOTE: these settings define where Node.js will start your UI application. Therefore, these
 # "ui" settings usually specify a localhost port/URL which is later proxied to a public URL (using Apache or similar)
 ui:
@@ -17,12 +17,12 @@ ui:
   # Trust X-FORWARDED-* headers from proxies (default = true)
   useProxies: true
 
-universal:
-  # Whether to inline "critical" styles into the server-side rendered HTML.
-  # Determining which styles are critical is a relatively expensive operation;
-  # this option can be disabled to boost server performance at the expense of
-  # loading smoothness.
-  inlineCriticalCss: true
+# Angular Server Side Rendering (SSR) settings
+ssr:
+  # Whether to tell Angular to inline "critical" styles into the server-side rendered HTML.
+  # Determining which styles are critical is a relatively expensive operation; this option is
+  # disabled (false) by default to boost server performance at the expense of loading smoothness.
+  inlineCriticalCss: false
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually


### PR DESCRIPTION
## Description
As of 7.6.2 / 8.0, we now have an option to control Angular's `inlineCriticalCss`.  This is **incorrectly documented** in our `config.example.yml` as being `environment.universal.inlineCriticalCss`.  

The correct config is `environment.ssr.inlineCriticalCss` as shown in https://github.com/DSpace/dspace-angular/blob/main/server.ts#L248 and https://github.com/DSpace/dspace-angular/blob/main/src/config/ssr-config.interface.ts

This small PR corrects the example in `config.example.yml` and cleans up a few other minor comments around the example configs in that file.

## Instructions for Reviewers
* This `config.example.yml` is not used anywhere in our codebase.  It's meant for documentation purposes & as a simple example.  So, this small PR does not require testing.