### PR TITLE
Added missing line to enable access to Content Reports

### DIFF
--- a/src/app/menu-resolver.service.ts
+++ b/src/app/menu-resolver.service.ts
@@ -169,6 +169,7 @@ export class MenuResolverService  {
     this.createExportMenuSections();
     this.createImportMenuSections();
     this.createAccessControlMenuSections();
+    this.createReportMenuSections();
     return this.waitForMenu$(MenuID.ADMIN);
   }
 


### PR DESCRIPTION
## Description
Since I developed the Contents Reports functionality prior to publication of DSpace 8.0, back in 2024, a line has been (accidentally?) deleted from file `menu-resolver.service.ts`, which invokes method `createReportMenuSections()` (still present but never called). This PR reinstates the deleted line, so that accessibility of the Content Reports section in the Admin menu will depend again on the `contentreport.enable` setting on the Java/REST side, as was initially intended.

Note: This PR applies to both DSpace versions 8.1 and 9.

## Instructions for Reviewers
Enable the `contentreport.enable` setting in your Java/REST layer, build and start the server, then start the Angular layer. When you log in with an administrator account, you should see the Content Reports sections in the Admin menu sidebar.

List of changes in this PR:
* Inserted `this.createReportMenuSections();` as line 172 in `/app/menu-resolver.service.ts`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

Note: All unchecked items above are not applicable to this PR.