### PR TITLE
[Draft] [Port to dspace-7_x] Prevent double rendering dynamic themes

### DIFF
--- a/src/app/shared/theme-support/theme.effects.spec.ts
+++ b/src/app/shared/theme-support/theme.effects.spec.ts
@@ -1,11 +1,9 @@
 import { ThemeEffects } from './theme.effects';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { cold, hot } from 'jasmine-marbles';
+import { hot } from 'jasmine-marbles';
 import { ROOT_EFFECTS_INIT } from '@ngrx/effects';
-import { SetThemeAction } from './theme.actions';
 import { provideMockStore } from '@ngrx/store/testing';
-import { BASE_THEME_NAME } from './theme.constants';
 
 describe('ThemeEffects', () => {
   let themeEffects: ThemeEffects;
@@ -41,14 +39,6 @@ describe('ThemeEffects', () => {
           }
         })
       );
-    });
-
-    it('should set the default theme', () => {
-      const expected = cold('--b-', {
-        b: new SetThemeAction(BASE_THEME_NAME)
-      });
-
-      expect(themeEffects.initTheme$).toBeObservable(expected);
     });
   });
 });

--- a/src/app/shared/theme-support/theme.effects.ts
+++ b/src/app/shared/theme-support/theme.effects.ts
@@ -1,29 +1,12 @@
 import { Injectable } from '@angular/core';
-import { createEffect, Actions, ofType, ROOT_EFFECTS_INIT } from '@ngrx/effects';
-import { map } from 'rxjs/operators';
-import { SetThemeAction } from './theme.actions';
-import { hasValue } from '../empty.util';
-import { BASE_THEME_NAME } from './theme.constants';
-import { getDefaultThemeConfig } from '../../../config/config.util';
+import { Actions } from '@ngrx/effects';
 
 @Injectable()
 export class ThemeEffects {
   /**
    * Initialize with a theme that doesn't depend on the route.
    */
-  initTheme$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(ROOT_EFFECTS_INIT),
-      map(() => {
-        const defaultThemeConfig = getDefaultThemeConfig();
-        if (hasValue(defaultThemeConfig)) {
-          return new SetThemeAction(defaultThemeConfig.name);
-        } else {
-          return new SetThemeAction(BASE_THEME_NAME);
-        }
-      })
-    )
-  );
+
 
   constructor(
     private actions$: Actions,

--- a/src/app/shared/theme-support/theme.service.ts
+++ b/src/app/shared/theme-support/theme.service.ts
@@ -334,6 +334,13 @@ export class ThemeService {
             take(1),
             map((theme: Theme) => this.getActionForMatch(theme, currentTheme))
           );
+        } else if (hasNoValue(currentTheme)) {
+          const defaultThemeConfig = getDefaultThemeConfig();
+          if (hasValue(defaultThemeConfig)) {
+            return [new SetThemeAction(defaultThemeConfig.name)];
+          } else {
+            return [new SetThemeAction(BASE_THEME_NAME)];
+          }
         } else {
           // If there are no themes configured, do nothing
           return observableOf(new NoOpAction());


### PR DESCRIPTION
## References
* Draft for fixing #4123
* Backport of [#4228] to dspace-7_x

## Description
The code changes in this PR forego setting an initial theme when dynamic themes are enabled. This way, when initially loading a page, it won't briefly show the base theme before rendering the dynamically configurated theme.

## Instructions for Reviewers
When hard refreshing a page with a dynamically set theme, the base theme won't be briefly loaded anymore.
