### PR TITLE
Correct small typo in en.json5

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6961,7 +6961,7 @@
 
   "external-login.confirm-email-sent.header": "Confirmation email sent",
 
-  "external-login.confirm-email-sent.info": " We have sent an emait to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
+  "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
 
   "external-login.provide-email.header": "Provide email",
 


### PR DESCRIPTION
Correct typo in the external-login.confirm-email-sent.info.

## References
* Fixes #4200
