### PR TITLE
added new statistics reports to communities and collections

### DIFF
--- a/src/app/statistics-page/collection-statistics-page/collection-statistics-page.component.ts
+++ b/src/app/statistics-page/collection-statistics-page/collection-statistics-page.component.ts
@@ -25,6 +25,10 @@ export class CollectionStatisticsPageComponent extends StatisticsPageDirective<C
    */
   types: string[] = [
     'TotalVisits',
+    'TotalVisitsItems',
+    'TotalDownloadsBitstreams',
+    'TopItems',
+    'TopBitstreams',
     'TotalVisitsPerMonth',
     'TopCountries',
     'TopCities',

--- a/src/app/statistics-page/community-statistics-page/community-statistics-page.component.ts
+++ b/src/app/statistics-page/community-statistics-page/community-statistics-page.component.ts
@@ -25,6 +25,10 @@ export class CommunityStatisticsPageComponent extends StatisticsPageDirective<Co
    */
   types: string[] = [
     'TotalVisits',
+    'TotalVisitsItems',
+    'TotalDownloadsBitstreams',
+    'TopItems',
+    'TopBitstreams',
     'TotalVisitsPerMonth',
     'TopCountries',
     'TopCities',

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4726,6 +4726,14 @@
 
   "statistics.table.title.TopCities": "Top city views",
 
+  "statistics.table.title.TotalVisitsItems": "Total items visits",
+
+  "statistics.table.title.TotalDownloadsBitstreams": "Total file visits",
+
+  "statistics.table.title.TopItems": "Top items views",
+
+  "statistics.table.title.TopBitstreams": "Top file views",
+
   "statistics.table.header.views": "Views",
 
   "statistics.table.no-name": "(object name could not be loaded)",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -7073,6 +7073,18 @@
   // "statistics.table.title.TopCities": "Top city views",
   "statistics.table.title.TopCities": "Visitas principales por ciudad",
 
+  //"statistics.table.title.TotalVisitsItems": "Total items visits",
+  "statistics.table.title.TotalVisitsItems": "Visitas totales de items",
+
+  //"statistics.table.title.TotalDownloadsBitstreams": "Total file visits",
+  "statistics.table.title.TotalDownloadsBitstreams": "Visitas totales de archivos",
+
+  //"statistics.table.title.TopItems": "Top items views",
+  "statistics.table.title.TopItems": "Visitas principales por items",
+
+  //"statistics.table.title.TopBitstreams": "Top file views",
+  "statistics.table.title.TopBitstreams": "Visitas principales por archivos",
+
   // "statistics.table.header.views": "Views",
   "statistics.table.header.views": "Visitas",
 


### PR DESCRIPTION
## References
* Related to DSpace/DSpace#8572
* Requires DSpace/DSpace#10437

## Description
This PR enabled new statistics reports on communities and collections statistics pages, this reports are:
- Top ten items visited
- Top ten bitstreams visited
- Total sum of visits to community/collection items
- Total sum of visits to  community/collection bitstreams

## Instructions for Reviewers
After setting up the PR backend and frontend, visit a community or collection with items and bitstreams that have recorded statistical data. Press the statistics button and you will see the four new reports enabled.

List of changes in this PR:
* Enabled 4 reports (Top ten items, top ten bitstreams, total sum of visits to items and total sum of visitis of bitstreams) to community statistics page
* Enabled 4 reports (Top ten items, top ten bitstreams, total sum of visits to items and total sum of visitis of bitstreams) to collection statistics page

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
