### PR TITLE
Accessibility when selecting a search filter 2

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
@@ -2,7 +2,7 @@
    [tabIndex]="-1"
    [routerLink]="[searchLink]"
    [queryParams]="addQueryParams$ | async"
-   (click)="filterService.minimizeAll()">
+   (click)="selectingFilter()">
   <label class="mb-0 d-flex w-100">
     <input type="checkbox" [checked]="false" class="my-1 align-self-stretch filter-checkbox"/>
     <span class="w-100 pl-1 break-facet">

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
@@ -2,7 +2,7 @@
    [tabIndex]="-1"
    [routerLink]="[searchLink]"
    [queryParams]="addQueryParams$ | async"
-   (click)="selectingFilter()">
+   (click)="announceFilter(); filterService.minimizeAll()">
   <label class="mb-0 d-flex w-100">
     <input type="checkbox" [checked]="false" class="my-1 align-self-stretch filter-checkbox"/>
     <span class="w-100 pl-1 break-facet">

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
@@ -78,11 +78,6 @@ export class SearchFacetOptionComponent implements OnInit {
 
   paginationId: string;
 
-  /**
-   * Stores selected filters
-   */
-  selectedFilters = new Set();
-
   constructor(protected searchService: SearchService,
               protected filterService: SearchFilterService,
               protected searchConfigService: SearchConfigurationService,
@@ -136,23 +131,9 @@ export class SearchFacetOptionComponent implements OnInit {
 
   /**
    * Announces to the screen reader that the page will be reloaded, which filter has been selected
-   * and then implement “filterService.minimizeAll()”
    */
-  selectingFilter() {
-    const filterValue = this.filterValue.value;
-    if (!this.selectedFilters.has(filterValue)) {
-      this.translateService.get('search-facet-option.update.announcement')
-        .subscribe(translatedMessage => {
-          const message = `${translatedMessage} ${filterValue}`;
-          this.liveRegionService.addMessage(message);
-
-          setTimeout(() => {
-            this.liveRegionService.clear();
-          }, this.liveRegionService.getMessageTimeOutMs());
-          this.selectedFilters.add(filterValue);
-        });
-    }
-    this.filterService.minimizeAll();
+  announceFilter() {
+    const message = this.translateService.instant('search-facet-option.update.announcement', { filter: this.filterValue.value });
+    this.liveRegionService.addMessage(message);
   }
-
 }

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
@@ -12,6 +12,7 @@ import {
   Router,
   RouterLink,
 } from '@angular/router';
+
 import {
   TranslateModule,
   TranslateService,
@@ -24,10 +25,13 @@ import { SearchConfigurationService } from '../../../../../../core/shared/search
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
 import { SearchService } from '../../../../../../core/shared/search/search.service';
 import { LiveRegionService } from '../../../../../../shared/live-region/live-region.service';
+
 import { currentPath } from '../../../../../utils/route.utils';
 import { ShortNumberPipe } from '../../../../../utils/short-number.pipe';
+
 import { FacetValue } from '../../../../models/facet-value.model';
 import { SearchFilterConfig } from '../../../../models/search-filter-config.model';
+
 import { getFacetValueForType } from '../../../../search.utils';
 
 @Component({

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6763,4 +6763,6 @@
   "register-page.registration.aria.label": "Enter your e-mail address",
 
   "forgot-email.form.aria.label": "Enter your e-mail address",
+
+  "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6764,5 +6764,5 @@
 
   "forgot-email.form.aria.label": "Enter your e-mail address",
 
-  "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
+  "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -10192,6 +10192,6 @@
   // "forgot-email.form.aria.label": "Enter your e-mail address",
   "forgot-email.form.aria.label": "Introduzca su dirección de correo electrónico",
 
-  // "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
-  "search-facet-option.update.announcement": "La página será recargada. filtro seleccionado: ",
+  // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
+  "search-facet-option.update.announcement": "La página será recargada. Filtro {{ filter }} seleccionado.",
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -10192,5 +10192,6 @@
   // "forgot-email.form.aria.label": "Enter your e-mail address",
   "forgot-email.form.aria.label": "Introduzca su dirección de correo electrónico",
 
-
+  // "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
+  "search-facet-option.update.announcement": "La página será recargada. filtro seleccionado: ",
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10241,6 +10241,6 @@
   // "forgot-email.form.aria.label": "Enter your e-mail address",
   "forgot-email.form.aria.label": "Digite seu e-mail",
 
-  // "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
-  "search-facet-option.update.announcement": "La página será recargada. filtro seleccionado: ",
+  // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
+  "search-facet-option.update.announcement": "A página será recarregada. O filtro {{ filter }} foi selecionado.",
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10240,4 +10240,7 @@
 
   // "forgot-email.form.aria.label": "Enter your e-mail address",
   "forgot-email.form.aria.label": "Digite seu e-mail",
+
+  // "search-facet-option.update.announcement": "The page will be reloaded. selected filter: ",
+  "search-facet-option.update.announcement": "La página será recargada. filtro seleccionado: ",
 }


### PR DESCRIPTION
## References
* Fixes #3299

## Description
Creation of a method which, when a search filter is clicked, announces to the user that the page will be reloaded and which filter has been selected.

## Instructions for Reviewers
List of changes in this PR:
* In the component “search-facet-option.component” the method “selectingFilter()” has been created which, making use of the services “LiveRegionService” and “TranslateService”, creates a message which, as soon as the search filter is clicked, announces to the user that the page will be reloaded and which filter is being applied.
* The “filterService.minimizeAll()” method that used to be called directly in the html is now called in the new method that has been created and is applied after the reload message is announced.
* New translation keys have been added.

**Include guidance for how to test or review your PR.**
1. Go to the search area where the filters are applied https://sandbox.dspace.org/search?query=;
2. Using a screen reader, select a filter and notice that a page reload message is announced.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).