### PR TITLE
Fixed dropdown/lookup & lookup-name fields being reset when hitting enter

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/lookup/dynamic-lookup.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/lookup/dynamic-lookup.component.html
@@ -94,11 +94,12 @@
          (scrolled)="onScroll()"
          [scrollWindow]="false">
 
-      <button class="dropdown-item disabled"
+      <button class="dropdown-item disabled" type="button"
               *ngIf="optionsList && optionsList.length === 0"
-              (click)="$event.stopPropagation(); clearFields(); sdRef.close();">{{'form.no-results' | translate}}
+              (click)="$event.stopPropagation(); clearFields(); sdRef.close();">
+        {{ 'form.no-results' | translate }}
       </button>
-      <button class="dropdown-item lookup-item"
+      <button class="dropdown-item lookup-item" type="button"
               *ngFor="let listEntry of optionsList"
               (click)="$event.stopPropagation(); onSelect(listEntry); sdRef.close();"
               title="{{ listEntry.display }}">

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -40,17 +40,19 @@
          (scrolled)="onScroll()"
          [scrollWindow]="false">
 
-      <button class="dropdown-item disabled" *ngIf="optionsList && optionsList.length === 0">{{'form.no-results' | translate}}</button>
+      <button class="dropdown-item disabled" type="button" *ngIf="optionsList && optionsList.length === 0">
+        {{ 'form.no-results' | translate }}
+      </button>
       <button class="dropdown-item collection-item text-truncate"
               (click)="onSelect(undefined); sdRef.close()" (mousedown)="onSelect(undefined); sdRef.close()"
               title="{{ 'dropdown.clear.tooltip' | translate }}" role="option"
-      >
+              type="button">
         <i>{{ 'dropdown.clear' | translate }}</i>
       </button>
       <button class="dropdown-item collection-item text-truncate" *ngFor="let listEntry of optionsList; let i = index"
               [class.active]="i === selectedIndex"
               (keydown.enter)="onSelect(listEntry); sdRef.close()" (mousedown)="onSelect(listEntry); sdRef.close()"
-              title="{{ listEntry.display }}" role="option"
+              title="{{ listEntry.display }}" role="option" type="button"
               [attr.id]="listEntry.display === (currentValue|async) ? ('combobox_' + id + '_selected') : null">
         {{inputFormatter(listEntry)}}
       </button>

--- a/src/app/shared/form/form.service.ts
+++ b/src/app/shared/form/form.service.ts
@@ -153,6 +153,9 @@ export class FormService {
   }
 
   public addControlErrors(field: AbstractControl, formId: string, fieldId: string, fieldIndex: number) {
+    if (field.errors === null) {
+      return;
+    }
     const errors: string[] = Object.keys(field.errors)
       .filter((errorKey) => field.errors[errorKey] === true)
       .map((errorKey) => `error.validation.${errorKey}`);


### PR DESCRIPTION
## References
* Fixes #3723

## Description
Fixed issue where hitting enter in a submission form containg a `dropdown`/`lookup` or `lookup-name` field would cause the first one to reset.

## Instructions for Reviewers
List of changes in this PR:
* Added `type="button"` to the buttons in those dropdowns, this prevents them from being triggered on submit
* Also added another small fix to the `FormService` class. [The `AbstractControl`'s `errors` property](https://v17.angular.io/api/forms/AbstractControl#errors) can be null when there are no errors, and this caused an issue when it was `null` because then `Object.keys(null)` was being called

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
