### PR TITLE
Fix for DSpace#2328 Highlighting the sidebar filter facets if any val…

### DIFF
--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -40,6 +40,7 @@ $warning:   #ec9433 !default;               // Orange
 $danger:    #cf4444 !default;               // Red
 $light:     #f8f9fa !default;               // As Bootstrap $gray-100
 $dark:      darken(#2b4e72, 17%) !default;  // Blue gray (darker)
+$highlightColor: rgba(30, 111, 144, 0.3) !default; // $info color with 0.3 opacity
 
 // Add new semantic colors here (you don't need to add existing semantic colors)
 $global-custom-semantic-colors: (

--- a/src/styles/_bootstrap_variables_mapping.scss
+++ b/src/styles/_bootstrap_variables_mapping.scss
@@ -91,6 +91,8 @@
 
   --bs-border-radius-lg: #{$bs-border-radius-lg};
 
+  --bs-highlight-color: #{$highlightColor};
+
 }
 
 // Some Bootstrap CSS variables are tied to classes

--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -543,3 +543,5 @@ ngb-tooltip-window {
   // We use underline to discern link from text as we can't make color lighter on a white bg
   text-decoration: underline;
 }
+
+ds-search-filter .facet-filter:has([type="checkbox"]:checked) { background: var(--bs-highlight-color); }


### PR DESCRIPTION
### Description

Fixes #2328

Collapsed sidebar filter facets should indicate if a value is selected 

### Instructions for Reviewers
When users apply multiple filters on the /search page, they often collapse individual facets. This makes it difficult to track which filters are active without expanding each section.

### Expected Behavior
Sidebar filter facets should clearly indicate if they're "active", especially when they're collapsed.

### List of Changes in this PR:

- Added a variable $highlightColor: rgba(30, 111, 144, 0.3) !default in src/styles/_bootstrap_variables.scss
- Mapped --bs-highlight-color: #{$highlightColor} in src/styles/_bootstrap_variables_mapping.scss
- Added background color (--bs-highlight-color) when checkbox is checked in ds-search-filter in src/styles/_global-styles.scss

### Steps to Test and Reproduce the Behavior:
On the /search page, when you select a checkbox within a filter, the filter becomes active. If you collapse the filter, it remains active as long as a checkbox is selected. If no checkbox is selected, the filter is not activated.


