### PR TITLE
fix typo in German translation of bitstream.edit.form.description.hint

### DIFF
--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -1242,7 +1242,7 @@
   "bitstream.edit.bitstream": "Bitstream: ",
 
   // "bitstream.edit.form.description.hint": "Optionally, provide a brief description of the file, for example \"<i>Main article</i>\" or \"<i>Experiment data readings</i>\".",
-  "bitstream.edit.form.description.hint": "Hier können Sie eine kurze Beschreibung der Datei angeben, zum Beispiel \"<i>Artikel</i>\" oder \"<i>Tabellenhanhang</i>\".",
+  "bitstream.edit.form.description.hint": "Hier können Sie eine kurze Beschreibung der Datei angeben, zum Beispiel \"<i>Artikel</i>\" oder \"<i>Tabellenanhang</i>\".",
 
   // "bitstream.edit.form.description.label": "Description",
   "bitstream.edit.form.description.label": "Beschreibung",


### PR DESCRIPTION
## Description

This PR fixes a typo in German translation of `bitstream.edit.form.description.hint`. This PR should be merged after PR https://github.com/DSpace/dspace-angular/pull/3980 has been successfully merged.