### PR TITLE
[DURACOM-339] fix downloads not working when matomo is disabled

### DIFF
--- a/src/app/shared/cookies/browser-orejime.service.ts
+++ b/src/app/shared/cookies/browser-orejime.service.ts
@@ -30,6 +30,7 @@ import {
   NativeWindowService,
 } from '../../core/services/window.service';
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
+import { MATOMO_ENABLED } from '../../statistics/matomo.service';
 import {
   hasValue,
   isEmpty,
@@ -90,7 +91,7 @@ export class BrowserOrejimeService extends OrejimeService {
 
   private readonly GOOGLE_ANALYTICS_SERVICE_NAME = 'google-analytics';
 
-  private readonly MATOMO_ENABLED = 'matomo.enabled';
+  private readonly MATOMO_ENABLED = MATOMO_ENABLED;
 
   /**
    * Initial Orejime configuration

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -31,6 +31,8 @@ import { isNotEmpty } from '../shared/empty.util';
 export const MATOMO_TRACKER_URL = 'matomo.tracker.url';
 export const MATOMO_SITE_ID = 'matomo.request.siteid';
 
+export const MATOMO_ENABLED = 'matomo.enabled';
+
 /**
  * Service to manage Matomo analytics integration.
  * Handles initialization and consent management for Matomo tracking.
@@ -139,6 +141,21 @@ export class MatomoService {
         getFirstCompletedRemoteData(),
         map((res: RemoteData<ConfigurationProperty>) => {
           return res.hasSucceeded && res.payload && isNotEmpty(res.payload.values) && res.payload.values[0];
+        }),
+      );
+  }
+
+  /**
+   * Checks if Matomo tracking is enabled by retrieving the configuration property.
+   * @returns An Observable that emits a boolean indicating whether Matomo tracking is enabled.
+   */
+  isMatomoEnabled$(): Observable<boolean> {
+    return this.configService.findByPropertyName(MATOMO_ENABLED)
+      .pipe(
+        getFirstCompletedRemoteData(),
+        map((res: RemoteData<ConfigurationProperty>) => {
+          return res.hasSucceeded && res.payload && isNotEmpty(res.payload.values) &&
+            res.payload.values[0]?.toLowerCase() === 'true';
         }),
       );
   }


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/4122

## Description
Fixed the bug where downloads were not working when matomo is disabled.

## Instructions for Reviewers
I inserted a check for the `matomo.enabled` configuration setting before using the `matomoService` to add the `visitorId` (that's where the download was failing).

List of changes in this PR:
* Added a check for `matomo.enabled` in `BitstreamDownloadPageComponent` to avoid calling a `matomoService` method is matomo is disabled;
* Added tests.

**Include guidance for how to test or review your PR.**
You can easily check that any download now starts when matomo is disabled, and still works when matomo is enabled.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
