### PR TITLE
Fix default sort and alignment issue

### DIFF
--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -155,7 +155,7 @@ describe('SearchConfigurationService', () => {
       service.getCurrentSort(defaults.pagination.id, {} as any);
     });
     it('should call getCurrentSort on the paginationService with the provided id and sort options', () => {
-      expect((service as any).paginationService.getCurrentSort).toHaveBeenCalledWith(defaults.pagination.id, {});
+      expect((service as any).paginationService.getCurrentSort).toHaveBeenCalledWith(defaults.pagination.id, {}, true);
     });
   });
 

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -207,7 +207,7 @@ export class SearchConfigurationService implements OnDestroy {
    * @returns {Observable<string>} Emits the current sorting settings
    */
   getCurrentSort(paginationId: string, defaultSort: SortOptions): Observable<SortOptions> {
-    return this.paginationService.getCurrentSort(paginationId, defaultSort);
+    return this.paginationService.getCurrentSort(paginationId, defaultSort, true);
   }
 
   /**

--- a/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
+++ b/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
@@ -125,7 +125,7 @@ describe('MyDSpaceConfigurationService', () => {
       service.getCurrentSort('page-id', defaults.sort);
     });
     it('should call getCurrentSort on the paginationService with the provided id and sort options', () => {
-      expect((service as any).paginationService.getCurrentSort).toHaveBeenCalledWith('page-id', defaults.sort);
+      expect((service as any).paginationService.getCurrentSort).toHaveBeenCalledWith('page-id', defaults.sort, true);
     });
   });
 

--- a/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.html
+++ b/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.html
@@ -5,12 +5,12 @@
     <div class="list-group list-group-horizontal" role="tablist">
       <a *ngFor="let option of allOptions"
          [attr.aria-current]="(currentOption$ | async)?.id === option.id"
-         class="list-group-item"
+         class="d-flex list-group-item"
          role="tab"
          [routerLink]="option.routerLink"
          [queryParams]="option.params"
          [class.active]="(currentOption$ | async)?.id === option.id">
-        {{ option.label | translate }}
+        <span class="my-auto">{{ option.label | translate }}</span>
       </a>
     </div>
   </div>

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -197,7 +197,7 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
     getConfigurationSearchConfig: observableOf(searchConfig),
     getCurrentConfiguration: observableOf('default'),
     getCurrentScope: observableOf('test-id'),
-    getCurrentSort: observableOf(sortOptionsList[0]),
+    getCurrentSort: observableOf(sortOptionsList[1]),
     updateFixedFilter: jasmine.createSpy('updateFixedFilter'),
     setPaginationId: jasmine.createSpy('setPaginationId'),
   });
@@ -297,13 +297,13 @@ describe('SearchComponent', () => {
     const expectedSearchOptions = Object.assign(paginatedSearchOptions$.value, {
       configuration: 'default',
       scope: '',
-      sort: sortOptionsList[0],
+      sort: sortOptionsList[1],
     });
     expect(comp.currentConfiguration$).toBeObservable(cold('b', {
       b: 'default',
     }));
     expect(comp.currentSortOptions$).toBeObservable(cold('b', {
-      b: sortOptionsList[0],
+      b: sortOptionsList[1],
     }));
     expect(comp.sortOptionsList$).toBeObservable(cold('b', {
       b: sortOptionsList,

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -387,14 +387,15 @@ export class SearchComponent implements OnDestroy, OnInit {
       map((searchConfig: SearchConfig) => this.searchConfigService.getConfigurationSortOptions(searchConfig)),
       distinctUntilChanged(),
     );
-    const sortOption$: Observable<SortOptions> = searchSortOptions$.pipe(
-      switchMap((searchSortOptions: SortOptions[]) => {
-        const defaultSort: SortOptions = searchSortOptions[0];
-        return this.searchConfigService.getCurrentSort(this.paginationId, defaultSort);
+    const searchOptions$: Observable<PaginatedSearchOptions> = this.getSearchOptions().pipe(distinctUntilChanged());
+
+    const sortOption$: Observable<SortOptions> = combineLatest([searchSortOptions$, searchOptions$]).pipe(
+      switchMap(([searchSortOptions, searchOptions]: [SortOptions[], PaginatedSearchOptions]) => {
+        const defaultSortOption = hasValue(searchOptions.sort?.field) && hasValue(searchOptions.sort?.field) ? searchOptions.sort : searchSortOptions[0];
+        return this.searchConfigService.getCurrentSort(this.paginationId, defaultSortOption);
       }),
       distinctUntilChanged(),
     );
-    const searchOptions$: Observable<PaginatedSearchOptions> = this.getSearchOptions().pipe(distinctUntilChanged());
 
     this.subs.push(combineLatest([configuration$, searchSortOptions$, searchOptions$, sortOption$, this.currentScope$]).pipe(
       filter(([configuration, searchSortOptions, searchOptions, sortOption, scope]: [string, SortOptions[], PaginatedSearchOptions, SortOptions, string]) => {


### PR DESCRIPTION
## References
* Fixes #2524

## Description
This PR fixes the issue with the default sort option being ignored from the discovery.xml file in the backend. 
The search should now use the default if present. If not present, the first option of the list of sort options will be used instead. 

This PR also contains a small fix for the vertical alignment of the com/col browse navigation text for smaller screens (smaller than 1100px). 

## Instructions for Reviewers
To verify that the default sort issue is fixed, perform the following steps: 
1. Make sure an easy to access discovery configuration has a default sort property set that is not the first in the list (e.g. the `workspaceConfiguration` configuration) 
2. Navigate to a search page using that configuration
3. Verify that the configured default sort property is used
4. Navigate to a different search page such as the default one
5. Verify this still works as expected

The alignment issue can be verified on com/col pages when using a smaller screen. 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
