### PR TITLE
[Port dspace-8_x] Fix redirect URLs of bitstreams with spaces in filename (new test ONLY)

### DIFF
--- a/src/app/core/data/bitstream-data.service.spec.ts
+++ b/src/app/core/data/bitstream-data.service.spec.ts
@@ -16,6 +16,7 @@ import { NotificationsService } from '../../shared/notifications/notifications.s
 import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service.stub';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { RequestParam } from '../cache/models/request-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { Bitstream } from '../shared/bitstream.model';
 import { BitstreamFormat } from '../shared/bitstream-format.model';
@@ -174,6 +175,32 @@ describe('BitstreamDataService', () => {
       } as PatchRequest));
       expect(service.invalidateByHref).toHaveBeenCalledWith('fake-bitstream1-self');
       expect(service.invalidateByHref).toHaveBeenCalledWith('fake-bitstream2-self');
+    });
+  });
+
+  describe('findByItemHandle', () => {
+    it('should encode the filename correctly in the search parameters', () => {
+      const handle = '123456789/1234';
+      const sequenceId = '5';
+      const filename = 'file with spaces.pdf';
+      const searchParams = [
+        new RequestParam('handle', handle),
+        new RequestParam('sequenceId', sequenceId),
+        new RequestParam('filename', filename),
+      ];
+      const linksToFollow: FollowLinkConfig<Bitstream>[] = [];
+
+      spyOn(service as any, 'getSearchByHref').and.callThrough();
+
+      service.getSearchByHref('byItemHandle', { searchParams }, ...linksToFollow).subscribe((href) => {
+        expect(service.getSearchByHref).toHaveBeenCalledWith(
+          'byItemHandle',
+          { searchParams },
+          ...linksToFollow,
+        );
+
+        expect(href).toBe(`${url}/bitstreams/search/byItemHandle?handle=123456789%2F1234&sequenceId=5&filename=file%20with%20spaces.pdf`);
+      });
     });
   });
 });


### PR DESCRIPTION
Manual port of #3876 by @msarmie to `dspace-8_x`.  This port ONLY includes the new unit test, as the bug doesn't exist on `dspace-8_x`.