### PR TITLE
Changing old name Sherpa Romeo to new name Open Policy Finder

### DIFF
--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -8147,7 +8147,7 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "سياسة الناشر",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
   "submission.sections.sherpa.publisher.policy.description": "تم العثور على المعلومات أدناه عبر شيربا روميو. وبناءً على سياسات الناشر الخاص بك، فإنه يقدم النصائح بشأن ما إذا كان الحظر ضروريًا أو الملفات المسموح لك بتحميلها. إذا كانت لديك أسئلة، يرجى الاتصال بمسؤول موقعك عبر نموذج التعليقات الموجود في التذييل.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -6860,8 +6860,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Política editorial",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "La següent informacióm s'ha trobat via Sherpa Romeo. En base a aquestes polítiques, es proporcionen consells sobre les necessitats d'un embargament i d'aquells fitxers que podeu utilitzar. Si teniu dubtes, si us plau, contacteu amb l'administrador del repositori mitjançant el formulari de suggeriments.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "La següent informacióm s'ha trobat via Open Policy Finder. En base a aquestes polítiques, es proporcionen consells sobre les necessitats d'un embargament i d'aquells fitxers que podeu utilitzar. Si teniu dubtes, si us plau, contacteu amb l'administrador del repositori mitjançant el formulari de suggeriments.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Els camins cap a l'accés Obert que aquesta revista permet es llisten a sota per versió d'article. Feu clic en un camí per a una visió més detallada",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -8547,8 +8547,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Politika nakladatele",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "Níže uvedené informace byly zjištěny prostřednictvím Sherpa Romeo. Na základě zásad vašeho vydavatele poskytuje rady ohledně toho, zda může být nutné embargo a/nebo které soubory smíte nahrát. Pokud máte dotazy, obraťte se na správce webu prostřednictvím formuláře pro zpětnou vazbu v zápatí.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "Níže uvedené informace byly zjištěny prostřednictvím Open Policy Finder. Na základě zásad vašeho vydavatele poskytuje rady ohledně toho, zda může být nutné embargo a/nebo které soubory smíte nahrát. Pokud máte dotazy, obraťte se na správce webu prostřednictvím formuláře pro zpětnou vazbu v zápatí.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Cesty otevřeného přístupu povolené politikou tohoto časopisu jsou uvedeny níže podle verze článku. Kliknutím na cestu získáte podrobnější zobrazení.",

--- a/src/assets/i18n/el.json5
+++ b/src/assets/i18n/el.json5
@@ -2524,7 +2524,7 @@
   "submission.sections.sherpa.publication.information.zetoPub": "Zeto Pub",
   "submission.sections.sherpa.publisher.policy": "Πολιτική εκδότη",
   "submission.sections.sherpa.publisher.policy.conditions": "Συνθήκες",
-  "submission.sections.sherpa.publisher.policy.description": "Οι παρακάτω πληροφορίες βρέθηκαν μέσω του Sherpa Romeo. Βάσει των πολιτικών του εκδότη σας, παρέχει συμβουλές σχετικά με το εάν μπορεί να είναι απαραίτητο ένα εμπάργκο ή/και ποια αρχεία επιτρέπεται να ανεβάσετε. Εάν έχετε ερωτήσεις, επικοινωνήστε με τον διαχειριστή του ιστότοπού σας μέσω της φόρμας σχολίων στο υποσέλιδο.",
+  "submission.sections.sherpa.publisher.policy.description": "Οι παρακάτω πληροφορίες βρέθηκαν μέσω του Open Policy Finder. Βάσει των πολιτικών του εκδότη σας, παρέχει συμβουλές σχετικά με το εάν μπορεί να είναι απαραίτητο ένα εμπάργκο ή/και ποια αρχεία επιτρέπεται να ανεβάσετε. Εάν έχετε ερωτήσεις, επικοινωνήστε με τον διαχειριστή του ιστότοπού σας μέσω της φόρμας σχολίων στο υποσέλιδο.",
   "submission.sections.sherpa.publisher.policy.embargo": "Απαγόρευση",
   "submission.sections.sherpa.publisher.policy.license": "Αδεια",
   "submission.sections.sherpa.publisher.policy.location": "Τοποθεσία",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5384,7 +5384,7 @@
 
   "submission.sections.sherpa.publisher.policy": "Publisher Policy",
 
