### PR TITLE
Fix pagination on the "Select bitstreams" modal of the "Access Control" tab

### DIFF
--- a/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.html
+++ b/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.html
@@ -7,19 +7,18 @@
   </button>
 </div>
 <div class="modal-body">
-  @if (data$ | async; as data) {
-    @if (data.payload.page.length > 0) {
+  @if (bitstreams$ | async; as bitstreams) {
+    @if (bitstreams.payload.page.length > 0) {
       <ds-viewable-collection
         [config]="paginationConfig"
         [context]="context"
-        [objects]="data"
+        [objects]="bitstreams"
         [selectable]="true"
         [selectionConfig]="{ repeatable: true, listId: LIST_ID }"
-        [showPaginator]="true"
-        (pageChange)="loadForPage($event)">
+        [showPaginator]="true">
       </ds-viewable-collection>
     }
-    @if (data && data.payload.page.length === 0) {
+    @if (bitstreams && bitstreams.payload.page.length === 0) {
       <div
         class="alert alert-info w-100" role="alert">
         {{'access-control-select-bitstreams-modal.no-items' | translate}}

--- a/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.spec.ts
+++ b/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.spec.ts
@@ -23,6 +23,7 @@ import { Bitstream } from '../../../core/shared/bitstream.model';
 import { Item } from '../../../core/shared/item.model';
 import { ObjectCollectionComponent } from '../../object-collection/object-collection.component';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
+import { PaginationServiceStub } from '../../testing/pagination-service.stub';
 import { createPaginatedList } from '../../testing/utils.test';
 import { FollowLinkConfig } from '../../utils/follow-link-config.model';
 import { ItemAccessControlSelectBitstreamsModalComponent } from './item-access-control-select-bitstreams-modal.component';
@@ -37,6 +38,8 @@ describe('ItemAccessControlSelectBitstreamsModalComponent', () => {
     },
   };
 
+  const mockPaginationService = new PaginationServiceStub();
+
   const translateServiceStub = {
     get: () => observableOf('test-message'),
     onLangChange: new EventEmitter(),
@@ -50,7 +53,7 @@ describe('ItemAccessControlSelectBitstreamsModalComponent', () => {
       providers: [
         NgbActiveModal,
         { provide: BitstreamDataService, useValue: mockBitstreamDataService },
-        { provide: PaginationService, useValue: {} },
+        { provide: PaginationService, useValue: mockPaginationService },
         { provide: TranslateService, useValue: translateServiceStub },
       ],
     })

--- a/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.ts
+++ b/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.ts
@@ -2,6 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import {
   Component,
   Input,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
@@ -9,7 +10,8 @@ import {
   TranslateModule,
   TranslateService,
 } from '@ngx-translate/core';
-import { BehaviorSubject } from 'rxjs';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { PaginatedList } from 'src/app/core/data/paginated-list.model';
 import { RemoteData } from 'src/app/core/data/remote-data';
 import { Bitstream } from 'src/app/core/shared/bitstream.model';
@@ -18,8 +20,6 @@ import { Context } from 'src/app/core/shared/context.model';
 import { BitstreamDataService } from '../../../core/data/bitstream-data.service';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { Item } from '../../../core/shared/item.model';
-import { getFirstCompletedRemoteData } from '../../../core/shared/operators';
-import { hasValue } from '../../empty.util';
 import { ObjectCollectionComponent } from '../../object-collection/object-collection.component';
 import { PaginationComponentOptions } from '../../pagination/pagination-component-options.model';
 
@@ -32,18 +32,21 @@ export const ITEM_ACCESS_CONTROL_SELECT_BITSTREAMS_LIST_ID = 'item-access-contro
   standalone: true,
   imports: [ObjectCollectionComponent, AsyncPipe, TranslateModule],
 })
-export class ItemAccessControlSelectBitstreamsModalComponent implements OnInit {
+export class ItemAccessControlSelectBitstreamsModalComponent implements OnInit, OnDestroy {
 
   LIST_ID = ITEM_ACCESS_CONTROL_SELECT_BITSTREAMS_LIST_ID;
 
   @Input() item!: Item;
   @Input() selectedBitstreams: string[] = [];
 
-  data$ = new BehaviorSubject<RemoteData<PaginatedList<Bitstream>> | null>(null);
-  paginationConfig: PaginationComponentOptions;
-  pageSize = 5;
-
+  bitstreams$: Observable<RemoteData<PaginatedList<Bitstream>>>;
   context: Context = Context.Bitstream;
+
+  paginationConfig = Object.assign(new PaginationComponentOptions(), {
+    id: 'iacsbm',
+    currentPage: 1,
+    pageSize: 5,
+  });
 
   constructor(
     private bitstreamService: BitstreamDataService,
@@ -52,23 +55,20 @@ export class ItemAccessControlSelectBitstreamsModalComponent implements OnInit {
     public activeModal: NgbActiveModal,
   ) { }
 
-  ngOnInit() {
-    this.loadForPage(1);
-
-    this.paginationConfig = new PaginationComponentOptions();
-    this.paginationConfig.id = 'iacsbm';
-    this.paginationConfig.currentPage = 1;
-    if (hasValue(this.pageSize)) {
-      this.paginationConfig.pageSize = this.pageSize;
-    }
+  ngOnInit(): void {
+    this.bitstreams$ = this.paginationService.getCurrentPagination(this.paginationConfig.id, this.paginationConfig).pipe(
+      switchMap((options: PaginationComponentOptions) => this.bitstreamService.findAllByItemAndBundleName(
+        this.item,
+        'ORIGINAL',
+        { elementsPerPage: options.pageSize, currentPage: options.currentPage },
+        true,
+        true,
+      )),
+    );
   }
 
-  loadForPage(page: number) {
-    this.bitstreamService.findAllByItemAndBundleName(this.item, 'ORIGINAL', { currentPage: page }, false)
-      .pipe(
-        getFirstCompletedRemoteData(),
-      )
-      .subscribe(this.data$);
+  ngOnDestroy(): void {
+    this.paginationService.clearPagination(this.paginationConfig.id);
   }
 
 }


### PR DESCRIPTION
## References

* Fixes #4140

## Description

Fixed pagination on the "Select bitstreams" modal of the "Edit Item > Access Control" page.

## Instructions for Reviewers

**Changes**

Refactored ItemAccessControlSelectBitstreamsModalComponent to:

- Simplify how the bitstreams are retrieved.
- Ensure the correct PaginationComponentOptions are being used.

**Include guidance for how to test or review your PR.**

- Upload a lot of bitstreams to the ORIGINAL bundle of an item (at least 6)
- Go the `/edit/access-control` page of that item.
- In the right column, switch "Bitstreams", select "0 bitstreams selected", click the looking glass icon.
- Verify:
    - Only the first 5 bitstreams are displayed.
    - The pagination header is correct ("Now showing 1 - 5 of X").
    - You can use the pagination buttons to show a different set of bitstreams.
    - You can still select/deselect bitstreams to apply access conditions on.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
