### PR TITLE
Add citation_doi tag to head meta (main branch port)

### DIFF
--- a/src/app/core/metadata/head-tag.service.ts
+++ b/src/app/core/metadata/head-tag.service.ts
@@ -186,6 +186,7 @@ export class HeadTagService {
     this.setCitationKeywordsTag();
 
     this.setCitationAbstractUrlTag();
+    this.setCitationDoiTag();
     this.setCitationPdfUrlTag();
     this.setCitationPublisherTag();
 
@@ -198,7 +199,6 @@ export class HeadTagService {
     // this.setCitationIssueTag();
     // this.setCitationFirstPageTag();
     // this.setCitationLastPageTag();
-    // this.setCitationDOITag();
     // this.setCitationPMIDTag();
 
     // this.setCitationFullTextTag();
@@ -316,6 +316,18 @@ export class HeadTagService {
         url = new URLCombiner(this.hardRedirectService.getCurrentOrigin(), this.router.url).toString();
       }
       this.addMetaTag('citation_abstract_html_url', url);
+    }
+  }
+
+  /**
+   * Add <meta name="citation_doi" ... >  to the <head>
+   */
+  private setCitationDoiTag(): void {
+    if (this.currentObject.value instanceof Item) {
+      const doi = this.getMetaTagValue('dc.identifier.doi');
+      if (hasValue(doi)) {
+        this.addMetaTag('citation_doi', doi);
+      }
     }
   }
 


### PR DESCRIPTION
port of #4034 by @alanorth

Fixes https://github.com/DSpace/dspace-angular/issues/4033
Description
Add missing <meta name="citation_doi" ...> fields to the XHTML head section for items that have DOIs. This is used by harvesters like Altmetric to monitor attention on identifiers in repositories and academic publishers.

See #4034 for testing / description details