### PR TITLE
Fix ssr error by only importing altcha on the client side

### DIFF
--- a/src/app/item-page/bitstreams/request-a-copy/bitstream-request-a-copy-page.component.html
+++ b/src/app/item-page/bitstreams/request-a-copy/bitstream-request-a-copy-page.component.html
@@ -86,8 +86,8 @@
 
   <!-- Captcha - to be rendered only if enabled in backend requestitem.cfg -->
   @if (!!(captchaEnabled$ | async)) {
-    <div *ngVar="challengeHref$ | async as href">
-      <ds-altcha-captcha autoload="onload" challengeUrl="{{ href }}" (payload)="handlePayload($event)">
+    <div>
+      <ds-altcha-captcha autoload="onload" challengeUrl="{{ challengeHref$ | async }}" (payload)="handlePayload($event)">
       </ds-altcha-captcha>
     </div>
   }

--- a/src/app/item-page/bitstreams/request-a-copy/bitstream-request-a-copy-page.component.ts
+++ b/src/app/item-page/bitstreams/request-a-copy/bitstream-request-a-copy-page.component.ts
@@ -1,5 +1,3 @@
-import 'altcha';
-
 import {
   AsyncPipe,
   Location,
@@ -65,7 +63,6 @@ import {
   isNotEmpty,
 } from '../../../shared/empty.util';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
-import { VarDirective } from '../../../shared/utils/var.directive';
 import { getItemPageRoute } from '../../item-page-routing-paths';
 import { AltchaCaptchaComponent } from './altcha-captcha.component';
 
@@ -78,7 +75,6 @@ import { AltchaCaptchaComponent } from './altcha-captcha.component';
     AsyncPipe,
     ReactiveFormsModule,
     BtnDisabledDirective,
-    VarDirective,
     AltchaCaptchaComponent,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/app/request-copy/email-request-copy/email-request-copy.component.ts
+++ b/src/app/request-copy/email-request-copy/email-request-copy.component.ts
@@ -1,5 +1,3 @@
-import 'altcha';
-
 import {
   AsyncPipe,
   Location,

--- a/src/modules/app/browser-app.config.ts
+++ b/src/modules/app/browser-app.config.ts
@@ -1,3 +1,5 @@
+import 'altcha';
+
 import {
   HttpClient,
   provideHttpClient,


### PR DESCRIPTION
## References
* Fixes #4145

## Description
The issue was caused by the fact that altcha was loaded server side, and that's not supported. When it tries to define the `altcha-widget` the server-side throws an exception.

I fixed it by removing the import everywhere, and putting it in `browser-app.config.ts`

I also removed an unnecessary ngVar, as they can be bad for performance.

## Instructions for Reviewers
Ensure that the ssr error is gone, and that the altcha captchas still work.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
