### PR TITLE
change searchFilter isOpenByDefault autoserialization

### DIFF
--- a/src/app/shared/search/models/search-filter-config.model.ts
+++ b/src/app/shared/search/models/search-filter-config.model.ts
@@ -52,7 +52,7 @@ export class SearchFilterConfig implements CacheableObject {
     /**
      * Defines if the item facet is collapsed by default or not on the search page
      */
-    @autoserialize
+    @autoserializeAs(Boolean, 'openByDefault')
       isOpenByDefault: boolean;
 
     /**


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/9404
* Backend / REST-API counterpart: https://github.com/DSpace/DSpace/pull/10169
* Requires https://github.com/DSpace/RestContract/pull/299

## Description
Change the autoserialization of the `isOpenByDefault` property of the searchfilter

## Instructions for Reviewers
Review together with the linked PR in the REST-API / Backend: https://github.com/DSpace/DSpace/pull/10169  
Changing to some property which the REST-API can deliver it allows to initially show the facets on the sidebar opened or closed.

Before:
the facets are always initially not opened, although it is configured in the backend.
![Screenshot 2024-12-27 at 12-11-10 Research Outputs](https://github.com/user-attachments/assets/bc3ff0f5-475b-4bf1-b795-cfd76ab3f11b)

After:  
Reload. page. The facets are initially openend when configured in the backend.
![Screenshot 2024-12-27 at 12-05-52 Research Outputs](https://github.com/user-attachments/assets/0d6cb850-3bcd-4a5b-a9d6-5b740e5385d0)

List of changes in this PR:
* Change the autoserialize property. Instead of `isOpenByDefault` the typescript value of the model is retrieved from `openByDefault`
  * This is necessary because properties starting with `is*` are reserved (in Spring?) as some Getter and thus cannot be converted to the corresponding json key name.
* No further frontend tests necessary, because the behaviour should be already been covered by other tests (see `search-filter.reducer.spec.ts` https://github.com/DSpace/dspace-angular/blob/6ac922971d996dabe33b8fca9edd325e43bd2af2/src/app/shared/search/search-filters/search-filter/search-filter.reducer.spec.ts#L120)

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
