### PR TITLE
[Port dspace-8_x] Store the state of the computed filters

### DIFF
--- a/src/app/shared/search/search-filters/search-filters.component.html
+++ b/src/app/shared/search/search-filters/search-filters.component.html
@@ -5,14 +5,14 @@
 }
 
 @if ((filters | async)?.hasSucceeded) {
-  <div [class.visually-hidden]="filtersWithComputedVisibility !== (filters | async)?.payload?.length">
+  <div [class.visually-hidden]="getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length">
     @for (filter of (filters | async)?.payload; track filter.name) {
       <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
     }
   </div>
 }
 
-@if(filtersWithComputedVisibility !== (filters | async)?.payload?.length) {
+@if(getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length) {
   <ngx-skeleton-loader [count]="defaultFilterCount"/>
 }
 

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -16,9 +16,9 @@ import {
   Observable,
 } from 'rxjs';
 import {
-  map,
   filter,
-  take
+  map,
+  take,
 } from 'rxjs/operators';
 
 import {
@@ -166,7 +166,7 @@ export class SearchFiltersComponent implements OnInit {
             // We haven't reached the total yet, proceed with increment
             return {
               shouldIncrement: true,
-              totalFilters
+              totalFilters,
             };
           }
           return { shouldIncrement: false };
@@ -184,14 +184,14 @@ export class SearchFiltersComponent implements OnInit {
             // Create new counter entry
             this.currentFiltersComputed.push({
               configuration: this.currentConfiguration,
-              filtersComputed: 1
+              filtersComputed: 1,
             });
           }
 
           // Pass along the total and updated count
           return {
             totalFilters: result.totalFilters,
-            currentComputed: this.getCurrentFiltersComputed(this.currentConfiguration)
+            currentComputed: this.getCurrentFiltersComputed(this.currentConfiguration),
           };
         }),
         // Check if we've reached the total after incrementing
@@ -201,7 +201,7 @@ export class SearchFiltersComponent implements OnInit {
             this.updateFinalFiltersComputed(this.currentConfiguration, result.currentComputed);
           }
           return result;
-        })
+        }),
       ).pipe(take(1)).subscribe(); // Execute the pipeline and immediately unsubscribe
     }
   }
@@ -213,7 +213,7 @@ export class SearchFiltersComponent implements OnInit {
    */
   private findConfigInCurrentFilters(configuration: string) {
     return this.currentFiltersComputed.find(
-      (configFilter) => configFilter.configuration === configuration
+      (configFilter) => configFilter.configuration === configuration,
     );
   }
 
@@ -224,7 +224,7 @@ export class SearchFiltersComponent implements OnInit {
    */
   private findConfigInFinalFilters(configuration: string) {
     return this.finalFiltersComputed.find(
-      (configFilter) => configFilter.configuration === configuration
+      (configFilter) => configFilter.configuration === configuration,
     );
   }
 
@@ -241,7 +241,7 @@ export class SearchFiltersComponent implements OnInit {
     } else {
       this.finalFiltersComputed.push({
         configuration,
-        filtersComputed: count
+        filtersComputed: count,
       });
     }
   }

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -17,7 +17,8 @@ import {
 } from 'rxjs';
 import {
   map,
-  filter
+  filter,
+  take
 } from 'rxjs/operators';
 
 import {
@@ -201,7 +202,7 @@ export class SearchFiltersComponent implements OnInit {
           }
           return result;
         })
