### PR TITLE
statistics menu leveling to improve user experience

### DIFF
--- a/cypress/e2e/collection-statistics.cy.ts
+++ b/cypress/e2e/collection-statistics.cy.ts
@@ -6,7 +6,8 @@ describe('Collection Statistics Page', () => {
 
   it('should load if you click on "Statistics" from a Collection page', () => {
     cy.visit('/collections/'.concat(Cypress.env('DSPACE_TEST_COLLECTION')));
-    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics"]').click();
+    cy.get('ds-expandable-navbar-section').contains('Statistics').parents('[data-test="navbar-section-wrapper"]').trigger('mouseenter', { force: true });
+    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics.collection"]').click();
     cy.location('pathname').should('eq', COLLECTIONSTATISTICSPAGE);
   });
 

--- a/cypress/e2e/community-statistics.cy.ts
+++ b/cypress/e2e/community-statistics.cy.ts
@@ -6,7 +6,8 @@ describe('Community Statistics Page', () => {
 
   it('should load if you click on "Statistics" from a Community page', () => {
     cy.visit('/communities/'.concat(Cypress.env('DSPACE_TEST_COMMUNITY')));
-    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics"]').click();
+    cy.get('ds-expandable-navbar-section').contains('Statistics').parents('[data-test="navbar-section-wrapper"]').trigger('mouseenter', { force: true });
+    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics.community"]').click();
     cy.location('pathname').should('eq', COMMUNITYSTATISTICSPAGE);
   });
 

--- a/cypress/e2e/homepage-statistics.cy.ts
+++ b/cypress/e2e/homepage-statistics.cy.ts
@@ -6,7 +6,8 @@ import { testA11y } from 'cypress/support/utils';
 describe('Site Statistics Page', () => {
   it('should load if you click on "Statistics" from homepage', () => {
     cy.visit('/');
-    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics"]').click();
+    cy.get('ds-expandable-navbar-section').contains('Statistics').parents('[data-test="navbar-section-wrapper"]').trigger('mouseenter', { force: true });
+    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics.site"]').click();
     cy.location('pathname').should('eq', '/statistics');
   });
 

--- a/cypress/e2e/item-statistics.cy.ts
+++ b/cypress/e2e/item-statistics.cy.ts
@@ -6,7 +6,8 @@ describe('Item Statistics Page', () => {
 
   it('should load if you click on "Statistics" from an Item/Entity page', () => {
     cy.visit('/entities/publication/'.concat(Cypress.env('DSPACE_TEST_ENTITY_PUBLICATION')));
-    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics"]').click();
+    cy.get('ds-expandable-navbar-section').contains('Statistics').parents('[data-test="navbar-section-wrapper"]').trigger('mouseenter', { force: true });
+    cy.get('ds-navbar ds-link-menu-item a[data-test="link-menu-item.menu.section.statistics.item"]').click();
     cy.location('pathname').should('eq', ITEMSTATISTICSPAGE);
   });
 

--- a/src/app/collection-page/collection-page-routes.ts
+++ b/src/app/collection-page/collection-page-routes.ts
@@ -106,17 +106,51 @@ export const ROUTES: Route[] = [
     ],
     data: {
       menu: {
-        public: [{
-          id: 'statistics_collection_:id',
-          active: true,
-          visible: true,
-          index: 2,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.statistics',
-            link: 'statistics/collections/:id/',
-          } as LinkMenuItemModel,
-        }],
+        public: [
+          {
+            id: 'statistics',
+            active: true,
+            visible: true,
+            index: 2,
+            model: {
+              type: MenuItemType.TEXT,
+              text: 'menu.section.statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_site',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.site',
+              link: 'statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_community_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.community',
+              link: 'statistics/communities/:id/',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_collection_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.collection',
+              link: 'statistics/collections/:id/',
+            } as LinkMenuItemModel,
+          }
+        ],
       },
     },
   },

--- a/src/app/collection-page/collection-page-routes.ts
+++ b/src/app/collection-page/collection-page-routes.ts
@@ -149,7 +149,7 @@ export const ROUTES: Route[] = [
               text: 'menu.section.statistics.collection',
               link: 'statistics/collections/:id/',
             } as LinkMenuItemModel,
-          }
+          },
         ],
       },
     },

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -134,7 +134,7 @@ export const ROUTES: Route[] = [
               text: 'menu.section.statistics.community',
               link: 'statistics/communities/:id',
             } as LinkMenuItemModel,
-          }
+          },
         ],
       },
     },

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -132,7 +132,7 @@ export const ROUTES: Route[] = [
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.statistics.community',
-              link: 'statistics/communities/:id/:name',
+              link: 'statistics/communities/:id',
             } as LinkMenuItemModel,
           }
         ],

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -102,17 +102,40 @@ export const ROUTES: Route[] = [
     ],
     data: {
       menu: {
-        public: [{
-          id: 'statistics_community_:id',
-          active: true,
-          visible: true,
-          index: 2,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.statistics',
-            link: 'statistics/communities/:id/',
-          } as LinkMenuItemModel,
-        }],
+        public: [
+          {
+            id: 'statistics',
+            active: true,
+            visible: true,
+            index: 2,
+            model: {
+              type: MenuItemType.TEXT,
+              text: 'menu.section.statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_site',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.site',
+              link: 'statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_community_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.community',
+              link: 'statistics/communities/:id/:name',
+            } as LinkMenuItemModel,
+          }
+        ],
       },
     },
   },

