### PR TITLE
[Port dspace-7_x] Clean up spacing in input forms

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -1,4 +1,4 @@
-<div [class.form-group]="(model.type !== 'GROUP' && asBootstrapFormGroup) || getClass('element', 'container').includes('form-group')"
+<div [class.form-group]="hasLabel || model.type === 'DATE' || (model.type !== 'GROUP' && asBootstrapFormGroup) || getClass('element', 'container').includes('form-group')"
      [class.d-none]="model.hidden"
      [formGroup]="group"
      [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
@@ -19,8 +19,7 @@
       <small *ngIf="hasHint && (formBuilderService.hasArrayGroupValue(model) || (!model.repeatable && (isRelationship === false || value?.value === null)) || (model.repeatable === true && context?.index === context?.context?.groups?.length - 1)) && (!showErrorMessages || errorMessages.length === 0)"
              class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
       <!-- In case of repeatable fields show empty space for all elements except the first -->
-      <div *ngIf="context?.index !== null
-              && (!showErrorMessages || errorMessages.length === 0)" class="clearfix w-100 mb-2"></div>
+      <div *ngIf="context?.parent?.groups?.length > 1 && (!showErrorMessages || errorMessages.length === 0)" class="clearfix w-100 mb-2"></div>
 
       <div *ngIf="!model.hideErrorMessages && showErrorMessages" [id]="id + '_errors'"
            [ngClass]="[getClass('element', 'errors'), getClass('grid', 'errors')]">
@@ -78,7 +77,7 @@
     </ds-existing-relation-list-element>
     <small *ngIf="hasHint && (model.repeatable === false || context?.index === context?.context?.groups?.length - 1) && (!showErrorMessages || errorMessages.length === 0)"
            class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
-    <div class="clearfix w-100 mb-2"></div>
+    <div *ngIf="context?.parent?.groups?.length > 1 && (!showErrorMessages || errorMessages.length === 0)" class="clearfix w-100 mb-2"></div>
   </ng-container>
   <ng-content></ng-content>
 </div>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.scss
@@ -14,3 +14,13 @@
   -moz-appearance: none;
   appearance: none;
 }
+
+.invalid-feedback {
+  margin-top: 0;
+}
+
+.col-form-label {
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-bottom: 0.5rem;
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/existing-metadata-list-element/existing-metadata-list-element.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/existing-metadata-list-element/existing-metadata-list-element.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex">
-    <span class="mr-auto text-contents">
+    <span class="mr-auto text-contents align-self-center">
         <ng-container *ngIf="!(metadataRepresentation$ | async)">
             <ds-themed-loading [showMessage]="false"></ds-themed-loading>
         </ng-container>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.scss
@@ -4,4 +4,5 @@
 
 legend {
   font-size: initial;
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Manual port of #4136 by @gingyx to DSpace 7.x.

I think this is a faithful port of the original PR. DSpace 9 switched to Angular Control Flow syntax so the patch had to be adapted to use the old `ngIf` syntax. Below on my DSpace 7.6.3 instance (don't mind the green branding of my theme, the functionality is the same).

# Before

![Screenshot 2025-04-12 at 16-22-01 CGSpace Edit Submission-fs8](https://github.com/user-attachments/assets/521b0e5d-9fff-4d67-8f7e-2f78087a9c1c)

# After

![Screenshot 2025-04-12 at 16-22-13 CGSpace Edit Submission-fs8](https://github.com/user-attachments/assets/eb62081f-4203-4fbe-9df8-14109c14168a)

The elements for each input are grouped together more coherently and the error text is aligned the same as the hint.