### PR TITLE
TEST / DEBUG PR: Submission save+sub stability / performance

### DIFF
--- a/src/app/submission/objects/submission-objects.actions.ts
+++ b/src/app/submission/objects/submission-objects.actions.ts
@@ -433,6 +433,7 @@ export class SaveSubmissionFormAction implements Action {
   payload: {
     submissionId: string;
     isManual?: boolean;
+    timestamp: number;
   };
 
   /**
@@ -442,7 +443,8 @@ export class SaveSubmissionFormAction implements Action {
    *    the submission's ID
    */
   constructor(submissionId: string, isManual: boolean = false) {
-    this.payload = { submissionId, isManual };
+    this.payload = { submissionId, isManual, timestamp: Date.now() };
+    console.log(`Creating SaveSubmissionFormAction for submission ${submissionId} at ${new Date().toISOString()}`);
   }
 }
 

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -402,6 +402,9 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
    * Initialize all subscriptions
    */
   subscriptions(): void {
+    // clear existing subscriptions first
+    this.onSectionDestroy();
+    this.subs = [];
     this.subs.push(
       /**
        * Subscribe to form's data
@@ -426,6 +429,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
           this.updateForm(sectionState);
         }),
     );
+    console.log(`Section ${this.sectionData.id} has ${this.subs.length} active subscriptions`);
   }
 
   /**


### PR DESCRIPTION
This is NOT a PR ready for merge, it is an early look at some experimentation I have been doing with debouncing of save dispatch actions, and more thorough subscription management / tracking to reduce the computation overhead and increase the stability of the submission service and form component.

* Debug console output added for testing
* Debouncer added to save operations
* More thorough sub management / tracking

I invite any testing, comments, reviews - one useful exercise is to keep the debug logging in but reverting the other changes and comparing the numbers of logged events. The work here shows a clear improvement, I think, but more work is needed.

I'm leaving the console output, commented-out lines in for now to help see alternatives and changes, and for live testing help.