### PR TITLE
Filters disappeared on reload

### DIFF
--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -88,14 +88,16 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.clearParams = this.searchConfigService.getCurrentFrontendFilters().pipe(
-      tap(() => this.filtersWithComputedVisibility = 0),
-      map((filters) => {
-        Object.keys(filters).forEach((f) => filters[f] = null);
-        return filters;
-      })
-    );
-    this.searchLink = this.getSearchLink();
+    this.router.events.subscribe(() => {
+      this.clearParams = this.searchConfigService.getCurrentFrontendFilters().pipe(
+        tap(() => this.filtersWithComputedVisibility = 0),
+        map((filters) => {
+          Object.keys(filters).forEach((f) => filters[f] = null);
+          return filters;
+        })
+      );
+      this.searchLink = this.getSearchLink();
+    });
   }
 
   /**


### PR DESCRIPTION
## References
Fix #4053 

## Description
The component does not detect navigation changes.

## Instructions for Reviewers
* Search for something in the searchbar  
* Click on the second page
*  Now the filters works

List of changes in this PR:
* SearchFiltersComponent

## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
