### PR TITLE
Store the state of the computed filters

### DIFF
--- a/src/app/shared/search/search-filters/search-filters.component.html
+++ b/src/app/shared/search/search-filters/search-filters.component.html
@@ -1,13 +1,13 @@
 <h3>{{"search.filters.head" | translate}}</h3>
 <div *ngIf="(filters | async)?.hasSucceeded">
-    <div [class.visually-hidden]="filtersWithComputedVisibility !== (filters | async)?.payload?.length"
-         *ngFor="let filter of (filters | async)?.payload; trackBy: trackUpdate">
-        <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
-    </div>
+  <div [class.visually-hidden]="getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length"
+       *ngFor="let filter of (filters | async)?.payload">
+    <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
+  </div>
 </div>
 
 
-<ng-container *ngIf="filtersWithComputedVisibility !== (filters | async)?.payload?.length">
+<ng-container *ngIf="getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length">
   <ngx-skeleton-loader [count]="defaultFilterCount"/>
 </ng-container>
 <a class="btn btn-primary" [routerLink]="[searchLink]" [queryParams]="clearParams | async" queryParamsHandling="merge" role="button"><i class="fas fa-undo"></i> {{"search.filters.reset" | translate}}</a>

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { BehaviorSubject, Observable } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { map, filter } from 'rxjs/operators';
 
 import { SearchService } from '../../../core/shared/search/search.service';
 import { RemoteData } from '../../../core/data/remote-data';
@@ -62,9 +62,16 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   searchLink: string;
 
   /**
-   * Filters for which visibility has been computed
+   * Keeps track of the filters computed for each configuration during the current rendering cycle
+   * This array stores objects with configuration identifier and number of computed filters
    */
-  filtersWithComputedVisibility = 0;
+  private currentFiltersComputed = [];
+
+  /**
+   * Stores the final count of computed filters for each configuration
+   * Used to determine when all filters for a configuration have been processed
+   */
+  private finalFiltersComputed = [];
 
   subs = [];
   defaultFilterCount: number;
