### PR TITLE
fix content projection not working for themed components

### DIFF
--- a/src/app/shared/theme-support/themed.component.spec.ts
+++ b/src/app/shared/theme-support/themed.component.spec.ts
@@ -85,6 +85,54 @@ describe('ThemedComponent', () => {
         expect(component.usedTheme).toEqual('custom');
       });
     }));
+
+    describe('it checks for ngContent and', () => {
+
+      it('returns all child nodes when selector is *', () => {
+        const element = document.createElement('div');
+        element.innerHTML = '<span>1</span><span>2</span>';
+        const result = (component as any).getNgContent(element, ['*']);
+        expect(result.length).toBe(1);
+        expect(result[0].length).toBe(2);
+        expect(result[0][0].textContent).toBe('1');
+        expect(result[0][1].textContent).toBe('2');
+      });
+
+      it('returns nodes matching specific selector', () => {
+        const element = document.createElement('div');
+        element.innerHTML = '<span class="match">1</span><span>2</span>';
+        const result = (component as any).getNgContent(element, ['.match']);
+        expect(result.length).toBe(1);
+        expect(result[0].length).toBe(1);
+        expect(result[0][0].textContent).toBe('1');
+      });
+
+      it('removes selected elements from the DOM', () => {
+        const element = document.createElement('div');
+        element.innerHTML = '<span class="match">1</span><span>2</span>';
+        (component as any).getNgContent(element, ['.match']);
+        expect(element.querySelectorAll('.match').length).toBe(0);
+      });
+
+      it('returns empty array when no elements match the selector', () => {
+        const element = document.createElement('div');
+        element.innerHTML = '<span>1</span><span>2</span>';
+        const result = (component as any).getNgContent(element, ['.no-match']);
+        expect(result.length).toBe(1);
+        expect(result[0].length).toBe(0);
+      });
+
+      it('handles multiple selectors', () => {
+        const element = document.createElement('div');
+        element.innerHTML = '<span class="match1">1</span><span class="match2">2</span>';
+        const result = (component as any).getNgContent(element, ['.match1', '.match2']);
+        expect(result.length).toBe(2);
+        expect(result[0].length).toBe(1);
+        expect(result[0][0].textContent).toBe('1');
+        expect(result[1].length).toBe(1);
+        expect(result[1][0].textContent).toBe('2');
+      });
+    });
   });
 
   describe('when the current theme doesn\'t match a themed component', () => {

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -5,6 +5,8 @@ import {
   ComponentRef,
   ElementRef,
   HostBinding,
+  inject,
+  Injector,
   OnChanges,
   OnDestroy,
   SimpleChanges,
@@ -39,6 +41,7 @@ import { ThemeService } from './theme.service';
   selector: 'ds-themed',
   styleUrls: ['./themed.component.scss'],
   templateUrl: './themed.component.html',
+  standalone: true,
 })
 export abstract class ThemedComponent<T extends object> implements AfterViewInit, OnDestroy, OnChanges {
   @ViewChild('vcr', { read: ViewContainerRef }) vcr: ViewContainerRef;
@@ -56,6 +59,8 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
   protected themeSub: Subscription;
 
   protected inAndOutputNames: (keyof T & keyof this)[] = [];
+
+  protected injector = inject(Injector);
 
   /**
    * A data attribute on the ThemedComponent to indicate which theme the rendered component came from.
@@ -133,8 +138,15 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
 
     this.lazyLoadSub = this.lazyLoadObs.subscribe(([simpleChanges, constructor]: [SimpleChanges, GenericConstructor<T>]) => {
       this.destroyComponentInstance();
+
+      // Get the ng-content selectors from the component metadata
+      const ngContentSelectors = this.getComponentNgContentSelectors(constructor);
+      const projectableNodes = this.getNgContent(this.themedElementContent.nativeElement, ngContentSelectors);
+
+      // Create component without using ComponentFactoryResolver
       this.compRef = this.vcr.createComponent(constructor, {
-        projectableNodes: [this.themedElementContent.nativeElement.childNodes],
+        injector: this.injector,
+        projectableNodes: projectableNodes,
       });
       if (hasValue(simpleChanges)) {
         this.ngOnChanges(simpleChanges);
@@ -147,6 +159,17 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
     });
   }
 
+  /**
+   * Retrieves ng-content selectors from a component type
+   */
+  private getComponentNgContentSelectors(componentType: GenericConstructor<any>): string[] {
+    const componentDef = (componentType as any).ɵcmp;
+    if (componentDef && componentDef.ngContentSelectors) {
+      return componentDef.ngContentSelectors;
+    }
+    return ['*']; // Default fallback
+  }
+
   protected destroyComponentInstance(): void {
     if (hasValue(this.compRef)) {
       this.compRef.destroy();
@@ -155,6 +178,28 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
     if (hasValue(this.vcr)) {
       this.vcr.clear();
     }
+  }
+
+  /**
+   * Extracts and returns the content nodes from the given element based on the provided ng-content selectors.
+   *
+   * @param {Element} element - The DOM element from which to extract content nodes.
+   * @param {string[]} ngSelectors - An array of ng-content selectors to match against the element's children.
+   * @returns {Node[][]} - A 2D array where each sub-array contains the nodes matching a specific selector.
+   */
+  protected getNgContent(element: Element, ngSelectors: string[]): Node[][] {
+    return ngSelectors.map(selector => {
+      if (selector === '*') {
+        // If the selector is '*', return all child nodes of the element.
+        return Array.from(element.childNodes);
+      } else {
+        // Otherwise, select and return the nodes matching the specific selector.
+        const selectedElements = Array.from(element.querySelectorAll(selector));
+        // Remove the selected elements from the DOM.
+        selectedElements.forEach(e => e.remove());
+        return selectedElements;
+      }
+    });
   }
 
   protected connectInputsAndOutputs(): void {


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/4126

## Description
Changed the logic for generation of `projectableNodes`. It seems that now Angular asks for a matrix of elements, where the n-th row contains what should be projected in the n-th `ng-content` element.

## Instructions for Reviewers
Follow the instructions on how to reproduce the bug in https://github.com/DSpace/dspace-angular/issues/4126. Now all components should project correctly in the corresponding outlet.

List of changes in this PR:
* Changed behavior behind the construction of the `projectableNodes` matrix;
* Added tests.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
