### PR TITLE
fixed deprecated import of TransferState

### DIFF
--- a/src/ngx-translate-loaders/translate-server.loader.ts
+++ b/src/ngx-translate-loaders/translate-server.loader.ts
@@ -1,4 +1,4 @@
-import { TransferState } from '@angular/platform-browser';
+import { TransferState } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
 import { readFileSync } from 'fs';
 import {


### PR DESCRIPTION
## Description

This PR fixes the ESLint deprecation warning

`'TransferState' is deprecated. TransferState has moved, please import TransferState from @angular/core`

This affects all DSpace version which use Angular 17 or above.
