### PR TITLE
Embed the community/collection on the edit EPerson page

### DIFF
--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -343,7 +343,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         this.groups$ = this.groupsDataService.findListByHref(eperson._links.groups.href, {
           currentPage: 1,
           elementsPerPage: this.config.pageSize,
-        });
+        }, undefined, undefined, followLink('object'));
       }
       this.formGroup.patchValue({
         firstName: eperson != null ? eperson.firstMetadataValue('eperson.firstname') : '',

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
@@ -8,7 +8,7 @@
         <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
           <ds-thumbnail [thumbnail]="item?.thumbnail | async"></ds-thumbnail>
         </ds-metadata-field-wrapper>
-        <ng-container *ngVar="(getFiles() | async) as bitstreams">
+        <ng-container *ngIf="(bitstreams$ | async) as bitstreams">
           <ds-metadata-field-wrapper [label]="('item.page.files' | translate)">
             <div *ngIf="bitstreams?.length > 0" class="file-section">
               <button class="btn btn-link" *ngFor="let file of bitstreams; let last=last;" (click)="downloadBitstreamFile(file?.uuid)">

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.ts
@@ -6,6 +6,8 @@ import {
 import {
   Component,
   Input,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -22,6 +24,7 @@ import { getFirstSucceededRemoteListPayload } from '../../../../core/shared/oper
 import { ThemedItemPageTitleFieldComponent } from '../../../../item-page/simple/field-components/specific-field/title/themed-item-page-field.component';
 import { ThemedThumbnailComponent } from '../../../../thumbnail/themed-thumbnail.component';
 import { fadeInOut } from '../../../animations/fade';
+import { hasValue } from '../../../empty.util';
 import { MetadataFieldWrapperComponent } from '../../../metadata-field-wrapper/metadata-field-wrapper.component';
 import { ThemedBadgesComponent } from '../../../object-collection/shared/badges/themed-badges.component';
 import { ItemSubmitterComponent } from '../../../object-collection/shared/mydspace-item-submitter/item-submitter.component';
@@ -41,7 +44,7 @@ import { ThemedItemDetailPreviewFieldComponent } from './item-detail-preview-fie
   standalone: true,
   imports: [NgIf, ThemedBadgesComponent, ThemedItemPageTitleFieldComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, VarDirective, NgFor, ThemedItemDetailPreviewFieldComponent, ItemSubmitterComponent, AsyncPipe, FileSizePipe, TranslateModule],
 })
-export class ItemDetailPreviewComponent {
+export class ItemDetailPreviewComponent implements OnChanges {
   /**
    * The item to display
    */
@@ -78,6 +81,12 @@ export class ItemDetailPreviewComponent {
     protected bitstreamDataService: BitstreamDataService,
     public dsoNameService: DSONameService,
   ) {
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (hasValue(changes.item)) {
+      this.bitstreams$ = this.getFiles();
+    }
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #3571
* Continuation of #3585
* `dspace-7_x` backport: https://github.com/DSpace/dspace-angular/pull/3721

## Description
Fixed issue where the edit EPerson page didn't show the comcol names when they weren't already cached. Also removed a template observable call from `ItemDetailPreviewComponent`.

## Instructions for Reviewers
List of changes in this PR:
* Embedded the `Group`'s linked `object` in the group overview of edit `EPerson`. Otherwise only already cached communities and collections would have a visible name

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
