### PR TITLE
Fix - Unpinned admin sidebar can remain expanded after cursor is moved out

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -158,12 +158,9 @@ export class AdminSidebarComponent extends MenuComponent implements OnInit {
     }
   }
 
-  public handleMouseLeave(event: any) {
-    if (!this.inFocus$.getValue()) {
-      this.collapsePreview(event);
-    } else {
-      event.preventDefault();
-    }
+  public handleMouseLeave(event: MouseEvent): void {
+    event.preventDefault();
+    this.collapsePreview(event);
   }
 
   /**

--- a/src/app/shared/menu/menu.component.ts
+++ b/src/app/shared/menu/menu.component.ts
@@ -223,7 +223,7 @@ export class MenuComponent implements OnInit, OnDestroy {
    * @param {Function} handler The function to delay
    * @param {number} ms The amount of ms to delay the handler function by
    */
-  private previewToggleDebounce(handler: () => void, ms: number): void {
+  protected previewToggleDebounce(handler: () => void, ms: number): void {
     if (hasValue(this.previewTimer)) {
       clearTimeout(this.previewTimer);
     }


### PR DESCRIPTION
Hi @tdonohue, I'am @jtimal  partner,  I like to share this PR with you. 

## References
* Fixes #3416

## Description
I have made a change to modify the current function in the side navigation admin component to collapse the navigation if the mouse leaves the component

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* I have changed the current function when the mouse is left on the navigation component on the administrator side and automatically collapse the menu without validating the focus settings
* 
To reproduce:

1. Log in for the admin sidebar to show up
2. Hover over the sidebar until it expands
3. Open at least one expandable menu section
4. Move the cursor out of the sidebar, but don't click anywhere so it doesn't lose focus

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
