### PR TITLE
Clean up spacing in input forms

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -1,5 +1,5 @@
-<div [class.mb-3]="(model.type !== 'GROUP' && asBootstrapFormGroup) || getClass('element', 'container').includes('mb-3')"
-  [class.d-none]="model.hidden"
+<div [class.mb-2]="hasLabel || model.type === 'DATE' || (model.type !== 'GROUP' && asBootstrapFormGroup) || getClass('element', 'container').includes('mb-2')"
+     [class.d-none]="model.hidden"
   [formGroup]="group"
   [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
   @if (!isCheckbox && hasLabel) {
@@ -24,8 +24,7 @@
              class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
       }
       <!-- In case of repeatable fields show empty space for all elements except the first -->
-      @if (context?.index !== null
-        && (!showErrorMessages || errorMessages.length === 0)) {
+      @if (context?.parent?.groups?.length > 1 && (!showErrorMessages || errorMessages.length === 0)) {
         <div class="clearfix w-100 mb-2"></div>
       }
 
@@ -99,7 +98,9 @@
       <small
       class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
     }
-    <div class="clearfix w-100 mb-2"></div>
+    @if (context?.parent?.groups?.length > 1 && (!showErrorMessages || errorMessages.length === 0)) {
+      <div class="clearfix w-100 mb-2"></div>
+    }
   }
   <ng-content></ng-content>
 </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.scss
@@ -15,7 +15,6 @@
   appearance: none;
 }
 
-
 :host ::ng-deep .btn-group-toggle > .btn input[type="radio"] {
   position: absolute;
   clip: rect(0,0,0,0);
@@ -32,4 +31,14 @@
 
 :host ::ng-deep .custom-control-input.is-invalid ~ .custom-control-label {
   color: var(--bs-form-invalid-color);
+}
+
+.invalid-feedback {
+  margin-top: 0;
+}
+
+.col-form-label {
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-bottom: 0.5rem;
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/existing-metadata-list-element/existing-metadata-list-element.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/existing-metadata-list-element/existing-metadata-list-element.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex">
-  <span class="me-auto text-contents">
+  <span class="me-auto text-contents align-self-center">
     @if ((metadataRepresentation$ | async) === undefined) {
       <ds-loading [showMessage]="false"></ds-loading>
     }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.scss
@@ -4,6 +4,7 @@
 
 legend {
   font-size: initial;
+  margin-bottom: 0;
 
   /* Changed from Bootstrap 5's legend to ensure that the date issues label is on a different line as it's input */
   float: none;


### PR DESCRIPTION
## Description
This PR standardizes spacing values for all input form fields and improves input form readability.

## Instructions for Reviewers
List of changes in this PR:

1. Updated `ds-dynamic-form-control-container.component.html` to reduce bottom margins on field labels and to remove excess spacing between fields.
2. Extended `ds-dynamic-form-control-container.component.scss` to conform error message margins to hint margins.
3. Extended `ds-dynamic-form-control-container.component.scss` to conform label padding and margins on non-repeatable tag fields to other fields.
4. Centered text vertically in `existing-metadata-list-element.component.html`.
5. Updated `date-picker.component.scss` to conform bottom margin on date field labels to other labels.

**BEFORE**
![form_cleanup_before](https://github.com/user-attachments/assets/a8defc7b-6d4f-429e-912e-cfcabdd41913)

**AFTER**
![form_cleanup_after](https://github.com/user-attachments/assets/299e67d7-41af-448e-a860-47d54a66c617)


How to test or review the PR:

* Create a new item through the admin sidebar.
* Verify the spacing changes in the item submission form.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).

- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.

- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`

- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)

- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.

- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).

- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.

- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.

- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.

- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.

- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).