-  "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
 
   "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -7102,8 +7102,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Política editorial",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "La siguiente informacióm se encontró vía Sherpa Romeo. En base a esas políticas, se proporcionan consejos sobre las necesidad de un embargo y de aquellos ficheros que puede utilizar. Si tiene dudas, por favor, contacte con el administrador del repositorio mediante el formulario de sugerencias.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "La siguiente informacióm se encontró vía Open Policy Finder. En base a esas políticas, se proporcionan consejos sobre las necesidad de un embargo y de aquellos ficheros que puede utilizar. Si tiene dudas, por favor, contacte con el administrador del repositorio mediante el formulario de sugerencias.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Los caminos hacia el Acceso Abierto que esta revista permite se relacionan, por versión de artículo, abajo. Pulse en un camino para una visión mas detallada",

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -7158,8 +7158,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Julkaisukäytännöt",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "Alla olevat tiedot on noudettu Sherpa Romeosta. Julkaisijan käytännöt määrittävät, vaaditaanko embargoa ja mitkä tiedostoista ovat ladattavissa. Jos sinulla on kysyttävää, ota yhteyttä ylläpitäjään.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "Alla olevat tiedot on noudettu Open Policy Findersta. Julkaisijan käytännöt määrittävät, vaaditaanko embargoa ja mitkä tiedostoista ovat ladattavissa. Jos sinulla on kysyttävää, ota yhteyttä ylläpitäjään.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Tämän kausijulkaisun käytäntöjen sallimat Open Access -reitit on lueteltu alla artikkeliversioittain. Napsauttamalla polkua saat yksityiskohtaisempia tietoja",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -6339,8 +6339,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Politique de l'éditeur",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "L'information ci-dessous provient de Sherpa Romeo. Elle vous permet de savoir quelle version vous êtes autorisé-e à déposer et si une restriction de diffusion (embargo) doit être appliquée. Si vous avez des questions, contactez votre administrateur-trice en utilisant le formulaire en pied de page.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "L'information ci-dessous provient de Open Policy Finder. Elle vous permet de savoir quelle version vous êtes autorisé-e à déposer et si une restriction de diffusion (embargo) doit être appliquée. Si vous avez des questions, contactez votre administrateur-trice en utilisant le formulaire en pied de page.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Les voies de libre accès autorisées par la politique de cette revue sont listées ci-dessous par version d'article. Cliquez sur l'une des voies pour plus de détails.",

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -7913,9 +7913,9 @@
   // TODO New key - Add a translation
   "submission.sections.sherpa.publisher.policy": "Publisher Policy",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
   // TODO New key - Add a translation
-  "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   // TODO New key - Add a translation

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -6885,8 +6885,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Policy dell'editore",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "Le informazioni riportate di seguito sono state reperite tramite Sherpa Romeo. In base alle policy del vostro editore, fornisce consigli sull'eventuale necessità di un embargo e/o su quali file è possibile caricare. In caso di domande, contattare l'amministratore del sito tramite il modulo di feedback nel piè di pagina.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "Le informazioni riportate di seguito sono state reperite tramite Open Policy Finder. In base alle policy del vostro editore, fornisce consigli sull'eventuale necessità di un embargo e/o su quali file è possibile caricare. In caso di domande, contattare l'amministratore del sito tramite il modulo di feedback nel piè di pagina.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "I percorsi open access consentiti dalle policy di questa rivista sono elencati di seguito per versione dell'articolo. Clicca su un percorso per vederlo nel dettaglio",

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -6809,7 +6809,7 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Баспагердің саясаты",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
   "submission.sections.sherpa.publisher.policy.description": "Төмендегі ақпарат Шерпа Ромео арқылы табылды. Баспагердің саясатына сүйене отырып, ол сізге эмбарго қажет пе және / немесе қандай файлдарды жүктеуге рұқсат етілгені туралы ұсыныстар береді. Егер сізде сұрақтар туындаса, төменгі деректемедегі кері байланыс нысаны арқылы веб-сайтыңыздың әкімшісіне хабарласыңыз.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -2621,7 +2621,7 @@
   "submission.sections.sherpa.publication.information.romeoPub": "Wydawca Romeo",
   "submission.sections.sherpa.publication.information.zetoPub": "Wydawca Zeto",
   "submission.sections.sherpa.publisher.policy": "Polityka wydawnicza",
