### PR TITLE
Update fr.json5 to add identifiers deposit's step translations in french

### DIFF
--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -6113,6 +6113,24 @@
   // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
   "submission.sections.general.sections_not_valid": "Sections incomplètes.",
 
+  //"submission.sections.identifiers.info": "The following identifiers will be created for your item:",
+  "submission.sections.identifiers.info": "Les identifiants uniques suivants seront attribués à votre document :",
+
+  //"submission.sections.identifiers.no_handle": "No handles have been minted for this item.",
+  "submission.sections.identifiers.no_handle": "Aucun handle n'a été crée pour ce document.",
+
+  //"submission.sections.identifiers.no_doi": "No DOIs have been minted for this item.",
+  "submission.sections.identifiers.no_doi": "Aucun DOI n'a été créé pour ce document.",
+
+  //"submission.sections.identifiers.handle_label": "Handle: ",
+  "submission.sections.identifiers.handle_label": "Handle : ",
+
+  //"submission.sections.identifiers.doi_label": "DOI: ",
+  "submission.sections.identifiers.doi_label": "DOI : ",
+
+  //"submission.sections.identifiers.otherIdentifiers_label": "Other identifiers: ",
+  "submission.sections.identifiers.otherIdentifiers_label": "Autres identifiants : ",
+
   // "submission.sections.submit.progressbar.accessCondition": "Item access conditions",
   "submission.sections.submit.progressbar.accessCondition": "Autorisations d'accès à l'Item",
 
@@ -6133,6 +6151,9 @@
 
   // "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
   "submission.sections.submit.progressbar.detect-duplicate": "Doublon(s) potentiel(s)",
+
+  //"submission.sections.submit.progressbar.identifiers": "Identifiers",
+  "submission.sections.submit.progressbar.identifiers": "Identifiants",
 
   // "submission.sections.submit.progressbar.license": "Deposit license",
   "submission.sections.submit.progressbar.license": "Licence du dépôt",


### PR DESCRIPTION
When configuring the [Identifier step in submission forms](https://wiki.lyrasis.org/display/DSDOC8x/Submission+User+Interface#SubmissionUserInterface-Configuringthe%22Identifiers%22step), french translations were missing. This PR is adding all necessary labels for this step.