### PR TITLE
[Draft] Prevent double rendering dynamic themes

### DIFF
--- a/src/app/shared/theme-support/theme.effects.spec.ts
+++ b/src/app/shared/theme-support/theme.effects.spec.ts
@@ -2,13 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { ROOT_EFFECTS_INIT } from '@ngrx/effects';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import {
-  cold,
-  hot,
-} from 'jasmine-marbles';
+import { hot } from 'jasmine-marbles';
 
-import { SetThemeAction } from './theme.actions';
-import { BASE_THEME_NAME } from './theme.constants';
 import { ThemeEffects } from './theme.effects';
 
 describe('ThemeEffects', () => {

--- a/src/app/shared/theme-support/theme.effects.spec.ts
+++ b/src/app/shared/theme-support/theme.effects.spec.ts
@@ -46,13 +46,5 @@ describe('ThemeEffects', () => {
         }),
       );
     });
-
-    it('should set the default theme', () => {
-      const expected = cold('--b-', {
-        b: new SetThemeAction(BASE_THEME_NAME),
-      });
-
-      expect(themeEffects.initTheme$).toBeObservable(expected);
-    });
   });
 });

--- a/src/app/shared/theme-support/theme.effects.ts
+++ b/src/app/shared/theme-support/theme.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Actions, } from '@ngrx/effects';
+import { Actions } from '@ngrx/effects';
 
 @Injectable()
 export class ThemeEffects {

--- a/src/app/shared/theme-support/theme.effects.ts
+++ b/src/app/shared/theme-support/theme.effects.ts
@@ -11,25 +11,14 @@ import { getDefaultThemeConfig } from '../../../config/config.util';
 import { hasValue } from '../empty.util';
 import { SetThemeAction } from './theme.actions';
 import { BASE_THEME_NAME } from './theme.constants';
+import { NoOpAction } from '../ngrx/no-op.action';
 
 @Injectable()
 export class ThemeEffects {
   /**
    * Initialize with a theme that doesn't depend on the route.
    */
-  initTheme$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(ROOT_EFFECTS_INIT),
-      map(() => {
-        const defaultThemeConfig = getDefaultThemeConfig();
-        if (hasValue(defaultThemeConfig)) {
-          return new SetThemeAction(defaultThemeConfig.name);
-        } else {
-          return new SetThemeAction(BASE_THEME_NAME);
-        }
-      }),
-    ),
-  );
+
 
   constructor(
     private actions$: Actions,

--- a/src/app/shared/theme-support/theme.effects.ts
+++ b/src/app/shared/theme-support/theme.effects.ts
@@ -1,17 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  Actions,
-  createEffect,
-  ofType,
-  ROOT_EFFECTS_INIT,
-} from '@ngrx/effects';
-import { map } from 'rxjs/operators';
-
-import { getDefaultThemeConfig } from '../../../config/config.util';
-import { hasValue } from '../empty.util';
-import { SetThemeAction } from './theme.actions';
-import { BASE_THEME_NAME } from './theme.constants';
-import { NoOpAction } from '../ngrx/no-op.action';
+import { Actions, } from '@ngrx/effects';
 
 @Injectable()
 export class ThemeEffects {

--- a/src/app/shared/theme-support/theme.service.ts
+++ b/src/app/shared/theme-support/theme.service.ts
@@ -383,6 +383,13 @@ export class ThemeService {
             take(1),
             map((theme: Theme) => this.getActionForMatch(theme, currentTheme)),
           );
+        } else if (hasNoValue(currentTheme)) {
+          const defaultThemeConfig = getDefaultThemeConfig();
+          if (hasValue(defaultThemeConfig)) {
+            return [new SetThemeAction(defaultThemeConfig.name)];
+          } else {
+            return [new SetThemeAction(BASE_THEME_NAME)];
+          }
         } else {
           // If there are no themes configured, do nothing
           return observableOf(new NoOpAction());

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -25,6 +25,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
+
 import { GenericConstructor } from '../../core/shared/generic-constructor';
 import {
   hasNoValue,

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -29,7 +29,7 @@ import {
 import { GenericConstructor } from '../../core/shared/generic-constructor';
 import {
   hasNoValue,
-  hasValue,
+  hasValue, hasValueOperator,
   isNotEmpty,
 } from '../empty.util';
 import { BASE_THEME_NAME } from './theme.constants';
@@ -71,6 +71,7 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
   protected abstract getComponentName(): string;
 
   protected abstract importThemedComponent(themeName: string): Promise<any>;
+
   protected abstract importUnthemedComponent(): Promise<any>;
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -99,16 +100,17 @@ export abstract class ThemedComponent<T extends object> implements AfterViewInit
   }
 
   initComponentInstance(changes?: SimpleChanges) {
-    this.themeSub = this.themeService?.getThemeName$().subscribe(() => {
-      this.renderComponentInstance(changes);
-    });
+    this.themeSub = this.themeService?.getThemeName$()
+      .pipe(hasValueOperator())
+      .subscribe(() => {
+        this.renderComponentInstance(changes);
+      });
   }
 
   protected renderComponentInstance(changes?: SimpleChanges): void {
     if (hasValue(this.lazyLoadSub)) {
       this.lazyLoadSub.unsubscribe();
     }
-
     if (hasNoValue(this.lazyLoadObs)) {
       this.lazyLoadObs = combineLatest([
         observableOf(changes),

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -25,11 +25,11 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
-
 import { GenericConstructor } from '../../core/shared/generic-constructor';
 import {
   hasNoValue,
-  hasValue, hasValueOperator,
+  hasValue,
+  hasValueOperator,
   isNotEmpty,
 } from '../empty.util';
 import { BASE_THEME_NAME } from './theme.constants';


### PR DESCRIPTION
## References
* Draft for fixing #4123

## Description
The code changes in this PR forego setting an initial theme when dynamic themes are enabled. This way, when initially loading a page, it won't briefly show the base theme before rendering the dynamically configurated theme.

## Instructions for Reviewers
When hard refreshing a page with a dynamically set theme, the base theme won't be briefly loaded anymore.
