### PR TITLE
Add note with link to Release Notes on homepage (for Testathon)

### DIFF
--- a/src/themes/dspace/app/home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.html
@@ -4,6 +4,7 @@
       <div class="d-flex flex-wrap">
         <div>
           <h1 class="display-2">DSpace 9</h1>
+          <p><i class="fas fa-circle-info"></i> This site is running DSpace 9. For more information, see the <a href="https://wiki.lyrasis.org/display/DSDOC9x/Release+Notes">DSpace 9 Release Notes</a>.</p>
           <p class="lead">DSpace is the world leading open source repository platform that enables
             organisations to:</p>
         </div>


### PR DESCRIPTION
## References
* Fixes DSpace/DSpace#10558

## Description
This is a small PR to add a link to the DSpace Release Notes on the homepage.  This is being included to help testers during Testathon to easily locate the release notes.

I've tested this locally to find something that looks good.