### PR TITLE
Fix YAML syntax in config.example.yml

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -28,11 +28,11 @@ ssr:
   # Whether to enable rendering of Search component on SSR.
   # If set to true the component will be included in the HTML returned from the server side rendering.
   # If set to false the component will not be included in the HTML returned from the server side rendering.
-  enableSearchComponent: false,
+  enableSearchComponent: false
   # Whether to enable rendering of Browse component on SSR.
   # If set to true the component will be included in the HTML returned from the server side rendering.
   # If set to false the component will not be included in the HTML returned from the server side rendering.
-  enableBrowseComponent: false,
+  enableBrowseComponent: false
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually


### PR DESCRIPTION
## Description

This PR fixes a minor syntax error in our `config.example.yml` added in #3709 

Because this example file is only for documentation purposes, we overlooked that these example configs were not valid YAML.

This needs to be ported to 8.x as well, since it exists there.  A manual port will need to be done for 7.x