### PR TITLE
Improving the color contrast of home news content

### DIFF
--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -99,8 +99,8 @@
   --ds-footer-logo-height: 50px;
   --ds-footer-n-coar-height: 20px;
 
-  --ds-home-news-link-color: #D2FC93;
-  --ds-home-news-link-hover-color: #{$ds-home-news-link-color};
+  --ds-home-news-link-color: #{$ds-home-news-link-color};
+  --ds-home-news-link-hover-color: #{darken($ds-home-news-link-color, 15%)};
   --ds-home-news-background-color: #{$gray-200};
 
   --ds-breadcrumb-bg: #{$gray-200} !important;

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -99,8 +99,8 @@
   --ds-footer-logo-height: 50px;
   --ds-footer-n-coar-height: 20px;
 
-  --ds-home-news-link-color: #{$ds-home-news-link-color};
-  --ds-home-news-link-hover-color: #{darken($ds-home-news-link-color, 15%)};
+  --ds-home-news-link-color: #D2FC93;
+  --ds-home-news-link-hover-color: #{$ds-home-news-link-color};
   --ds-home-news-background-color: #{$gray-200};
 
   --ds-breadcrumb-bg: #{$gray-200} !important;

--- a/src/themes/dspace/app/home-page/home-news/home-news.component.scss
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.scss
@@ -4,6 +4,7 @@
   div.background-image-container {
     color: white;
     position: relative;
+    font-weight: 600;
 
     .background-image > img {
       background-color: var(--bs-info);
@@ -67,6 +68,11 @@
     @include hover {
       color: var(--ds-home-news-link-hover-color);
     }
+  }
+
+  .lead {
+    font-size: 1.25rem;
+    font-weight: 400;
   }
 }
 

--- a/src/themes/dspace/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_css_variable_overrides.scss
@@ -11,7 +11,7 @@
     --ds-header-height: 90px;
   }
 
-  --ds-banner-text-background: rgba(0, 0, 0, 0.45);
+  --ds-banner-text-background: rgba(0, 0, 0, 0.50);
   --ds-banner-background-gradient-width: 300px;
 
   --ds-header-navbar-border-bottom-height: 5px;

--- a/src/themes/dspace/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_css_variable_overrides.scss
@@ -11,7 +11,7 @@
     --ds-header-height: 90px;
   }
 
-  --ds-banner-text-background: rgba(0, 0, 0, 0.50);
+  --ds-banner-text-background: rgba(0, 0, 0, 0.58);
   --ds-banner-background-gradient-width: 300px;
 
   --ds-header-navbar-border-bottom-height: 5px;

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -83,7 +83,7 @@ $navbar-dark-color: #fff;
 
 /*** CUSTOM DSPACE VARIABLES ***/
 
-$ds-home-news-link-color: #92c642;
+$ds-home-news-link-color: #D2FC93;
 $ds-header-navbar-border-bottom-color: #92c642;
 
 $ds-breadcrumb-link-color: #154E66 !default;


### PR DESCRIPTION
## References
* Fixes #3810 
* Fixes #1157

## Description
Improved color contrast of home news content.

## Instructions for Reviewers
List of changes in this PR:
* In the “home-news.component” component, the font weight has been increased,
* In the style file “_theme_css_variable_overrides.scss” the banner has been darkened a little.

Use an accessibility tool to see if the home news content is more accessible.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
