### PR TITLE
Themeable DsDynamicLookupRelationModalComponent

### DIFF
--- a/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
+++ b/src/app/item-page/edit-item-page/item-relationships/edit-relationship-list/edit-relationship-list.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/common';
 import {
   Component,
+  ComponentRef,
   EventEmitter,
   Inject,
   Input,
@@ -73,6 +74,7 @@ import {
   isNotEmpty,
 } from '../../../../shared/empty.util';
 import { DsDynamicLookupRelationModalComponent } from '../../../../shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
+import { ThemedDsDynamicLookupRelationModalComponent } from '../../../../shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component';
 import { RelationshipOptions } from '../../../../shared/form/builder/models/relationship-options.model';
 import { ThemedLoadingComponent } from '../../../../shared/loading/themed-loading.component';
 import { ItemSearchResult } from '../../../../shared/object-collection/shared/item-search-result.model';
@@ -286,159 +288,163 @@ export class EditRelationshipListComponent implements OnInit, OnDestroy {
    * Open the dynamic lookup modal to search for items to add as relationships
    */
   openLookup() {
-    this.modalRef = this.modalService.open(DsDynamicLookupRelationModalComponent, {
+
+    this.modalRef = this.modalService.open(ThemedDsDynamicLookupRelationModalComponent, {
       size: 'lg',
     });
-    const modalComp: DsDynamicLookupRelationModalComponent = this.modalRef.componentInstance;
-    modalComp.repeatable = true;
-    modalComp.isEditRelationship = true;
-    modalComp.listId = this.listId;
-    modalComp.item = this.item;
-    modalComp.relationshipType = this.relationshipType;
-    modalComp.currentItemIsLeftItem$ = this.currentItemIsLeftItem$;
-    modalComp.toAdd = [];
-    modalComp.toRemove = [];
-    modalComp.isPending = false;
-    modalComp.repeatable = this.isRepeatable();
-    modalComp.hiddenQuery = '-search.resourceid:' + this.item.uuid;
-
-    this.item.owningCollection.pipe(
-      getFirstSucceededRemoteDataPayload(),
-    ).subscribe((collection: Collection) => {
-      modalComp.collection = collection;
-    });
-
-    modalComp.select = (...selectableObjects: ItemSearchResult[]) => {
-      selectableObjects.forEach((searchResult) => {
-        const relatedItem: Item = searchResult.indexableObject;
-
-        const foundIndex = modalComp.toRemove.findIndex((itemSearchResult: ItemSearchResult) => itemSearchResult.indexableObject.uuid === relatedItem.uuid);
-
-        if (foundIndex !== -1) {
-          modalComp.toRemove.splice(foundIndex,1);
-        } else {
-
-          this.getRelationFromId(relatedItem)
-            .subscribe((relationship: Relationship) => {
-              if (!relationship ) {
-                modalComp.toAdd.push(searchResult);
-              } else {
-                const foundIndexRemove = modalComp.toRemove.findIndex( el => el.indexableObject.uuid === relatedItem.uuid);
-                if (foundIndexRemove !== -1) {
-                  modalComp.toRemove.splice(foundIndexRemove,1);
-                }
-              }
-
-              this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
-              // emit the last page again to trigger a fieldupdates refresh
-              this.relationshipsRd$.next(this.relationshipsRd$.getValue());
-            });
-        }
-      });
-    };
-    modalComp.deselect = (...selectableObjects: ItemSearchResult[]) => {
-      selectableObjects.forEach((searchResult) => {
-        const relatedItem: Item = searchResult.indexableObject;
-
-        const foundIndex = modalComp.toAdd.findIndex( el => el.indexableObject.uuid === relatedItem.uuid);
-
-        if (foundIndex !== -1) {
-          modalComp.toAdd.splice(foundIndex,1);
-        } else {
-          modalComp.toRemove.push(searchResult);
-        }
-        this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
-      });
-    };
-
-
-
-    modalComp.submitEv = () => {
-      modalComp.isPending = true;
-      const isLeft = this.currentItemIsLeftItem$.getValue();
-      const addOperations = modalComp.toAdd.map((searchResult: ItemSearchResult) => ({ type: 'add', searchResult }));
-      const removeOperations = modalComp.toRemove.map((searchResult: ItemSearchResult) => ({ type: 'remove', searchResult }));
-      observableFrom([...addOperations, ...removeOperations]).pipe(
-        concatMap(({ type, searchResult }: { type: string, searchResult: ItemSearchResult }) => {
-          const relatedItem: Item = searchResult.indexableObject;
-          if (type === 'add') {
-            return this.relationshipService.getNameVariant(this.listId, relatedItem.uuid).pipe(
-              switchMap((nameVariant) => {
-                const update = {
-                  uuid: `${this.relationshipType.id}-${relatedItem.uuid}`,
-                  nameVariant,
-                  type: this.relationshipType,
-                  originalIsLeft: isLeft,
-                  originalItem: this.item,
-                  relatedItem,
-                } as RelationshipIdentifiable;
-                return this.objectUpdatesService.saveAddFieldUpdate(this.url, update);
-              }),
-              take(1),
-            );
-          } else if (type === 'remove') {
-            return this.relationshipService.getNameVariant(this.listId, relatedItem.uuid).pipe(
-              switchMap((nameVariant) => {
-                return this.getRelationFromId(searchResult.indexableObject).pipe(
-                  map( (relationship: Relationship) => {
-                    const update = {
-                      uuid: relationship.id,
-                      nameVariant,
-                      type: this.relationshipType,
-                      originalIsLeft: isLeft,
-                      originalItem: this.item,
-                      relatedItem,
-                      relationship,
-                    } as RelationshipIdentifiable;
-                    return this.objectUpdatesService.saveRemoveFieldUpdate(this.url,update);
-                  }),
-                );
-              }),
-              take(1),
-            );
-          } else {
-            return EMPTY;
-          }
-        }),
-        toArray(),
-      ).subscribe({
-        complete: () => {
-          this.editItemRelationshipsService.submit(this.item, this.url);
-          this.submitModal.emit();
-        },
-      });
-    };
-
-
-    modalComp.discardEv = () => {
-      modalComp.toAdd.forEach( (searchResult) => {
-        this.selectableListService.deselectSingle(this.listId,searchResult);
-      });
-
-      modalComp.toRemove.forEach( (searchResult) => {
-        this.selectableListService.selectSingle(this.listId,searchResult);
-      });
-
+    const modalComp$ = this.modalRef.componentInstance.compRef$.pipe(
+      hasValueOperator(),
+      map((compRef: ComponentRef<DsDynamicLookupRelationModalComponent>) => compRef.instance),
+      take(1),
+    );
+    modalComp$.subscribe((modalComp: DsDynamicLookupRelationModalComponent) => {
+      modalComp.repeatable = true;
+      modalComp.isEditRelationship = true;
+      modalComp.listId = this.listId;
+      modalComp.item = this.item;
+      modalComp.relationshipType = this.relationshipType;
+      modalComp.currentItemIsLeftItem$ = this.currentItemIsLeftItem$;
       modalComp.toAdd = [];
       modalComp.toRemove = [];
-      this.loading$.next(false);
-    };
+      modalComp.isPending = false;
+      modalComp.repeatable = this.isRepeatable();
+      modalComp.hiddenQuery = '-search.resourceid:' + this.item.uuid;
 
-    modalComp.closeEv = () => {
-      this.loading$.next(false);
-    };
-
-    this.relatedEntityType$
-      .pipe(take(1))
-      .subscribe((relatedEntityType) => {
-        modalComp.relationshipOptions = Object.assign(
-          new RelationshipOptions(), {
-            relationshipType: relatedEntityType.label,
-            searchConfiguration: relatedEntityType.label.toLowerCase(),
-            nameVariants: 'true',
-          },
-        );
+      this.item.owningCollection.pipe(
+        getFirstSucceededRemoteDataPayload(),
+      ).subscribe((collection: Collection) => {
+        modalComp.collection = collection;
       });
+
+      modalComp.select = (...selectableObjects: ItemSearchResult[]) => {
+        selectableObjects.forEach((searchResult) => {
+          const relatedItem: Item = searchResult.indexableObject;
+
+          const foundIndex = modalComp.toRemove.findIndex((itemSearchResult: ItemSearchResult) => itemSearchResult.indexableObject.uuid === relatedItem.uuid);
+
+          if (foundIndex !== -1) {
+            modalComp.toRemove.splice(foundIndex,1);
+          } else {
+
+            this.getRelationFromId(relatedItem)
+              .subscribe((relationship: Relationship) => {
+                if (!relationship ) {
+                  modalComp.toAdd.push(searchResult);
+                } else {
+                  const foundIndexRemove = modalComp.toRemove.findIndex( el => el.indexableObject.uuid === relatedItem.uuid);
+                  if (foundIndexRemove !== -1) {
+                    modalComp.toRemove.splice(foundIndexRemove,1);
+                  }
+                }
+
+                this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
+                // emit the last page again to trigger a fieldupdates refresh
+                this.relationshipsRd$.next(this.relationshipsRd$.getValue());
+              });
+          }
+        });
+      };
+      modalComp.deselect = (...selectableObjects: ItemSearchResult[]) => {
+        selectableObjects.forEach((searchResult) => {
+          const relatedItem: Item = searchResult.indexableObject;
+
+          const foundIndex = modalComp.toAdd.findIndex( el => el.indexableObject.uuid === relatedItem.uuid);
+
+          if (foundIndex !== -1) {
+            modalComp.toAdd.splice(foundIndex,1);
+          } else {
+            modalComp.toRemove.push(searchResult);
+          }
+          this.loading$.next(isNotEmpty(modalComp.toAdd) || isNotEmpty(modalComp.toRemove));
+        });
+      };
+      modalComp.submitEv = () => {
+        modalComp.isPending = true;
+        const isLeft = this.currentItemIsLeftItem$.getValue();
+        const addOperations = modalComp.toAdd.map((searchResult: ItemSearchResult) => ({ type: 'add', searchResult }));
+        const removeOperations = modalComp.toRemove.map((searchResult: ItemSearchResult) => ({ type: 'remove', searchResult }));
+        observableFrom([...addOperations, ...removeOperations]).pipe(
+          concatMap(({ type, searchResult }: { type: string, searchResult: ItemSearchResult }) => {
+            const relatedItem: Item = searchResult.indexableObject;
+            if (type === 'add') {
+              return this.relationshipService.getNameVariant(this.listId, relatedItem.uuid).pipe(
+                switchMap((nameVariant) => {
+                  const update = {
+                    uuid: `${this.relationshipType.id}-${relatedItem.uuid}`,
+                    nameVariant,
+                    type: this.relationshipType,
+                    originalIsLeft: isLeft,
+                    originalItem: this.item,
+                    relatedItem,
+                  } as RelationshipIdentifiable;
+                  return this.objectUpdatesService.saveAddFieldUpdate(this.url, update);
+                }),
+                take(1),
+              );
+            } else if (type === 'remove') {
+              return this.relationshipService.getNameVariant(this.listId, relatedItem.uuid).pipe(
+                switchMap((nameVariant) => {
+                  return this.getRelationFromId(searchResult.indexableObject).pipe(
+                    map( (relationship: Relationship) => {
+                      const update = {
+                        uuid: relationship.id,
+                        nameVariant,
+                        type: this.relationshipType,
+                        originalIsLeft: isLeft,
+                        originalItem: this.item,
+                        relatedItem,
+                        relationship,
+                      } as RelationshipIdentifiable;
+                      return this.objectUpdatesService.saveRemoveFieldUpdate(this.url,update);
+                    }),
+                  );
+                }),
+                take(1),
+              );
+            } else {
+              return EMPTY;
+            }
+          }),
+          toArray(),
+        ).subscribe({
+          complete: () => {
+            this.editItemRelationshipsService.submit(this.item, this.url);
+            this.submitModal.emit();
+          },
+        });
+      };
+
+
+      modalComp.discardEv = () => {
+        modalComp.toAdd.forEach( (searchResult) => {
+          this.selectableListService.deselectSingle(this.listId,searchResult);
+        });
+
+        modalComp.toRemove.forEach( (searchResult) => {
+          this.selectableListService.selectSingle(this.listId,searchResult);
+        });
+
+        modalComp.toAdd = [];
+        modalComp.toRemove = [];
+        this.loading$.next(false);
+      };
+
+      modalComp.closeEv = () => {
+        this.loading$.next(false);
+      };
+
+      this.relatedEntityType$
+        .pipe(take(1))
+        .subscribe((relatedEntityType) => {
+          modalComp.relationshipOptions = Object.assign(
+            new RelationshipOptions(), {
+              relationshipType: relatedEntityType.label,
+              searchConfiguration: relatedEntityType.label.toLowerCase(),
+              nameVariants: 'true',
+            },
+          );
+        });
+    });
 
     this.selectableListService.deselectAll(this.listId);
   }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectorRef,
   Component,
   ComponentFactoryResolver,
+  ComponentRef,
   ContentChildren,
   DoCheck,
   EventEmitter,
@@ -105,6 +106,7 @@ import { BtnDisabledDirective } from '../../../btn-disabled.directive';
 import {
   hasNoValue,
   hasValue,
+  hasValueOperator,
   isNotEmpty,
   isNotUndefined,
 } from '../../../empty.util';
@@ -125,6 +127,7 @@ import {
 import { ExistingRelationListElementComponent } from './existing-relation-list-element/existing-relation-list-element.component';
 import { DYNAMIC_FORM_CONTROL_TYPE_CUSTOM_SWITCH } from './models/custom-switch/custom-switch.model';
 import { DsDynamicLookupRelationModalComponent } from './relation-lookup-modal/dynamic-lookup-relation-modal.component';
+import { ThemedDsDynamicLookupRelationModalComponent } from './relation-lookup-modal/themed-dynamic-lookup-relation-modal.component';
 
 @Component({
   selector: 'ds-dynamic-form-control-container',
@@ -378,7 +381,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
    * Open a modal where the user can select relationships to be added to item being submitted
    */
   openLookup() {
-    this.modalRef = this.modalService.open(DsDynamicLookupRelationModalComponent, {
+    this.modalRef = this.modalService.open(ThemedDsDynamicLookupRelationModalComponent, {
       size: 'lg',
     });
 
@@ -402,24 +405,30 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
 
     this.submissionService.dispatchSave(this.model.submissionId);
 
-    const modalComp = this.modalRef.componentInstance;
+    const modalComp$ = this.modalRef.componentInstance.compRef$.pipe(
+      hasValueOperator(),
+      map((compRef: ComponentRef<DsDynamicLookupRelationModalComponent>) => compRef.instance),
+      take(1),
+    );
 
-    if (hasValue(this.model.value) && !this.model.readOnly) {
-      if (typeof this.model.value === 'string') {
-        modalComp.query = this.model.value;
-      } else if (typeof this.model.value.value === 'string') {
-        modalComp.query = this.model.value.value;
+    modalComp$.subscribe((modalComp: DsDynamicLookupRelationModalComponent) => {
+      if (hasValue(this.model.value) && !this.model.readOnly) {
+        if (typeof this.model.value === 'string') {
+          modalComp.query = this.model.value;
+        } else if (typeof this.model.value.value === 'string') {
+          modalComp.query = this.model.value.value;
+        }
       }
-    }
 
-    modalComp.repeatable = this.model.repeatable;
-    modalComp.listId = this.listId;
-    modalComp.relationshipOptions = this.model.relationship;
-    modalComp.label = this.model.relationship.relationshipType;
-    modalComp.metadataFields = this.model.metadataFields;
-    modalComp.item = this.item;
-    modalComp.collection = this.collection;
-    modalComp.submissionId = this.model.submissionId;
+      modalComp.repeatable = this.model.repeatable;
+      modalComp.listId = this.listId;
+      modalComp.relationshipOptions = this.model.relationship;
+      modalComp.label = this.model.relationship.relationshipType;
+      modalComp.metadataFields = this.model.metadataFields;
+      modalComp.item = this.item;
+      modalComp.collection = this.collection;
+      modalComp.submissionId = this.model.submissionId;
+    });
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -73,7 +73,7 @@ import { ThemedDynamicLookupRelationSearchTabComponent } from './search-tab/them
 import { DsDynamicLookupRelationSelectionTabComponent } from './selection-tab/dynamic-lookup-relation-selection-tab.component';
 
 @Component({
-  selector: 'ds-dynamic-lookup-relation-modal',
+  selector: 'ds-base-dynamic-lookup-relation-modal',
   styleUrls: ['./dynamic-lookup-relation-modal.component.scss'],
   templateUrl: './dynamic-lookup-relation-modal.component.html',
   providers: [

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component.ts
@@ -1,0 +1,36 @@
+import { ThemedComponent } from '../../../../theme-support/themed.component';
+import { DsDynamicLookupRelationModalComponent } from './dynamic-lookup-relation-modal.component';
+import { Component, Output, EventEmitter } from '@angular/core';
+import { ListableObject } from '../../../../object-collection/shared/listable-object.model';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../my-dspace-page/my-dspace-page.component';
+import { SearchConfigurationService } from '../../../../../core/shared/search/search-configuration.service';
+
+@Component({
+  selector: 'ds-themed-dynamic-lookup-relation-modal',
+  templateUrl: '../../../../theme-support/themed.component.html',
+  providers: [
+    {
+      provide: SEARCH_CONFIG_SERVICE,
+      useClass: SearchConfigurationService
+    }
+  ],
+})
+export class ThemedDsDynamicLookupRelationModalComponent extends ThemedComponent<DsDynamicLookupRelationModalComponent> {
+  @Output() selectEvent: EventEmitter<ListableObject[]> = new EventEmitter<ListableObject[]>();
+
+  protected inAndOutputNames: (keyof DsDynamicLookupRelationModalComponent & keyof this)[] = [
+    'selectEvent',
+  ];
+
+  protected getComponentName(): string {
+    return 'DsDynamicLookupRelationModalComponent';
+  }
+
+  protected importThemedComponent(themeName: string): Promise<any> {
+    return import(`../../../../../../themes/${themeName}/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component`);
+  }
+
+  protected importUnthemedComponent(): Promise<any> {
+    return import(`./dynamic-lookup-relation-modal.component`);
+  }
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component.ts
@@ -1,0 +1,35 @@
+import {
+  Component,
+  EventEmitter,
+  Output,
+} from '@angular/core';
+
+import { ListableObject } from '../../../../object-collection/shared/listable-object.model';
+import { ThemedComponent } from '../../../../theme-support/themed.component';
+import { DsDynamicLookupRelationModalComponent } from './dynamic-lookup-relation-modal.component';
+
+@Component({
+  selector: 'ds-dynamic-lookup-relation-modal',
+  templateUrl: '../../../../theme-support/themed.component.html',
+  standalone: true,
+  imports: [DsDynamicLookupRelationModalComponent],
+})
+export class ThemedDsDynamicLookupRelationModalComponent extends ThemedComponent<DsDynamicLookupRelationModalComponent> {
+  @Output() selectEvent: EventEmitter<ListableObject[]> = new EventEmitter<ListableObject[]>();
+
+  protected inAndOutputNames: (keyof DsDynamicLookupRelationModalComponent & keyof this)[] = [
+    'selectEvent',
+  ];
+
+  protected getComponentName(): string {
+    return 'DsDynamicLookupRelationModalComponent';
+  }
+
+  protected importThemedComponent(themeName: string): Promise<any> {
+    return import(`../../../../../../themes/${themeName}/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component`);
+  }
+
+  protected importUnthemedComponent(): Promise<any> {
+    return import(`./dynamic-lookup-relation-modal.component`);
+  }
+}

--- a/src/app/shared/form/form.module.ts
+++ b/src/app/shared/form/form.module.ts
@@ -7,6 +7,7 @@ import { DsDynamicListComponent } from './builder/ds-dynamic-form-ui/models/list
 import { DsDynamicLookupComponent } from './builder/ds-dynamic-form-ui/models/lookup/dynamic-lookup.component';
 import { DsDynamicDisabledComponent } from './builder/ds-dynamic-form-ui/models/disabled/dynamic-disabled.component';
 import { DsDynamicLookupRelationModalComponent } from './builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
+import { ThemedDsDynamicLookupRelationModalComponent } from './builder/ds-dynamic-form-ui/relation-lookup-modal/themed-dynamic-lookup-relation-modal.component';
 import { DsDynamicScrollableDropdownComponent } from './builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component';
 import { DsDynamicTagComponent } from './builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component';
 import { DsDynamicOneboxComponent } from './builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component';
@@ -56,6 +57,7 @@ const COMPONENTS = [
   ThemedDynamicLookupRelationExternalSourceTabComponent,
   DsDynamicDisabledComponent,
   DsDynamicLookupRelationModalComponent,
+  ThemedDsDynamicLookupRelationModalComponent,
   DsDynamicScrollableDropdownComponent,
   DsDynamicTagComponent,
   DsDynamicOneboxComponent,

--- a/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -2,22 +2,12 @@ import { Component } from '@angular/core';
 import {
   DsDynamicLookupRelationModalComponent as BaseComponent
 } from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
-import { SEARCH_CONFIG_SERVICE } from '../../../../../../../../app/my-dspace-page/my-dspace-page.component';
-import {
-  SearchConfigurationService
-} from '../../../../../../../../app/core/shared/search/search-configuration.service';
 
 
 @Component({
   selector: 'ds-dynamic-lookup-relation-modal',
   styleUrls: ['../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.scss'],
-  // templateUrl: '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html',
-  templateUrl: './dynamic-lookup-relation-modal.component.html',
-  providers: [
-    {
-      provide: SEARCH_CONFIG_SERVICE,
-      useClass: SearchConfigurationService
-    }
-  ],
+  templateUrl: '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html',
+  // templateUrl: './dynamic-lookup-relation-modal.component.html',
 })
 export class DsDynamicLookupRelationModalComponent extends BaseComponent {}

--- a/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -1,0 +1,37 @@
+import {
+  AsyncPipe,
+  NgForOf,
+  NgIf,
+} from '@angular/common';
+import { Component } from '@angular/core';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { BtnDisabledDirective } from '../../../../../../../../app/shared/btn-disabled.directive';
+import { DsDynamicLookupRelationModalComponent as BaseComponent } from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
+import { ThemedDynamicLookupRelationExternalSourceTabComponent } from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/themed-dynamic-lookup-relation-external-source-tab.component';
+import { ThemedDynamicLookupRelationSearchTabComponent } from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/themed-dynamic-lookup-relation-search-tab.component';
+import { DsDynamicLookupRelationSelectionTabComponent } from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/selection-tab/dynamic-lookup-relation-selection-tab.component';
+import { ThemedLoadingComponent } from '../../../../../../../../app/shared/loading/themed-loading.component';
+
+
+@Component({
+  selector: 'ds-themed-dynamic-lookup-relation-modal',
+  styleUrls: ['../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.scss'],
+  templateUrl: '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html',
+  // templateUrl: './dynamic-lookup-relation-modal.component.html',
+  imports: [
+    ThemedDynamicLookupRelationExternalSourceTabComponent,
+    TranslateModule,
+    ThemedLoadingComponent,
+    NgIf,
+    NgbNavModule,
+    ThemedDynamicLookupRelationSearchTabComponent,
+    AsyncPipe,
+    NgForOf,
+    DsDynamicLookupRelationSelectionTabComponent,
+    BtnDisabledDirective,
+  ],
+  standalone: true,
+})
+export class DsDynamicLookupRelationModalComponent extends BaseComponent {}

--- a/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/themes/custom/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import {
+  DsDynamicLookupRelationModalComponent as BaseComponent
+} from '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../../../app/my-dspace-page/my-dspace-page.component';
+import {
+  SearchConfigurationService
+} from '../../../../../../../../app/core/shared/search/search-configuration.service';
+
+
+@Component({
+  selector: 'ds-dynamic-lookup-relation-modal',
+  styleUrls: ['../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.scss'],
+  // templateUrl: '../../../../../../../../app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html',
+  templateUrl: './dynamic-lookup-relation-modal.component.html',
+  providers: [
+    {
+      provide: SEARCH_CONFIG_SERVICE,
+      useClass: SearchConfigurationService
+    }
+  ],
+})
+export class DsDynamicLookupRelationModalComponent extends BaseComponent {}

--- a/src/themes/custom/lazy-theme.module.ts
+++ b/src/themes/custom/lazy-theme.module.ts
@@ -156,6 +156,9 @@ import { ItemStatusComponent } from './app/item-page/edit-item-page/item-status/
 import { EditBitstreamPageComponent } from './app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component';
 import { FormModule } from '../../app/shared/form/form.module';
 import { RequestCopyModule } from 'src/app/request-copy/request-copy.module';
+import {
+  DsDynamicLookupRelationModalComponent
+} from './app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
 
 const DECLARATIONS = [
   FileSectionComponent,
@@ -239,6 +242,7 @@ const DECLARATIONS = [
   SubmissionSectionUploadFileComponent,
   ItemStatusComponent,
   EditBitstreamPageComponent,
+  DsDynamicLookupRelationModalComponent,
 ];
 
 @NgModule({

--- a/src/themes/custom/lazy-theme.module.ts
+++ b/src/themes/custom/lazy-theme.module.ts
@@ -73,6 +73,7 @@ import { BrowseByComponent } from './app/shared/browse-by/browse-by.component';
 import { ComcolPageBrowseByComponent } from './app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component';
 import { ComcolPageContentComponent } from './app/shared/comcol/comcol-page-content/comcol-page-content.component';
 import { ComcolPageHandleComponent } from './app/shared/comcol/comcol-page-handle/comcol-page-handle.component';
+import { DsDynamicLookupRelationModalComponent } from './app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component';
 import { DsDynamicLookupRelationExternalSourceTabComponent } from './app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/dynamic-lookup-relation-external-source-tab.component';
 import { ExternalSourceEntryImportModalComponent } from './app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/external-source-entry-import-modal/external-source-entry-import-modal.component';
 import { DsDynamicLookupRelationSearchTabComponent } from './app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component';
@@ -105,7 +106,6 @@ import { ThumbnailComponent } from './app/thumbnail/thumbnail.component';
 import { WorkflowItemDeleteComponent } from './app/workflowitems-edit-page/workflow-item-delete/workflow-item-delete.component';
 import { WorkflowItemSendBackComponent } from './app/workflowitems-edit-page/workflow-item-send-back/workflow-item-send-back.component';
 import { WorkspaceItemsDeletePageComponent } from './app/workspaceitems-edit-page/workspaceitems-delete-page/workspaceitems-delete-page.component';
-
 
 const DECLARATIONS = [
   FileSectionComponent,
@@ -201,6 +201,7 @@ const DECLARATIONS = [
   AdminSearchPageComponent,
   AdminWorkflowPageComponent,
   SearchResultsSkeletonComponent,
+  DsDynamicLookupRelationModalComponent,
 ];
 
 @NgModule({


### PR DESCRIPTION
## Description
Added new ThemedDsDynamicLookupRelationModalComponent. Updated the usages of the modal.

## Instructions for Reviewers
List of changes in this PR:
* ThemedDsDynamicLookupRelationModalComponent

For the themed components:

 - Set the theme to custom theme in  `config.yml`
 - Uncomment the  `CustomEagerThemeModule`  in  `src/themes/eager-themes.module.ts`
 - Test if the new components in the custom theme folder can be themed
 - This component is used in the Edit Relationships tab so on the REST side entities should be initialized.

## Checklist

- [ x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).