### PR TITLE
Bump cross-spawn from 7.0.3 to 7.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10081,10 +10081,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
## References
* Related to #3894 and #3895

## Description
This PR simply bumps the version of `cross-spawn` specified in our package-lock.json to avoid CVE-2024-21538.  `cross-spawn` is only used in development, so it's unlikely this CVE would impact DSpace in production. However, bumping up just in case.

It's a port of #3894 and #3895 to `main`.
