### PR TITLE
Attempt to stabilize a few randomly failing e2e tests

### DIFF
--- a/cypress/e2e/admin-add-new-modals.cy.ts
+++ b/cypress/e2e/admin-add-new-modals.cy.ts
@@ -12,6 +12,7 @@ describe('Admin Add New Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
+    cy.get('[data-test="admin-menu-section-new-title"]').should('be.visible');
     cy.get('[data-test="admin-menu-section-new-title"]').click();
 
     cy.get('a[data-test="menu.section.new_community"]').click();
@@ -25,6 +26,7 @@ describe('Admin Add New Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
+    cy.get('[data-test="admin-menu-section-new-title"]').should('be.visible');
     cy.get('[data-test="admin-menu-section-new-title"]').click();
 
     cy.get('a[data-test="menu.section.new_collection"]').click();
@@ -38,6 +40,7 @@ describe('Admin Add New Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
+    cy.get('[data-test="admin-menu-section-new-title"]').should('be.visible');
     cy.get('[data-test="admin-menu-section-new-title"]').click();
 
     cy.get('a[data-test="menu.section.new_item"]').click();

--- a/cypress/e2e/admin-edit-modals.cy.ts
+++ b/cypress/e2e/admin-edit-modals.cy.ts
@@ -12,7 +12,8 @@ describe('Admin Edit Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
-    cy.get('#admin-menu-section-edit-title').click();
+    cy.get('[data-test="admin-menu-section-edit-title"]').should('be.visible');
+    cy.get('[data-test="admin-menu-section-edit-title"]').click();
 
     cy.get('a[data-test="menu.section.edit_community"]').click();
 
@@ -25,7 +26,8 @@ describe('Admin Edit Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
-    cy.get('#admin-menu-section-edit-title').click();
+    cy.get('[data-test="admin-menu-section-edit-title"]').should('be.visible');
+    cy.get('[data-test="admin-menu-section-edit-title"]').click();
 
     cy.get('a[data-test="menu.section.edit_collection"]').click();
 
@@ -38,7 +40,8 @@ describe('Admin Edit Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
-    cy.get('#admin-menu-section-edit-title').click();
+    cy.get('[data-test="admin-menu-section-edit-title"]').should('be.visible');
+    cy.get('[data-test="admin-menu-section-edit-title"]').click();
 
     cy.get('a[data-test="menu.section.edit_item"]').click();
 

--- a/cypress/e2e/admin-export-modals.cy.ts
+++ b/cypress/e2e/admin-export-modals.cy.ts
@@ -12,7 +12,8 @@ describe('Admin Export Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
-    cy.get('#admin-menu-section-export-title').click();
+    cy.get('[data-test="admin-menu-section-export-title"]').should('be.visible');
+    cy.get('[data-test="admin-menu-section-export-title"]').click();
 
     cy.get('a[data-test="menu.section.export_metadata"]').click();
 
@@ -25,7 +26,8 @@ describe('Admin Export Modals', () => {
     cy.get('[data-test="sidebar-collapse-toggle"]').click();
 
     // Click on entry of menu
-    cy.get('#admin-menu-section-export-title').click();
+    cy.get('[data-test="admin-menu-section-export-title"]').should('be.visible');
+    cy.get('[data-test="admin-menu-section-export-title"]').click();
 
     cy.get('a[data-test="menu.section.export_batch"]').click();
 

--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -13,9 +13,11 @@ beforeEach(() => {
 
 describe('Edit Item > Edit Metadata tab', () => {
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="metadata"]').should('be.visible');
     cy.get('a[data-test="metadata"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="metadata"]').should('be.visible');
     cy.get('a[data-test="metadata"]').should('have.class', 'active');
 
     // <ds-edit-item-page> tag must be loaded
@@ -34,9 +36,11 @@ describe('Edit Item > Edit Metadata tab', () => {
 describe('Edit Item > Status tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="status"]').should('be.visible');
     cy.get('a[data-test="status"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="status"]').should('be.visible');
     cy.get('a[data-test="status"]').should('have.class', 'active');
 
     // <ds-item-status> tag must be loaded
@@ -50,9 +54,11 @@ describe('Edit Item > Status tab', () => {
 describe('Edit Item > Bitstreams tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="bitstreams"]').should('be.visible');
     cy.get('a[data-test="bitstreams"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="bitstreams"]').should('be.visible');
     cy.get('a[data-test="bitstreams"]').should('have.class', 'active');
 
     // <ds-item-bitstreams> tag must be loaded
@@ -77,9 +83,11 @@ describe('Edit Item > Bitstreams tab', () => {
 describe('Edit Item > Curate tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="curate"]').should('be.visible');
     cy.get('a[data-test="curate"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="curate"]').should('be.visible');
     cy.get('a[data-test="curate"]').should('have.class', 'active');
 
     // <ds-item-curate> tag must be loaded
@@ -93,9 +101,11 @@ describe('Edit Item > Curate tab', () => {
 describe('Edit Item > Relationships tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="relationships"]').should('be.visible');
     cy.get('a[data-test="relationships"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="relationships"]').should('be.visible');
     cy.get('a[data-test="relationships"]').should('have.class', 'active');
 
     // <ds-item-relationships> tag must be loaded
@@ -109,9 +119,11 @@ describe('Edit Item > Relationships tab', () => {
 describe('Edit Item > Version History tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="versionhistory"]').should('be.visible');
     cy.get('a[data-test="versionhistory"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="versionhistory"]').should('be.visible');
     cy.get('a[data-test="versionhistory"]').should('have.class', 'active');
 
     // <ds-item-version-history> tag must be loaded
@@ -125,9 +137,11 @@ describe('Edit Item > Version History tab', () => {
 describe('Edit Item > Access Control tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="access-control"]').should('be.visible');
     cy.get('a[data-test="access-control"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="access-control"]').should('be.visible');
     cy.get('a[data-test="access-control"]').should('have.class', 'active');
 
     // <ds-item-access-control> tag must be loaded
@@ -141,9 +155,11 @@ describe('Edit Item > Access Control tab', () => {
 describe('Edit Item > Collection Mapper tab', () => {
 
   it('should pass accessibility tests', () => {
+    cy.get('a[data-test="mapper"]').should('be.visible');
     cy.get('a[data-test="mapper"]').click();
 
-    // Our selected tab should be active
+    // Our selected tab should be both visible & active
+    cy.get('a[data-test="mapper"]').should('be.visible');
     cy.get('a[data-test="mapper"]').should('have.class', 'active');
 
     // <ds-item-collection-mapper> tag must be loaded


### PR DESCRIPTION
## Description
This small PR is an attempt to stabilize a few randomly failing e2e tests.

1. Sometimes tests which use the Admin sidebar will fail randomly if the sidebar link is not yet visible when it's clicked on.  The first commit in this PR attempts to fix that issue.
2. `item-edit.cy.ts` will sometimes randomly fail if the tabs have not fully loaded.  The second commit attempts to fix this issue by waiting on the current tab to be visible before clicking on it, and then ensuring it's visible again after reload of the page.

## Instructions for Reviewers
* This PR only touches e2e tests.  If those pass, it can be merged.