### PR TITLE
Update Docker Compose scripts for Solr 9 compatibility 

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -93,7 +93,10 @@ services:
     volumes:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
-    # Initialize all DSpace Solr cores using the mounted configsets (see above), then start Solr
+    # NOTE: We are not running Solr as "root", but we need root permissions to copy our cores to the mounted
+    # /var/solr/data directory. Then we start Solr as the "solr" user.
+    user: root
+    # Initialize all DSpace Solr cores, then start Solr
     entrypoint:
     - /bin/bash
     - '-c'
@@ -111,7 +114,8 @@ services:
       cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent
       precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
       cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
-      exec solr -f
+      chown -R solr:solr /var/solr
+      runuser -u solr -- solr-foreground
 volumes:
   assetstore:
   pgdata:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -97,11 +97,16 @@ services:
     volumes:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
+    # NOTE: We are not running Solr as "root", but we need root permissions to copy our cores to the mounted
+    # /var/solr/data directory. Then we start Solr as the "solr" user.
+    user: root
     # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
     # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
     # * Second, copy configsets to this core:
     #   Updates to Solr configs require the container to be rebuilt/restarted:
     #   `docker compose -p d7 -f docker/docker-compose.yml -f docker/docker-compose-rest.yml up -d --build dspacesolr`
+    # * Third, ensure all new folders are owned by "solr" user
+    # * Finally, start Solr as the "solr" user via the provided solr-foreground script
     entrypoint:
     - /bin/bash
     - '-c'
@@ -119,7 +124,8 @@ services:
       cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent
       precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
       cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
-      exec solr -f
+      chown -R solr:solr /var/solr
+      runuser -u solr -- solr-foreground
 volumes:
   assetstore:
   pgdata:


### PR DESCRIPTION
## References
* Ports changes from https://github.com/DSpace/DSpace/pull/10627 to the Docker Compose scripts in Angular.

## Description
Solr 9 compatibility requires minor updates to how Solr image is initialized in our Docker Compose scripts (because Solr changed their own Docker images in version 9).  This is why our e2e tests are currently *failing* on `main`, because the backend is now using Solr 9 (as of https://github.com/DSpace/DSpace/pull/10627)

## Instructions for Reviewers
* If e2e tests now succeed, that means these changes are working properly.
* No changes to DSpace code exist in this PR.  It only updates Docker Compose scripts used to run the backend and e2e tests.