### PR TITLE
Prefetch rest responses

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -380,3 +380,9 @@ vocabularies:
 comcolSelectionSort:
   sortField: 'dc.title'
   sortDirection: 'ASC'
+
+prefetch:
+  urls:
+    - /api
+    - /api/discover
+  refreshInterval: 60000

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -381,8 +381,11 @@ comcolSelectionSort:
   sortField: 'dc.title'
   sortDirection: 'ASC'
 
+# REST response prefetching configuration
 prefetch:
+  # The URLs for which the response will be prefetched
   urls:
     - /api
     - /api/discover
+  # How often the responses are refreshed in milliseconds
   refreshInterval: 60000

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "ngx-pagination": "6.0.3",
     "ngx-sortablejs": "^11.1.0",
     "ngx-ui-switch": "^14.0.3",
+    "node-html-parser": "^7.0.1",
     "nouislider": "^14.6.3",
     "pem": "1.14.7",
     "prop-types": "^15.8.1",

--- a/server.ts
+++ b/server.ts
@@ -71,6 +71,7 @@ const cookieParser = require('cookie-parser');
 const configJson = join(DIST_FOLDER, 'assets/config.json');
 const hashedFileMapping = new ServerHashedFileMapping(DIST_FOLDER, 'index.html');
 const appConfig: AppConfig = buildAppConfig(configJson, hashedFileMapping);
+hashedFileMapping.addThemeStyles();
 hashedFileMapping.save();
 
 // cache of SSR pages for known bots, only enabled in production mode

--- a/server.ts
+++ b/server.ts
@@ -49,7 +49,7 @@ import { UIServerConfig } from './src/config/ui-server-config.interface';
 
 import { ServerAppModule } from './src/main.server';
 
-import { buildAppConfig } from './src/config/config.server';
+import { buildAppConfig, setupEndpointPrefetching } from './src/config/config.server';
 import { APP_CONFIG, AppConfig } from './src/config/app-config.interface';
 import { extendEnvironmentWithAppConfig } from './src/config/config.util';
 import { logStartupMessage } from './startup-message';
@@ -67,7 +67,8 @@ const indexHtml = join(DIST_FOLDER, 'index.html');
 
 const cookieParser = require('cookie-parser');
 
-const appConfig: AppConfig = buildAppConfig(join(DIST_FOLDER, 'assets/config.json'));
+const destConfigPath = join(DIST_FOLDER, 'assets/config.json');
+const appConfig: AppConfig = buildAppConfig(destConfigPath);
 
 // cache of SSR pages for known bots, only enabled in production mode
 let botCache: LRU<string, any>;
