### PR TITLE
Fix auth in UI with LDAP if password authentication is disabled

### DIFF
--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -129,11 +129,23 @@ export class AuthInterceptor implements HttpInterceptor {
    */
   private sortAuthMethods(authMethodModels: AuthMethod[]): AuthMethod[] {
     const sortedAuthMethodModels: AuthMethod[] = [];
+    let passwordAuthFound = false;
+    let ldapAuthFound = false;
+
     authMethodModels.forEach((method) => {
       if (method.authMethodType === AuthMethodType.Password) {
         sortedAuthMethodModels.push(method);
+        passwordAuthFound = true;
+      }
+      if (method.authMethodType === AuthMethodType.Ldap) {
+        ldapAuthFound = true;
       }
     });
+
+    // Using password authentication method to provide UI for LDAP authentication even if password auth is not present in server
+    if (ldapAuthFound && !(passwordAuthFound)) {
+      sortedAuthMethodModels.push(new AuthMethod(AuthMethodType.Password,0));
+    }
 
     authMethodModels.forEach((method) => {
       if (method.authMethodType !== AuthMethodType.Password) {


### PR DESCRIPTION
## References

* Fixes https://github.com/DSpace/DSpace/issues/8312 (see also discussion in duplicate issue #2701)
* Expands on #2414

## Description

If LDAP authentication is enabled but Password authentication is not, Angular UI shows a blank login dialog. This PR fixes the issue by forcing Password dialog to be present (as the same password dialog is used in both password- and ldap-based authentication) as part of the enumeration and sorting of login methods. 

## Instructions for Reviewers

Details on functionality: When enumerating the authentication methods for sorting, additional local variables to record whether password auth and/or ldap auth are present. In the special case where ldap auth is present and password auth is not, password auth is added anyway. This is needed because there is no renderAuthMethodFor decorator related to ldap auth (and overall, ldap auth is barely referenced anywhere outside the auth.method.ts as the UI is the same for password authentication). Because of the new variables the form will appear only once compared to the situation where a decorator would be present both password and ldap auth (as mentioned in discussion of #2701).

So far, the code has only been tested with DSpace 7.6.x. However, there seems to be no essential changes in auth.interceptor.ts after introducing the reordering functionality #2414 so it's at least mergeable to main branch as well.

Steps to test the issue (i.e. adjusting values of plugin.sequence.org.dspace.authenticate.AuthenticationMethod in DSpace server settings) are described in https://github.com/DSpace/DSpace/issues/8312

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
