### PR TITLE
apply spellCheck configuration to input model

### DIFF
--- a/src/app/shared/form/builder/parsers/onebox-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/onebox-field-parser.ts
@@ -21,6 +21,7 @@ import {
 } from '../ds-dynamic-form-ui/models/onebox/dynamic-onebox.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { FieldParser } from './field-parser';
+import { environment } from '../../../../../environments/environment';
 
 export class OneboxFieldParser extends FieldParser {
 

--- a/src/app/shared/form/builder/parsers/onebox-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/onebox-field-parser.ts
@@ -90,6 +90,7 @@ export class OneboxFieldParser extends FieldParser {
       return new DynamicOneboxModel(oneboxModelConfig);
     } else {
       const inputModelConfig: DsDynamicInputModelConfig = this.initModel(null, label);
+      inputModelConfig.spellCheck = environment.form.spellCheck;
       this.setValues(inputModelConfig, fieldValue);
 
       return new DsDynamicInputModel(inputModelConfig);

--- a/src/app/shared/form/builder/parsers/onebox-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/onebox-field-parser.ts
@@ -3,6 +3,7 @@ import {
   DynamicSelectModelConfig,
 } from '@ng-dynamic-forms/core';
 
+import { environment } from '../../../../../environments/environment';
 import { isNotEmpty } from '../../../empty.util';
 import {
   DsDynamicInputModel,
@@ -21,7 +22,6 @@ import {
 } from '../ds-dynamic-form-ui/models/onebox/dynamic-onebox.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { FieldParser } from './field-parser';
-import { environment } from '../../../../../environments/environment';
 
 export class OneboxFieldParser extends FieldParser {
 


### PR DESCRIPTION
## Description

With this PR, the `spellCheck` attribute is also applied to simple input fields based on the application configuration `form.spellCheck`. Currently, the `spellCheck` attribute is only set for textarea fields (see #2003).