--- a/src/app/home-page/home-page-routes.ts
+++ b/src/app/home-page/home-page-routes.ts
@@ -34,7 +34,7 @@ export const ROUTES: Route[] = [
               text: 'menu.section.statistics.site',
               link: 'statistics',
             } as LinkMenuItemModel,
-          }
+          },
         ],
       },
     },

--- a/src/app/home-page/home-page-routes.ts
+++ b/src/app/home-page/home-page-routes.ts
@@ -13,17 +13,29 @@ export const ROUTES: Route[] = [
     data: {
       title: 'home.title',
       menu: {
-        public: [{
-          id: 'statistics_site',
-          active: true,
-          visible: true,
-          index: 2,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.statistics',
-            link: 'statistics',
-          } as LinkMenuItemModel,
-        }],
+        public: [
+          {
+            id: 'statistics',
+            active: true,
+            visible: true,
+            index: 2,
+            model: {
+              type: MenuItemType.TEXT,
+              text: 'menu.section.statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_site',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.site',
+              link: 'statistics',
+            } as LinkMenuItemModel,
+          }
+        ],
       },
     },
     resolve: {

--- a/src/app/item-page/item-page-routes.ts
+++ b/src/app/item-page/item-page-routes.ts
@@ -67,17 +67,62 @@ export const ROUTES: Route[] = [
     ],
     data: {
       menu: {
-        public: [{
-          id: 'statistics_item_:id',
-          active: true,
-          visible: true,
-          index: 2,
-          model: {
-            type: MenuItemType.LINK,
-            text: 'menu.section.statistics',
-            link: 'statistics/items/:id/',
-          } as LinkMenuItemModel,
-        }],
+        public: [
+          {
+            id: 'statistics',
+            active: true,
+            visible: true,
+            index: 2,
+            model: {
+              type: MenuItemType.TEXT,
+              text: 'menu.section.statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_site',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.site',
+              link: 'statistics',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_community_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.community',
+              link: 'statistics/communities/:id/',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_collection_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.collection',
+              link: 'statistics/collections/:id/',
+            } as LinkMenuItemModel,
+          },
+          {
+            id: 'statistics_item_:id',
+            parentID: 'statistics',
+            active: false,
+            visible: true,
+            model: {
+              type: MenuItemType.LINK,
+              text: 'menu.section.statistics.item',
+              link: 'statistics/items/:id/',
+            } as LinkMenuItemModel,
+          }
+        ],
       },
     },
   },

--- a/src/app/item-page/item-page-routes.ts
+++ b/src/app/item-page/item-page-routes.ts
@@ -121,7 +121,7 @@ export const ROUTES: Route[] = [
               text: 'menu.section.statistics.item',
               link: 'statistics/items/:id/',
             } as LinkMenuItemModel,
-          }
+          },
         ],
       },
     },

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3370,6 +3370,14 @@
 
   "menu.section.statistics": "Statistics",
 
+  "menu.section.statistics.site": "Site Statistics",
+
+  "menu.section.statistics.community": "Community Statistics",
+
+  "menu.section.statistics.collection": "Collection Statistics",
+
+  "menu.section.statistics.item": "Item Statistics",
+
   "menu.section.statistics_task": "Statistics Task",
 
   "menu.section.toggle.access_control": "Toggle Access Control section",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -5039,6 +5039,18 @@
   // "menu.section.statistics": "Statistics",
   "menu.section.statistics": "Estadísticas",
 
+  //"menu.section.statistics.site": "Site Statistics",
+  "menu.section.statistics.site": "Estadísticas del sitio",
+
+  //"menu.section.statistics.community": "Community Statistics",
+  "menu.section.statistics.community": "Estadísticas de la comunidad",
+
+  //"menu.section.statistics.collection": "Collection Statistics",
+  "menu.section.statistics.collection": "Estadísticas de la colección",
+
+  //"menu.section.statistics.item": "Item Statistics",
+  "menu.section.statistics.item": "Estadísticas del item",
+
   // "menu.section.statistics_task": "Statistics Task",
   "menu.section.statistics_task": "Tarea de estadísticas",
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #1392 

## Description
This PR changes the statistics button to a menu with sublevels that, depending on where the user is, shows you more or fewer options.

## Instructions for Reviewers

List of changes in this PR:
* Changed statistics button on main bar to a menu with sublevels. 
* Enabled different subleveles depending where the user is: 
** To main page allow view main statistics
** To community page allow view main statistics and selected community statistics
** To collection page allow view main statistics, selected community statistics and selected collection statistics
** To collection page allow view main statistics, selected community statistics, selected collection statistics and item selected item statistics

To check this PR: 
1. Over main page you will see the statistics menu, if you pass mouse over it, you will see the statistics allowed options.
2. A similar behavior will work over community, collection or item page but the allowed options will change when you get deeper on the repo structure 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