-      ).subscribe().unsubscribe(); // Execute the pipeline and immediately unsubscribe
+      ).pipe(take(1)).subscribe(); // Execute the pipeline and immediately unsubscribe
     }
   }
 

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -15,7 +15,10 @@ import {
   BehaviorSubject,
   Observable,
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  filter
+} from 'rxjs/operators';
 
 import {
   APP_CONFIG,
@@ -82,9 +85,16 @@ export class SearchFiltersComponent implements OnInit {
   searchLink: string;
 
   /**
-   * Filters for which visibility has been computed
+   * Keeps track of the filters computed for each configuration during the current rendering cycle
+   * This array stores objects with configuration identifier and number of computed filters
    */
-  filtersWithComputedVisibility = 0;
+  private currentFiltersComputed = [];
+
+  /**
+   * Stores the final count of computed filters for each configuration
+   * Used to determine when all filters for a configuration have been processed
+   */
+  private finalFiltersComputed = [];
 
   subs = [];
   filterLabel = 'search';
@@ -136,7 +146,122 @@ export class SearchFiltersComponent implements OnInit {
 
   countFiltersWithComputedVisibility(computed: boolean) {
     if (computed) {
-      this.filtersWithComputedVisibility += 1;
+      this.filters.pipe(
+        // Get filter data and check if we need to increment the counter
+        map(filtersData => {
+          if (filtersData && filtersData.hasSucceeded && filtersData.payload) {
+            const totalFilters = filtersData.payload.length;
+            const currentComputed = this.getCurrentFiltersComputed(this.currentConfiguration);
+
+            // If we've already computed all filters for this configuration
+            if (currentComputed >= totalFilters) {
+              // Register in finalFiltersComputed if not already registered
+              if (!this.findConfigInFinalFilters(this.currentConfiguration)) {
+                this.updateFinalFiltersComputed(this.currentConfiguration, totalFilters);
+              }
+              return { shouldIncrement: false };
+            }
+
+            // We haven't reached the total yet, proceed with increment
+            return {
+              shouldIncrement: true,
+              totalFilters
+            };
+          }
+          return { shouldIncrement: false };
+        }),
+        // Only continue if we need to increment the counter
+        filter(result => result.shouldIncrement),
+        // Increment the counter for the current configuration
+        map(result => {
+          const filterConfig = this.findConfigInCurrentFilters(this.currentConfiguration);
+
+          if (filterConfig) {
+            // Update existing counter
+            filterConfig.filtersComputed += 1;
+          } else {
+            // Create new counter entry
+            this.currentFiltersComputed.push({
+              configuration: this.currentConfiguration,
+              filtersComputed: 1
+            });
+          }
+
+          // Pass along the total and updated count
+          return {
+            totalFilters: result.totalFilters,
+            currentComputed: this.getCurrentFiltersComputed(this.currentConfiguration)
+          };
+        }),
+        // Check if we've reached the total after incrementing
+        map(result => {
+          if (result.currentComputed === result.totalFilters) {
+            // If we've reached the total, update final filters count
+            this.updateFinalFiltersComputed(this.currentConfiguration, result.currentComputed);
+          }
+          return result;
+        })
+      ).subscribe().unsubscribe(); // Execute the pipeline and immediately unsubscribe
     }
+  }
+
+  /**
+   * Finds a configuration entry in the currentFiltersComputed array
+   * @param configuration The configuration identifier to search for
+   * @returns The filter configuration object if found, otherwise undefined
+   */
+  private findConfigInCurrentFilters(configuration: string) {
+    return this.currentFiltersComputed.find(
+      (configFilter) => configFilter.configuration === configuration
+    );
+  }
+
+  /**
+   * Finds a configuration entry in the finalFiltersComputed array
+   * @param configuration The configuration identifier to search for
+   * @returns The filter configuration object if found, otherwise undefined
+   */
+  private findConfigInFinalFilters(configuration: string) {
+    return this.finalFiltersComputed.find(
+      (configFilter) => configFilter.configuration === configuration
+    );
+  }
+
+  /**
+   * Updates or adds a new entry in the finalFiltersComputed array
+   * @param configuration The configuration identifier to update
+   * @param count The number of computed filters to set for this configuration
+   */
+  private updateFinalFiltersComputed(configuration: string, count: number) {
+    const filterConfig = this.findConfigInFinalFilters(configuration);
+
+    if (filterConfig) {
+      filterConfig.filtersComputed = count;
+    } else {
+      this.finalFiltersComputed.push({
+        configuration,
+        filtersComputed: count
+      });
+    }
+  }
+
+  /**
+   * Gets the current number of computed filters for a specific configuration
+   * @param configuration The configuration identifier to get the count for
+   * @returns The number of computed filters, or 0 if none found
+   */
+  private getCurrentFiltersComputed(configuration: string) {
+    const configFilter = this.findConfigInCurrentFilters(configuration);
+    return configFilter?.filtersComputed || 0;
+  }
+
+  /**
+   * Gets the final number of computed filters for a specific configuration
+   * @param configuration The configuration identifier to get the count for
+   * @returns The number of computed filters in the final state, or 0 if none found
+   */
+  getFinalFiltersComputed(configuration: string): number {
+    const configFilter = this.findConfigInFinalFilters(configuration);
+    return configFilter?.filtersComputed || 0;
   }
 }


### PR DESCRIPTION
## References

Port of #4121 for DSpace dspace-8_x branch

* Fix #4097 

## Description
Store the state of the computed filters in the array finalFiltersComputed.

## Instructions for Reviewers
The counter filtersWithComputedVisibility doesn't store the count of filters computed when you change between options in the select box in /mydspace, causing the ngIf in the HTML is always false, and no filters options render on the web.

List of changes in this PR:
* First, countFiltersWithComputedVisibility now store the count every time a new filter is "computed" till it reach the maximum filters configured.
* Second, added some utility functions to find the current and final counter, and a function to update the count.
* Third, update the ngIf, to use the new functions.
* Fourth, removed the trackBy: trackUpdate in the ngFor because when you enter in /mydspace from the link in the dropdown it seems that it interferes.

How to test:
1. Enter in /mydspace from URL or from the link in the dropdown when you are logged in.
2. Change between options in the select box from the sidebar
3. The filters should be loaded without problem

## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
