### PR TITLE
Fix redirect URLs of bitstreams with spaces in filename

### DIFF
--- a/src/app/core/data/bitstream-data.service.spec.ts
+++ b/src/app/core/data/bitstream-data.service.spec.ts
@@ -21,6 +21,7 @@ import { NotificationsService } from '../../shared/notifications/notifications.s
 import objectContaining = jasmine.objectContaining;
 import { RemoteData } from './remote-data';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
+import { RequestParam } from '../cache/models/request-param.model';
 
 describe('BitstreamDataService', () => {
   let service: BitstreamDataService;
@@ -130,6 +131,32 @@ describe('BitstreamDataService', () => {
       } as PatchRequest));
       expect(service.invalidateByHref).toHaveBeenCalledWith('fake-bitstream1-self');
       expect(service.invalidateByHref).toHaveBeenCalledWith('fake-bitstream2-self');
+    });
+  });
+
+  describe('findByItemHandle', () => {
+    it('should encode the filename correctly in the search parameters', () => {
+      const handle = '123456789/1234';
+      const sequenceId = '5';
+      const filename = 'file with spaces.pdf';
+      const searchParams = [
+        new RequestParam('handle', handle),
+        new RequestParam('sequenceId', sequenceId),
+        new RequestParam('filename', filename)
+      ];
+      const linksToFollow: FollowLinkConfig<Bitstream>[] = [];
+
+      spyOn(service as any, 'getSearchByHref').and.callThrough();
+
+      service.getSearchByHref('byItemHandle', { searchParams }, ...linksToFollow).subscribe((href) => {
+        expect(service.getSearchByHref).toHaveBeenCalledWith(
+          'byItemHandle',
+          { searchParams },
+          ...linksToFollow
+        );
+
+        expect(href).toBe(`${url}/bitstreams/search/byItemHandle?handle=123456789%2F1234&sequenceId=5&filename=file%20with%20spaces.pdf`);
+      });
     });
   });
 });

--- a/src/app/core/data/bitstream-data.service.ts
+++ b/src/app/core/data/bitstream-data.service.ts
@@ -171,7 +171,7 @@ export class BitstreamDataService extends IdentifiableDataService<Bitstream> imp
       searchParams.push(new RequestParam('sequenceId', sequenceId));
     }
     if (hasValue(filename)) {
-      searchParams.push(new RequestParam('filename', encodeURIComponent(filename)));
+      searchParams.push(new RequestParam('filename', filename));
     }
 
     const hrefObs = this.getSearchByHref(


### PR DESCRIPTION
## References
* Fixes #3871

## Description
Removes `encodeURIComponent` in [bitstream-data.service.ts#L174](https://github.com/DSpace/dspace-angular/blob/dspace-7.6.2/src/app/core/data/bitstream-data.service.ts#L174) because [RequestParam](https://github.com/DSpace/dspace-angular/blob/dspace-7.6.2/src/app/core/cache/models/request-param.model.ts) is already encoding values

This extra encoding causes spaces to be encoded twice `%20` to `%2520` and URL redirect fails with 404 error.