@@ -90,7 +97,6 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.router.events.subscribe(() => {
       this.clearParams = this.searchConfigService.getCurrentFrontendFilters().pipe(
-        tap(() => this.filtersWithComputedVisibility = 0),
         map((filters) => {
           Object.keys(filters).forEach((f) => filters[f] = null);
           return filters;
@@ -127,7 +133,122 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
 
   countFiltersWithComputedVisibility(computed: boolean) {
     if (computed) {
-      this.filtersWithComputedVisibility += 1;
+      this.filters.pipe(
+        // Get filter data and check if we need to increment the counter
+        map(filtersData => {
+          if (filtersData && filtersData.hasSucceeded && filtersData.payload) {
+            const totalFilters = filtersData.payload.length;
+            const currentComputed = this.getCurrentFiltersComputed(this.currentConfiguration);
+
+            // If we've already computed all filters for this configuration
+            if (currentComputed >= totalFilters) {
+              // Register in finalFiltersComputed if not already registered
+              if (!this.findConfigInFinalFilters(this.currentConfiguration)) {
+                this.updateFinalFiltersComputed(this.currentConfiguration, totalFilters);
+              }
+              return { shouldIncrement: false };
+            }
+
+            // We haven't reached the total yet, proceed with increment
+            return {
+              shouldIncrement: true,
+              totalFilters
+            };
+          }
+          return { shouldIncrement: false };
+        }),
+        // Only continue if we need to increment the counter
+        filter(result => result.shouldIncrement),
+        // Increment the counter for the current configuration
+        map(result => {
+          const filterConfig = this.findConfigInCurrentFilters(this.currentConfiguration);
+
+          if (filterConfig) {
+            // Update existing counter
+            filterConfig.filtersComputed += 1;
+          } else {
+            // Create new counter entry
+            this.currentFiltersComputed.push({
+              configuration: this.currentConfiguration,
+              filtersComputed: 1
+            });
+          }
+
+          // Pass along the total and updated count
+          return {
+            totalFilters: result.totalFilters,
+            currentComputed: this.getCurrentFiltersComputed(this.currentConfiguration)
+          };
+        }),
+        // Check if we've reached the total after incrementing
+        map(result => {
+          if (result.currentComputed === result.totalFilters) {
+            // If we've reached the total, update final filters count
+            this.updateFinalFiltersComputed(this.currentConfiguration, result.currentComputed);
+          }
+          return result;
+        })
+      ).subscribe().unsubscribe(); // Execute the pipeline and immediately unsubscribe
     }
+  }
+
+  /**
+   * Finds a configuration entry in the currentFiltersComputed array
+   * @param configuration The configuration identifier to search for
+   * @returns The filter configuration object if found, otherwise undefined
+   */
+  private findConfigInCurrentFilters(configuration: string) {
+    return this.currentFiltersComputed.find(
+      (configFilter) => configFilter.configuration === configuration
+    );
+  }
+
+  /**
+   * Finds a configuration entry in the finalFiltersComputed array
+   * @param configuration The configuration identifier to search for
+   * @returns The filter configuration object if found, otherwise undefined
+   */
+  private findConfigInFinalFilters(configuration: string) {
+    return this.finalFiltersComputed.find(
+      (configFilter) => configFilter.configuration === configuration
+    );
+  }
+
+  /**
+   * Updates or adds a new entry in the finalFiltersComputed array
+   * @param configuration The configuration identifier to update
+   * @param count The number of computed filters to set for this configuration
+   */
+  private updateFinalFiltersComputed(configuration: string, count: number) {
+    const filterConfig = this.findConfigInFinalFilters(configuration);
+
+    if (filterConfig) {
+      filterConfig.filtersComputed = count;
+    } else {
+      this.finalFiltersComputed.push({
+        configuration,
+        filtersComputed: count
+      });
+    }
+  }
+
+  /**
+   * Gets the current number of computed filters for a specific configuration
+   * @param configuration The configuration identifier to get the count for
+   * @returns The number of computed filters, or 0 if none found
+   */
+  private getCurrentFiltersComputed(configuration: string) {
+    const configFilter = this.findConfigInCurrentFilters(configuration);
+    return configFilter?.filtersComputed || 0;
+  }
+
+  /**
+   * Gets the final number of computed filters for a specific configuration
+   * @param configuration The configuration identifier to get the count for
+   * @returns The number of computed filters in the final state, or 0 if none found
+   */
+  getFinalFiltersComputed(configuration: string): number {
+    const configFilter = this.findConfigInFinalFilters(configuration);
+    return configFilter?.filtersComputed || 0;
   }
 }

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -95,15 +95,13 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.router.events.subscribe(() => {
-      this.clearParams = this.searchConfigService.getCurrentFrontendFilters().pipe(
-        map((filters) => {
-          Object.keys(filters).forEach((f) => filters[f] = null);
-          return filters;
-        })
-      );
-      this.searchLink = this.getSearchLink();
-    });
+    this.clearParams = this.searchConfigService.getCurrentFrontendFilters().pipe(
+      map((filters) => {
+        Object.keys(filters).forEach((f) => filters[f] = null);
+        return filters;
+      })
+    );
+    this.searchLink = this.getSearchLink();
   }
 
   /**

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { BehaviorSubject, Observable } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { map, filter, take } from 'rxjs/operators';
 
 import { SearchService } from '../../../core/shared/search/search.service';
 import { RemoteData } from '../../../core/data/remote-data';
@@ -188,7 +188,7 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
           }
           return result;
         })
-      ).subscribe().unsubscribe(); // Execute the pipeline and immediately unsubscribe
+      ).pipe(take(1)).subscribe(); // Execute the pipeline and immediately unsubscribe
     }
   }
 


### PR DESCRIPTION
## References
* Fixes #4097 

## Description
Store the state of the computed filters in the array finalFiltersComputed.

## Instructions for Reviewers
The counter filtersWithComputedVisibility doesn't store the count of filters computed when you change between options in the select box in /mydspace, causing the ngIf in the HTML is always false, and no filters options render on the web.

List of changes in this PR:
* First, countFiltersWithComputedVisibility now store the count every time a new filter is "computed" till it reach the maximum filters configured.
* Second, added some utility functions to find the current and final counter, and a function to update the count.
* Third, update the ngIf, to use the new functions.
* Fourth, removed the trackBy: trackUpdate in the ngFor because when you enter in /mydspace from the link in the dropdown it seems that it interferes.

How to test:
1. Enter in /mydspace from URL or from the link in the dropdown when you are logged in.
2. Change between options in the select box from the sidebar
3. The filters should be loaded without problem

## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