@@ -487,7 +488,7 @@ function saveToCache(req, page: any) {
  */
 function hasNotSucceeded(statusCode) {
   const rgx = new RegExp(/^20+/);
-  return !rgx.test(statusCode)
+  return !rgx.test(statusCode);
 }
 
 function retrieveHeaders(response) {
@@ -612,8 +613,12 @@ function healthCheck(req, res) {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = (mainModule && mainModule.filename) || '';
-if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
-  start();
-}
+setupEndpointPrefetching(appConfig, destConfigPath, environment).then(() => {
+  if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
+    start();
+  }
+}).catch((error) => {
+  console.error('Errored while prefetching Endpoint Maps', error);
+});
 
 export * from './src/main.server';

--- a/server.ts
+++ b/server.ts
@@ -617,7 +617,7 @@ function healthCheck(req, res) {
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = (mainModule && mainModule.filename) || '';
-setupEndpointPrefetching(appConfig, destConfigPath, environment).then(() => {
+setupEndpointPrefetching(appConfig, destConfigPath, environment, hashedFileMapping).then(() => {
   if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
     start();
   }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -36,6 +36,8 @@ import {
 } from '../config/app-config.interface';
 import { StoreDevModules } from '../config/store/devtools';
 import { environment } from '../environments/environment';
+import { HashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping';
+import { BrowserHashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping.browser';
 import { EagerThemesModule } from '../themes/eager-themes.module';
 import { appEffects } from './app.effects';
 import {
@@ -153,6 +155,10 @@ export const commonAppConfig: ApplicationConfig = {
       provide: HTTP_INTERCEPTORS,
       useClass: DspaceRestInterceptor,
       multi: true,
+    },
+    {
+      provide: HashedFileMapping,
+      useClass: BrowserHashedFileMapping,
     },
     // register the dynamic matcher used by form. MUST be provided by the app module
     ...DYNAMIC_MATCHER_PROVIDERS,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,8 @@ import { MetaReducer, StoreModule, USER_PROVIDED_META_REDUCERS } from '@ngrx/sto
 import { TranslateModule } from '@ngx-translate/core';
 import { ScrollToModule } from '@nicky-lenaers/ngx-scroll-to';
 import { DYNAMIC_MATCHER_PROVIDERS } from '@ng-dynamic-forms/core';
+import { HashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping';
+import { BrowserHashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping.browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -102,6 +104,10 @@ const PROVIDERS = [
     provide: HTTP_INTERCEPTORS,
     useClass: LogInterceptor,
     multi: true
+  },
+  {
+    provide: HashedFileMapping,
+    useClass: BrowserHashedFileMapping,
   },
   // register the dynamic matcher used by form. MUST be provided by the app module
   ...DYNAMIC_MATCHER_PROVIDERS,

--- a/src/app/core/auth/auth.interceptor.spec.ts
+++ b/src/app/core/auth/auth.interceptor.spec.ts
@@ -13,6 +13,8 @@ import { RouterStub } from '../../shared/testing/router.stub';
 import { TruncatablesState } from '../../shared/truncatable/truncatable.reducer';
 import { AuthServiceStub } from '../../shared/testing/auth-service.stub';
 import { RestRequestMethod } from '../data/rest-request-method';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from 'src/environments/environment.test';
 
 describe(`AuthInterceptor`, () => {
   let service: DspaceRestService;
@@ -39,6 +41,7 @@ describe(`AuthInterceptor`, () => {
           multi: true,
         },
         { provide: Store, useValue: store },
+        { provide: APP_CONFIG, useValue: environment },
       ],
     });
 

--- a/src/app/core/browse/browse-definition-data.service.ts
+++ b/src/app/core/browse/browse-definition-data.service.ts
@@ -6,55 +6,16 @@ import { RemoteDataBuildService } from '../cache/builders/remote-data-build.serv
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable } from 'rxjs';
 import { RemoteData } from '../data/remote-data';
 import { PaginatedList } from '../data/paginated-list.model';
 import { FindListOptions } from '../data/find-list-options.model';
 import { IdentifiableDataService } from '../data/base/identifiable-data.service';
 import { FindAllData, FindAllDataImpl } from '../data/base/find-all-data';
 import { dataService } from '../data/base/data-service.decorator';
-import { isNotEmpty, isNotEmptyOperator, hasValue } from '../../shared/empty.util';
-import { take } from 'rxjs/operators';
-import { BrowseDefinitionRestRequest } from '../data/request.models';
 import { RequestParam } from '../cache/models/request-param.model';
 import { SearchData, SearchDataImpl } from '../data/base/search-data';
 import { BrowseDefinition } from '../shared/browse-definition.model';
-
-/**
- * Create a GET request for the given href, and send it.
- * Use a GET request specific for BrowseDefinitions.
- */
-export const createAndSendBrowseDefinitionGetRequest = (requestService: RequestService,
-                                                        responseMsToLive: number,
-                                                        href$: string | Observable<string>,
-                                                        useCachedVersionIfAvailable: boolean = true): void => {
-  if (isNotEmpty(href$)) {
-    if (typeof href$ === 'string') {
-      href$ = observableOf(href$);
-    }
-
-    href$.pipe(
-      isNotEmptyOperator(),
-      take(1)
-    ).subscribe((href: string) => {
-      const requestId = requestService.generateRequestId();
-      const request = new BrowseDefinitionRestRequest(requestId, href);
-      if (hasValue(responseMsToLive)) {
-        request.responseMsToLive = responseMsToLive;
-      }
-      requestService.send(request, useCachedVersionIfAvailable);
-    });
-  }
-};
-
-/**
- * Custom extension of {@link FindAllDataImpl} to be able to send BrowseDefinitionRestRequests
- */
-class BrowseDefinitionFindAllDataImpl extends FindAllDataImpl<BrowseDefinition> {
-  createAndSendGetRequest(href$: string | Observable<string>, useCachedVersionIfAvailable: boolean = true) {
-    createAndSendBrowseDefinitionGetRequest(this.requestService, this.responseMsToLive, href$, useCachedVersionIfAvailable);
-  }
-}
 
 /**
  * Data service responsible for retrieving browse definitions from the REST server
@@ -64,7 +25,7 @@ class BrowseDefinitionFindAllDataImpl extends FindAllDataImpl<BrowseDefinition> 
 })
 @dataService(BROWSE_DEFINITION)
 export class BrowseDefinitionDataService extends IdentifiableDataService<BrowseDefinition> implements FindAllData<BrowseDefinition>, SearchData<BrowseDefinition> {
-  private findAllData: BrowseDefinitionFindAllDataImpl;
+  private findAllData: FindAllData<BrowseDefinition>;
   private searchData: SearchDataImpl<BrowseDefinition>;
 
   constructor(
@@ -75,7 +36,7 @@ export class BrowseDefinitionDataService extends IdentifiableDataService<BrowseD
   ) {
     super('browses', requestService, rdbService, objectCache, halService);
     this.searchData = new SearchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
-    this.findAllData = new BrowseDefinitionFindAllDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
+    this.findAllData = new FindAllDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
   }
 
   /**
@@ -159,10 +120,6 @@ export class BrowseDefinitionDataService extends IdentifiableDataService<BrowseD
       reRequestOnStale,
       ...linksToFollow,
     );
-  }
-
-  createAndSendGetRequest(href$: string | Observable<string>, useCachedVersionIfAvailable: boolean = true) {
-    createAndSendBrowseDefinitionGetRequest(this.requestService, this.responseMsToLive, href$, useCachedVersionIfAvailable);
   }
 }
 

--- a/src/app/core/cache/builders/remote-data-build.service.ts
+++ b/src/app/core/cache/builders/remote-data-build.service.ts
@@ -16,7 +16,7 @@ import { ObjectCacheService } from '../object-cache.service';
 import { LinkService } from './link.service';
 import { HALLink } from '../../shared/hal-link.model';
 import { GenericConstructor } from '../../shared/generic-constructor';
-import { getClassForType } from './build-decorators';
+import { getClassForObject } from './build-decorators';
 import { HALResource } from '../../shared/hal-resource.model';
 import { PAGINATED_LIST } from '../../data/paginated-list.resource-type';
 import { getUrlWithoutEmbedParams } from '../../index/index.selectors';
@@ -90,7 +90,7 @@ export class RemoteDataBuildService {
    * @param obj  The object to turn in to a class instance based on its type property
    */
   private plainObjectToInstance<T>(obj: any): T {
-    const type: GenericConstructor<T> = getClassForType(obj.type);
+    const type: GenericConstructor<T> = getClassForObject(obj);
     if (typeof type === 'function') {
       return Object.assign(new type(), obj) as T;
     } else {

--- a/src/app/core/cache/object-cache.service.ts
+++ b/src/app/core/cache/object-cache.service.ts
@@ -10,7 +10,7 @@ import { coreSelector } from '../core.selectors';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { selfLinkFromAlternativeLinkSelector, selfLinkFromUuidSelector } from '../index/index.selectors';
 import { GenericConstructor } from '../shared/generic-constructor';
-import { getClassForType } from './builders/build-decorators';
+import { getClassForObject } from './builders/build-decorators';
 import { LinkService } from './builders/link.service';
 import { AddDependentsObjectCacheAction, AddPatchObjectCacheAction, AddToObjectCacheAction, ApplyPatchObjectCacheAction, RemoveDependentsObjectCacheAction, RemoveFromObjectCacheAction } from './object-cache.actions';
 
@@ -139,7 +139,7 @@ export class ObjectCacheService {
         }
       ),
       map((entry: ObjectCacheEntry) => {
-        const type: GenericConstructor<T> = getClassForType((entry.data as any).type);
+        const type: GenericConstructor<T> = getClassForObject(entry.data as any);
         if (typeof type !== 'function') {
           throw new Error(`${type} is not a valid constructor for ${JSON.stringify(entry.data)}`);
         }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -183,6 +183,7 @@ import { ValueListBrowseDefinition } from './shared/value-list-browse-definition
 import { NonHierarchicalBrowseDefinition } from './shared/non-hierarchical-browse-definition';
 import { BulkAccessConditionOptions } from './config/models/bulk-access-condition-options.model';
 import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
+import { StatisticsEndpoint } from '../statistics/statistics-endpoint.model';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
@@ -381,7 +382,8 @@ export const models =
     IdentifierData,
     Subscription,
     ItemRequest,
-    BulkAccessConditionOptions
+    BulkAccessConditionOptions,
+    StatisticsEndpoint,
   ];
 
 @NgModule({

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -182,16 +182,17 @@ import { FlatBrowseDefinition } from './shared/flat-browse-definition.model';
 import { ValueListBrowseDefinition } from './shared/value-list-browse-definition.model';
 import { NonHierarchicalBrowseDefinition } from './shared/non-hierarchical-browse-definition';
 import { BulkAccessConditionOptions } from './config/models/bulk-access-condition-options.model';
+import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
  * If there is no mock version available for the endpoint, the actual REST response will be used just like in production mode
  */
-export const restServiceFactory = (mocks: ResponseMapMock, http: HttpClient) => {
+export const restServiceFactory = (mocks: ResponseMapMock, http: HttpClient, appConfig: AppConfig) => {
   if (environment.production) {
-    return new DspaceRestService(http);
+    return new DspaceRestService(http, appConfig);
   } else {
-    return new EndpointMockingRestService(mocks, http);
+    return new EndpointMockingRestService(mocks, http, appConfig);
   }
 };
 
@@ -212,7 +213,7 @@ const PROVIDERS = [
   SiteDataService,
   DSOResponseParsingService,
   { provide: MOCK_RESPONSE_MAP, useValue: mockResponseMap },
-  { provide: DspaceRestService, useFactory: restServiceFactory, deps: [MOCK_RESPONSE_MAP, HttpClient] },
+  { provide: DspaceRestService, useFactory: restServiceFactory, deps: [MOCK_RESPONSE_MAP, HttpClient, APP_CONFIG] },
   EPersonDataService,
   LinkHeadService,
   HALEndpointService,

--- a/src/app/core/data/base-response-parsing.service.ts
+++ b/src/app/core/data/base-response-parsing.service.ts
@@ -6,7 +6,7 @@ import { PageInfo } from '../shared/page-info.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { GenericConstructor } from '../shared/generic-constructor';
 import { PaginatedList, buildPaginatedList } from './paginated-list.model';
-import { getClassForType } from '../cache/builders/build-decorators';
+import { getClassForObject } from '../cache/builders/build-decorators';
 import { environment } from '../../../environments/environment';
 import { CacheableObject } from '../cache/cacheable-object.model';
 import { RestRequest } from './rest-request.model';
@@ -111,7 +111,7 @@ export abstract class BaseResponseParsingService {
   protected deserialize<ObjectDomain>(obj): any {
     const type: string = obj.type;
     if (hasValue(type)) {
-      const objConstructor = getClassForType(type) as GenericConstructor<ObjectDomain>;
+      const objConstructor = getClassForObject(obj) as GenericConstructor<ObjectDomain>;
 
       if (hasValue(objConstructor)) {
         const serializer = new this.serializerConstructor(objConstructor);

--- a/src/app/core/data/base/create-data.ts
+++ b/src/app/core/data/base/create-data.ts
@@ -5,22 +5,30 @@
  *
  * http://www.dspace.org/license/
  */
-import { CacheableObject } from '../../cache/cacheable-object.model';
-import { BaseDataService } from './base-data.service';
-import { RequestParam } from '../../cache/models/request-param.model';
 import { Observable } from 'rxjs';
-import { RemoteData } from '../remote-data';
-import { hasValue, isNotEmptyOperator } from '../../../shared/empty.util';
-import { distinctUntilChanged, map, take, takeWhile } from 'rxjs/operators';
-import { DSpaceSerializer } from '../../dspace-rest/dspace.serializer';
-import { getClassForType } from '../../cache/builders/build-decorators';
-import { CreateRequest } from '../request.models';
+import {
+  distinctUntilChanged,
+  map,
+  take,
+  takeWhile,
+} from 'rxjs/operators';
+import {
+  hasValue,
+  isNotEmptyOperator,
+} from '../../../shared/empty.util';
 import { NotificationOptions } from '../../../shared/notifications/models/notification-options.model';
-import { RequestService } from '../request.service';
-import { RemoteDataBuildService } from '../../cache/builders/remote-data-build.service';
-import { HALEndpointService } from '../../shared/hal-endpoint.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
+import { getClassForObject } from '../../cache/builders/build-decorators';
+import { RemoteDataBuildService } from '../../cache/builders/remote-data-build.service';
+import { CacheableObject } from '../../cache/cacheable-object.model';
+import { RequestParam } from '../../cache/models/request-param.model';
 import { ObjectCacheService } from '../../cache/object-cache.service';
+import { DSpaceSerializer } from '../../dspace-rest/dspace.serializer';
+import { HALEndpointService } from '../../shared/hal-endpoint.service';
+import { RemoteData } from '../remote-data';
+import { CreateRequest } from '../request.models';
+import { RequestService } from '../request.service';
+import { BaseDataService } from './base-data.service';
 
 /**
  * Interface for a data service that can create objects.
@@ -78,7 +86,7 @@ export class CreateDataImpl<T extends CacheableObject> extends BaseDataService<T
    */
   createOnEndpoint(object: T, endpoint$: Observable<string>): Observable<RemoteData<T>> {
     const requestId = this.requestService.generateRequestId();
-    const serializedObject = new DSpaceSerializer(getClassForType(object.type)).serialize(object);
+    const serializedObject = new DSpaceSerializer(getClassForObject(object)).serialize(object);
 
     endpoint$.pipe(
       take(1),

--- a/src/app/core/data/browse-response-parsing.service.spec.ts
+++ b/src/app/core/data/browse-response-parsing.service.spec.ts
@@ -4,6 +4,7 @@ import { ObjectCacheService } from '../cache/object-cache.service';
 import { HIERARCHICAL_BROWSE_DEFINITION } from '../shared/hierarchical-browse-definition.resource-type';
 import { FLAT_BROWSE_DEFINITION } from '../shared/flat-browse-definition.resource-type';
 import { VALUE_LIST_BROWSE_DEFINITION } from '../shared/value-list-browse-definition.resource-type';
+import { BROWSE_DEFINITION } from '../shared/browse-definition.resource-type';
 
 class TestService extends BrowseResponseParsingService {
   constructor(protected objectCache: ObjectCacheService) {
@@ -45,19 +46,22 @@ describe('BrowseResponseParsingService', () => {
 
     it('should deserialize flatBrowses correctly', () => {
       let deserialized = service.deserialize(mockFlatBrowse);
-      expect(deserialized.type).toBe(FLAT_BROWSE_DEFINITION);
+      expect(deserialized.type).toBe(BROWSE_DEFINITION);
+      expect(deserialized.browseType).toBe(FLAT_BROWSE_DEFINITION);
       expect(deserialized.id).toBe(mockFlatBrowse.id);
     });
 
     it('should deserialize valueList browses correctly', () => {
       let deserialized = service.deserialize(mockValueList);
-      expect(deserialized.type).toBe(VALUE_LIST_BROWSE_DEFINITION);
+      expect(deserialized.type).toBe(BROWSE_DEFINITION);
+      expect(deserialized.browseType).toBe(VALUE_LIST_BROWSE_DEFINITION);
       expect(deserialized.id).toBe(mockValueList.id);
     });
 
     it('should deserialize hierarchicalBrowses correctly', () => {
       let deserialized = service.deserialize(mockHierarchicalBrowse);
-      expect(deserialized.type).toBe(HIERARCHICAL_BROWSE_DEFINITION);
+      expect(deserialized.type).toBe(BROWSE_DEFINITION);
+      expect(deserialized.browseType).toBe(HIERARCHICAL_BROWSE_DEFINITION);
       expect(deserialized.id).toBe(mockHierarchicalBrowse.id);
     });
   });

--- a/src/app/core/data/default-change-analyzer.service.ts
+++ b/src/app/core/data/default-change-analyzer.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
-import { compare } from 'fast-json-patch';
-import { Operation } from 'fast-json-patch';
-import { getClassForType } from '../cache/builders/build-decorators';
+import {
+  compare,
+  Operation,
+} from 'fast-json-patch';
+import { getClassForObject } from '../cache/builders/build-decorators';
+import { TypedObject } from '../cache/typed-object.model';
 import { DSpaceNotNullSerializer } from '../dspace-rest/dspace-not-null.serializer';
 import { ChangeAnalyzer } from './change-analyzer';
-import { TypedObject } from '../cache/typed-object.model';
 
 /**
  * A class to determine what differs between two
@@ -22,8 +24,8 @@ export class DefaultChangeAnalyzer<T extends TypedObject> implements ChangeAnaly
    *    The second object to compare
    */
   diff(object1: T, object2: T): Operation[] {
-    const serializer1 = new DSpaceNotNullSerializer(getClassForType(object1.type));
-    const serializer2 = new DSpaceNotNullSerializer(getClassForType(object2.type));
+    const serializer1 = new DSpaceNotNullSerializer(getClassForObject(object1));
+    const serializer2 = new DSpaceNotNullSerializer(getClassForObject(object2));
     return compare(serializer1.serialize(object1), serializer2.serialize(object2));
   }
 }

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -1,24 +1,33 @@
 /* eslint-disable max-classes-per-file */
-import { hasNoValue, hasValue, isNotEmpty } from '../../shared/empty.util';
-import { DSpaceSerializer } from '../dspace-rest/dspace.serializer';
-import { Serializer } from '../serializer';
-import { PageInfo } from '../shared/page-info.model';
-import { ObjectCacheService } from '../cache/object-cache.service';
-import { GenericConstructor } from '../shared/generic-constructor';
-import { PaginatedList, buildPaginatedList } from './paginated-list.model';
-import { getClassForType } from '../cache/builders/build-decorators';
-import { environment } from '../../../environments/environment';
-import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
-import { DSpaceObject } from '../shared/dspace-object.model';
 import { Injectable } from '@angular/core';
-import { ResponseParsingService } from './parsing.service';
-import { ParsedResponse } from '../cache/response.models';
-import { RestRequestMethod } from './rest-request-method';
-import { getUrlWithoutEmbedParams, getEmbedSizeParams } from '../index/index.selectors';
-import { URLCombiner } from '../url-combiner/url-combiner';
+import { environment } from '../../../environments/environment';
+import {
+  hasNoValue,
+  hasValue,
+  isNotEmpty,
+} from '../../shared/empty.util';
+import { getClassForObject } from '../cache/builders/build-decorators';
 import { CacheableObject } from '../cache/cacheable-object.model';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { ParsedResponse } from '../cache/response.models';
+import { DSpaceSerializer } from '../dspace-rest/dspace.serializer';
+import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
+import {
+  getEmbedSizeParams,
+  getUrlWithoutEmbedParams,
+} from '../index/index.selectors';
+import { Serializer } from '../serializer';
+import { DSpaceObject } from '../shared/dspace-object.model';
+import { GenericConstructor } from '../shared/generic-constructor';
+import { PageInfo } from '../shared/page-info.model';
+import { URLCombiner } from '../url-combiner/url-combiner';
+import {
+  buildPaginatedList,
+  PaginatedList,
+} from './paginated-list.model';
+import { ResponseParsingService } from './parsing.service';
+import { RestRequestMethod } from './rest-request-method';
 import { RestRequest } from './rest-request.model';
-
 
 /**
  * Return true if obj has a value for `_links.self`
@@ -210,15 +219,10 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
    */
   protected getConstructorFor<ObjectDomain>(obj: any): GenericConstructor<ObjectDomain> {
     if (hasValue(obj?.type)) {
-      const constructor = getClassForType(obj.type) as GenericConstructor<ObjectDomain>;
+      const constructor = getClassForObject(obj) as GenericConstructor<ObjectDomain>;
 
       if (hasValue(constructor)) {
         return constructor;
-      }
-
-      // Browses have a subtype, so to get the correct constructor it has to be retrieved based on 'browseType'
-      if (obj.type === 'browse') {
-        return getClassForType(obj.browseType) as GenericConstructor<ObjectDomain>;
       }
     }
 

--- a/src/app/core/data/endpoint-map-response-parsing.service.ts
+++ b/src/app/core/data/endpoint-map-response-parsing.service.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { hasValue } from '../../shared/empty.util';
+import { getClassForObject } from '../cache/builders/build-decorators';
+import { CacheableObject } from '../cache/cacheable-object.model';
+import { ParsedResponse } from '../cache/response.models';
+import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
+import { DSpaceObject } from '../shared/dspace-object.model';
+import { GenericConstructor } from '../shared/generic-constructor';
 
 import {
   DspaceRestResponseParsingService,
-  isCacheableObject
+  isCacheableObject,
 } from './dspace-rest-response-parsing.service';
-import { hasValue } from '../../shared/empty.util';
-import { getClassForType } from '../cache/builders/build-decorators';
-import { GenericConstructor } from '../shared/generic-constructor';
-import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
-import { ParsedResponse } from '../cache/response.models';
-import { DSpaceObject } from '../shared/dspace-object.model';
-import { environment } from '../../../environments/environment';
-import { CacheableObject } from '../cache/cacheable-object.model';
 import { RestRequest } from './rest-request.model';
 
 /**
@@ -42,7 +42,7 @@ export class EndpointMapResponseParsingService extends DspaceRestResponseParsing
         const type: string = processRequestDTO.type;
         let objConstructor;
         if (hasValue(type)) {
-          objConstructor = getClassForType(type);
+          objConstructor = getClassForObject(processRequestDTO);
         }
 
         if (isCacheableObject(processRequestDTO) && hasValue(objConstructor)) {
@@ -73,7 +73,7 @@ export class EndpointMapResponseParsingService extends DspaceRestResponseParsing
   protected deserialize<ObjectDomain>(obj): any {
     const type: string = obj.type;
     if (hasValue(type)) {
-      const objConstructor = getClassForType(type) as GenericConstructor<ObjectDomain>;
+      const objConstructor = getClassForObject(obj) as GenericConstructor<ObjectDomain>;
 
       if (hasValue(objConstructor)) {
         const serializer = new this.serializerConstructor(objConstructor);

--- a/src/app/core/data/endpoint-map-response-parsing.service.ts
+++ b/src/app/core/data/endpoint-map-response-parsing.service.ts
@@ -110,7 +110,7 @@ export class EndpointMapResponseParsingService extends DspaceRestResponseParsing
       return;
     }
 
-    if (hasValue(this.getConstructorFor<any>((co as any).type))) {
+    if (hasValue(this.getConstructorFor<any>(co as any))) {
       this.objectCache.add(co, hasValue(request.responseMsToLive) ? request.responseMsToLive : environment.cache.msToLive.default, request.uuid, alternativeURL);
     }
   }

--- a/src/app/core/data/request.effects.ts
+++ b/src/app/core/data/request.effects.ts
@@ -1,26 +1,42 @@
-import { Injectable, Injector } from '@angular/core';
+import {
+  Injectable,
+  Injector,
+} from '@angular/core';
 
-import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, filter, map, mergeMap, take } from 'rxjs/operators';
+import {
+  Actions,
+  createEffect,
+  ofType,
+} from '@ngrx/effects';
+import {
+  catchError,
+  filter,
+  map,
+  mergeMap,
+  take,
+} from 'rxjs/operators';
 
-import { hasValue, isNotEmpty } from '../../shared/empty.util';
+import {
+  hasValue,
+  isNotEmpty,
+} from '../../shared/empty.util';
 import { StoreActionTypes } from '../../store.actions';
-import { getClassForType } from '../cache/builders/build-decorators';
-import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
+import { getClassForObject } from '../cache/builders/build-decorators';
+import { ParsedResponse } from '../cache/response.models';
 import { DspaceRestService } from '../dspace-rest/dspace-rest.service';
 import { DSpaceSerializer } from '../dspace-rest/dspace.serializer';
+import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
+import { RequestEntry } from './request-entry.model';
+import { RequestError } from './request-error.model';
 import {
   RequestActionTypes,
   RequestErrorAction,
   RequestExecuteAction,
   RequestSuccessAction,
-  ResetResponseTimestampsAction
+  ResetResponseTimestampsAction,
 } from './request.actions';
 import { RequestService } from './request.service';
-import { ParsedResponse } from '../cache/response.models';
-import { RequestError } from './request-error.model';
 import { RestRequestWithResponseParser } from './rest-request-with-response-parser.model';
-import { RequestEntry } from './request-entry.model';
 
 @Injectable()
 export class RequestEffects {
@@ -37,7 +53,7 @@ export class RequestEffects {
     mergeMap((request: RestRequestWithResponseParser) => {
       let body = request.body;
       if (isNotEmpty(request.body) && !request.isMultipart) {
-        const serializer = new DSpaceSerializer(getClassForType(request.body.type));
+        const serializer = new DSpaceSerializer(getClassForObject(request.body));
         body = serializer.serialize(request.body);
       }
       return this.restApi.request(request.method, request.href, body, request.options, request.isMultipart).pipe(

--- a/src/app/core/dspace-rest/dspace-rest.service.spec.ts
+++ b/src/app/core/dspace-rest/dspace-rest.service.spec.ts
@@ -5,6 +5,8 @@ import { DEFAULT_CONTENT_TYPE, DspaceRestService } from './dspace-rest.service';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { HttpHeaders } from '@angular/common/http';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from '../../../environments/environment.test';
 
 describe('DspaceRestService', () => {
   let dspaceRestService: DspaceRestService;
@@ -19,7 +21,10 @@ describe('DspaceRestService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [DspaceRestService]
+      providers: [
+        DspaceRestService,
+        { provide: APP_CONFIG, useValue: environment },
+      ],
     });
 
     dspaceRestService = TestBed.inject(DspaceRestService);

--- a/src/app/core/dspace-rest/dspace-rest.service.ts
+++ b/src/app/core/dspace-rest/dspace-rest.service.ts
@@ -1,12 +1,13 @@
-import { Observable, throwError as observableThrowError } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
-import { Injectable } from '@angular/core';
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { Injectable, Inject } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 
-import { RawRestResponse } from './raw-rest-response.model';
+import { RawRestResponse, rawBootstrapToRawRestResponse } from './raw-rest-response.model';
 import { RestRequestMethod } from '../data/rest-request-method';
 import { hasNoValue, hasValue, isNotEmpty } from '../../shared/empty.util';
 import { DSpaceObject } from '../shared/dspace-object.model';
+import { APP_CONFIG, AppConfig } from '../../../config/app-config.interface';
 
 export const DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8';
 export interface HttpOptions {
@@ -25,8 +26,10 @@ export interface HttpOptions {
 @Injectable()
 export class DspaceRestService {
 
-  constructor(protected http: HttpClient) {
-
+  constructor(
+    protected http: HttpClient,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+  ) {
   }
 
   /**
@@ -105,7 +108,14 @@ export class DspaceRestService {
       requestOptions.headers = requestOptions.headers.set('Content-Type', DEFAULT_CONTENT_TYPE);
     }
 
-    return this.performRequest(method, url, requestOptions);
+    return this.retrieveResponseFromConfig(method, url).pipe(switchMap(response => {
+        if (hasValue(response)) {
+          return observableOf(response);
+        } else {
+          return this.performRequest(method, url, requestOptions);
+        }
+      })
+    );
   }
 
   performRequest(method: RestRequestMethod, url: string, requestOptions: HttpOptions): Observable<RawRestResponse> {
@@ -150,4 +160,20 @@ export class DspaceRestService {
     return form;
   }
 
+  /**
+   * Returns an observable which emits a RawRestResponse if the request has been prefetched and stored in the config.
+   * Emits null otherwise.
+   */
+  retrieveResponseFromConfig(method: RestRequestMethod, url: string): Observable<RawRestResponse> {
+    if (method !== RestRequestMethod.OPTIONS && method !== RestRequestMethod.GET) {
+      return observableOf(null);
+    }
+
+    const prefetchedResponses = this.appConfig?.prefetch?.bootstrap;
+    if (hasValue(prefetchedResponses?.[url])) {
+      return observableOf(rawBootstrapToRawRestResponse(prefetchedResponses[url]));
+    } else {
+      return observableOf(null);
+    }
+  }
 }

--- a/src/app/core/dspace-rest/dspace-rest.service.ts
+++ b/src/app/core/dspace-rest/dspace-rest.service.ts
@@ -104,6 +104,11 @@ export class DspaceRestService {
       // Because HttpHeaders is immutable, the set method returns a new object instead of updating the existing headers
       requestOptions.headers = requestOptions.headers.set('Content-Type', DEFAULT_CONTENT_TYPE);
     }
+
+    return this.performRequest(method, url, requestOptions);
+  }
+
+  performRequest(method: RestRequestMethod, url: string, requestOptions: HttpOptions): Observable<RawRestResponse> {
     return this.http.request(method, url, requestOptions).pipe(
       map((res) => ({
         payload: res.body,

--- a/src/app/core/dspace-rest/raw-rest-response.model.ts
+++ b/src/app/core/dspace-rest/raw-rest-response.model.ts
@@ -11,3 +11,24 @@ export interface RawRestResponse {
   statusCode: number;
   statusText: string;
 }
+
+export interface RawBootstrapResponse {
+  payload: {
+    [name: string]: any;
+    _embedded?: any;
+    _links?: any;
+    page?: any;
+  };
+  headers?: Record<string, string>;
+  statusCode: number;
+  statusText: string;
+}
+
+export function rawBootstrapToRawRestResponse(bootstrapResponse: RawBootstrapResponse): RawRestResponse {
+  return {
+    payload: bootstrapResponse.payload,
+    headers: new HttpHeaders(bootstrapResponse.headers),
+    statusCode: bootstrapResponse.statusCode,
+    statusText: bootstrapResponse.statusText,
+  };
+}

--- a/src/app/core/forward-client-ip/forward-client-ip.interceptor.spec.ts
+++ b/src/app/core/forward-client-ip/forward-client-ip.interceptor.spec.ts
@@ -4,6 +4,8 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from 'src/environments/environment.test';
 
 describe('ForwardClientIpInterceptor', () => {
   let service: DspaceRestService;
@@ -25,7 +27,8 @@ describe('ForwardClientIpInterceptor', () => {
           useClass: ForwardClientIpInterceptor,
           multi: true,
         },
-        { provide: REQUEST, useValue: { get: () => undefined, connection: { remoteAddress: clientIp } } }
+        { provide: REQUEST, useValue: { get: () => undefined, connection: { remoteAddress: clientIp } } },
+        { provide: APP_CONFIG, useValue: environment },
       ],
     });
 

--- a/src/app/core/locale/locale.interceptor.spec.ts
+++ b/src/app/core/locale/locale.interceptor.spec.ts
@@ -7,6 +7,8 @@ import { RestRequestMethod } from '../data/rest-request-method';
 import { LocaleService } from './locale.service';
 import { LocaleInterceptor } from './locale.interceptor';
 import { of } from 'rxjs';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from '../../../environments/environment.test';
 
 describe(`LocaleInterceptor`, () => {
   let service: DspaceRestService;
@@ -31,6 +33,7 @@ describe(`LocaleInterceptor`, () => {
           multi: true,
         },
         { provide: LocaleService, useValue: mockLocaleService },
+        { provide: APP_CONFIG, useValue: environment },
       ],
     });
 

--- a/src/app/core/log/log.interceptor.spec.ts
+++ b/src/app/core/log/log.interceptor.spec.ts
@@ -13,6 +13,8 @@ import { CorrelationIdService } from '../../correlation-id/correlation-id.servic
 import { UUIDService } from '../shared/uuid.service';
 import { StoreModule } from '@ngrx/store';
 import { appReducers, storeModuleConfig } from '../../app.reducer';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from '../../../environments/environment.test';
 
 
 describe('LogInterceptor', () => {
@@ -49,6 +51,7 @@ describe('LogInterceptor', () => {
         { provide: Router, useValue: router },
         { provide: CorrelationIdService, useClass: CorrelationIdService },
         { provide: UUIDService, useClass: UUIDService },
+        { provide: APP_CONFIG, useValue: environment },
       ],
     });
 

--- a/src/app/core/provide-core.ts
+++ b/src/app/core/provide-core.ts
@@ -19,6 +19,7 @@ import {
 import { AccessStatusObject } from '../shared/object-collection/shared/badges/access-status-badge/access-status.model';
 import { IdentifierData } from '../shared/object-list/identifier-data/identifier-data.model';
 import { Subscription } from '../shared/subscriptions/models/subscription.model';
+import { StatisticsEndpoint } from '../statistics/statistics-endpoint.model';
 import { SubmissionCoarNotifyConfig } from '../submission/sections/section-coar-notify/submission-coar-notify.config';
 import { SystemWideAlert } from '../system-wide-alert/system-wide-alert.model';
 import { AuthStatus } from './auth/models/auth-status.model';
@@ -192,4 +193,5 @@ export const models =
     SubmissionCoarNotifyConfig,
     NotifyRequestsStatus,
     SystemWideAlert,
+    StatisticsEndpoint,
   ];

--- a/src/app/core/shared/browse-definition.model.ts
+++ b/src/app/core/shared/browse-definition.model.ts
@@ -1,10 +1,17 @@
 import { autoserialize } from 'cerialize';
 import { CacheableObject } from '../cache/cacheable-object.model';
+import { excludeFromEquals } from '../utilities/equals.decorators';
+import { BROWSE_DEFINITION } from './browse-definition.resource-type';
 
 /**
  * Base class for BrowseDefinition models
  */
 export abstract class BrowseDefinition extends CacheableObject {
+  static type = BROWSE_DEFINITION;
+
+  @excludeFromEquals
+  type = BROWSE_DEFINITION;
+
 
   @autoserialize
   id: string;

--- a/src/app/core/shared/flat-browse-definition.model.ts
+++ b/src/app/core/shared/flat-browse-definition.model.ts
@@ -1,5 +1,5 @@
 import { inheritSerialization, deserialize } from 'cerialize';
-import { typedObject } from '../cache/builders/build-decorators';
+import { typedObjectWithSubType } from '../cache/builders/build-decorators';
 import { excludeFromEquals } from '../utilities/equals.decorators';
 import { FLAT_BROWSE_DEFINITION } from './flat-browse-definition.resource-type';
 import { ResourceType } from './resource-type';
@@ -9,16 +9,16 @@ import { HALLink } from './hal-link.model';
 /**
  * BrowseDefinition model for browses of type 'flatBrowse'
  */
-@typedObject
+@typedObjectWithSubType('browseType')
 @inheritSerialization(NonHierarchicalBrowseDefinition)
 export class FlatBrowseDefinition extends NonHierarchicalBrowseDefinition {
-  static type = FLAT_BROWSE_DEFINITION;
+  static browseType = FLAT_BROWSE_DEFINITION;
 
   /**
    * The object type
    */
   @excludeFromEquals
-  type: ResourceType = FLAT_BROWSE_DEFINITION;
+  browseType: ResourceType = FLAT_BROWSE_DEFINITION;
 
   get self(): string {
     return this._links.self.href;

--- a/src/app/core/shared/hierarchical-browse-definition.model.ts
+++ b/src/app/core/shared/hierarchical-browse-definition.model.ts
@@ -1,5 +1,8 @@
 import { autoserialize, autoserializeAs, deserialize, inheritSerialization } from 'cerialize';
-import { typedObject } from '../cache/builders/build-decorators';
+import {
+  typedObject,
+  typedObjectWithSubType,
+} from '../cache/builders/build-decorators';
 import { excludeFromEquals } from '../utilities/equals.decorators';
 import { HIERARCHICAL_BROWSE_DEFINITION } from './hierarchical-browse-definition.resource-type';
 import { HALLink } from './hal-link.model';
@@ -9,16 +12,16 @@ import { BrowseDefinition } from './browse-definition.model';
 /**
  * BrowseDefinition model for browses of type 'hierarchicalBrowse'
  */
-@typedObject
+@typedObjectWithSubType('browseType')
 @inheritSerialization(BrowseDefinition)
 export class HierarchicalBrowseDefinition extends BrowseDefinition {
-  static type = HIERARCHICAL_BROWSE_DEFINITION;
+  static browseType = HIERARCHICAL_BROWSE_DEFINITION;
 
   /**
    * The object type
    */
   @excludeFromEquals
-  type: ResourceType = HIERARCHICAL_BROWSE_DEFINITION;
+  browseType: ResourceType = HIERARCHICAL_BROWSE_DEFINITION;
 
   @autoserialize
   facetType: string;

--- a/src/app/core/shared/value-list-browse-definition.model.ts
+++ b/src/app/core/shared/value-list-browse-definition.model.ts
@@ -1,5 +1,5 @@
 import { inheritSerialization, deserialize } from 'cerialize';
-import { typedObject } from '../cache/builders/build-decorators';
+import { typedObjectWithSubType } from '../cache/builders/build-decorators';
 import { excludeFromEquals } from '../utilities/equals.decorators';
 import { VALUE_LIST_BROWSE_DEFINITION } from './value-list-browse-definition.resource-type';
 import { ResourceType } from './resource-type';
@@ -9,16 +9,16 @@ import { HALLink } from './hal-link.model';
 /**
  * BrowseDefinition model for browses of type 'valueList'
  */
-@typedObject
+@typedObjectWithSubType('browseType')
 @inheritSerialization(NonHierarchicalBrowseDefinition)
 export class ValueListBrowseDefinition extends NonHierarchicalBrowseDefinition {
-  static type = VALUE_LIST_BROWSE_DEFINITION;
+  static browseType = VALUE_LIST_BROWSE_DEFINITION;
 
   /**
    * The object type
    */
   @excludeFromEquals
-  type: ResourceType = VALUE_LIST_BROWSE_DEFINITION;
+  browseType: ResourceType = VALUE_LIST_BROWSE_DEFINITION;
 
   get self(): string {
     return this._links.self.href;

--- a/src/app/core/xsrf/xsrf.interceptor.spec.ts
+++ b/src/app/core/xsrf/xsrf.interceptor.spec.ts
@@ -7,6 +7,8 @@ import { CookieService } from '../services/cookie.service';
 import { CookieServiceMock } from '../../shared/mocks/cookie.service.mock';
 import { XsrfInterceptor } from './xsrf.interceptor';
 import { HttpXsrfTokenExtractorMock } from '../../shared/mocks/http-xsrf-token-extractor.mock';
+import { APP_CONFIG } from '../../../config/app-config.interface';
+import { environment } from 'src/environments/environment.test';
 
 describe(`XsrfInterceptor`, () => {
   let service: DspaceRestService;
@@ -35,7 +37,8 @@ describe(`XsrfInterceptor`, () => {
           multi: true,
         },
         { provide: HttpXsrfTokenExtractor, useValue: new HttpXsrfTokenExtractorMock(testToken) },
-        { provide: CookieService, useValue: new CookieServiceMock() }
+        { provide: CookieService, useValue: new CookieServiceMock() },
+        { provide: APP_CONFIG, useValue: environment },
       ],
     });
 

--- a/src/app/init.service.spec.ts
+++ b/src/app/init.service.spec.ts
@@ -31,6 +31,8 @@ import objectContaining = jasmine.objectContaining;
 import createSpyObj = jasmine.createSpyObj;
 import SpyObj = jasmine.SpyObj;
 import { getTestScheduler } from 'jasmine-marbles';
+import { HrefOnlyDataService } from './core/data/href-only-data.service';
+import { getMockHrefOnlyDataService } from './shared/mocks/href-only-data.service.mock';
 
 let spy: SpyObj<any>;
 
@@ -180,6 +182,7 @@ describe('InitService', () => {
           { provide: ActivatedRoute, useValue: new MockActivatedRoute() },
           { provide: MenuService, useValue: menuServiceSpy },
           { provide: ThemeService, useValue: getMockThemeService() },
+          { provide: HrefOnlyDataService, useValue: getMockHrefOnlyDataService() },
           provideMockStore({ initialState }),
           AppComponent,
           RouteService,

--- a/src/app/init.service.ts
+++ b/src/app/init.service.ts
@@ -21,9 +21,11 @@ import { MetadataService } from './core/metadata/metadata.service';
 import { BreadcrumbsService } from './breadcrumbs/breadcrumbs.service';
 import { ThemeService } from './shared/theme-support/theme.service';
 import { isAuthenticationBlocking } from './core/auth/selectors';
-import { distinctUntilChanged, find } from 'rxjs/operators';
+import { distinctUntilChanged, find, take } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { MenuService } from './shared/menu/menu.service';
+import { hasValue } from './shared/empty.util';
+import { HrefOnlyDataService } from './core/data/href-only-data.service';
 
 /**
  * Performs the initialization of the app.
@@ -53,7 +55,7 @@ export abstract class InitService {
     protected breadcrumbsService: BreadcrumbsService,
     protected themeService: ThemeService,
     protected menuService: MenuService,
-
+    protected hrefOnlyDataService: HrefOnlyDataService,
   ) {
   }
 
@@ -200,5 +202,16 @@ export abstract class InitService {
       distinctUntilChanged(),
       find((b: boolean) => b === false)
     );
+  }
+
+  /**
+   * Use the bootstrapped requests to prefill the cache
+   */
+  protected initBootstrapEndpoints() {
+    if (hasValue(this.appConfig?.prefetch?.bootstrap)) {
+      for (let url of Object.getOwnPropertyNames(this.appConfig.prefetch.bootstrap)) {
+        this.hrefOnlyDataService.findByHref(url, false).pipe(take(1)).subscribe();
+      }
+    }
   }
 }

--- a/src/app/shared/mocks/dspace-rest/endpoint-mocking-rest.service.spec.ts
+++ b/src/app/shared/mocks/dspace-rest/endpoint-mocking-rest.service.spec.ts
@@ -3,6 +3,7 @@ import { of as observableOf } from 'rxjs';
 import { RestRequestMethod } from '../../../core/data/rest-request-method';
 import { EndpointMockingRestService } from './endpoint-mocking-rest.service';
 import { ResponseMapMock } from './mocks/response-map.mock';
+import { environment } from '../../../../environments/environment.test';
 
 describe('EndpointMockingRestService', () => {
   let service: EndpointMockingRestService;
@@ -27,7 +28,7 @@ describe('EndpointMockingRestService', () => {
       request: observableOf(serverHttpResponse)
     });
 
-    service = new EndpointMockingRestService(mockResponseMap, httpStub);
+    service = new EndpointMockingRestService(mockResponseMap, httpStub, environment);
   });
 
   describe('get', () => {

--- a/src/app/shared/mocks/dspace-rest/endpoint-mocking-rest.service.ts
+++ b/src/app/shared/mocks/dspace-rest/endpoint-mocking-rest.service.ts
@@ -8,6 +8,7 @@ import { RawRestResponse } from '../../../core/dspace-rest/raw-rest-response.mod
 import { DspaceRestService, HttpOptions } from '../../../core/dspace-rest/dspace-rest.service';
 import { MOCK_RESPONSE_MAP, ResponseMapMock } from './mocks/response-map.mock';
 import { environment } from '../../../../environments/environment';
+import { APP_CONFIG, AppConfig } from '../../../../config/app-config.interface';
 
 /**
  * Service to access DSpace's REST API.
@@ -21,9 +22,10 @@ export class EndpointMockingRestService extends DspaceRestService {
 
   constructor(
     @Inject(MOCK_RESPONSE_MAP) protected mockResponseMap: ResponseMapMock,
-    protected http: HttpClient
+    protected http: HttpClient,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) {
-    super(http);
+    super(http, appConfig);
   }
 
   /**

--- a/src/app/shared/theme-support/theme.service.spec.ts
+++ b/src/app/shared/theme-support/theme.service.spec.ts
@@ -1,6 +1,7 @@
 import { of as observableOf } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
+import { HashedFileMapping } from '../../../modules/dynamic-hash/hashed-file-mapping';
 import { LinkService } from '../../core/cache/builders/link.service';
 import { hot } from 'jasmine-marbles';
 import { SetThemeAction } from './theme.actions';
@@ -45,6 +46,10 @@ class MockLinkService {
     }
   }
 }
+
+const mockHashedFileMapping = {
+  resolve: (path: string) => path,
+};
 
 describe('ThemeService', () => {
   let themeService: ThemeService;
@@ -96,6 +101,10 @@ describe('ThemeService', () => {
         provideMockActions(() => mockActions),
         { provide: DSpaceObjectDataService, useValue: mockDsoService },
         { provide: Router, useValue: new RouterMock() },
+        {
+          provide: HashedFileMapping,
+          useValue: mockHashedFileMapping,
+        },
       ]
     });
 
@@ -393,6 +402,10 @@ describe('ThemeService', () => {
           provideMockStore({ initialState }),
           { provide: DSpaceObjectDataService, useValue: mockDsoService },
           { provide: Router, useValue: new RouterMock() },
+          {
+            provide: HashedFileMapping,
+            useValue: mockHashedFileMapping,
+          },
         ]
       });
 

--- a/src/app/shared/theme-support/theme.service.ts
+++ b/src/app/shared/theme-support/theme.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Injector } from '@angular/core';
 import { Store, createFeatureSelector, createSelector, select } from '@ngrx/store';
 import { BehaviorSubject, EMPTY, Observable, of as observableOf } from 'rxjs';
+import { HashedFileMapping } from '../../../modules/dynamic-hash/hashed-file-mapping';
 import { ThemeState } from './theme.reducer';
 import { SetThemeAction, ThemeActionTypes } from './theme.actions';
 import { expand, filter, map, switchMap, take, toArray } from 'rxjs/operators';
@@ -57,6 +58,7 @@ export class ThemeService {
     @Inject(GET_THEME_CONFIG_FOR_FACTORY) private gtcf: (str) => ThemeConfig,
     private router: Router,
     @Inject(DOCUMENT) private document: any,
+    private hashedFileMapping: HashedFileMapping,
   ) {
     // Create objects from the theme configs in the environment file
     this.themes = environment.themes.map((themeConfig: ThemeConfig) => themeFactory(themeConfig, injector));
@@ -182,7 +184,10 @@ export class ThemeService {
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
     link.setAttribute('class', 'theme-css');
-    link.setAttribute('href', `${encodeURIComponent(themeName)}-theme.css`);
+    link.setAttribute(
+      'href',
+      this.hashedFileMapping.resolve(`${encodeURIComponent(themeName)}-theme.css`),
+    );
     // wait for the new css to download before removing the old one to prevent a
     // flash of unstyled content
     link.onload = () => {

--- a/src/app/statistics/statistics.module.ts
+++ b/src/app/statistics/statistics.module.ts
@@ -3,14 +3,6 @@ import { CommonModule } from '@angular/common';
 import { CoreModule } from '../core/core.module';
 import { SharedModule } from '../shared/shared.module';
 import { ViewTrackerComponent } from './angulartics/dspace/view-tracker.component';
-import { StatisticsEndpoint } from './statistics-endpoint.model';
-
-/**
- * Declaration needed to make sure all decorator functions are called in time
- */
-export const models = [
-  StatisticsEndpoint
-];
 
 @NgModule({
   imports: [

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -22,6 +22,7 @@ import { HomeConfig } from './homepage-config.interface';
 import { MarkdownConfig } from './markdown-config.interface';
 import { FilterVocabularyConfig } from './filter-vocabulary-config';
 import { DiscoverySortConfig } from './discovery-sort.config';
+import { PrefetchConfig } from './prefetch-config';
 
 interface AppConfig extends Config {
   ui: UIServerConfig;
@@ -48,6 +49,7 @@ interface AppConfig extends Config {
   markdown: MarkdownConfig;
   vocabularies: FilterVocabularyConfig[];
   comcolSelectionSort: DiscoverySortConfig;
+  prefetch: PrefetchConfig;
 }
 
 /**

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -265,10 +265,10 @@ export const buildAppConfig = (destConfigPath?: string, mapping?: ServerHashedFi
   return appConfig;
 };
 
-export const setupEndpointPrefetching = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<void> => {
+export const setupEndpointPrefetching = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<NodeJS.Timeout> => {
   await prefetchResponses(appConfig, destConfigPath, env, hfm);
 
-  setInterval(() => void prefetchResponses(appConfig, destConfigPath, env, hfm), appConfig.prefetch.refreshInterval);
+  return setInterval(() => void prefetchResponses(appConfig, destConfigPath, env, hfm), appConfig.prefetch.refreshInterval);
 };
 
 export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<void> => {

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -2,6 +2,7 @@ import { red, blue, green, bold } from 'colors';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { join } from 'path';
+import { ServerHashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping.server';
 
 import { AppConfig } from './app-config.interface';
 import { Config } from './config.interface';
@@ -159,6 +160,7 @@ const buildBaseUrl = (config: ServerConfig): void => {
   ].join('');
 };
 
+
 /**
  * Build app config with the following chain of override.
  *
@@ -169,7 +171,7 @@ const buildBaseUrl = (config: ServerConfig): void => {
  * @param destConfigPath optional path to save config file
  * @returns app config
  */
-export const buildAppConfig = (destConfigPath?: string): AppConfig => {
+export const buildAppConfig = (destConfigPath?: string, mapping?: ServerHashedFileMapping): AppConfig => {
   // start with default app config
   const appConfig: AppConfig = new DefaultAppConfig();
 
@@ -236,7 +238,12 @@ export const buildAppConfig = (destConfigPath?: string): AppConfig => {
   buildBaseUrl(appConfig.rest);
 
   if (isNotEmpty(destConfigPath)) {
-    writeFileSync(destConfigPath, JSON.stringify(appConfig, null, 2));
+    const content = JSON.stringify(appConfig, null, 2);
+
+    writeFileSync(destConfigPath, content);
+    if (mapping !== undefined) {
+      mapping.add(destConfigPath, content);
+    }
 
     console.log(`Angular ${bold('config.json')} file generated correctly at ${bold(destConfigPath)} \n`);
   }

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -259,7 +259,7 @@ export const setupEndpointPrefetching = async (appConfig: AppConfig, destConfigP
 };
 
 export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<void> => {
-  console.info('Prefetching endpoint maps');
+  console.info('Prefetching REST responses');
   const restConfig = appConfig.rest;
   const prefetchConfig = appConfig.prefetch;
 

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -252,13 +252,13 @@ export const buildAppConfig = (destConfigPath?: string, mapping?: ServerHashedFi
   return appConfig;
 };
 
-export const setupEndpointPrefetching = async (appConfig: AppConfig, destConfigPath: string, env: any): Promise<void> => {
-  await prefetchResponses(appConfig, destConfigPath, env);
+export const setupEndpointPrefetching = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<void> => {
+  await prefetchResponses(appConfig, destConfigPath, env, hfm);
 
-  setInterval(() => void prefetchResponses(appConfig, destConfigPath, env), appConfig.prefetch.refreshInterval);
+  setInterval(() => void prefetchResponses(appConfig, destConfigPath, env, hfm), appConfig.prefetch.refreshInterval);
 };
 
-export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: string, env: any): Promise<void> => {
+export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: string, env: any, hfm: ServerHashedFileMapping): Promise<void> => {
   console.info('Prefetching endpoint maps');
   const restConfig = appConfig.rest;
   const prefetchConfig = appConfig.prefetch;
@@ -288,6 +288,8 @@ export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: st
 
   prefetchConfig.bootstrap = mapping;
 
+  const content = JSON.stringify(appConfig, null, 2);
   extendEnvironmentWithAppConfig(env, appConfig, false);
-  writeFileSync(destConfigPath, JSON.stringify(appConfig, null, 2));
+  hfm.add(destConfigPath, content, true);
+  hfm.save();
 };

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -243,7 +243,7 @@ export const buildAppConfig = (destConfigPath?: string, mapping?: ServerHashedFi
 
     writeFileSync(destConfigPath, content);
     if (mapping !== undefined) {
-      mapping.add(destConfigPath, content);
+      mapping.add(destConfigPath, content, true);
     }
 
     console.log(`Angular ${bold('config.json')} file generated correctly at ${bold(destConfigPath)} \n`);

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -269,7 +269,13 @@ export const prefetchResponses = async (appConfig: AppConfig, destConfigPath: st
   for (const relativeUrl of prefetchConfig.urls) {
     const url = baseUrl + relativeUrl;
 
-    const response = await fetch(url);
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (e) {
+      console.warn(`Failed to prefetch REST response for url "${url}". Aborting prefetching. Is the REST server offline?`);
+      return;
+    }
 
     const headers: Record<string, string> = {};
     response.headers.forEach((value, header) => {

--- a/src/config/config.util.ts
+++ b/src/config/config.util.ts
@@ -10,12 +10,15 @@ import { ThemeConfig } from './theme.model';
 /**
  * Extend Angular environment with app config.
  *
- * @param env       environment object
- * @param appConfig app config
+ * @param env          environment object
+ * @param appConfig    app config
+ * @param logToConsole whether to log a message in the console
  */
-const extendEnvironmentWithAppConfig = (env: any, appConfig: AppConfig): void => {
+const extendEnvironmentWithAppConfig = (env: any, appConfig: AppConfig, logToConsole = true): void => {
   mergeConfig(env, appConfig);
-  console.log(`Environment extended with app config`);
+  if (logToConsole) {
+    console.log(`Environment extended with app config`);
+  }
 };
 
 /**

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -22,6 +22,7 @@ import { HomeConfig } from './homepage-config.interface';
 import { MarkdownConfig } from './markdown-config.interface';
 import { FilterVocabularyConfig } from './filter-vocabulary-config';
 import { DiscoverySortConfig } from './discovery-sort.config';
+import { PrefetchConfig } from './prefetch-config';
 
 export class DefaultAppConfig implements AppConfig {
   production = false;
@@ -431,5 +432,12 @@ export class DefaultAppConfig implements AppConfig {
   comcolSelectionSort: DiscoverySortConfig = {
     sortField:'dc.title',
     sortDirection:'ASC',
+  };
+
+  // EndpointMap prefetching configuration
+  prefetch: PrefetchConfig = {
+    urls: [],
+    bootstrap: {},
+    refreshInterval: 60000, // refresh every minute
   };
 }

--- a/src/config/prefetch-config.ts
+++ b/src/config/prefetch-config.ts
@@ -1,0 +1,18 @@
+import { Config } from './config.interface';
+import { RawBootstrapResponse } from '../app/core/dspace-rest/raw-rest-response.model';
+
+export interface PrefetchConfig extends Config {
+  /**
+   * The URLs that should be pre-fetched
+   */
+  urls: string[];
+  /**
+   * A mapping of URL to response
+   * bootstrap values should not be set manually, they will be overwritten.
+   */
+  bootstrap: Record<string, RawBootstrapResponse>;
+  /**
+   * How often the HAL endpoints should be refreshed
+   */
+  refreshInterval: number;
+}

--- a/src/config/prefetch-config.ts
+++ b/src/config/prefetch-config.ts
@@ -12,7 +12,7 @@ export interface PrefetchConfig extends Config {
    */
   bootstrap: Record<string, RawBootstrapResponse>;
   /**
-   * How often the HAL endpoints should be refreshed
+   * How often the responses should be refreshed in milliseconds
    */
   refreshInterval: number;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -313,5 +313,11 @@ export const environment: BuildConfig = {
       vocabulary: 'srsc',
       enabled: true
     }
-  ]
+  ],
+
+  prefetch: {
+    urls: [],
+    bootstrap: {},
+    refreshInterval: 60000,
+  }
 };

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -3,14 +3,15 @@ import 'reflect-metadata';
 import 'core-js/es/reflect';
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { BrowserAppModule } from './modules/app/browser-app.module';
 
 import { environment } from './environments/environment';
 import { AppConfig } from './config/app-config.interface';
 import { extendEnvironmentWithAppConfig } from './config/config.util';
 import { enableProdMode } from '@angular/core';
+import { BrowserHashedFileMapping } from './modules/dynamic-hash/hashed-file-mapping.browser';
 
+const hashedFileMapping = new BrowserHashedFileMapping();
 const bootstrap = () => platformBrowserDynamic()
   .bootstrapModule(BrowserAppModule, {});
 
@@ -32,7 +33,7 @@ const main = () => {
     return bootstrap();
   } else {
     // Configuration must be fetched explicitly
-    return fetch('assets/config.json')
+    return fetch(hashedFileMapping.resolve('assets/config.json'))
       .then((response) => response.json())
       .then((appConfig: AppConfig) => {
         // extend environment with app config for browser when not prerendered

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -11,7 +11,7 @@ import { extendEnvironmentWithAppConfig } from './config/config.util';
 import { enableProdMode } from '@angular/core';
 import { BrowserHashedFileMapping } from './modules/dynamic-hash/hashed-file-mapping.browser';
 
-const hashedFileMapping = new BrowserHashedFileMapping();
+const hashedFileMapping = new BrowserHashedFileMapping(document);
 const bootstrap = () => platformBrowserDynamic()
   .bootstrapModule(BrowserAppModule, {});
 

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -104,7 +104,12 @@ export class BrowserInitService extends InitService {
 
       this.initKlaro();
 
-      this.initBootstrapEndpoints();
+      this.initBootstrapEndpoints$().subscribe(_ => {
+        if (hasValue(this.appConfig?.prefetch?.bootstrap)) {
+          // Clear bootstrap once finished so the dspace-rest.service does not keep using the bootstrapped responses
+          this.appConfig.prefetch.bootstrap = undefined;
+        }
+      });
 
       await this.authenticationReady$().toPromise();
 
@@ -175,18 +180,6 @@ export class BrowserInitService extends InitService {
     firstValueFrom(this.authenticationReady$()).then(() => {
         this.sub.unsubscribe();
       });
-  }
-
-  /**
-   * Use the bootstrapped requests from the server to prefill the cache on the client
-   */
-  override initBootstrapEndpoints() {
-    super.initBootstrapEndpoints();
-
-    if (hasValue(this.appConfig?.prefetch?.bootstrap)) {
-      // Clear bootstrap once finished so the dspace-rest.service does not keep using the bootstrap
-      this.appConfig.prefetch.bootstrap = undefined;
-    }
   }
 
 }

--- a/src/modules/app/server-init.service.ts
+++ b/src/modules/app/server-init.service.ts
@@ -21,6 +21,7 @@ import { BreadcrumbsService } from '../../app/breadcrumbs/breadcrumbs.service';
 import { ThemeService } from '../../app/shared/theme-support/theme.service';
 import { take } from 'rxjs/operators';
 import { MenuService } from '../../app/shared/menu/menu.service';
+import { HrefOnlyDataService } from '../../app/core/data/href-only-data.service';
 
 /**
  * Performs server-side initialization.
@@ -38,7 +39,8 @@ export class ServerInitService extends InitService {
     protected metadata: MetadataService,
     protected breadcrumbsService: BreadcrumbsService,
     protected themeService: ThemeService,
-    protected menuService: MenuService
+    protected menuService: MenuService,
+    protected hrefOnlyDataService: HrefOnlyDataService,
   ) {
     super(
       store,
@@ -51,6 +53,7 @@ export class ServerInitService extends InitService {
       breadcrumbsService,
       themeService,
       menuService,
+      hrefOnlyDataService,
     );
   }
 
@@ -66,6 +69,8 @@ export class ServerInitService extends InitService {
       this.initAngulartics();
       this.initRouteListeners();
       this.themeService.listenForThemeChanges(false);
+
+      this.initBootstrapEndpoints();
 
       await this.authenticationReady$().toPromise();
 

--- a/src/modules/app/server-init.service.ts
+++ b/src/modules/app/server-init.service.ts
@@ -70,7 +70,7 @@ export class ServerInitService extends InitService {
       this.initRouteListeners();
       this.themeService.listenForThemeChanges(false);
 
-      this.initBootstrapEndpoints();
+      this.initBootstrapEndpoints$().subscribe();
 
       await this.authenticationReady$().toPromise();
 

--- a/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
@@ -5,7 +5,12 @@
  *
  * http://www.dspace.org/license/
  */
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import {
+  Inject,
+  Injectable,
+  Optional,
+} from '@angular/core';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import { hasValue } from '../../app/shared/empty.util';
@@ -21,9 +26,11 @@ import {
  */
 @Injectable()
 export class BrowserHashedFileMapping extends HashedFileMapping {
-  constructor() {
+  constructor(
+    @Optional() @Inject(DOCUMENT) protected document: any,
+  ) {
     super();
-    const element = document.querySelector(`script#${ID}`);
+    const element = document?.querySelector(`script#${ID}`);
 
     if (hasValue(element?.textContent)) {
       const mapping = JSON.parse(element.textContent);

--- a/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
@@ -1,0 +1,38 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import { Injectable } from '@angular/core';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
+import { hasValue } from '../../app/shared/empty.util';
+import {
+  HashedFileMapping,
+  ID,
+} from './hashed-file-mapping';
+
+/**
+ * Client-side implementation of {@link HashedFileMapping}.
+ * Reads out the mapping from index.html before the app is bootstrapped.
+ * Afterwards, {@link resolve} can be used to grab the latest file.
+ */
+@Injectable()
+export class BrowserHashedFileMapping extends HashedFileMapping {
+  constructor() {
+    super();
+    const element = document.querySelector(`script#${ID}`);
+
+    if (hasValue(element?.textContent)) {
+      const mapping = JSON.parse(element.textContent);
+
+      if (isObject(mapping)) {
+        Object.entries(mapping)
+              .filter(([key, value]) => isString(key) && isString(value))
+              .forEach(([plainPath, hashPath]) => this.map.set(plainPath, hashPath));
+      }
+    }
+  }
+}

--- a/src/modules/dynamic-hash/hashed-file-mapping.server.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.server.ts
@@ -1,0 +1,115 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import crypto from 'crypto';
+import {
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import glob from 'glob';
+import { parse } from 'node-html-parser';
+import {
+  extname,
+  join,
+  relative,
+} from 'path';
+import zlib from 'zlib';
+import {
+  HashedFileMapping,
+  ID,
+} from './hashed-file-mapping';
+
+/**
+ * Server-side implementation of {@link HashedFileMapping}.
+ * Registers dynamically hashed files and stores them in index.html for the browser to use.
+ */
+export class ServerHashedFileMapping extends HashedFileMapping {
+  public readonly indexPath: string;
+  private readonly indexContent: string;
+
+  constructor(
+    private readonly root: string,
+    file: string,
+  ) {
+    super();
+    this.root = join(root, '');
+    this.indexPath = join(root, file);
+    this.indexContent = readFileSync(this.indexPath).toString();
+  }
+
+  /**
+   * Add a new file to the mapping by an absolute path (within the root directory).
+   * If {@link content} is provided, the {@link path} itself does not have to exist.
+   * Otherwise, it is read out from the original path.
+   * The original path is never overwritten.
+   */
+  add(path: string, content?: string, compress = false) {
+    if (content === undefined) {
+      readFileSync(path);
+    }
+
+    // remove previous files
+    const ext = extname(path);
+    glob.GlobSync(path.replace(`${ext}`, `.*${ext}*`))
+        .found
+        .forEach(p => rmSync(p));
+
+    // hash the content
+    const hash = crypto.createHash('md5')
+                       .update(content)
+                       .digest('hex');
+
+    // add the hash to the path
+    const hashPath = path.replace(`${ext}`, `.${hash}${ext}`);
+
+    // store it in the mapping
+    this.map.set(path, hashPath);
+
+    // write the file
+    writeFileSync(hashPath, content);
+
+    if (compress) {
+      // write the file as .br
+      zlib.brotliCompress(content, (err, compressed) => {
+        if (err) {
+          throw new Error('Brotli compress failed');
+        } else {
+          writeFileSync(hashPath + '.br', compressed);
+        }
+      });
+
+      // write the file as .gz
+      zlib.gzip(content, (err, compressed) => {
+        if (err) {
+          throw new Error('Gzip compress failed');
+        } else {
+          writeFileSync(hashPath + '.gz', compressed);
+        }
+      });
+    }
+  }
+
+  /**
+   * Save the mapping as JSON in the index file.
+   * The updated index file itself is hashed as well, and must be sent {@link resolve}.
+   */
+  save(): void {
+    const out = Array.from(this.map.entries())
+                     .reduce((object, [plain, hashed]) => {
+                       object[relative(this.root, plain)] = relative(this.root, hashed);
+                       return object;
+                     }, {});
+
+    let root = parse(this.indexContent);
+    root.querySelector(`head > script#${ID}`)?.remove();
+    root.querySelector('head')
+        .appendChild(`<script id="${ID}">${JSON.stringify(out)}</script>` as any);
+
+    this.add(this.indexPath, root.toString());
+  }
+}

--- a/src/modules/dynamic-hash/hashed-file-mapping.server.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.server.ts
@@ -106,9 +106,9 @@ export class ServerHashedFileMapping extends HashedFileMapping {
                      }, {});
 
     let root = parse(this.indexContent);
-    root.querySelector(`head > script#${ID}`)?.remove();
+    root.querySelector(`script#${ID}`)?.remove();
     root.querySelector('head')
-        .appendChild(`<script id="${ID}">${JSON.stringify(out)}</script>` as any);
+        .appendChild(`<script id="${ID}" type="application/json">${JSON.stringify(out)}</script>` as any);
 
     this.add(this.indexPath, root.toString());
   }

--- a/src/modules/dynamic-hash/hashed-file-mapping.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.ts
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+export const ID = 'hashed-file-mapping';
+
+/**
+ * A mapping of plain path to hashed path, used for cache-busting files that are created dynamically after DSpace has been built.
+ * The production server can register hashed files here and attach the map to index.html.
+ * The browser can then use it to resolve hashed files and circumvent the browser cache.
+ *
+ * This can ensure that e.g. configuration changes are consistently served to all CSR clients.
+ */
+export abstract class HashedFileMapping {
+  protected readonly map: Map<string, string> = new Map();
+
+  /**
+   * Resolve a hashed path based on a plain path.
+   */
+  resolve(plainPath: string): string {
+    if (this.map.has(plainPath)) {
+      const hashPath = this.map.get(plainPath);
+      return hashPath;
+    }
+    return plainPath;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,6 +4372,17 @@ css-select@^4.2.0, css-select@^4.3.0:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-vendor@^2.0.8:
   version "2.0.8"
   resolved "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz"
@@ -4380,7 +4391,7 @@ css-vendor@^2.0.8:
     "@babel/runtime" "^7.8.3"
     is-in-browser "^1.0.2"
 
-css-what@^6.0.1:
+css-what@^6.0.1, css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
@@ -6183,6 +6194,11 @@ hdr-histogram-percentiles-obj@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz"
   integrity sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -8276,6 +8292,14 @@ node-gyp@^9.0.0:
     semver "^7.3.5"
     tar "^6.1.2"
     which "^2.0.2"
+
+node-html-parser@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-7.0.1.tgz#e3056550bae48517ebf161a0b0638f4b0123dfe3"
+  integrity sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
 
 node-releases@^2.0.8:
   version "2.0.10"


### PR DESCRIPTION
## References
* Fixes #3961 
* Contains the changes from #3993 
* 8_x backport #4082 
* 7_x backport #4083 

## Description
Prefetch & store REST responses for configured endpoints/urls to reduce request chaining and associated overhead.

### How it works
On (Angular) server start, and periodically, a request is sent to every configured endpoint/url.
The responses & headers are stored in the config for later use.

During initialization of either the server or the browser a `findByHref` call is done for all configured endpoints.
The `DspaceRestService` will retrieve the responses from the config instead of making actual requests to the REST server during these calls.
By using the `findByHref` method the responses are then added to the cache.
On the browser side the stored responses are then cleared from the config so future requests are actually sent to the REST server.

### Gains
The biggest gains with these changes should be with CSR on slow connections.
The images below show that CSR initial load is almost halved.

(The 'pointless gap' mentioned on the image will be tackled with issue #4074)
![20250220-112824](https://github.com/user-attachments/assets/11312964-d7fc-4e3f-8200-ac6eb514819e)
![20250220-112801](https://github.com/user-attachments/assets/f186ce3d-8108-4811-9dd3-2c00112e1511)


## Instructions for Reviewers
In `config.prod.yml` (or a different configuration file used for your local prod environment) configure the following values:
```
prefetch:
  urls:
    - /api
    - /api/statistics
    - /api/discover
    - /api/discover/search
    - /api/config/properties/google.analytics.key
    - /api/config/properties/registration.verification.enabled
    - /api/config/properties/websvc.opensearch.enable
    - /api/config/properties/websvc.opensearch.svccontext
    - /api/discover/browses?size=9999
    - /api/core/sites
    # - {other frequently accessed REST urls you might want to add} 
  # refreshInterval: 60000 # Uncomment & change to refresh more/less often.
```

Then start the Angular server in prod mode and use DSpace as you normally would.

For the best effect, the configured urls should be endpoints that Angular will retrieve on every load or very often.

## Points of discussion
### Prefetch interval
At the moment, the default interval to refresh the stored responses is 60 seconds. Is this appropriate?

### Storage of bootstrapped responses
The bootstrapped responses at this moment are stored in the `config.json` file for simplicity. Should this be moved to a separate JSON file?

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
