### PR TITLE
Fix infinite loading submission forms

### DIFF
--- a/src/app/core/submission/submission-rest.service.spec.ts
+++ b/src/app/core/submission/submission-rest.service.spec.ts
@@ -58,11 +58,11 @@ describe('SubmissionRestService test suite', () => {
 
   describe('getDataById', () => {
     it('should send a new SubmissionRequest', () => {
-      const expected = new SubmissionRequest(requestService.generateRequestId(), resourceHref);
+      const request = new SubmissionRequest(requestService.generateRequestId(), resourceHref);
       scheduler.schedule(() => service.getDataById(resourceEndpoint, resourceScope).subscribe());
       scheduler.flush();
 
-      expect(requestService.send).toHaveBeenCalledWith(expected);
+      expect(requestService.send).toHaveBeenCalledWith(request, false);
     });
   });
 

--- a/src/app/core/submission/submission-rest.service.ts
+++ b/src/app/core/submission/submission-rest.service.ts
@@ -5,12 +5,15 @@ import {
   filter,
   map,
   mergeMap,
+  skipWhile,
+  take,
   tap,
 } from 'rxjs/operators';
 
 import {
   hasValue,
   isNotEmpty,
+  isNotEmptyOperator,
 } from '../../shared/empty.util';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { ErrorResponse } from '../cache/response.models';
@@ -25,10 +28,12 @@ import {
 } from '../data/request.models';
 import { RequestService } from '../data/request.service';
 import { RequestError } from '../data/request-error.model';
-import { RestRequest } from '../data/rest-request.model';
 import { HttpOptions } from '../dspace-rest/dspace-rest.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
-import { getFirstCompletedRemoteData } from '../shared/operators';
+import {
+  getFirstCompletedRemoteData,
+  getRemoteDataPayload,
+} from '../shared/operators';
 import { SubmitDataResponseDefinitionObject } from '../shared/submit-data-response-definition.model';
 import { URLCombiner } from '../url-combiner/url-combiner';
 import { SubmissionResponse } from './submission-response.model';
@@ -78,7 +83,7 @@ export class SubmissionRestService {
    * @param collectionId
    *    The owning collection for the object
    */
-  protected getEndpointByIDHref(endpoint, resourceID, collectionId?: string): string {
+  protected getEndpointByIDHref(endpoint: string, resourceID: string, collectionId?: string): string {
     let url = isNotEmpty(resourceID) ? `${endpoint}/${resourceID}` : `${endpoint}`;
     url = new URLCombiner(url, '?embed=item,sections,collection').toString();
     if (collectionId) {
@@ -116,21 +121,35 @@ export class SubmissionRestService {
    *    The endpoint link name
    * @param id
    *    The submission Object to retrieve
+   * @param useCachedVersionIfAvailable
+   *     If this is true, the request will only be sent if there's no valid & cached version. Defaults to false
    * @return Observable<SubmitDataResponseDefinitionObject>
    *     server response
    */
-  public getDataById(linkName: string, id: string): Observable<SubmitDataResponseDefinitionObject> {
-    const requestId = this.requestService.generateRequestId();
-    return this.halService.getEndpoint(linkName).pipe(
+  public getDataById(linkName: string, id: string, useCachedVersionIfAvailable = false): Observable<SubmitDataResponseDefinitionObject> {
+    const requestHref$: Observable<string> = this.halService.getEndpoint(linkName).pipe(
       map((endpointURL: string) => this.getEndpointByIDHref(endpointURL, id)),
-      filter((href: string) => isNotEmpty(href)),
-      distinctUntilChanged(),
-      map((endpointURL: string) => new SubmissionRequest(requestId, endpointURL)),
-      tap((request: RestRequest) => {
-        this.requestService.send(request);
-      }),
-      mergeMap(() => this.fetchRequest(requestId)),
-      distinctUntilChanged());
+      isNotEmptyOperator(),
+      take(1),
+    );
+
+    const startTime: number = new Date().getTime();
+    requestHref$.subscribe((href: string) => {
+      const requestId: string = this.requestService.generateRequestId();
+      const request: SubmissionRequest = new SubmissionRequest(requestId, href);
+      this.requestService.send(request, useCachedVersionIfAvailable);
+    });
+
+    return this.rdbService.buildSingle<SubmissionResponse>(requestHref$).pipe(
+      // This skip ensures that if a stale object is present in the cache when you do a
+      // call it isn't immediately returned, but we wait until the remote data for the new request
+      // is created. If useCachedVersionIfAvailable is false it also ensures you don't get a
+      // cached completed object
+      skipWhile((rd: RemoteData<SubmissionResponse>) => rd.isStale || (!useCachedVersionIfAvailable && rd.lastUpdated < startTime)),
+      getFirstCompletedRemoteData(),
+      getRemoteDataPayload(),
+      map((response: SubmissionResponse) => response.dataDefinition),
+    );
   }
 
   /**


### PR DESCRIPTION
## References
* Possibly related to #3697

## Description
Updated the `SubmissionRestService#getDataById` method to prevent the form from getting stuck in an infinite loop when quick successive calls are made to it. This happens because the `getDataById` sometimes tries to return the data of a specific request that was actually never dispatched, because a similar request was already being made.

## Instructions for Reviewers
This issue happens when `RequestService#send` is called twice with the same value in a short time, because it prevents sending requests a second time when the same request was already fired by another method (as long as that request is still in the `isPending` state). Because `getDataById` explicitly listens from data from a specific request (`this.fetchRequest(requestId)`), it is possible that it tries to fetch the data of a request that was never dispatched. This refactor instead listens to data coming in based on the url of the request.

**Guidance for how to test or review this PR:**
This issue only happens when this line returns false, so for testing I would recommend adding a console.log wrapper around this, this way you know when you also have the same edge case:
https://github.com/DSpace/dspace-angular/blob/e976ddb07c6ca80e04e2ea2a2bc84b12fb7f9fdc/src/app/core/submission/submission-rest.service.ts#L130 

I was able to reproduce this error by refreshing the `/workspaceitems/{id}/edit` page multiple times (this doesn't happen on the default DSpace forms, but if you have customizations that cause the `SubmissionRestService#getDataById` from being called multiple times you can experience this issue)

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
