### PR TITLE
[Post dspace-7_x] Restrict Angular SSR to paths in the sitemap

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -23,6 +23,8 @@ ssr:
   # Determining which styles are critical is a relatively expensive operation; this option is
   # disabled (false) by default to boost server performance at the expense of loading smoothness.
   inlineCriticalCss: false
+  # Path prefixes to enable SSR for. By default these are limited to paths of primary DSpace objects.
+  paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ]
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually

--- a/server.ts
+++ b/server.ts
@@ -238,7 +238,7 @@ export function app() {
  * The callback function to serve server side angular
  */
 function ngApp(req, res) {
-  if (environment.universal.preboot) {
+  if (environment.universal.preboot && req.method === 'GET' && (req.path === '/' || environment.universal.paths.some(pathPrefix => req.path.startsWith(pathPrefix)))) {
     // Render the page to user via SSR (server side rendering)
     serverSideRender(req, res);
   } else {

--- a/src/config/universal-config.interface.ts
+++ b/src/config/universal-config.interface.ts
@@ -13,4 +13,9 @@ export interface UniversalConfig extends Config {
    * loading smoothness.
    */
   inlineCriticalCss?: boolean;
+
+  /**
+   * Paths to enable SSR for. Defaults to the home page and paths in the sitemap.
+   */
+  paths: Array<string>;
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -9,5 +9,6 @@ export const environment: Partial<BuildConfig> = {
     async: true,
     time: false,
     inlineCriticalCss: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
   }
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -12,6 +12,7 @@ export const environment: BuildConfig = {
     async: true,
     time: false,
     inlineCriticalCss: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
   },
 
   // Angular Universal server settings.

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,6 +14,7 @@ export const environment: Partial<BuildConfig> = {
     async: true,
     time: false,
     inlineCriticalCss: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
   }
 };
 


### PR DESCRIPTION
Manual port of #3682 to DSpace 7.6.x.

There are minor differences due to a refactoring of the Universal preboot configuration to "SSR" in DSpace 8 and main.