### PR TITLE
submission-forms mergeMap issues fix

### DIFF
--- a/src/app/submission/sections/sections.service.ts
+++ b/src/app/submission/sections/sections.service.ts
@@ -12,12 +12,12 @@ import isEqual from 'lodash/isEqual';
 import {
   combineLatest,
   Observable,
+  switchMap,
 } from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
   map,
-  mergeMap,
   take,
 } from 'rxjs/operators';
 
@@ -206,7 +206,7 @@ export class SectionsService {
       errorsState$ = this.getSectionErrors(submissionId, sectionId);
     } else {
       errorsState$ = this.getSectionState(submissionId, sectionId, sectionType).pipe(
-        mergeMap((state: SubmissionSectionObject) => this.formService.getFormErrors(state.formId).pipe(
+        switchMap((state: SubmissionSectionObject) => this.formService.getFormErrors(state.formId).pipe(
           map((formErrors: FormError[]) => {
             const pathCombiner = new JsonPatchOperationPathCombiner('sections', sectionId);
             const sectionErrors = formErrors


### PR DESCRIPTION
## References
* Fixes #3972 

## Description
This PR fixes a bug caused by a `mergeMap` in submission by replacing it with a `switchMap` which is a more suitable map for the specific situation the map is used in. (more elaborate technical details below)

## Instructions for Reviewers
How to reproduce: Follow the steps from issue #3972, as this requires a very specific custom setup for the error to occur (or at least one setup I could find, there are likely others)

## Technical details
What this `mergeMap` is trying to achieve:
For "submission-form" sections, retrieve the "section-wide" errors (to display on top of the section) from the section's state and combine them with metadata field errors retrieved from the form's state (requires the form ID from the section state, thus inside a map operator to combine observables).

Why `mergeMap` causes issues:
This type of map is known for the inconsistent order of execution from the internal observable it's trying to merge with. It is mainly used when we shouldn't care about the order, but when we want all of the observable emissions to complete within.
A use-case would be when several requests are sent in the inner observable, say two patch requests, it would be of importance that all of the observables complete.
In our case, this sometimes causes the emission for an empty array of errors to fire AFTER the emission containing the error we require to be displayed. Because the empty array fires last, it will make whatever code using this map to think there are no errors, when there in fact are some, but they got drowned by the later executing observable.

Why `switchMap` is a better alternative here:
This type of map will ONLY accept the latest emission of the inner observable, meaning it will cancel any pending observable emission (e.g. empty array of errors). This should cause the errors to always emit correctly, because the latest emission is the correct one, regardless of how long each emission takes to complete.

I know that was a lot to go through and try to explain, but hopefully that paints a picture why `switchMap` is a safer option in this (and frankly many other) case, avoiding potentially very hard to spot issues.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
