### PR TITLE
Fix accessibility issues with placeholder text in submission forms

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -220,6 +220,11 @@ submission:
         - value: default
           style: text-muted
           icon: fa-circle-xmark
+  # If set to true avoid setting placeholder for simple fields, where the placeholder would be the same as the label.
+  # The default is set to true as placeholders that do not provide additional information to the field are to be avoided as they could cause accessibility issue.
+  # More info on the topic can be found at https://www.deque.com/blog/accessible-forms-the-problem-with-placeholders/
+  ignorePlaceholderForSimpleFields:
+
 
 #  Default Language in which the UI will be rendered if the user's browser language is not an active language
 defaultLanguage: en

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -1,14 +1,14 @@
 <div [class.mb-2]="hasLabel || model.type === 'DATE' || (model.type !== 'GROUP' && asBootstrapFormGroup) || getClass('element', 'container').includes('mb-2')"
      [class.d-none]="model.hidden"
-  [formGroup]="group"
-  [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
+     [formGroup]="group"
+     [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
   @if (!isCheckbox && hasLabel && !isDateField) {
     <label
       [id]="'label_' + model.id"
       [for]="id"
       class="form-label"
       [innerHTML]="(model.required && model.label) ? (model.label | translate) + ' *' : (model.label | translate)"
-    [ngClass]="[getClass('element', 'label'), getClass('grid', 'label')]"></label>
+      [ngClass]="[getClass('element', 'label'), getClass('grid', 'label')]"></label>
   }
   <ng-container *ngTemplateOutlet="startTemplate?.templateRef; context: { $implicit: model };"></ng-container>
   <!--    Should be *ngIf instead of class d-none, but that breaks the #componentViewContainer reference-->
@@ -20,8 +20,7 @@
       </div>
 
       @if (hasHint && (formBuilderService.hasArrayGroupValue(model) || (!model.repeatable && (isRelationship === false || value?.value === null)) || (model.repeatable === true && context?.index === context?.context?.groups?.length - 1)) && (!showErrorMessages || errorMessages.length === 0)) {
-<small
-             class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
+        <small class="text-muted ds-hint" [innerHTML]="model.hint | translate" [ngClass]="getClass('element', 'hint')"></small>
       }
       <!-- In case of repeatable fields show empty space for all elements except the first -->
       @if (context?.parent?.groups?.length > 1 && (!showErrorMessages || errorMessages.length === 0)) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -2,7 +2,7 @@
      [class.d-none]="model.hidden"
   [formGroup]="group"
   [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
-  @if (!isCheckbox && hasLabel) {
+  @if (!isCheckbox && hasLabel && !isDateField) {
     <label
       [id]="'label_' + model.id"
       [for]="id"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.spec.ts
@@ -382,4 +382,12 @@ describe('DsDynamicFormControlContainerComponent test suite', () => {
     expect(testFn(formModel[25])).toEqual(DsDynamicFormGroupComponent);
   });
 
+  it('should not show a label if is a checkbox or a date field', () => {
+    const checkboxLabel =  fixture.debugElement.query(By.css('#label_' + formModel[0].id));
+    const dsDatePickerLabel =  fixture.debugElement.query(By.css('#label_' + formModel[22].id));
+
+    expect(checkboxLabel).toBeNull();
+    expect(dsDatePickerLabel).toBeNull();
+  });
+
 });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -99,7 +99,6 @@ import { SubmissionObject } from '../../../../core/submission/models/submission-
 import { SubmissionObjectDataService } from '../../../../core/submission/submission-object-data.service';
 import { paginatedRelationsToItems } from '../../../../item-page/simple/item-types/shared/item-relationships-utils';
 import { SubmissionService } from '../../../../submission/submission.service';
-import { BtnDisabledDirective } from '../../../btn-disabled.directive';
 import {
   hasNoValue,
   hasValue,
@@ -122,6 +121,7 @@ import {
 } from './existing-metadata-list-element/existing-metadata-list-element.component';
 import { ExistingRelationListElementComponent } from './existing-relation-list-element/existing-relation-list-element.component';
 import { DYNAMIC_FORM_CONTROL_TYPE_CUSTOM_SWITCH } from './models/custom-switch/custom-switch.model';
+import { DYNAMIC_FORM_CONTROL_TYPE_DSDATEPICKER } from './models/date-picker/date-picker.model';
 import { DsDynamicLookupRelationModalComponent } from './relation-lookup-modal/dynamic-lookup-relation-modal.component';
 
 @Component({
@@ -139,7 +139,6 @@ import { DsDynamicLookupRelationModalComponent } from './relation-lookup-modal/d
     NgbTooltipModule,
     NgTemplateOutlet,
     ExistingRelationListElementComponent,
-    BtnDisabledDirective,
   ],
   standalone: true,
 })
@@ -300,6 +299,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
   get isCheckbox(): boolean {
     return this.model.type === DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX || this.model.type === DYNAMIC_FORM_CONTROL_TYPE_CUSTOM_SWITCH;
   }
+
 
   get isDateField(): boolean {
     return this.model.type === DYNAMIC_FORM_CONTROL_TYPE_DSDATEPICKER;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -301,6 +301,10 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     return this.model.type === DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX || this.model.type === DYNAMIC_FORM_CONTROL_TYPE_CUSTOM_SWITCH;
   }
 
+  get isDateField(): boolean {
+    return this.model.type === DYNAMIC_FORM_CONTROL_TYPE_DSDATEPICKER;
+  }
+
   ngOnChanges(changes: SimpleChanges) {
     if (changes && !this.isRelationship && hasValue(this.group.get(this.model.id))) {
       super.ngOnChanges(changes);

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.html
@@ -2,7 +2,7 @@
   <fieldset class="d-flex">
     @if (!model.repeatable) {
       <legend [id]="'legend_' + model.id" [ngClass]="[getClass('element', 'label'), getClass('grid', 'label')]">
-        {{model.placeholder}} @if (model.required) {
+        {{model.label}} @if (model.required) {
         <span>*</span>
       }
     </legend>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -14,7 +14,7 @@
     }
     <input class="form-control"
       [attr.aria-controls]="'combobox_' + id + '_listbox'"
-      [attr.aria-label]="model.placeholder"
+      [attr.aria-label]="model.label"
       [attr.autoComplete]="model.autoComplete"
       [class.is-invalid]="showErrorMessages"
       [class.scrollable-dropdown-input]="!model.readOnly"
@@ -32,11 +32,11 @@
 
   <div #dropdownMenu ngbDropdownMenu
     class="dropdown-menu scrollable-dropdown-menu w-100"
-    [attr.aria-label]="model.placeholder | translate">
+    [attr.aria-label]="model.label | translate">
     <div class="scrollable-menu"
       role="listbox"
       [id]="'combobox_' + id + '_listbox'"
-      [attr.aria-label]="model.placeholder | translate"
+      [attr.aria-label]="model.label | translate"
       infiniteScroll
       [infiniteScrollDistance]="2"
       [infiniteScrollThrottle]="50"

--- a/src/app/shared/form/builder/parsers/date-field-parser.spec.ts
+++ b/src/app/shared/form/builder/parsers/date-field-parser.spec.ts
@@ -67,4 +67,12 @@ describe('DateFieldParser test suite', () => {
 
     expect(fieldModel.value).toEqual(expectedValue);
   });
+
+  it('should skip setting the placeholder when ignore ignorePlaceholderForSimpleFields is true', () => {
+    const parser = new DateFieldParser(submissionId, field, initFormValues, parserOptions, translateService);
+    parser.ignorePlaceholderForSimpleFields = true;
+    const fieldModel = parser.parse();
+
+    expect(fieldModel.placeholder).toBeNull();
+  });
 });

--- a/src/app/shared/form/builder/parsers/date-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/date-field-parser.ts
@@ -11,8 +11,8 @@ export class DateFieldParser extends FieldParser {
 
   public modelFactory(fieldValue?: FormFieldMetadataValueObject, label?: boolean): any {
     let malformedDate = false;
-    const inputDateModelConfig: DynamicDsDateControlModelConfig = this.initModel(null, false, true);
-    inputDateModelConfig.legend = this.configData.label;
+    const inputDateModelConfig: DynamicDsDatePickerModelConfig = this.initModel(null, label, true);
+    inputDateModelConfig.legend = this.configData.repeatable ? null : this.configData.label;
     inputDateModelConfig.disabled = inputDateModelConfig.readOnly;
     inputDateModelConfig.toggleIcon = 'fas fa-calendar';
     this.setValues(inputDateModelConfig as any, fieldValue);

--- a/src/app/shared/form/builder/parsers/date-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/date-field-parser.ts
@@ -11,7 +11,7 @@ export class DateFieldParser extends FieldParser {
 
   public modelFactory(fieldValue?: FormFieldMetadataValueObject, label?: boolean): any {
     let malformedDate = false;
-    const inputDateModelConfig: DynamicDsDatePickerModelConfig = this.initModel(null, label, true);
+    const inputDateModelConfig: DynamicDsDateControlModelConfig = this.initModel(null, label, true);
     inputDateModelConfig.legend = this.configData.repeatable ? null : this.configData.label;
     inputDateModelConfig.disabled = inputDateModelConfig.readOnly;
     inputDateModelConfig.toggleIcon = 'fas fa-calendar';

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -36,6 +36,7 @@ import { VisibilityType } from './../../../../submission/sections/visibility-typ
 import { setLayout } from './parser.utils';
 import { ParserOptions } from './parser-options';
 import { ParserType } from './parser-type';
+import { environment } from "../../../../../environments/environment";
 
 export const SUBMISSION_ID: InjectionToken<string> = new InjectionToken<string>('submissionId');
 export const CONFIG_DATA: InjectionToken<FormFieldModel> = new InjectionToken<FormFieldModel>('configData');
@@ -310,7 +311,9 @@ export abstract class FieldParser {
     if (hint) {
       controlModel.hint = this.configData.hints || '&nbsp;';
     }
-    controlModel.placeholder = this.configData.label;
+    if (!environment.submission.hidePlaceholderForBasicFields) {
+      controlModel.placeholder = this.configData.label;
+    }
 
     if (this.configData.mandatory && setErrors) {
       this.markAsRequired(controlModel);

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -11,6 +11,7 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import uniqueId from 'lodash/uniqueId';
 
+import { environment } from '../../../../../environments/environment';
 import { SubmissionScopeType } from '../../../../core/submission/submission-scope-type';
 import { VocabularyOptions } from '../../../../core/submission/vocabularies/models/vocabulary-options.model';
 import { isNgbDateStruct } from '../../../date.util';
@@ -36,7 +37,6 @@ import { VisibilityType } from './../../../../submission/sections/visibility-typ
 import { setLayout } from './parser.utils';
 import { ParserOptions } from './parser-options';
 import { ParserType } from './parser-type';
-import { environment } from "../../../../../environments/environment";
 
 export const SUBMISSION_ID: InjectionToken<string> = new InjectionToken<string>('submissionId');
 export const CONFIG_DATA: InjectionToken<FormFieldModel> = new InjectionToken<FormFieldModel>('configData');
@@ -58,6 +58,8 @@ export abstract class FieldParser {
    */
   protected typeField: string;
 
+  ignorePlaceholderForSimpleFields: boolean;
+
   constructor(
     @Inject(SUBMISSION_ID) protected submissionId: string,
     @Inject(CONFIG_DATA) protected configData: FormFieldModel,
@@ -65,6 +67,7 @@ export abstract class FieldParser {
     @Inject(PARSER_OPTIONS) protected parserOptions: ParserOptions,
     protected translate: TranslateService,
   ) {
+    this.ignorePlaceholderForSimpleFields = environment.submission.ignorePlaceholderForSimpleFields;
   }
 
   public abstract modelFactory(fieldValue?: FormFieldMetadataValueObject, label?: boolean): any;
@@ -311,7 +314,7 @@ export abstract class FieldParser {
     if (hint) {
       controlModel.hint = this.configData.hints || '&nbsp;';
     }
-    if (!environment.submission.hidePlaceholderForBasicFields) {
+    if (!this.ignorePlaceholderForSimpleFields) {
       controlModel.placeholder = this.configData.label;
     }
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -250,7 +250,7 @@ export class DefaultAppConfig implements AppConfig {
         ],
       },
     },
-    hidePlaceholderForBasicFields: true
+    ignorePlaceholderForSimpleFields: true,
   };
 
   // Default Language in which the UI will be rendered if the user's browser language is not an active language

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -250,6 +250,7 @@ export class DefaultAppConfig implements AppConfig {
         ],
       },
     },
+    hidePlaceholderForBasicFields: true
   };
 
   // Default Language in which the UI will be rendered if the user's browser language is not an active language

--- a/src/config/submission-config.interface.ts
+++ b/src/config/submission-config.interface.ts
@@ -36,5 +36,5 @@ export interface SubmissionConfig extends Config {
   duplicateDetection: DuplicateDetectionConfig;
   typeBind: TypeBindConfig;
   icons: IconsConfig;
-  hidePlaceholderForBasicFields?: boolean;
+  ignorePlaceholderForSimpleFields?: boolean;
 }

--- a/src/config/submission-config.interface.ts
+++ b/src/config/submission-config.interface.ts
@@ -36,4 +36,5 @@ export interface SubmissionConfig extends Config {
   duplicateDetection: DuplicateDetectionConfig;
   typeBind: TypeBindConfig;
   icons: IconsConfig;
+  hidePlaceholderForBasicFields?: boolean;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -177,6 +177,7 @@ export const environment: BuildConfig = {
         ],
       },
     },
+    ignorePlaceholderForSimpleFields: false,
   },
 
   // NOTE: will log all redux actions and transfers in console


### PR DESCRIPTION
## References
Fixes #4198

## Description
Following what is described in https://www.deque.com/blog/accessible-forms-the-problem-with-placeholders/ as an issue with placeholder, this PR gives the possibility to disable, via a configuration property, the placeholders in simple fields during submission. (fields where it would just be the replica of the label)

## Instructions for Reviewers

If the newly introduced param ignorePlaceholderForSimpleFields is set to true in the default-app.config.ts the placeholders in submission shouldn't be visible unless they are different from the label and bring some additional information.

If set to false all the placeholders should be visible as before.

List of changes in this PR:

Make placeholder presence configurable
Fix wrongly used placeholder in date field

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
