### PR TITLE
Fix issue where required cookies are removed by orejime

### DIFF
--- a/src/app/shared/cookies/orejime-configuration.ts
+++ b/src/app/shared/cookies/orejime-configuration.ts
@@ -115,6 +115,7 @@ export function getOrejimeConfiguration(_window: NativeWindowRef): any {
         name: 'authentication',
         purposes: ['functional'],
         required: true,
+        optOut: true,
         cookies: [
           TOKENITEM,
           IMPERSONATING_COOKIE,
@@ -125,6 +126,7 @@ export function getOrejimeConfiguration(_window: NativeWindowRef): any {
         name: 'preferences',
         purposes: ['functional'],
         required: true,
+        optOut: true,
         cookies: [
           LANG_COOKIE,
         ],
@@ -133,6 +135,7 @@ export function getOrejimeConfiguration(_window: NativeWindowRef): any {
         name: 'acknowledgement',
         purposes: ['functional'],
         required: true,
+        optOut: true,
         cookies: [
           [/^orejime-.+$/],
           HAS_AGREED_END_USER,


### PR DESCRIPTION
## References  
* Fixes #4133
* Fixes #3963
  
## Description  
This issue was caused by some unintuitive behavior of the orejime cookie popup. If apps are required, their cookies are still automatically deleted before the user has clicked "accept" or "decline" in the popup. And in the case where you don't have optional cookies that popup is never shown, so as a result all required cookies keep being deleted every time you refresh the page.

The solution was to set `optOut: true` for all required apps. This means that the cookies will be assumed to be allowed unless the user turns them off. Since they're required as well, the user can't turn them off. You'd expect `optOut` to be implied by the `required` option. But it seems like it isn't.
  
## Instructions for Reviewers  
- Ensure changes to the language are persisted after you reload the page manually.
- Test this both with, and without optional cookies. E.g. you can add a bogus google analytics key to your backend config, to have an optional cookie
- If you have no optional cookies you shouldn't see the popup at all
- if have have optional cookies the language should persist after a reload both before and after you've accepted or declined the popup
  
## Checklist  
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).  
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.  
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`  
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)  
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.  
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).  
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.  
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.  
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.  
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.  
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.  
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
