### PR TITLE
added main link method on item component to use in thumbnails.

### DIFF
--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.spec.ts
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.spec.ts
@@ -96,6 +96,9 @@ describe('JournalComponent', () => {
     getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
       return createSuccessfulRemoteDataObject$(new Bitstream());
     },
+    findPrimaryBitstreamByItemAndName(): Observable<RemoteData<Bitstream>> {
+      return createSuccessfulRemoteDataObject$(new Bitstream());
+    },
   };
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({

--- a/src/app/item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/item-page/simple/item-types/publication/publication.component.html
@@ -17,7 +17,7 @@
   <div class="col-xs-12 col-md-4">
     <ng-container *ngIf="!(mediaViewer.image || mediaViewer.video)">
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
-        <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
+        <ds-thumbnail [thumbnail]="object?.thumbnail | async" [link]="thumbnailLink$ | async"></ds-thumbnail>
       </ds-metadata-field-wrapper>
     </ng-container>
     <div *ngIf="mediaViewer.image || mediaViewer.video" class="mb-2">

--- a/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
@@ -97,6 +97,9 @@ describe('PublicationComponent', () => {
       getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
         return createSuccessfulRemoteDataObject$(new Bitstream());
       },
+      findPrimaryBitstreamByItemAndName(): Observable<RemoteData<Bitstream>> {
+        return createSuccessfulRemoteDataObject$(new Bitstream());
+      },
     };
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -18,7 +18,7 @@
   <div class="col-xs-12 col-md-4">
     <ng-container *ngIf="!(mediaViewer.image || mediaViewer.video)">
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
-        <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
+        <ds-thumbnail [thumbnail]="object?.thumbnail | async" [link]="thumbnailLink$ | async"></ds-thumbnail>
       </ds-metadata-field-wrapper>
     </ng-container>
     <div *ngIf="mediaViewer.image || mediaViewer.video" class="mb-2">

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
@@ -94,6 +94,9 @@ describe('UntypedItemComponent', () => {
       getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
         return createSuccessfulRemoteDataObject$(new Bitstream());
       },
+      findPrimaryBitstreamByItemAndName(): Observable<RemoteData<Bitstream>> {
+        return createSuccessfulRemoteDataObject$(new Bitstream());
+      },
     };
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/thumbnail/themed-thumbnail.component.ts
+++ b/src/app/thumbnail/themed-thumbnail.component.ts
@@ -19,6 +19,8 @@ export class ThemedThumbnailComponent extends ThemedComponent<ThumbnailComponent
 
   @Input() thumbnail: Bitstream | RemoteData<Bitstream>;
 
+  @Input() link: string = undefined;
+
   @Input() defaultImage?: string | null;
 
   @Input() alt?: string;
@@ -29,6 +31,7 @@ export class ThemedThumbnailComponent extends ThemedComponent<ThumbnailComponent
 
   protected inAndOutputNames: (keyof ThumbnailComponent & keyof this)[] = [
     'thumbnail',
+    'link',
     'defaultImage',
     'alt',
     'placeholder',

--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -7,7 +7,11 @@
     </div>
   </div>
   <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-  <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+  <a *ngIf="src !== null && link" target="_blank" [href]="link">
+    <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+    [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
+  </a>
+  <img *ngIf="src !== null && !link" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
        [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
   <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
     <div class="inner">

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -42,6 +42,11 @@ export class ThumbnailComponent implements OnChanges {
   @Input() thumbnail: Bitstream | RemoteData<Bitstream>;
 
   /**
+   * A link to open when a user clicks on thumbnail image
+   */
+  @Input() link: string = undefined;
+
+  /**
    * The default image, used if the thumbnail isn't set or can't be downloaded.
    * If defaultImage is null, a HTML placeholder is used instead.
    */


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #3384

## Description
A optional param was added to ds-thumbnail component to allow open a link if a user clicks on the bitstream. Also if an item has a main bitstream, this link is used. If it does not have one assigned, it takes the first available bitstream of the item's ORIGINAL bundle


## Instructions for Reviewers

List of changes in this PR:
* added a optional link parameter to thumbnail component
* added a method to get the link of the main bitstream or the first item bitstream on ItemComponent 
* Updated unit test which involve thumbnail Component or Item Component to fit new changes
* Added unit test for getMainBitstream method on ItemComponent

To test this PR:
1. Open an item with bitstream and thumbnail assigned 
2. Clicks on the thumbnail icon to open the link

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