-  "submission.sections.sherpa.publisher.policy.description": "Poniższe informacje zostały znalezione za pośrednictwem Sherpa Romeo. W oparciu o politykę Twojego wydawcy, zawiera ona porady dotyczące tego, czy embargo może być konieczne i/lub jakie pliki możesz przesłać. Jeśli masz pytania, skontaktuj się z administratorem strony poprzez formularz.",
+  "submission.sections.sherpa.publisher.policy.description": "Poniższe informacje zostały znalezione za pośrednictwem Open Policy Finder. W oparciu o politykę Twojego wydawcy, zawiera ona porady dotyczące tego, czy embargo może być konieczne i/lub jakie pliki możesz przesłać. Jeśli masz pytania, skontaktuj się z administratorem strony poprzez formularz.",
   "submission.sections.sherpa.publisher.policy.openaccess": "Rodzaje Open Access dozwolone przez politykę wydawniczą tego czasopisma są wymienione poniżej. Kliknij na wybrany rodzaj, aby przejść do szczegółowego widoku",
   "submission.sections.sherpa.publisher.policy.more.information": "Aby uzuyskać więcej informacji, kliknij tutaj:",
   "submission.sections.sherpa.publisher.policy.version": "Wersja",

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -8057,8 +8057,8 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Política do Editor",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
-  "submission.sections.sherpa.publisher.policy.description": "As informações abaixo foram encontradas via Sherpa Romeo. Com base nas políticas de seu editor, ele fornece conselhos sobre se um embargo pode ser necessário e/ou quais arquivos você tem permissão para enviar. Se você tiver dúvidas, entre em contato com o administrador do site por meio do formulário de sugestões no rodapé.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.sherpa.publisher.policy.description": "As informações abaixo foram encontradas via Open Policy Finder. Com base nas políticas de seu editor, ele fornece conselhos sobre se um embargo pode ser necessário e/ou quais arquivos você tem permissão para enviar. Se você tiver dúvidas, entre em contato com o administrador do site por meio do formulário de sugestões no rodapé.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
   "submission.sections.sherpa.publisher.policy.openaccess": "Os caminhos de Open Access permitidos pela política desta revista estão listados abaixo por versão do artigo. Clique em um caminho para uma visualização mais detalhada",

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -8101,7 +8101,7 @@
   // "submission.sections.sherpa.publisher.policy": "Publisher Policy",
   "submission.sections.sherpa.publisher.policy": "Política da editora",
 
-  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Sherpa Romeo. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  // "submission.sections.sherpa.publisher.policy.description": "The below information was found via Open Policy Finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
   "submission.sections.sherpa.publisher.policy.description": "A seguinte informação foi obtida através do diretório SHERPA, com base nas políticas disponíveis das editoras/revistas. Fornece informações úteis, sobre as versões dos ficheiros que deverá carregar em repositórios, bem como tipo de embargo ou restrições de acesso poderá ser aconselhável. As informações do SHERPA são fidedignas tanto quanto é do nosso conhecimento, mas não devem ser assumidas como aconselhamento jurídico. Se tiver dúvidas, por favor contacte o(s) administrador(es) do seu repositório através do formulário de feedback no rodapé.",
 
   // "submission.sections.sherpa.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -2238,7 +2238,7 @@
   "submission.sections.sherpa.publication.information.zetoPub": "Zeto Pub",
   "submission.sections.sherpa.publisher.policy": "Chính sách của nhà xuất bản",
   "submission.sections.sherpa.publisher.policy.conditions": "Điều kiện",
-  "submission.sections.sherpa.publisher.policy.description": "Thông tin dưới đây được tìm thấy thông qua Sherpa Romeo. Dựa trên các chính sách của nhà xuất bản của bạn hệ thống sẽ đưa ra lời khuyên về việc có cần thiết phải hạn chế hay không và/hoặc những tệp nào mà bạn được phép tải lên. Nếu bạn có thắc mắc vui lòng liên hệ với quản trị viên.",
+  "submission.sections.sherpa.publisher.policy.description": "Thông tin dưới đây được tìm thấy thông qua Open Policy Finder. Dựa trên các chính sách của nhà xuất bản của bạn hệ thống sẽ đưa ra lời khuyên về việc có cần thiết phải hạn chế hay không và/hoặc những tệp nào mà bạn được phép tải lên. Nếu bạn có thắc mắc vui lòng liên hệ với quản trị viên.",
   "submission.sections.sherpa.publisher.policy.embargo": "Hạn chế",
   "submission.sections.sherpa.publisher.policy.license": "Bản quyền",
   "submission.sections.sherpa.publisher.policy.location": "Vị trí",


### PR DESCRIPTION
## References
* Fixes #3680

## Description
Changing from the old name “Sherpa Romeo” to the new name “Open Policy Finder” in the translation files.

## Instructions for Reviewers
List of changes in this PR:
* In the .json5 translation files where the name “Sherpa Romeo” appeared, it was changed to “Open Policy Finder”.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
