### PR TITLE
[Port dspace-7_x] fix #3241: Configuring the URI link target

### DIFF
--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -18,7 +18,10 @@
 
 <!-- Render value as a link (href and label) -->
 <ng-template #link let-value="value">
-    <a class="dont-break-out ds-simple-metadata-link" target="_blank" [href]="value">
+    <a class="dont-break-out ds-simple-metadata-link"
+      [href]="value"
+      [attr.target]="getLinkAttributes(value).target"
+      [attr.rel]="getLinkAttributes(value).rel">
       {{value}}
     </a>
 </ng-template>

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
@@ -73,4 +73,20 @@ describe('MetadataValuesComponent', () => {
     expect(comp.hasLink(mdValue)).toBe(true);
   });
 
+  it('should return correct target and rel for internal links', () => {
+    spyOn(comp, 'hasInternalLink').and.returnValue(true);
+    const urlValue = '/internal-link';
+    const result = comp.getLinkAttributes(urlValue);
+    expect(result.target).toBe('_self');
+    expect(result.rel).toBe('');
+  });
+
+  it('should return correct target and rel for external links', () => {
+    spyOn(comp, 'hasInternalLink').and.returnValue(false);
+    const urlValue = 'https://www.dspace.org';
+    const result = comp.getLinkAttributes(urlValue);
+    expect(result.target).toBe('_blank');
+    expect(result.rel).toBe('noopener noreferrer');
+  });
+
 });

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -4,6 +4,7 @@ import { APP_CONFIG, AppConfig } from '../../../../config/app-config.interface';
 import { BrowseDefinition } from '../../../core/shared/browse-definition.model';
 import { hasValue } from '../../../shared/empty.util';
 import { VALUE_LIST_BROWSE_DEFINITION } from '../../../core/shared/value-list-browse-definition.resource-type';
+import { environment } from '../../../../environments/environment';
 
 /**
  * This component renders the configured 'values' into the ds-metadata-field-wrapper component.
@@ -89,5 +90,26 @@ export class MetadataValuesComponent implements OnChanges {
       return {value: value};
     }
     return queryParams;
+  }
+
+  /**
+   * Checks if the given link value is an internal link.
+   * @param linkValue - The link value to check.
+   * @returns True if the link value starts with the base URL defined in the environment configuration, false otherwise.
+   */
+  hasInternalLink(linkValue: string): boolean {
+    return linkValue.startsWith(environment.ui.baseUrl);
+  }
+
+  /**
+   * This method performs a validation and determines the target of the url.
+   * @returns - Returns the target url.
+   */
+ getLinkAttributes(urlValue: string): { target: string, rel: string } {
+    if (this.hasInternalLink(urlValue)) {
+      return { target: '_self', rel: '' };
+    } else {
+      return { target: '_blank', rel: 'noopener noreferrer' };
+    }
   }
 }

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -105,7 +105,7 @@ export class MetadataValuesComponent implements OnChanges {
    * This method performs a validation and determines the target of the url.
    * @returns - Returns the target url.
    */
- getLinkAttributes(urlValue: string): { target: string, rel: string } {
+  getLinkAttributes(urlValue: string): { target: string, rel: string } {
     if (this.hasInternalLink(urlValue)) {
       return { target: '_self', rel: '' };
     } else {


### PR DESCRIPTION
Manual port of #3322 by @IgorBaptist4 and @Andrea-Guevara to `dspace-7_x`.

Includes porting `hasInternalLink()` method in `metadata-values.component.ts` because this method didn't exist in 7.6.x.