### PR TITLE
Move `enablePerformanceProfiler` option to last in list in `config.example.yml`

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -19,9 +19,6 @@ ui:
 
 # Angular Server Side Rendering (SSR) settings
 ssr:
-  # Enable request performance profiling data collection and printing the results in the server console.
-  # Defaults to false. Enabling in production is NOT recommended
-  enablePerformanceProfiler: false
   # Whether to tell Angular to inline "critical" styles into the server-side rendered HTML.
   # Determining which styles are critical is a relatively expensive operation; this option is
   # disabled (false) by default to boost server performance at the expense of loading smoothness.
@@ -48,6 +45,9 @@ ssr:
   # REST resources with the internal URL configured. By default, these internal URLs are replaced with public URLs.
   # Disable this setting to avoid URL replacement during SSR. In this the state is not transferred to avoid security issues.
   replaceRestUrl: true
+  # Enable request performance profiling data collection and printing the results in the server console.
+  # Defaults to false. Enabling in production is NOT recommended
+  #enablePerformanceProfiler: false
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually


### PR DESCRIPTION
## Description
Tiny PR to cleanup `config.example.yml` (which is just an example configuration).  This moves the `enablePerformanceProfiler` option for `ssr` to the last item in the list & comments it out by default.  This option should never be used in production and is a debugging tool, so it makes no sense to list it first.

## Instructions for Reviewers
* This changes no code in DSpace.  This `config.example.yml` is unused and is just meant for documentation.