### PR TITLE
Fix: prevent bitstream format cache issue by disabling cached version

### DIFF
--- a/src/app/core/data/bitstream-data.service.spec.ts
+++ b/src/app/core/data/bitstream-data.service.spec.ts
@@ -37,6 +37,8 @@ import {
 } from './request.models';
 import { RequestService } from './request.service';
 import objectContaining = jasmine.objectContaining;
+import { RestResponse } from '../cache/response.models';
+import { RequestEntry } from './request-entry.model';
 
 describe('BitstreamDataService', () => {
   let service: BitstreamDataService;
@@ -47,6 +49,7 @@ describe('BitstreamDataService', () => {
   let rdbService: RemoteDataBuildService;
   let bundleDataService: BundleDataService;
   const bitstreamFormatHref = 'rest-api/bitstreamformats';
+  let responseCacheEntry: RequestEntry;
 
   const bitstream1 = Object.assign(new Bitstream(), {
     id: 'fake-bitstream1',
@@ -71,8 +74,13 @@ describe('BitstreamDataService', () => {
   const url = 'fake-bitstream-url';
 
   beforeEach(() => {
+    responseCacheEntry = new RequestEntry();
+    responseCacheEntry.request = { href: 'https://rest.api/' } as any;
+    responseCacheEntry.response = new RestResponse(true, 200, 'Success');
+
     objectCache = jasmine.createSpyObj('objectCache', {
       remove: jasmine.createSpy('remove'),
+      getByHref: observableOf(responseCacheEntry),
     });
     requestService = getMockRequestService();
     halService = Object.assign(new HALEndpointServiceStub(url));

--- a/src/app/core/data/bitstream-data.service.ts
+++ b/src/app/core/data/bitstream-data.service.ts
@@ -173,9 +173,11 @@ export class BitstreamDataService extends IdentifiableDataService<Bitstream> imp
     this.requestService.setStaleByHrefSubstring(bitsreamFormatUrl);
     // Delete also cache by uuid as the format could be cached also there
     this.objectCache.getByHref(bitsreamFormatUrl).pipe(take(1)).subscribe((cachedRequest) => {
-      const requestUuid = cachedRequest.requestUUIDs[0];
-      if (this.requestService.hasByUUID(requestUuid)) {
-        this.requestService.setStaleByUUID(requestUuid);
+      if (cachedRequest.requestUUIDs && cachedRequest.requestUUIDs.length > 0){
+        const requestUuid = cachedRequest.requestUUIDs[0];
+        if (this.requestService.hasByUUID(requestUuid)) {
+          this.requestService.setStaleByUUID(requestUuid);
+        }
       }
     });
   }

--- a/src/app/core/data/bitstream-data.service.ts
+++ b/src/app/core/data/bitstream-data.service.ts
@@ -163,10 +163,21 @@ export class BitstreamDataService extends IdentifiableDataService<Bitstream> imp
       sendRequest(this.requestService),
       take(1),
     ).subscribe(() => {
-      this.requestService.removeByHrefSubstring(bitstream.self + '/format');
+      this.deleteFormatCache(bitstream);
     });
-
     return this.rdbService.buildFromRequestUUID(requestId);
+  }
+
+  private deleteFormatCache(bitstream: Bitstream) {
+    const bitsreamFormatUrl = bitstream.self + '/format';
+    this.requestService.setStaleByHrefSubstring(bitsreamFormatUrl);
+    // Delete also cache by uuid as the format could be cached also there
+    this.objectCache.getByHref(bitsreamFormatUrl).pipe(take(1)).subscribe((cachedRequest) => {
+      const requestUuid = cachedRequest.requestUUIDs[0];
+      if (this.requestService.hasByUUID(requestUuid)) {
+        this.requestService.setStaleByUUID(requestUuid);
+      }
+    });
   }
 
   /**

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
@@ -246,7 +246,7 @@ export class ItemEditBitstreamBundleComponent implements OnInit, OnDestroy {
           switchMap(() => this.bundleService.getBitstreams(
             this.bundle.id,
             paginatedOptions,
-            followLink('format'),
+            followLink('format', { useCachedVersionIfAvailable: false }),
           )),
         );
       }),

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
@@ -246,7 +246,7 @@ export class ItemEditBitstreamBundleComponent implements OnInit, OnDestroy {
           switchMap(() => this.bundleService.getBitstreams(
             this.bundle.id,
             paginatedOptions,
-            followLink('format', { useCachedVersionIfAvailable: false }),
+            followLink('format'),
           )),
         );
       }),


### PR DESCRIPTION
## References
* Fixes #4137

## Description
Disable cache to ensure the updated bitstream format is displayed immediately after update.

## Instructions for Reviewers
Fixes an issue where bitstream format changes did not appear immediately after saving due to cached data. Cache is now disabled specifically when fetching the bitstream's format to ensure the updated value is shown.

**Steps to reproduce the behavior:**
1. Log in as a user with edit item permissions;
2. Go to my space;
3. Select a submitted item;
4. Edit item;
5. Open bitstream tab;
6. Click the Edit button.
7. Change file format.
8. The newly saved format should be displayed.

List of changes in this PR:
* Disabled cache when resolving `followLink('format')` by setting `{ useCachedVersionIfAvailable: false }` in `item-edit-bitstream-bundle.component.ts`.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
