### PR TITLE
added alternative content tag and controls on bitstreams

### DIFF
--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -199,6 +199,15 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
   );
 
   /**
+   * The Dynamic Switch Model for set as alternative content
+   */
+  alternativeContentModel = new DynamicCustomSwitchModel({
+    id: 'alternativeContent',
+    name: 'alternativeContent',
+  },
+  );
+
+  /**
    * The Dynamic TextArea Model for the file's description
    */
   descriptionModel = new DsDynamicTextAreaModel({
@@ -316,7 +325,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
   /**
    * All input models in a simple array for easier iterations
    */
-  inputModels = [this.primaryBitstreamModel, this.fileNameModel, this.descriptionModel, this.selectedFormatModel,
+  inputModels = [this.primaryBitstreamModel, this.alternativeContentModel, this.fileNameModel, this.descriptionModel, this.selectedFormatModel,
     this.newFormatModel];
 
   /**
@@ -328,6 +337,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       id: 'fileNamePrimaryContainer',
       group: [
         this.primaryBitstreamModel,
+        this.alternativeContentModel,
         this.fileNameModel,
       ],
     }, {
@@ -367,6 +377,14 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
     primaryBitstream: {
       grid: {
         container: 'col-12',
+      },
+      element: {
+        container: 'text-right',
+      },
+    },
+    alternativeContent: {
+      grid: {
+        container: 'col-12 mt-2',
       },
       element: {
         container: 'text-right',
@@ -548,6 +566,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       fileNamePrimaryContainer: {
         fileName: bitstream.name,
         primaryBitstream: this.primaryBitstreamUUID === bitstream.uuid,
+        alternativeContent: bitstream.firstMetadataValue('dc.type') === "alternative content"
       },
       descriptionContainer: {
         description: bitstream.firstMetadataValue('dc.description'),
@@ -614,7 +633,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
    */
   private updateFieldTranslation(fieldModel) {
     fieldModel.label = this.translate.instant(this.KEY_PREFIX + fieldModel.id + this.LABEL_KEY_SUFFIX);
-    if (fieldModel.id !== this.primaryBitstreamModel.id) {
+    if (fieldModel.id !== this.primaryBitstreamModel.id &&   fieldModel.id !== this.alternativeContentModel.id) {
       fieldModel.hint = this.translate.instant(this.KEY_PREFIX + fieldModel.id + this.HINT_KEY_SUFFIX);
     }
   }
@@ -640,6 +659,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
     const isNewFormat = this.selectedFormat.id !== this.originalFormat.id;
     const isPrimary = updatedValues.fileNamePrimaryContainer.primaryBitstream;
     const wasPrimary = this.primaryBitstreamUUID === this.bitstream.uuid;
+    const isAlternativeContent = updatedValues.fileNamePrimaryContainer.alternativeContent;
 
     let bitstream$;
     let bundle$: Observable<Bundle>;
@@ -704,6 +724,11 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       );
     } else {
       bitstream$ = observableOf(this.bitstream);
+    }
+    if (isAlternativeContent) {
+      updatedBitstream.setMetadata('dc.type', undefined, ...['alternative content']);
+    } else {
+      updatedBitstream.removeMetadata('dc.type');
     }
 
     combineLatest([bundle$, bitstream$]).pipe(

--- a/src/app/item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/app/item-page/simple/field-components/file-section/file-section.component.html
@@ -3,7 +3,8 @@
     <div class="file-section">
       <ds-file-download-link *ngFor="let file of bitstreams; let last=last;" [bitstream]="file" [item]="item">
         <span>
-          <span *ngIf="primaryBitsreamId === file.id" class="badge badge-primary">{{ 'item.page.bitstreams.primary' | translate }}</span> 
+          <span *ngIf="primaryBitsreamId === file.id" class="badge badge-primary">{{ 'item.page.bitstreams.primary' | translate }}</span>
+          <span *ngIf="file.metadata['dc.type']?.[0]?.value === 'alternative content'" class="badge badge-info">{{ 'item.page.bitstreams.alternativeContent' | translate }}</span>
           {{ dsoNameService.getName(file) }}
         </span>
         <span> ({{(file?.sizeBytes) | dsFileSize }})</span>

--- a/src/app/shared/mocks/submission.mock.ts
+++ b/src/app/shared/mocks/submission.mock.ts
@@ -1622,6 +1622,7 @@ export const mockUploadFilesData = {
 
 export const mockFileFormData = {
   primary: [true],
+  alternativeContent: [true],
   metadata: {
     'dc.title': [
       {

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -232,7 +232,7 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
       comp.formModel = compAsAny.buildFileEditForm();
 
-      const models = [DynamicCustomSwitchModel, DynamicFormGroupModel, DynamicFormArrayModel];
+      const models = [DynamicCustomSwitchModel, DynamicCustomSwitchModel, DynamicFormGroupModel, DynamicFormArrayModel];
 
       expect(comp.formModel).toBeDefined();
       expect(comp.formModel.length).toBe(models.length);
@@ -240,7 +240,7 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
         expect(comp.formModel[i] instanceof model).toBeTruthy();
       });
 
-      expect((comp.formModel[2] as DynamicFormArrayModel).groups.length).toBe(2);
+      expect((comp.formModel[3] as DynamicFormArrayModel).groups.length).toBe(2);
       const startDateModel = formbuilderService.findById('startDate', comp.formModel);
       expect(startDateModel.max).toEqual(maxStartDate);
       const endDateModel = formbuilderService.findById('endDate', comp.formModel);
@@ -305,6 +305,7 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       compAsAny.fileData = fileData;
       compAsAny.pathCombiner = pathCombiner;
       compAsAny.isPrimary = null;
+      compAsAny.isAlternativeContent = null;
       formService.validateAllFormFields.and.callFake(() => null);
       formService.isValid.and.returnValue(of(true));
       formService.getFormData.and.returnValue(of(mockFileFormData));
@@ -333,6 +334,14 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       expect(uploadService.updatePrimaryBitstreamOperation).toHaveBeenCalledWith(pathCombiner.getPath(path),  compAsAny.isPrimary,  mockFileFormData.primary[0], compAsAny.fileId);
 
       const pathFragment = ['files', fileIndex];
+
+      path = 'alternativecontent';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath([...pathFragment, path]),
+        true,
+        false,
+        true,
+      );
 
       path = 'metadata/dc.title';
       expect(operationsBuilder.add).toHaveBeenCalledWith(

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -64,6 +64,8 @@ import {
   BITSTREAM_FORM_ACCESS_CONDITION_START_DATE_LAYOUT,
   BITSTREAM_FORM_ACCESS_CONDITION_TYPE_CONFIG,
   BITSTREAM_FORM_ACCESS_CONDITION_TYPE_LAYOUT,
+  BITSTREAM_FORM_ALTERNATIVE_CONTENT,
+  BITSTREAM_FORM_ALTERNATIVE_CONTENT_LAYOUT,
   BITSTREAM_FORM_PRIMARY,
   BITSTREAM_FORM_PRIMARY_LAYOUT,
   BITSTREAM_METADATA_FORM_GROUP_CONFIG,
@@ -99,6 +101,12 @@ implements OnInit, OnDestroy {
    * @type {boolean, null}
    */
   isPrimary: boolean;
+
+  /**
+   * The indicator if is alternative content bitstream
+   * @type {boolean, null}
+   */
+  isAlternativeContent: boolean;
 
   /**
    * The list of available access condition
@@ -221,6 +229,9 @@ implements OnInit, OnDestroy {
     const primaryBitstreamModel: any = this.formBuilderService.findById('primary', formModel, this.fileIndex);
     primaryBitstreamModel.value = this.isPrimary || false;
 
+    const alternativeContentBitstreamModel: any = this.formBuilderService.findById('alternativeContent', formModel, this.fileIndex);
+    alternativeContentBitstreamModel.value = this.isAlternativeContent || false;
+
     this.fileData.accessConditions.forEach((accessCondition, index) => {
       Array.of('name', 'startDate', 'endDate')
         .filter((key) => accessCondition.hasOwnProperty(key) && isNotEmpty(accessCondition[key]))
@@ -323,6 +334,8 @@ implements OnInit, OnDestroy {
     const formModel: DynamicFormControlModel[] = [];
 
     formModel.push(new DynamicCustomSwitchModel(BITSTREAM_FORM_PRIMARY, BITSTREAM_FORM_PRIMARY_LAYOUT));
+
+    formModel.push(new DynamicCustomSwitchModel(BITSTREAM_FORM_ALTERNATIVE_CONTENT, BITSTREAM_FORM_ALTERNATIVE_CONTENT_LAYOUT));
 
     const metadataGroupModelConfig = Object.assign({}, BITSTREAM_METADATA_FORM_GROUP_CONFIG);
     metadataGroupModelConfig.group = this.formBuilderService.modelFromConfiguration(
@@ -436,6 +449,14 @@ implements OnInit, OnDestroy {
       take(1),
       mergeMap((formData: any) => {
         this.uploadService.updatePrimaryBitstreamOperation(this.pathCombiner.getPath('primary'), this.isPrimary, formData.primary[0], this.fileId);
+
+        //Set operations to bitstream alternative content flag
+        const alternativeContentPath = 'alternativecontent';
+        if (formData.alternativeContent[0]) {
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, alternativeContentPath]), true, false, true);
+        } else {
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, alternativeContentPath]));
+        }
 
         // collect bitstream metadata
         Object.keys((formData.metadata))

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
@@ -70,6 +70,19 @@ export const BITSTREAM_FORM_PRIMARY: DynamicSwitchModelConfig = {
   label: 'bitstream.edit.form.primaryBitstream.label',
 };
 
+export const BITSTREAM_FORM_ALTERNATIVE_CONTENT_LAYOUT: DynamicFormControlLayout = {
+  element: {
+    host: 'col-12',
+    container: 'text-right',
+  },
+};
+
+export const BITSTREAM_FORM_ALTERNATIVE_CONTENT: DynamicSwitchModelConfig = {
+  id: 'alternativeContent',
+  name: 'alternativeContent',
+  label: 'bitstream.edit.form.alternativeContent.label',
+};
+
 
 export const BITSTREAM_FORM_ACCESS_CONDITION_START_DATE_CONFIG: DynamicDatePickerModelConfig = {
   id: 'startDate',

--- a/src/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -68,6 +68,12 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit, 
   @Input() isPrimary: boolean | null;
 
   /**
+   * The indicator if is alternative content bitstream
+   * @type {boolean, null}
+   */
+  @Input() isAlternativeContent: boolean | null;
+
+  /**
    * The list of available access condition
    * @type {Array}
    */
@@ -287,6 +293,7 @@ export class SubmissionSectionUploadFileComponent implements OnChanges, OnInit, 
     activeModal.componentInstance.pathCombiner = this.pathCombiner;
     activeModal.componentInstance.submissionId = this.submissionId;
     activeModal.componentInstance.isPrimary = this.isPrimary;
+    activeModal.componentInstance.isAlternativeContent = this.isAlternativeContent;
   }
 
   togglePrimaryBitstream(event) {

--- a/src/app/submission/sections/upload/file/themed-section-upload-file.component.ts
+++ b/src/app/submission/sections/upload/file/themed-section-upload-file.component.ts
@@ -30,6 +30,12 @@ export class ThemedSubmissionSectionUploadFileComponent
    */
    @Input() isPrimary: boolean | null;
 
+   /**
+   * The indicator if is alternative content bitstream
+   * @type {boolean, null}
+   */
+   @Input() isAlternativeContent: boolean | null;
+
   /**
    * The submission id
    * @type {string}
@@ -83,6 +89,7 @@ export class ThemedSubmissionSectionUploadFileComponent
   protected inAndOutputNames: (keyof SubmissionSectionUploadFileComponent & keyof this)[] = [
     'availableAccessConditionOptions',
     'isPrimary',
+    'isAlternativeContent',
     'collectionId',
     'collectionPolicyType',
     'configMetadataForm',

--- a/src/app/submission/sections/upload/section-upload.component.html
+++ b/src/app/submission/sections/upload/section-upload.component.html
@@ -31,6 +31,7 @@
   <ng-container *ngFor="let fileEntry of fileList; let i = index;">
     <ds-submission-upload-section-file
                                        [isPrimary]="primaryBitstreamUUID ? primaryBitstreamUUID === fileEntry.uuid : null"
+                                       [isAlternativeContent]="fileEntry.metadata['dc.type'] ? fileEntry.metadata['dc.type'][0].value === 'alternative content' : null"
                                        [availableAccessConditionOptions]="availableAccessConditionOptions"
                                        [collectionId]="collectionId"
                                        [collectionPolicyType]="collectionPolicyType"

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -928,6 +928,8 @@
 
   "bitstream.edit.form.primaryBitstream.label": "Primary File",
 
+  "bitstream.edit.form.alternativeContent.label": "Alternative Content File",
+
   "bitstream.edit.form.selectedFormat.hint": "If the format is not in the above list, <b>select \"format not in list\" above</b> and describe it under \"Describe new format\".",
 
   "bitstream.edit.form.selectedFormat.label": "Selected Format",
@@ -2791,6 +2793,8 @@
   "item.page.bitstreams.collapse": "Collapse",
 
   "item.page.bitstreams.primary": "Primary",
+
+  "item.page.bitstreams.alternativeContent": "Alternative Content",
 
   "item.page.filesection.original.bundle": "Original bundle",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -1391,6 +1391,9 @@
   // "bitstream.edit.form.primaryBitstream.label": "Primary File",
   "bitstream.edit.form.primaryBitstream.label": "Archivo principal",
 
+  //"bitstream.edit.form.alternativeContent.label": "Alternative Content File",
+  "bitstream.edit.form.alternativeContent.label": "Archivo con contenido alternativo",
+
   // "bitstream.edit.form.selectedFormat.hint": "If the format is not in the above list, <b>select \"format not in list\" above</b> and describe it under \"Describe new format\".",
   "bitstream.edit.form.selectedFormat.hint": "Si el formato no está en la lista anterior, <b>seleccione \"el formato no está en la lista\" arriba</b> y descríbalo en \"Describir el nuevo formato\".",
 
@@ -4171,6 +4174,9 @@
 
   // "item.page.bitstreams.primary": "Primary",
   "item.page.bitstreams.primary": "Principal",
+
+  //"item.page.bitstreams.alternativeContent": "Alternative Content",
+  "item.page.bitstreams.alternativeContent": "Contenido alternativo",
 
   // "item.page.filesection.original.bundle": "Original bundle",
   "item.page.filesection.original.bundle": "Bloque original",


### PR DESCRIPTION
## References
* Related to #3808
* Requires DSpace/DSpace#10431

## Description
This PR allows to set a tag in the list of bitstreams on item page to indicate if its an alternative content, you can set the tag on bitstreams of archived items or in the upload section edit bitstream of a itemworkspace.

## Instructions for Reviewers
1. Log with a user that can send new items.
2. Add a bitstream to a new item
3. Click on edit bitstream data, and you will se a checkbox to enable or disable alternative content tag
4. archive the item.
5. Check the item page to see alternative content tag on items file lists

Alternative:
1.  Log with a user that can edit archived items.
2. Find and item with bitstreams
3. click on edit item button 
4. Go to bitstream list page
5. Edit a bitstream and you will se a checkbox to enable or disable alternative content tag
6. Save changes
7. Check the item page to see alternative content tag on items file lists

List of changes in this PR:
* Enabled alternative content checkbox on upload section
* Enabled alternative content checkbox on archived item's bitstream edit page
* Enabled a badge tag to "alternative content" on the bitstream list.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
