### PR TITLE
System Wide Alert - adding the contextual help

### DIFF
--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.html
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.html
@@ -1,5 +1,16 @@
 <div class="container">
-    <h1 id="header">{{'system-wide-alert.form.header' | translate}}</h1>
+    <h1 id="header">
+      <span
+        *dsContextHelp="{
+          content: 'system-wide-alert-form.tooltip.system.alert',
+          id: 'system-alert',
+          iconPlacement: 'right',
+          tooltipPlacement: ['top', 'right', 'bottom']
+        }"
+      >
+        {{'system-wide-alert.form.header' | translate}}
+      </span>
+    </h1>
     <div [formGroup]="alertForm" [class]="'ng-invalid'">
         <div class="form-group">
             <div class="row mb-2">

--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
@@ -14,6 +14,7 @@ import { UiSwitchModule } from 'ngx-ui-switch';
 
 import { RequestService } from '../../core/data/request.service';
 import { SystemWideAlertDataService } from '../../core/data/system-wide-alert-data.service';
+import { ContextHelpDirective } from '../../shared/context-help.directive';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import {
   createFailedRemoteDataObject$,
@@ -69,7 +70,13 @@ describe('SystemWideAlertFormComponent', () => {
         { provide: Router, useValue: router },
         { provide: RequestService, useValue: requestService },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(SystemWideAlertFormComponent, {
+        remove: {
+          imports: [ContextHelpDirective],
+        },
+      })
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
@@ -44,6 +44,7 @@ import { RequestService } from '../../core/data/request.service';
 import { SystemWideAlertDataService } from '../../core/data/system-wide-alert-data.service';
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { BtnDisabledDirective } from '../../shared/btn-disabled.directive';
+import { ContextHelpDirective } from '../../shared/context-help.directive';
 import {
   hasValue,
   isNotEmpty,
@@ -60,7 +61,7 @@ import { SystemWideAlert } from '../system-wide-alert.model';
   styleUrls: ['./system-wide-alert-form.component.scss'],
   templateUrl: './system-wide-alert-form.component.html',
   standalone: true,
-  imports: [FormsModule, ReactiveFormsModule, UiSwitchModule, NgIf, NgbDatepickerModule, NgbTimepickerModule, AsyncPipe, TranslateModule, BtnDisabledDirective],
+  imports: [FormsModule, ReactiveFormsModule, UiSwitchModule, NgIf, NgbDatepickerModule, NgbTimepickerModule, AsyncPipe, TranslateModule, BtnDisabledDirective, ContextHelpDirective],
 })
 export class SystemWideAlertFormComponent implements OnInit {
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6781,4 +6781,6 @@
   "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
 
   "dynamic-form-array.sortable-list.label": "Sortable list",
+
+  "system-wide-alert-form.tooltip.system.alert": "On this page, you can create alert or warning texts that will be displayed throughout the system for more effective communication with users. To activate this, you must add the desired text, select the active option button and click save. If you want to activate the timer feature for a countdown, this is also possible, which does not mean that the system will be suspended, but that the message will disappear at the end of the countdown. If you want to deactivate an alert in the system, simply select the option on the inactive button and click save.",
 }

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -10194,4 +10194,7 @@
 
   // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
   "search-facet-option.update.announcement": "La página será recargada. Filtro {{ filter }} seleccionado.",
+
+  // "system-wide-alert-form.tooltip.system.alert": "On this page, you can create alert or warning texts that will be displayed throughout the system for more effective communication with users. To activate this, you must add the desired text, select the active option button and click save. If you want to activate the timer feature for a countdown, this is also possible, which does not mean that the system will be suspended, but that the message will disappear at the end of the countdown. If you want to deactivate an alert in the system, simply select the option on the inactive button and click save.",
+  "system-wide-alert-form.tooltip.system.alert": "En esta página puedes crear textos de alerta o aviso que se mostrarán en todo el sistema para una comunicación más eficaz con los usuarios. Para activarlo, debes añadir el texto deseado, seleccionar el botón de opción activa y hacer clic en guardar. Si quieres activar la función de temporizador para una cuenta regresiva, también es posible, lo que no significa que el sistema se suspenderá, sino que el mensaje desaparecerá al final de la cuenta regresiva. Si deseas desactivar una alerta del sistema, sólo tiene que seleccionar la opción del botón inactivo y hacer clic en guardar.",
 }

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -10243,4 +10243,7 @@
 
   // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
   "search-facet-option.update.announcement": "A página será recarregada. O filtro {{ filter }} foi selecionado.",
+
+  // "system-wide-alert-form.tooltip.system.alert": "On this page, you can create alert or warning texts that will be displayed throughout the system for more effective communication with users. To activate this, you must add the desired text, select the active option button and click save. If you want to activate the timer feature for a countdown, this is also possible, which does not mean that the system will be suspended, but that the message will disappear at the end of the countdown. If you want to deactivate an alert in the system, simply select the option on the inactive button and click save.",
+  "system-wide-alert-form.tooltip.system.alert": "Nessa página, é possível criar textos de alerta ou aviso que serão exibidos em todo o sistema para uma comunicação mais eficaz com os usuários. Para ativar isso, você deve adicionar o texto desejado, selecionar o botão da opção ativo e clicar em salvar. Se quiser ativar o recurso de cronômetro para uma contagem regressiva, isso também é possível, o que não significa que o sistema será suspenso, mas que a mensagem desaparecerá ao final da contagem regressiva. Se você quiser desativar um alerta no sistema, basta selecionar a opção no botão para inativo e clicar em salvar.",
 }


### PR DESCRIPTION
## References
* Fixes #3817

## Description
Addition of the contextual help feature via the “*dsContextHelp” directive to the “system-wide-alert-form” component.

## Instructions for Reviewers
List of changes in this PR:
* Following the example of other components in which contextual help was implemented, the “*dsContextHelp” directive was imported into ts and used in the html of the “system-wide-alert-form” component.
* New translation keys have been created.

**Include guidance for how to test or review your PR.**
1. Click on the contextual help button to the right of the language selection in the header.
2. Read the contextual help text that will appear in the headings.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
