### PR TITLE
Fix: adding tooltips to indicate functionality of buttons when switching views of search results

### DIFF
--- a/src/app/shared/view-mode-switch/view-mode-switch.component.html
+++ b/src/app/shared/view-mode-switch/view-mode-switch.component.html
@@ -3,6 +3,7 @@
     <button
       [attr.aria-current]="currentMode === viewModeEnum.ListElement"
       [attr.aria-label]="'search.view-switch.show-list' | translate"
+      [title]="'search.view-switch.show-list' | translate"
       routerLink="."
       [queryParams]="{view: 'list'}"
       queryParamsHandling="merge"
@@ -17,6 +18,7 @@
     <button
       [attr.aria-current]="currentMode === viewModeEnum.GridElement"
       [attr.aria-label]="'search.view-switch.show-grid' | translate"
+      [title]="'search.view-switch.show-grid' | translate"
       routerLink="."
       [queryParams]="{view: 'grid'}"
       queryParamsHandling="merge"
@@ -31,6 +33,7 @@
     <button
       [attr.aria-current]="currentMode === viewModeEnum.DetailedListElement"
       [attr.aria-label]="'search.view-switch.show-detail' | translate"
+      [title]="'search.view-switch.show-detail' | translate"
       routerLink="."
       [queryParams]="{view: 'detailed'}"
       queryParamsHandling="merge"
@@ -45,6 +48,7 @@
     <button
       [attr.aria-current]="currentMode === viewModeEnum.GeospatialMap"
       [attr.aria-label]="'search.view-switch.show-geospatialMap' | translate"
+      [title]="'search.view-switch.show-geospatialMap' | translate"
        routerLink="."
        [queryParams]="{view: 'geospatialMap'}"
        queryParamsHandling="merge"


### PR DESCRIPTION
## References
* Fixes #4188

## Description
Added tooltips to the view mode switch buttons in the search results to indicate their functionality.

## Instructions for Reviewers
This PR enhances the user experience by providing tooltips on buttons that switch between different view modes in the search results. 
![tooltip](https://github.com/user-attachments/assets/dcb85596-f841-4ab0-be80-00a1e19987a8)



List of changes in this PR:
* Updated the `view-mode-switch.component.html` file.
* Added `title` attributes to each view switch button to display tooltips on hover.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
