### PR TITLE
[DURACOM-350] fix cache issue after mydspace action

### DIFF
--- a/src/app/shared/mydspace-actions/mydspace-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.ts
@@ -107,15 +107,19 @@ export abstract class MyDSpaceActionsComponent<T extends DSpaceObject, TService 
     };
     // This assures that the search cache is empty before reloading mydspace.
     // See https://github.com/DSpace/dspace-angular/pull/468
-    this.invalidateCacheForCurrentSearchUrl();
+    this.invalidateCacheForCurrentSearchUrl(true);
   }
 
-  invalidateCacheForCurrentSearchUrl(): void {
+  invalidateCacheForCurrentSearchUrl(shouldNavigate = false): void {
     const url = decodeURIComponent(this.router.url);
     this.searchService.getEndpoint().pipe(
       take(1),
       tap((cachedHref: string) => this.requestService.removeByHrefSubstring(cachedHref)),
-    ).subscribe(() => this.router.navigateByUrl(url));
+    ).subscribe(() => {
+      if (shouldNavigate) {
+        this.router.navigateByUrl(url);
+      }
+    });
   }
 
   /**

--- a/src/app/shared/mydspace-actions/mydspace-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.ts
@@ -101,13 +101,17 @@ export abstract class MyDSpaceActionsComponent<T extends DSpaceObject, TService 
   reload(): void {
 
     this.router.navigated = false;
-    const url = decodeURIComponent(this.router.url);
     // override the route reuse strategy
     this.router.routeReuseStrategy.shouldReuseRoute = () => {
       return false;
     };
     // This assures that the search cache is empty before reloading mydspace.
     // See https://github.com/DSpace/dspace-angular/pull/468
+    this.invalidateCacheForCurrentSearchUrl();
+  }
+
+  invalidateCacheForCurrentSearchUrl(): void {
+    const url = decodeURIComponent(this.router.url);
     this.searchService.getEndpoint().pipe(
       take(1),
       tap((cachedHref: string) => this.requestService.removeByHrefSubstring(cachedHref)),

--- a/src/app/shared/mydspace-actions/mydspace-reloadable-actions.spec.ts
+++ b/src/app/shared/mydspace-actions/mydspace-reloadable-actions.spec.ts
@@ -219,6 +219,7 @@ describe('MyDSpaceReloadableActionsComponent', () => {
       spyOn(component, 'reloadObjectExecution').and.callThrough();
       spyOn(component, 'convertReloadedObject').and.callThrough();
       spyOn(component.processCompleted, 'emit').and.callThrough();
+      spyOn(component, 'invalidateCacheForCurrentSearchUrl').and.callThrough();
 
       (component as any).objectDataService = mockDataService;
     });
@@ -239,10 +240,11 @@ describe('MyDSpaceReloadableActionsComponent', () => {
       });
     });
 
-    it('should emit the reloaded object in case of success', (done) => {
+    it('should emit the reloaded object and invalidate cache in case of success', (done) => {
 
       component.startActionExecution().subscribe( (result) => {
         expect(component.processCompleted.emit).toHaveBeenCalledWith({ result: true, reloadedObject: result as any });
+        expect(component.invalidateCacheForCurrentSearchUrl).toHaveBeenCalled();
         done();
       });
     });

--- a/src/app/shared/mydspace-actions/mydspace-reloadable-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-reloadable-actions.ts
@@ -105,6 +105,8 @@ export abstract class MyDSpaceReloadableActionsComponent<T extends DSpaceObject,
     if (result) {
       if (reloadedObject) {
         this.processCompleted.emit({ result, reloadedObject });
+        // Ensure that next time the page is requested the objects have the correct render type.
+        this.invalidateCacheForCurrentSearchUrl();
       } else {
         this.reload();
       }

--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.ts
@@ -25,7 +25,6 @@ import {
   Subscription,
   switchMap,
 } from 'rxjs';
-import { take } from 'rxjs/operators';
 
 import { RemoteData } from '../../../../core/data/remote-data';
 import { SearchService } from '../../../../core/shared/search/search.service';
@@ -145,7 +144,7 @@ export class SearchFilterComponent implements OnInit, OnChanges, OnDestroy {
           this.filterService.expand(this.filter.name);
         }
       }),
-      this.getIsActive().pipe(take(1)).subscribe(() => {
+      this.getIsActive().subscribe(() => {
         this.isVisibilityComputed.emit(true);
       }),
     );

--- a/src/app/shared/search/search-filters/search-filters.component.html
+++ b/src/app/shared/search/search-filters/search-filters.component.html
@@ -5,14 +5,14 @@
 }
 
 @if ((filters | async)?.hasSucceeded) {
-  <div [class.visually-hidden]="getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length">
+  <div [class.visually-hidden]="getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length">
     @for (filter of (filters | async)?.payload; track filter.name) {
       <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
     }
   </div>
 }
 
-@if(getFinalFiltersComputed(this.currentConfiguration) !== (filters | async)?.payload?.length) {
+@if(getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length) {
   <ngx-skeleton-loader [count]="defaultFilterCount"/>
 }
 

--- a/src/app/shared/search/search-filters/search-filters.component.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.ts
@@ -251,18 +251,8 @@ export class SearchFiltersComponent implements OnInit {
    * @param configuration The configuration identifier to get the count for
    * @returns The number of computed filters, or 0 if none found
    */
-  private getCurrentFiltersComputed(configuration: string) {
+  getCurrentFiltersComputed(configuration: string): number {
     const configFilter = this.findConfigInCurrentFilters(configuration);
-    return configFilter?.filtersComputed || 0;
-  }
-
-  /**
-   * Gets the final number of computed filters for a specific configuration
-   * @param configuration The configuration identifier to get the count for
-   * @returns The number of computed filters in the final state, or 0 if none found
-   */
-  getFinalFiltersComputed(configuration: string): number {
-    const configFilter = this.findConfigInFinalFilters(configuration);
     return configFilter?.filtersComputed || 0;
   }
 }


### PR DESCRIPTION
## References

Fixes https://github.com/DSpace/dspace-angular/issues/4205

## Description

This PR fixes a cache issue that occurs after executing any reloadable action in MyDSpace.
The problem arises because we update the rendered results immediately—so the item becomes visible right away—but we don't invalidate the cache. As a result, when the same search request is triggered again (for example, by switching between configurations), the cached data causes a mismatch in the item's render type. This leads to an empty list element appearing in the DOM.

So following the same logic we have on the reload method in src/app/shared/mydspace-actions/mydspace-actions.ts, I have applied a cache invalidation happening after any of the reloadable actions in MyDSpace.

Regarding the second problem mentioned in the issue, the one describing a duplicated search result, I belive is actually a duplicated item as we can also see from the banner in the item preview:

![duplicated-workflow-items](https://github.com/user-attachments/assets/773660a0-a3c0-4bf1-add3-42263f0b610c)


## Instructions for Reviewers

List of changes in this PR:

Added method to invalidate cache after success of reloadable action.

To reproduce:

Navigate to the "Workflow tasks" view.
Claim one of the available workflow items.
Switch to another discovery configuration.
Return to the "Workflow tasks" view.

Expectation:

The list of items is rendered correctly and the items have the correct status.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
