### PR TITLE
Minor fixes to Cypress e2e tests

### DIFF
--- a/cypress/e2e/admin-sidebar.cy.ts
+++ b/cypress/e2e/admin-sidebar.cy.ts
@@ -1,5 +1,4 @@
 import { testA11y } from 'cypress/support/utils';
-import { Options } from 'cypress-axe';
 
 describe('Admin Sidebar', () => {
   beforeEach(() => {
@@ -16,13 +15,6 @@ describe('Admin Sidebar', () => {
     cy.get('ds-expandable-admin-sidebar-section').click({ multiple: true });
 
     // Analyze <ds-admin-sidebar> for accessibility
-    testA11y('ds-admin-sidebar',
-        {
-          rules: {
-            // Currently all expandable sections have nested interactive elements
-            // See https://github.com/DSpace/dspace-angular/issues/2178
-            'nested-interactive': { enabled: false },
-          },
-        } as Options);
+    testA11y('ds-admin-sidebar');
   });
 });

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,10 +1,16 @@
 {
   "extends": "../tsconfig.json",
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "../cypress.config.ts"
   ],
   "compilerOptions": {
     "sourceMap": false,
+    "typeRoots": [
+      "../node_modules",
+      "../node_modules/@types",
+      "../src/typings.d.ts"
+    ],
     "types": [
       "cypress",
       "cypress-axe",


### PR DESCRIPTION
## Description
This small PR fixes two small issues with Cypress e2e tests:
* First, it re-enables an accessibility validation test in `admin-sidebar.cy.ts`, as the prior accessibility issue was fixed in #2178.
* Second, it fixes the `tsconfig.json` for the Cypress tests to allow IDEs (especially VS Code) to recognize `*.cy.ts` files & provide autocomplete, etc. 
    * This issue appeared to be related to https://github.com/cypress-io/cypress/issues/26930#issuecomment-1602799361
    * The fix was to add `../node_modules` to the (default) list of `typeRoots` that are defined in our root `tsconfig.json` file.  That small addition allows IDEs to more easily locate the type definitions related to Cypress, allowing for autocomplete, etc.

## Instructions for Reviewers
* The first change will be auto-tested by this PR.  If the accessibility check succeeds, then this fix is correct.
* The second changes is most easily tested in VS Code by opening any `*.cy.ts` file in the `cypress` directory.  Currently, on `main`, if you open one of these files, a lot of the type definitions will be unrecognized & you'll see red lines in the opened files.  However, with this PR in place, those red lines go away.

NOTE: There are no direct changes to DSpace in this PR.  The two small changes only impact e2e tests.
