### PR TITLE
Color contrast of placeholder text

### DIFF
--- a/src/app/shared/starts-with/text/starts-with-text.component.html
+++ b/src/app/shared/starts-with/text/starts-with-text.component.html
@@ -8,6 +8,6 @@
       </span>
     </div>
   </div>
-  <small class="text-muted">{{'browse.startsWith.type_text' | translate}}</small>
+  <small>{{'browse.startsWith.type_text' | translate}}</small>
 </div>
 </form>

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -445,6 +445,8 @@ ngb-accordion {
 }
 
 .form-control, .page-link {
+  border: 2px solid $gray-700;
+
     &:disabled {
         color: lighten($gray-700, 10%);
     }

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -445,8 +445,11 @@ ngb-accordion {
 }
 
 .form-control, .page-link {
-    &:disabled::placeholder {
+    &:disabled {
         color: lighten($gray-700, 10%);
+    }
+    &::placeholder {
+        color: $gray-700;
     }
     &:focus {
         box-shadow: none;


### PR DESCRIPTION
## References
* Fixes #3809

## Description
Improving the color contrast of the placeholder text and the descriptive text “Filter results by typing the first few letters”

## Instructions for Reviewers
List of changes in this PR:
* The text-muted class has been removed from the small/explanatory text placeholder in the starts-with-text component.
* The color of the placeholder text in the global styling file “_global-styles.scss” has been adjusted.

Check the color contrast of the placeholders with an accessibility tool!

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
