### PR TITLE
[DURACOM-353] fix orejime callbacks

### DIFF
--- a/src/app/shared/cookies/browser-orejime.service.spec.ts
+++ b/src/app/shared/cookies/browser-orejime.service.spec.ts
@@ -433,4 +433,31 @@ describe('BrowserOrejimeService', () => {
       expect(service.orejimeConfig.apps).not.toContain(jasmine.objectContaining({ name: googleAnalytics }));
     });
   });
+
+  describe('applyUpdateSettingsCallbackToApps', () => {
+    let user2: EPerson;
+    let mockApp1, mockApp2;
+    let updateSettingsSpy;
+
+    beforeEach(() => {
+      user2 = Object.assign(new EPerson(), { uuid: 'test-user' });
+      mockApp1 = { name: 'app1', callback: jasmine.createSpy('originalCallback1') };
+      mockApp2 = { name: 'app2', callback: jasmine.createSpy('originalCallback2') };
+      service.orejimeConfig.apps = [mockApp1, mockApp2];
+      updateSettingsSpy = spyOn(service, 'updateSettingsForUsers');
+    });
+
+    it('calls updateSettingsForUsers in a debounced manner when a callback is triggered', (done) => {
+      service.applyUpdateSettingsCallbackToApps(user2);
+
+      mockApp1.callback(true);
+      mockApp2.callback(false);
+
+      setTimeout(() => {
+        expect(updateSettingsSpy).toHaveBeenCalledTimes(1);
+        expect(updateSettingsSpy).toHaveBeenCalledWith(user2);
+        done();
+      }, 400);
+    });
+  });
 });

--- a/src/app/shared/cookies/browser-orejime.service.ts
+++ b/src/app/shared/cookies/browser-orejime.service.ts
@@ -413,7 +413,9 @@ export class BrowserOrejimeService extends OrejimeService {
    * @param user
    */
   updateSettingsForUsers(user: EPerson) {
-    this.setSettingsForUser(user, this.cookieService.get(this.getStorageName(user.uuid)));
+    if (user) {
+      this.setSettingsForUser(user, this.cookieService.get(this.getStorageName(user.uuid)));
+    }
   }
 
   /**

--- a/src/app/shared/cookies/browser-orejime.service.ts
+++ b/src/app/shared/cookies/browser-orejime.service.ts
@@ -192,10 +192,37 @@ export class BrowserOrejimeService extends OrejimeService {
         this.translateConfiguration();
 
         this.orejimeConfig.apps = this.filterConfigApps(appsToHide);
-        this.lazyOrejime.then(({ init }) => {
+
+        this.applyUpdateSettingsCallbackToApps(user);
+
+        void this.lazyOrejime.then(({ init }) => {
           this.orejimeInstance = init(this.orejimeConfig);
         });
       });
+  }
+
+  /**
+   * Applies a debounced callback to update user settings for all apps in the Orejime configuration.
+   *
+   * This method modifies the `callback` property of each app in the `orejimeConfig.apps` array.
+   * It ensures that the `updateSettingsForUsers` method is called in a debounced manner whenever
+   * a consent change occurs for any app. Additionally, it preserves and invokes the original
+   * callback for each app if one is defined.
+   *
+   * @param {EPerson} user - The authenticated user whose settings are being updated.
+   */
+  applyUpdateSettingsCallbackToApps(user: EPerson) {
+    const updateSettingsCallback = debounce(() => this.updateSettingsForUsers(user), updateDebounce);
+
+    this.orejimeConfig.apps.forEach((app) => {
+      const originalCallback = app.callback;
+      app.callback = (consent: boolean) => {
+        updateSettingsCallback();
+        if (originalCallback) {
+          originalCallback(consent);
+        }
+      };
+    });
   }
 
   /**
@@ -220,7 +247,6 @@ export class BrowserOrejimeService extends OrejimeService {
    * @param user The authenticated user
    */
   private initializeUser(user: EPerson) {
-    this.orejimeConfig.callback = debounce((consent, app) => this.updateSettingsForUsers(user), updateDebounce);
     this.orejimeConfig.cookieName = this.getStorageName(user.uuid);
 
     const anonCookie = this.cookieService.get(ANONYMOUS_STORAGE_NAME_OREJIME);


### PR DESCRIPTION
## References
* Fixes #4106

## Description
Since orejime does not have a "global" callback property, we need to apply the method that updates user preferences to each app in orejime's config, and of course we need to call any custom callback already there for each app.

## Instructions for Reviewers

List of changes in this PR:
* Created the `applyUpdateSettingsCallbackToApps` method. This method changes the `callback` property of each app by calling the method that updates the saved user settings, and then calls any `callback` function set to that app in config.
* Wrote tests.

To test this PR, you need to add a non-mandatory cookie to the orejime configuration and then enable/disable that cookie. Changes should be persisted on the REST side, and any original callback should be called.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
