### PR TITLE
Ensure `/reload/` (hard reload) path is included in SSR paths.

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -24,7 +24,9 @@ ssr:
   # disabled (false) by default to boost server performance at the expense of loading smoothness.
   inlineCriticalCss: false
   # Path prefixes to enable SSR for. By default these are limited to paths of primary DSpace objects.
-  paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ]
+  # NOTE: The "/handle/" path ensures Handle redirects work via SSR.  The "/reload/" path ensures
+  # hard refreshes (e.g. after login) trigger SSR while fully reloading the page.
+  paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ]
   # Whether to enable rendering of Search component on SSR.
   # If set to true the component will be included in the HTML returned from the server side rendering.
   # If set to false the component will not be included in the HTML returned from the server side rendering.

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -8,7 +8,7 @@ export const environment: Partial<BuildConfig> = {
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
-    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
     enableSearchComponent: false,
     enableBrowseComponent: false,
   },

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -12,7 +12,7 @@ export const environment: BuildConfig = {
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
-    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
     enableSearchComponent: false,
     enableBrowseComponent: false,
   },

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,7 +13,7 @@ export const environment: Partial<BuildConfig> = {
     enabled: false,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
-    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/' ],
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
     enableSearchComponent: false,
     enableBrowseComponent: false,
   },


### PR DESCRIPTION
## References
* Fixes #3934

## Description
This small PR just ensures that `/reload/` paths always trigger SSR.  This fixes the odd behavior seen in #3934.

## Instructions for Reviewers
* Review code
* If you are able to reproduce the issues in #3934, ensure they no longer occur.
   * NOTE: For some reason the issues described in #3934 do not seem to occur in all environments. For example, they are not reproducible on sandbox.dspace.org.  However, *when* these issues occur, the fix is to add `/reload/` to the `ssr.paths`.
