### PR TITLE
System Wide Alerts should send countdown date to REST API in ISO-8601 format

### DIFF
--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.spec.ts
@@ -184,7 +184,7 @@ describe('SystemWideAlertFormComponent', () => {
       expectedAlert.message = 'New message';
       expectedAlert.active = true;
       const countDownTo = new Date(2023, 0, 25, 4, 26);
-      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
 
       comp.save();
 
@@ -207,7 +207,7 @@ describe('SystemWideAlertFormComponent', () => {
       expectedAlert.message = 'New message';
       expectedAlert.active = true;
       const countDownTo = new Date(2023, 0, 25, 4, 26);
-      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
 
       comp.save(false);
 
@@ -254,7 +254,7 @@ describe('SystemWideAlertFormComponent', () => {
       expectedAlert.message = 'New message';
       expectedAlert.active = true;
       const countDownTo = new Date(2023, 0, 25, 4, 26);
-      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
 
       comp.save();
 
@@ -276,7 +276,7 @@ describe('SystemWideAlertFormComponent', () => {
       expectedAlert.message = 'New message';
       expectedAlert.active = true;
       const countDownTo = new Date(2023, 0, 25, 4, 26);
-      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
 
       comp.save();
 
@@ -301,7 +301,7 @@ describe('SystemWideAlertFormComponent', () => {
       expectedAlert.message = 'New message';
       expectedAlert.active = true;
       const countDownTo = new Date(2023, 0, 25, 4, 26);
-      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      expectedAlert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
 
       comp.save();
 

--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
@@ -253,7 +253,7 @@ export class SystemWideAlertFormComponent implements OnInit {
     alert.active = this.formActive.value;
     if (this.counterEnabled$.getValue()) {
       const countDownTo = new Date(this.date.year, this.date.month - 1, this.date.day, this.time.hour, this.time.minute);
-      alert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toUTCString();
+      alert.countdownTo = utcToZonedTime(countDownTo, 'UTC').toISOString();
     } else {
       alert.countdownTo = null;
     }


### PR DESCRIPTION

## References
* Required by https://github.com/DSpace/DSpace/pull/10432 for System Wide Alerts to work properly

## Description
Currently, if you set a "countdown timer" on the System-Wide Alert page, the date is sent to the REST API in a non-standard format that looks like this: `Thu, 14 Nov 2019 00:55:16 GMT`

This format seems to work fine for the current codebase, but it cannot be parsed by the backend if you use PR https://github.com/DSpace/DSpace/pull/10432

This small PR updates the date to be sent in ISO-8601 format, e.g. `2019-11-14T00:55:31.820Z`, which is required by https://github.com/DSpace/DSpace/pull/10432

## Instructions for Reviewers
* Should only be merged / tested with https://github.com/DSpace/DSpace/pull/10432
* Verify that System Wide Alerts can now be saved with a countdown timer (previously they would throw an error).
