### PR TITLE
Fix export button enabled in bulk access management without selecting step 2

### DIFF
--- a/src/app/access-control/bulk-access/bulk-access.component.spec.ts
+++ b/src/app/access-control/bulk-access/bulk-access.component.spec.ts
@@ -1,4 +1,7 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  Component,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -62,10 +65,17 @@ describe('BulkAccessComponent', () => {
     'file': {  },
   };
 
-  const mockSettings: any = jasmine.createSpyObj('AccessControlFormContainerComponent',  {
-    getValue: jasmine.createSpy('getValue'),
-    reset: jasmine.createSpy('reset'),
-  });
+  @Component({
+    selector: 'ds-bulk-access-settings',
+    template: '',
+    exportAs: 'dsBulkSettings',
+    standalone: true,
+  })
+  class MockBulkAccessSettingsComponent {
+    isFormValid = jasmine.createSpy('isFormValid').and.returnValue(false);
+    getValue = jasmine.createSpy('getValue');
+    reset = jasmine.createSpy('reset');
+  }
   const selection: any[] = [{ indexableObject: { uuid: '1234' } }, { indexableObject: { uuid: '5678' } }];
   const selectableListState: SelectableListState = { id: 'test', selection };
   const expectedIdList = ['1234', '5678'];
@@ -93,6 +103,9 @@ describe('BulkAccessComponent', () => {
             BulkAccessSettingsComponent,
           ],
         },
+        add: {
+          imports: [MockBulkAccessSettingsComponent],
+        },
       })
       .compileComponents();
   });
@@ -109,13 +122,12 @@ describe('BulkAccessComponent', () => {
     fixture.destroy();
   });
 
-  describe('when there are no elements selected', () => {
+  describe('when there are no elements selected and step two form is invalid', () => {
 
     beforeEach(() => {
 
       (component as any).selectableListService.getSelectableList.and.returnValue(of(selectableListStateEmpty));
       fixture.detectChanges();
-      component.settings = mockSettings;
     });
 
     it('should create', () => {
@@ -138,7 +150,6 @@ describe('BulkAccessComponent', () => {
 
       (component as any).selectableListService.getSelectableList.and.returnValue(of(selectableListState));
       fixture.detectChanges();
-      component.settings = mockSettings;
     });
 
     it('should create', () => {
@@ -149,14 +160,28 @@ describe('BulkAccessComponent', () => {
       expect(component.objectsSelected$.value).toEqual(expectedIdList);
     });
 
-    it('should enable the execute button when there are objects selected', () => {
+    it('should not enable the execute button when there are objects selected and step two form is invalid', () => {
       component.objectsSelected$.next(['1234']);
-      expect(component.canExport()).toBe(true);
+      expect(component.canExport()).toBe(false);
     });
 
     it('should call the settings reset method when reset is called', () => {
       component.reset();
       expect(component.settings.reset).toHaveBeenCalled();
+    });
+  });
+  describe('when there are elements selected and the step two form is valid', () => {
+
+    beforeEach(() => {
+
+      (component as any).selectableListService.getSelectableList.and.returnValue(of(selectableListState));
+      fixture.detectChanges();
+      (component as any).settings.isFormValid.and.returnValue(true);
+    });
+
+    it('should enable the execute button when there are objects selected and step two form is valid', () => {
+      component.objectsSelected$.next(['1234']);
+      expect(component.canExport()).toBe(true);
     });
 
     it('should call the bulkAccessControlService executeScript method when submit is called', () => {

--- a/src/app/access-control/bulk-access/bulk-access.component.ts
+++ b/src/app/access-control/bulk-access/bulk-access.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   OnInit,
   ViewChild,
@@ -31,6 +32,7 @@ import { BulkAccessSettingsComponent } from './settings/bulk-access-settings.com
     BtnDisabledDirective,
   ],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BulkAccessComponent implements OnInit {
 
@@ -70,7 +72,7 @@ export class BulkAccessComponent implements OnInit {
   }
 
   canExport(): boolean {
-    return this.objectsSelected$.value?.length > 0;
+    return this.objectsSelected$.value?.length > 0  && this.settings?.isFormValid();
   }
 
   /**

--- a/src/app/access-control/bulk-access/settings/bulk-access-settings.component.ts
+++ b/src/app/access-control/bulk-access/settings/bulk-access-settings.component.ts
@@ -42,4 +42,8 @@ export class BulkAccessSettingsComponent {
     this.controlForm.reset();
   }
 
+  isFormValid() {
+    return this.controlForm.isValid();
+  }
+
 }

--- a/src/app/shared/access-control-form-container/access-control-array-form/access-control-array-form.component.ts
+++ b/src/app/shared/access-control-form-container/access-control-array-form/access-control-array-form.component.ts
@@ -135,6 +135,10 @@ export class AccessControlArrayFormComponent implements OnInit {
     return item.id;
   }
 
+  isValid() {
+    return this.ngForm.valid;
+  }
+
 }
 
 

--- a/src/app/shared/access-control-form-container/access-control-form-container.component.ts
+++ b/src/app/shared/access-control-form-container/access-control-form-container.component.ts
@@ -176,5 +176,9 @@ export class AccessControlFormContainerComponent<T extends DSpaceObject> impleme
     this.selectableListService.deselectAll(ITEM_ACCESS_CONTROL_SELECT_BITSTREAMS_LIST_ID);
   }
 
+  isValid() {
+    return this.bitstreamAccessCmp.isValid() || this.itemAccessCmp.isValid();
+  }
+
 }
 


### PR DESCRIPTION
## References
- Fixes #3893
- Backport PR #4169

## Description
The export button in Bulk Access Management was not considering the state of step 2 in the form. This has been fixed.

## Instructions for Reviewers
List of changes in this PR:
* Export button in Bulk Access Management has an extra check in `canExport` now.
* Tests for the component are modified. This includes tests for the new case and some refactoring to handle the dynamically loaded components.

This can be tested by logging in as Admin and navigating to Bulk Access Management. The button should activate only when there is some selection in both steps.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
