### PR TITLE
Escaping ':' in search queries, except if advanced=true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log
 junit.xml
 
 /src/mirador-viewer/config.local.js
+.vscode

--- a/cypress/e2e/search-navbar.cy.ts
+++ b/cypress/e2e/search-navbar.cy.ts
@@ -17,7 +17,7 @@ describe('Search from Navigation Bar', () => {
   // NOTE: these tests currently assume this query will return results!
   const query = Cypress.env('DSPACE_TEST_SEARCH_TERM');
 
-  it('should go to search page with correct query if submitted (from home)', () => {
+  it.only('should go to search page with correct query if submitted (from home)', () => {
     cy.visit('/');
     // This is the GET command that will actually run the search
     cy.intercept('GET', '/server/api/discover/search/objects*').as('search-results');
@@ -26,6 +26,8 @@ describe('Search from Navigation Bar', () => {
     page.submitQueryByPressingEnter();
     // New URL should include query param
     cy.url().should('include', 'query='.concat(query));
+    // New URL should NOT include the extended param
+    cy.url().should('not.include', 'extended=true');
     // Wait for search results to come back from the above GET command
     cy.wait('@search-results');
     // At least one search result should be displayed

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function (config) {
     ],
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
-      captureConsole: false,
+      captureConsole: false, // Set to true to get output from tests in the terminal
       jasmine: {
         failSpecWithNoExpectations: true
       }

--- a/src/app/core/shared/search/models/paginated-search-options.model.ts
+++ b/src/app/core/shared/search/models/paginated-search-options.model.ts
@@ -14,7 +14,7 @@ export class PaginatedSearchOptions extends SearchOptions {
   pagination?: PaginationComponentOptions;
   sort?: SortOptions;
 
-  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions, view?: ViewMode}) {
+  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions, view?: ViewMode, advanced?: boolean}) {
     super(options);
     this.pagination = options.pagination;
     this.sort = options.sort;

--- a/src/app/core/shared/search/models/paginated-search-options.model.ts
+++ b/src/app/core/shared/search/models/paginated-search-options.model.ts
@@ -14,7 +14,7 @@ export class PaginatedSearchOptions extends SearchOptions {
   pagination?: PaginationComponentOptions;
   sort?: SortOptions;
 
-  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions, view?: ViewMode, advanced?: boolean}) {
+  constructor(options: {configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[], fixedFilter?: any, pagination?: PaginationComponentOptions, sort?: SortOptions, view?: ViewMode, expert?: boolean}) {
     super(options);
     this.pagination = options.pagination;
     this.sort = options.sort;

--- a/src/app/core/shared/search/models/search-options.model.spec.ts
+++ b/src/app/core/shared/search/models/search-options.model.spec.ts
@@ -1,6 +1,101 @@
 import { DSpaceObjectType } from '../../dspace-object-type.model';
 import { SearchFilter } from './search-filter.model';
-import { SearchOptions } from './search-options.model';
+import {
+  escapeLuceneSpecialChars,
+  SearchOptions,
+} from './search-options.model';
+
+describe('escapeLuceneSpecialChars', () => {
+
+  it('should return plain text unchanged', () => {
+    expect(escapeLuceneSpecialChars('hello world')).toEqual('hello world');
+  });
+
+  it('should escape +', () => {
+    expect(escapeLuceneSpecialChars('a+b')).toEqual('a\\+b');
+  });
+
+  it('should escape -', () => {
+    expect(escapeLuceneSpecialChars('a-b')).toEqual('a\\-b');
+  });
+
+  it('should escape & (and thereby &&)', () => {
+    expect(escapeLuceneSpecialChars('a&&b')).toEqual('a\\&\\&b');
+  });
+
+  it('should escape | (and thereby ||)', () => {
+    expect(escapeLuceneSpecialChars('a||b')).toEqual('a\\|\\|b');
+  });
+
+  it('should escape !', () => {
+    expect(escapeLuceneSpecialChars('!a')).toEqual('\\!a');
+  });
+
+  it('should escape (', () => {
+    expect(escapeLuceneSpecialChars('(a')).toEqual('\\(a');
+  });
+
+  it('should escape )', () => {
+    expect(escapeLuceneSpecialChars('a)')).toEqual('a\\)');
+  });
+
+  it('should escape {', () => {
+    expect(escapeLuceneSpecialChars('{a')).toEqual('\\{a');
+  });
+
+  it('should escape }', () => {
+    expect(escapeLuceneSpecialChars('a}')).toEqual('a\\}');
+  });
+
+  it('should escape [', () => {
+    expect(escapeLuceneSpecialChars('[a')).toEqual('\\[a');
+  });
+
+  it('should escape ]', () => {
+    expect(escapeLuceneSpecialChars('a]')).toEqual('a\\]');
+  });
+
+  it('should escape ^', () => {
+    expect(escapeLuceneSpecialChars('^a')).toEqual('\\^a');
+  });
+
+  it('should escape "', () => {
+    expect(escapeLuceneSpecialChars('"a"')).toEqual('\\"a\\"');
+  });
+
+  it('should escape ~', () => {
+    expect(escapeLuceneSpecialChars('a~')).toEqual('a\\~');
+  });
+
+  it('should escape *', () => {
+    expect(escapeLuceneSpecialChars('a*')).toEqual('a\\*');
+  });
+
+  it('should escape ?', () => {
+    expect(escapeLuceneSpecialChars('a?')).toEqual('a\\?');
+  });
+
+  it('should escape :', () => {
+    expect(escapeLuceneSpecialChars('title:foo')).toEqual('title\\:foo');
+  });
+
+  it('should escape \\', () => {
+    expect(escapeLuceneSpecialChars('a\\b')).toEqual('a\\\\b');
+  });
+
+  it('should escape /', () => {
+    expect(escapeLuceneSpecialChars('a/b')).toEqual('a\\/b');
+  });
+
+  it('should escape multiple special characters in one string', () => {
+    expect(escapeLuceneSpecialChars('(hello+world)')).toEqual('\\(hello\\+world\\)');
+  });
+
+  it('should escape all special characters when they appear together', () => {
+    expect(escapeLuceneSpecialChars('+-&|!(){}[]^"~*?:\\/')).toEqual('\\+\\-\\&\\|\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/');
+  });
+
+});
 
 describe('SearchOptions', () => {
   let options: SearchOptions;
@@ -38,6 +133,18 @@ describe('SearchOptions', () => {
         'f.example=second%20value&' +
         'f.range=%5B2002%20TO%202021%5D,equals',
       );
+    });
+
+    it('should escape Lucene special characters in the query', () => {
+      const specialOptions = new SearchOptions({ query: 'title:foo (bar)+baz' });
+      const outcome = specialOptions.toRestUrl(baseUrl);
+      expect(outcome).toEqual('www.rest.com?query=title%5C%3Afoo%20%5C(bar%5C)%5C%2Bbaz');
+    });
+
+    it('should not escape the query when expert mode is enabled', () => {
+      const expertOptions = new SearchOptions({ query: 'title:foo', expert: true });
+      const outcome = expertOptions.toRestUrl(baseUrl);
+      expect(outcome).toEqual('www.rest.com?query=title%3Afoo');
     });
 
   });

--- a/src/app/core/shared/search/models/search-options.model.ts
+++ b/src/app/core/shared/search/models/search-options.model.ts
@@ -50,10 +50,11 @@ export class SearchOptions {
       args.push(this.encodedFixedFilter);
     }
     if (isNotEmpty(this.query)) {
-      if (!this.advanced){
-        this.query.replace(':', '\:');
+      if (!this.advanced) {
+        args.push(`query=${encodeURIComponent(this.query.replace(':', '\\:'))}`);
+      } else {
+        args.push(`query=${encodeURIComponent(this.query)}`);
       }
-      args.push(`query=${encodeURIComponent(this.query)}`);
     }
     if (isNotEmpty(this.scope)) {
       args.push(`scope=${encodeURIComponent(this.scope)}`);

--- a/src/app/core/shared/search/models/search-options.model.ts
+++ b/src/app/core/shared/search/models/search-options.model.ts
@@ -16,7 +16,7 @@ export class SearchOptions {
   view?: ViewMode = ViewMode.ListElement;
   scope?: string;
   query?: string;
-  advanced?: boolean;
+  expert?: boolean;
   dsoTypes?: DSpaceObjectType[];
   filters?: SearchFilter[];
   fixedFilter?: string;
@@ -24,7 +24,7 @@ export class SearchOptions {
   constructor(
     options: {
       configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[],
-      fixedFilter?: string, advanced?: boolean
+      fixedFilter?: string, expert?: boolean
     },
   ) {
     this.configuration = options.configuration;
@@ -33,7 +33,7 @@ export class SearchOptions {
     this.dsoTypes = options.dsoTypes;
     this.filters = options.filters;
     this.fixedFilter = options.fixedFilter;
-    this.advanced = options.advanced;
+    this.expert = options.expert;
   }
 
   /**
@@ -50,7 +50,7 @@ export class SearchOptions {
       args.push(this.encodedFixedFilter);
     }
     if (isNotEmpty(this.query)) {
-      if (!this.advanced) {
+      if (!this.expert) {
         args.push(`query=${encodeURIComponent(this.query.replace(':', '\\:'))}`);
       } else {
         args.push(`query=${encodeURIComponent(this.query)}`);

--- a/src/app/core/shared/search/models/search-options.model.ts
+++ b/src/app/core/shared/search/models/search-options.model.ts
@@ -19,11 +19,12 @@ export class SearchOptions {
   dsoTypes?: DSpaceObjectType[];
   filters?: SearchFilter[];
   fixedFilter?: string;
+  advanced?: boolean;
 
   constructor(
     options: {
       configuration?: string, scope?: string, query?: string, dsoTypes?: DSpaceObjectType[], filters?: SearchFilter[],
-      fixedFilter?: string
+      fixedFilter?: string, advanced?: boolean
     },
   ) {
     this.configuration = options.configuration;
@@ -32,6 +33,7 @@ export class SearchOptions {
     this.dsoTypes = options.dsoTypes;
     this.filters = options.filters;
     this.fixedFilter = options.fixedFilter;
+    this.advanced = options.advanced;
   }
 
   /**
@@ -48,6 +50,9 @@ export class SearchOptions {
       args.push(this.encodedFixedFilter);
     }
     if (isNotEmpty(this.query)) {
+      if (!this.advanced){
+        this.query.replace(':', '\:');
+      }
       args.push(`query=${encodeURIComponent(this.query)}`);
     }
     if (isNotEmpty(this.scope)) {

--- a/src/app/core/shared/search/models/search-options.model.ts
+++ b/src/app/core/shared/search/models/search-options.model.ts
@@ -16,10 +16,10 @@ export class SearchOptions {
   view?: ViewMode = ViewMode.ListElement;
   scope?: string;
   query?: string;
+  advanced?: boolean;
   dsoTypes?: DSpaceObjectType[];
   filters?: SearchFilter[];
   fixedFilter?: string;
-  advanced?: boolean;
 
   constructor(
     options: {

--- a/src/app/core/shared/search/models/search-options.model.ts
+++ b/src/app/core/shared/search/models/search-options.model.ts
@@ -9,6 +9,14 @@ import { ViewMode } from '../../view-mode.model';
 import { SearchFilter } from './search-filter.model';
 
 /**
+ * Escapes all Lucene special characters in a query string so they are treated as literals.
+ * Special characters: + - & | ! ( ) { } [ ] ^ " ~ * ? : \ /
+ */
+export function escapeLuceneSpecialChars(query: string): string {
+  return query.replace(/[+\-&|!(){}[\]^"~*?:\\/]/g, '\\$&');
+}
+
+/**
  * This model class represents all parameters needed to request information about a certain search request
  */
 export class SearchOptions {
@@ -51,7 +59,7 @@ export class SearchOptions {
     }
     if (isNotEmpty(this.query)) {
       if (!this.expert) {
-        args.push(`query=${encodeURIComponent(this.query.replace(':', '\\:'))}`);
+        args.push(`query=${encodeURIComponent(escapeLuceneSpecialChars(this.query))}`);
       } else {
         args.push(`query=${encodeURIComponent(this.query)}`);
       }

--- a/src/app/shared/search-form/search-form.component.html
+++ b/src/app/shared/search-form/search-form.component.html
@@ -10,7 +10,7 @@
         </button>
       }
     <div class="checkbox-wrapper-8">
-      <input class="tgl" id="cb3-8" name="advanced" type="checkbox" [(ngModel)]="advanced"/>
+      <input class="tgl" id="cb3-8" name="expert" type="checkbox" [(ngModel)]="expert"/>
       <label class="tgl-btn" [attr.data-tg-off]="('search.form.expert_off' | translate )" 
         [attr.data-tg-on]="('search.form.expert_on' | translate )" for="cb3-8"></label>
     </div>

--- a/src/app/shared/search-form/search-form.component.html
+++ b/src/app/shared/search-form/search-form.component.html
@@ -12,7 +12,7 @@
       <input type="text" [(ngModel)]="query" name="query" class="form-control"
         [attr.aria-label]="searchPlaceholder" [attr.data-test]="'search-box' | dsBrowserOnly"
         [placeholder]="searchPlaceholder" tabindex="0">
-      <input type="checkbox" [(ngModel)]="advanced" [attr.name]="{{ ('search.form.advanced' | translate ) }}" checked />
+      <input type="checkbox" [(ngModel)]="advanced" name="advanced" checked /><label for="advanced">{{ "('search.form.advanced' | translate )" }}</label>
       <button type="submit" class="search-button btn btn-{{brandColor}}" [attr.data-test]="'search-button' | dsBrowserOnly" role="button" tabindex="0"><i class="fas fa-search"></i> {{ ('search.form.search' | translate) }}</button>
     </div>
   </div>

--- a/src/app/shared/search-form/search-form.component.html
+++ b/src/app/shared/search-form/search-form.component.html
@@ -9,10 +9,14 @@
           {{dsoNameService.getName(selectedScope | async) || ('search.form.scope.all' | translate)}}
         </button>
       }
-      <input type="text" [(ngModel)]="query" name="query" class="form-control"
+    <div class="checkbox-wrapper-8">
+      <input class="tgl" id="cb3-8" name="advanced" type="checkbox" [(ngModel)]="advanced"/>
+      <label class="tgl-btn" [attr.data-tg-off]="('search.form.expert_off' | translate )" 
+        [attr.data-tg-on]="('search.form.expert_on' | translate )" for="cb3-8"></label>
+    </div>
+    <input type="text" [(ngModel)]="query" name="query" class="form-control"
         [attr.aria-label]="searchPlaceholder" [attr.data-test]="'search-box' | dsBrowserOnly"
         [placeholder]="searchPlaceholder" tabindex="0">
-      <input type="checkbox" [(ngModel)]="advanced" name="advanced" checked /><label for="advanced">{{ "('search.form.advanced' | translate )" }}</label>
       <button type="submit" class="search-button btn btn-{{brandColor}}" [attr.data-test]="'search-button' | dsBrowserOnly" role="button" tabindex="0"><i class="fas fa-search"></i> {{ ('search.form.search' | translate) }}</button>
     </div>
   </div>

--- a/src/app/shared/search-form/search-form.component.html
+++ b/src/app/shared/search-form/search-form.component.html
@@ -12,6 +12,7 @@
       <input type="text" [(ngModel)]="query" name="query" class="form-control"
         [attr.aria-label]="searchPlaceholder" [attr.data-test]="'search-box' | dsBrowserOnly"
         [placeholder]="searchPlaceholder" tabindex="0">
+      <input type="checkbox" [(ngModel)]="advanced" [attr.name]="{{ ('search.form.advanced' | translate ) }}" checked />
       <button type="submit" class="search-button btn btn-{{brandColor}}" [attr.data-test]="'search-button' | dsBrowserOnly" role="button" tabindex="0"><i class="fas fa-search"></i> {{ ('search.form.search' | translate) }}</button>
     </div>
   </div>

--- a/src/app/shared/search-form/search-form.component.scss
+++ b/src/app/shared/search-form/search-form.component.scss
@@ -7,3 +7,127 @@
 .scope-button {
   max-width: var(--ds-search-form-scope-max-width);
 }
+
+// Copied from https://getcssscan.com/css-checkboxes-examples
+.checkbox-wrapper-8 .tgl {
+  display: none;
+}
+
+.checkbox-wrapper-8 .tgl,
+.checkbox-wrapper-8 .tgl:after,
+.checkbox-wrapper-8 .tgl:before,
+.checkbox-wrapper-8 .tgl *,
+.checkbox-wrapper-8 .tgl *:after,
+.checkbox-wrapper-8 .tgl *:before,
+.checkbox-wrapper-8 .tgl+.tgl-btn {
+  box-sizing: border-box;
+}
+
+.checkbox-wrapper-8 .tgl::-moz-selection,
+.checkbox-wrapper-8 .tgl:after::-moz-selection,
+.checkbox-wrapper-8 .tgl:before::-moz-selection,
+.checkbox-wrapper-8 .tgl *::-moz-selection,
+.checkbox-wrapper-8 .tgl *:after::-moz-selection,
+.checkbox-wrapper-8 .tgl *:before::-moz-selection,
+.checkbox-wrapper-8 .tgl+.tgl-btn::-moz-selection,
+.checkbox-wrapper-8 .tgl::selection,
+.checkbox-wrapper-8 .tgl:after::selection,
+.checkbox-wrapper-8 .tgl:before::selection,
+.checkbox-wrapper-8 .tgl *::selection,
+.checkbox-wrapper-8 .tgl *:after::selection,
+.checkbox-wrapper-8 .tgl *:before::selection,
+.checkbox-wrapper-8 .tgl+.tgl-btn::selection {
+  background: none;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn {
+  outline: 0;
+  display: block;
+  width: 6em;
+  height: 100%;
+  position: relative;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:after,
+.checkbox-wrapper-8 .tgl+.tgl-btn:before {
+  position: relative;
+  display: block;
+  content: "";
+  width: 50%;
+  height: 100%;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:after {
+  left: 0;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:before {
+  display: none;
+}
+
+.checkbox-wrapper-8 .tgl:checked+.tgl-btn:after {
+  left: 50%;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn {
+  overflow: hidden;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  transition: all 0.2s ease;
+  font-family: sans-serif;
+  background: #888;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:after,
+.checkbox-wrapper-8 .tgl+.tgl-btn:before {
+  display: inline-block;
+  transition: all 0.2s ease;
+  width: 100%;
+  text-align: center;
+  position: absolute;
+  line-height: 2em;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:after {
+  left: 100%;
+  margin-top: 3px;
+  content: attr(data-tg-on);
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:before {
+  left: 0;
+  margin-top: 3px;
+  content: attr(data-tg-off);
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:active {
+  background: #888;
+}
+
+.checkbox-wrapper-8 .tgl+.tgl-btn:active:before {
+  left: -10%;
+}
+
+.checkbox-wrapper-8 .tgl:checked+.tgl-btn {
+  background: #86d993;
+}
+
+.checkbox-wrapper-8 .tgl:checked+.tgl-btn:before {
+  left: -100%;
+}
+
+.checkbox-wrapper-8 .tgl:checked+.tgl-btn:after {
+  left: 0;
+}
+
+.checkbox-wrapper-8 .tgl:checked+.tgl-btn:active:after {
+  left: 10%;
+}

--- a/src/app/shared/search-form/search-form.component.spec.ts
+++ b/src/app/shared/search-form/search-form.component.spec.ts
@@ -87,7 +87,7 @@ describe('SearchFormComponent', () => {
 
     fixture.detectChanges();
     tick();
-    const queryInput = de.query(By.css('input')).nativeElement;
+    const queryInput = de.query(By.css('input[name="query"]')).nativeElement;
 
     expect(queryInput.value).toBe(testString);
   }));

--- a/src/app/shared/search-form/search-form.component.ts
+++ b/src/app/shared/search-form/search-form.component.ts
@@ -56,7 +56,7 @@ export class SearchFormComponent implements OnChanges {
   /**
    * True to pass the search query without esacping of special characters.
    */
-  @Input() advanced: boolean;
+  @Input() expert: boolean;
 
   /**
    * True when the search component should show results on the current page

--- a/src/app/shared/search-form/search-form.component.ts
+++ b/src/app/shared/search-form/search-form.component.ts
@@ -54,6 +54,11 @@ export class SearchFormComponent implements OnChanges {
   @Input() query: string;
 
   /**
+   * True to pass the search query without esacping of special characters.
+   */
+  @Input() advanced: boolean;
+
+  /**
    * True when the search component should show results on the current page
    */
   @Input() inPlaceSearch: boolean;

--- a/src/app/shared/search-form/themed-search-form.component.ts
+++ b/src/app/shared/search-form/themed-search-form.component.ts
@@ -19,7 +19,7 @@ export class ThemedSearchFormComponent extends ThemedComponent<SearchFormCompone
 
   @Input() query: string;
 
-  @Input() advanced: boolean;
+  @Input() expert: boolean;
 
   @Input() inPlaceSearch: boolean;
 
@@ -41,7 +41,7 @@ export class ThemedSearchFormComponent extends ThemedComponent<SearchFormCompone
 
   protected inAndOutputNames: (keyof SearchFormComponent & keyof this)[] = [
     'query',
-    'advanced',
+    'expert',
     'inPlaceSearch',
     'scope',
     'hideScopeInUrl',

--- a/src/app/shared/search-form/themed-search-form.component.ts
+++ b/src/app/shared/search-form/themed-search-form.component.ts
@@ -19,6 +19,8 @@ export class ThemedSearchFormComponent extends ThemedComponent<SearchFormCompone
 
   @Input() query: string;
 
+  @Input() advanced: boolean;
+
   @Input() inPlaceSearch: boolean;
 
   @Input() scope: string;
@@ -39,6 +41,7 @@ export class ThemedSearchFormComponent extends ThemedComponent<SearchFormCompone
 
   protected inAndOutputNames: (keyof SearchFormComponent & keyof this)[] = [
     'query',
+    'advanced',
     'inPlaceSearch',
     'scope',
     'hideScopeInUrl',

--- a/src/app/shared/search/advanced-search/advanced-search.component.ts
+++ b/src/app/shared/search/advanced-search/advanced-search.component.ts
@@ -133,6 +133,7 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
     if (isNotEmpty(this.currentValue)) {
       this.searchFilterService.minimizeAll();
       this.subs.push(this.searchConfigurationService.selectNewAppliedFilterParams(this.currentFilter, this.currentValue.trim(), this.currentOperator).pipe(take(1)).subscribe((params: Params) => {
+        params.advanced = true;
         void this.router.navigate([this.searchService.getSearchLink()], {
           queryParams: params,
         });

--- a/src/app/shared/search/advanced-search/advanced-search.component.ts
+++ b/src/app/shared/search/advanced-search/advanced-search.component.ts
@@ -133,7 +133,7 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
     if (isNotEmpty(this.currentValue)) {
       this.searchFilterService.minimizeAll();
       this.subs.push(this.searchConfigurationService.selectNewAppliedFilterParams(this.currentFilter, this.currentValue.trim(), this.currentOperator).pipe(take(1)).subscribe((params: Params) => {
-        params.advanced = true;
+        params.expert = true;
         void this.router.navigate([this.searchService.getSearchLink()], {
           queryParams: params,
         });

--- a/src/app/shared/search/search-configuration.service.ts
+++ b/src/app/shared/search/search-configuration.service.ts
@@ -188,11 +188,11 @@ export class SearchConfigurationService implements OnDestroy {
   }
 
   /**
-   * @returns {Observable<boolean>} Emits the current advanced string
+   * @returns {Observable<boolean>} Emits the current expert string
    */
-  getCurrentAdvanced(defaultAdvanced: boolean) {
-    return this.routeService.getQueryParameterValue('advanced').pipe(map((advanced) => {
-      return advanced === 'true' || defaultAdvanced;
+  getCurrentExpert(defaultExpert: boolean) {
+    return this.routeService.getQueryParameterValue('expert').pipe(map((expert) => {
+      return expert === 'true' || defaultExpert;
     }));
   }
 
@@ -369,7 +369,7 @@ export class SearchConfigurationService implements OnDestroy {
       this.getConfigurationPart(defaults.configuration),
       this.getScopePart(defaults.scope),
       this.getQueryPart(defaults.query),
-      this.getAdvancedPart(defaults.advanced),
+      this.getExpertPart(defaults.expert),
       this.getDSOTypePart(),
       this.getFiltersPart(),
       this.getFixedFilterPart(),
@@ -394,7 +394,7 @@ export class SearchConfigurationService implements OnDestroy {
       this.getSortPart(paginationId, defaults.sort),
       this.getScopePart(defaults.scope),
       this.getQueryPart(defaults.query),
-      this.getAdvancedPart(defaults.advanced),
+      this.getExpertPart(defaults.expert),
       this.getDSOTypePart(),
       this.getFiltersPart(),
       this.getFixedFilterPart(),
@@ -447,12 +447,11 @@ export class SearchConfigurationService implements OnDestroy {
   }
 
   /**
-   * @returns {Observable<{advanced: boolean}>} Emits the current advanced boolean as a partial SearchOptions object
+   * @returns {Observable<{expert: boolean}>} Emits the current expert boolean as a partial SearchOptions object
    */
-  private getAdvancedPart(defaultAdvanced: boolean): Observable<{advanced: boolean}> {
-    return this.getCurrentAdvanced(defaultAdvanced).pipe(map((advanced) => {
-      console.log("getAdvancedPart", advanced)
-      return { advanced };
+  private getExpertPart(defaultExpert: boolean): Observable<{expert: boolean}> {
+    return this.getCurrentExpert(defaultExpert).pipe(map((expert) => {
+      return { expert };
     }));
   }
 

--- a/src/app/shared/search/search-configuration.service.ts
+++ b/src/app/shared/search/search-configuration.service.ts
@@ -188,6 +188,15 @@ export class SearchConfigurationService implements OnDestroy {
   }
 
   /**
+   * @returns {Observable<boolean>} Emits the current advanced string
+   */
+  getCurrentAdvanced(defaultAdvanced: boolean) {
+    return this.routeService.getQueryParameterValue('advanced').pipe(map((advanced) => {
+      return advanced === 'true' || defaultAdvanced;
+    }));
+  }
+
+  /**
    * @returns {Observable<number>} Emits the current DSpaceObject type as a number
    */
   getCurrentDSOType(): Observable<DSpaceObjectType> {
@@ -360,6 +369,7 @@ export class SearchConfigurationService implements OnDestroy {
       this.getConfigurationPart(defaults.configuration),
       this.getScopePart(defaults.scope),
       this.getQueryPart(defaults.query),
+      this.getAdvancedPart(defaults.advanced),
       this.getDSOTypePart(),
       this.getFiltersPart(),
       this.getFixedFilterPart(),
@@ -384,6 +394,7 @@ export class SearchConfigurationService implements OnDestroy {
       this.getSortPart(paginationId, defaults.sort),
       this.getScopePart(defaults.scope),
       this.getQueryPart(defaults.query),
+      this.getAdvancedPart(defaults.advanced),
       this.getDSOTypePart(),
       this.getFiltersPart(),
       this.getFixedFilterPart(),
@@ -432,6 +443,16 @@ export class SearchConfigurationService implements OnDestroy {
   private getQueryPart(defaultQuery: string): Observable<any> {
     return this.getCurrentQuery(defaultQuery).pipe(map((query) => {
       return { query };
+    }));
+  }
+
+  /**
+   * @returns {Observable<{advanced: boolean}>} Emits the current advanced boolean as a partial SearchOptions object
+   */
+  private getAdvancedPart(defaultAdvanced: boolean): Observable<{advanced: boolean}> {
+    return this.getCurrentAdvanced(defaultAdvanced).pipe(map((advanced) => {
+      console.log("getAdvancedPart", advanced)
+      return { advanced };
     }));
   }
 

--- a/src/app/shared/search/search.component.html
+++ b/src/app/shared/search/search.component.html
@@ -106,6 +106,7 @@
 <ng-template #searchForm>
   <ds-search-form id="search-form"
     [query]="(searchOptions$ | async)?.query"
+    [advanced]="(searchOptions$ | async)?.advanced"
     [scope]="(searchOptions$ | async)?.scope"
     [hideScopeInUrl]="hideScopeInUrl"
     [currentUrl]="searchLink"

--- a/src/app/shared/search/search.component.html
+++ b/src/app/shared/search/search.component.html
@@ -106,7 +106,7 @@
 <ng-template #searchForm>
   <ds-search-form id="search-form"
     [query]="(searchOptions$ | async)?.query"
-    [advanced]="(searchOptions$ | async)?.advanced"
+    [expert]="(searchOptions$ | async)?.expert"
     [scope]="(searchOptions$ | async)?.scope"
     [hideScopeInUrl]="hideScopeInUrl"
     [currentUrl]="searchLink"

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -300,7 +300,7 @@ describe('SearchComponent', () => {
       configuration: 'default',
       scope: '',
       sort: sortOptionsList[0],
-      advanced: false,
+      expert: false,
     });
     expect(comp.currentConfiguration$).toBeObservable(cold('b', {
       b: 'default',

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -300,6 +300,7 @@ describe('SearchComponent', () => {
       configuration: 'default',
       scope: '',
       sort: sortOptionsList[0],
+      advanced: false,
     });
     expect(comp.currentConfiguration$).toBeObservable(cold('b', {
       b: 'default',

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -231,7 +231,7 @@ export class SearchComponent implements OnDestroy, OnInit {
   /**
    * True to pass the query as-is without escaping of special characters.
    */
-  @Input() advanced = false;
+  @Input() expert = false;
 
   /**
    * The fallback scope when no scope is defined in the url, if this is also undefined no scope will be set
@@ -426,7 +426,6 @@ export class SearchComponent implements OnDestroy, OnInit {
       debounceTime(100),
     ).subscribe(([configuration, searchSortOptions, searchOptions, sortOption, scope]: [string, SortOptions[], PaginatedSearchOptions, SortOptions, string]) => {
       // Build the PaginatedSearchOptions object
-      console.log("searchOptions", searchOptions);
       const combinedOptions = Object.assign({}, searchOptions,
         {
           configuration: searchOptions.configuration || configuration,
@@ -435,10 +434,9 @@ export class SearchComponent implements OnDestroy, OnInit {
       if (combinedOptions.query === '') {
         combinedOptions.query = this.query;
       }
-      if (combinedOptions.advanced === undefined) {
-        combinedOptions.advanced = this.advanced;
+      if (combinedOptions.expert === undefined) {
+        combinedOptions.expert = this.expert;
       }
-      console.log(this.advanced, combinedOptions.advanced);
       if (isEmpty(combinedOptions.scope)) {
         combinedOptions.scope = scope;
       }

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -426,6 +426,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       debounceTime(100),
     ).subscribe(([configuration, searchSortOptions, searchOptions, sortOption, scope]: [string, SortOptions[], PaginatedSearchOptions, SortOptions, string]) => {
       // Build the PaginatedSearchOptions object
+      console.log("searchOptions", searchOptions);
       const combinedOptions = Object.assign({}, searchOptions,
         {
           configuration: searchOptions.configuration || configuration,
@@ -433,8 +434,11 @@ export class SearchComponent implements OnDestroy, OnInit {
         });
       if (combinedOptions.query === '') {
         combinedOptions.query = this.query;
+      }
+      if (combinedOptions.advanced === undefined) {
         combinedOptions.advanced = this.advanced;
       }
+      console.log(this.advanced, combinedOptions.advanced);
       if (isEmpty(combinedOptions.scope)) {
         combinedOptions.scope = scope;
       }
@@ -542,7 +546,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       followLinks.push(followLink<WorkspaceItem>('supervisionOrders', { isOptional: true }) as any);
     }
 
-    const searchOptionsWithHidden = Object.assign (new PaginatedSearchOptions({}), searchOptions);
+    const searchOptionsWithHidden = Object.assign(new PaginatedSearchOptions({}), searchOptions);
     if (isNotEmpty(this.hiddenQuery)) {
       if (isNotEmpty(searchOptionsWithHidden.query)) {
         searchOptionsWithHidden.query = searchOptionsWithHidden.query + ' AND ' + this.hiddenQuery;

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -229,6 +229,11 @@ export class SearchComponent implements OnDestroy, OnInit {
   @Input() query: string;
 
   /**
+   * True to pass the query as-is without escaping of special characters.
+   */
+  @Input() advanced = false;
+
+  /**
    * The fallback scope when no scope is defined in the url, if this is also undefined no scope will be set
    */
   @Input() scope: string;
@@ -428,6 +433,7 @@ export class SearchComponent implements OnDestroy, OnInit {
         });
       if (combinedOptions.query === '') {
         combinedOptions.query = this.query;
+        combinedOptions.advanced = this.advanced;
       }
       if (isEmpty(combinedOptions.scope)) {
         combinedOptions.scope = scope;

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4944,7 +4944,9 @@
 
   "search.form.search": "Search",
 
-  "search.form.search": "Advanced",
+  "search.form.expert_on": "Expert",
+
+  "search.form.expert_off": "Simple",
 
   "search.form.search_dspace": "All repository",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4944,6 +4944,8 @@
 
   "search.form.search": "Search",
 
+  "search.form.search": "Advanced",
+
   "search.form.search_dspace": "All repository",
 
   "search.form.scope.all": "All of DSpace",


### PR DESCRIPTION
## References

https://github.com/DSpace/DSpace/issues/9670 

## Description

Fixes DSpace/DSpace#9670 by escaping ':' in search queries, except if 'advanced == true'.
It does the following:
- adds an 'advanced' field to the search-form.component, search-options.model, search.component
- changes the search-options.model to escape ':' characters, unless 'advanced == true'
- adds a checkbox to the search-form.component
- adds one entry to the src/assets/i18n/en.json5

TODO:
- [x] add tests
- [x] make sure this looks good
- [x] add other translations

## Instructions for Reviewers

Try to search for something which includes a colon at the end of the word.
Then click the 'advanced' checkbox and try to search using advanced search features.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
