### PR TITLE
Show restricted thumbnails to users with access rights

### DIFF
--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -1,5 +1,5 @@
 <div class="thumbnail" [class.limit-width]="limitWidth">
-  @if (isLoading$ | async) {
+  @if (isLoading()) {
     <div class="thumbnail-content outer">
       <div class="inner">
         <div class="centered">
@@ -9,11 +9,14 @@
     </div>
   }
   <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-  @if ((src$ | async) !== null) {
-    <img class="thumbnail-content img-fluid" [ngClass]="{'d-none': (isLoading$ | async)}"
-      [src]="(src$ | async) | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
+  @if (src() !== null) {
+    <img class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading()}"
+         [src]="src() | dsSafeUrl"
+         [alt]="alt | translate"
+         (error)="errorHandler()"
+         (load)="successHandler()">
   }
-  @if ((src$ | async) === null && (isLoading$ | async) === false) {
+  @if (src() === null && isLoading() === false) {
     <div class="thumbnail-content outer">
       <div class="inner">
         <div class="thumbnail-placeholder centered lead">

--- a/src/app/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/thumbnail/thumbnail.component.spec.ts
@@ -99,32 +99,32 @@ describe('ThumbnailComponent', () => {
     });
 
     describe('loading', () => {
-      it('should start out with isLoading$ true', () => {
-        expect(comp.isLoading$.getValue()).toBeTrue();
+      it('should start out with isLoading true', () => {
+        expect(comp.isLoading()).toBeTrue();
       });
 
       it('should set isLoading$ to false once an image is successfully loaded', () => {
         comp.setSrc('http://bit.stream');
         fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
-        expect(comp.isLoading$.getValue()).toBeFalse();
+        expect(comp.isLoading()).toBeFalse();
       });
 
       it('should set isLoading$ to false once the src is set to null', () => {
         comp.setSrc(null);
-        expect(comp.isLoading$.getValue()).toBeFalse();
+        expect(comp.isLoading()).toBeFalse();
       });
 
       it('should show a loading animation while isLoading$ is true', () => {
         expect(de.query(By.css('ds-loading'))).toBeTruthy();
 
-        comp.isLoading$.next(false);
+        comp.isLoading.set(false);
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('ds-loading'))).toBeFalsy();
       });
 
       describe('with a thumbnail image', () => {
         beforeEach(() => {
-          comp.src$.next('https://bit.stream');
+          comp.src.set('https://bit.stream');
           fixture.detectChanges();
         });
 
@@ -133,7 +133,7 @@ describe('ThumbnailComponent', () => {
           expect(img).toBeTruthy();
           expect(img.classes['d-none']).toBeTrue();
 
-          comp.isLoading$.next(false);
+          comp.isLoading.set(false);
           fixture.detectChanges();
           img = fixture.debugElement.query(By.css('img.thumbnail-content'));
           expect(img).toBeTruthy();
@@ -144,14 +144,14 @@ describe('ThumbnailComponent', () => {
 
       describe('without a thumbnail image', () => {
         beforeEach(() => {
-          comp.src$.next(null);
+          comp.src.set(null);
           fixture.detectChanges();
         });
 
         it('should only show the HTML placeholder once done loading', () => {
           expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
 
-          comp.isLoading$.next(false);
+          comp.isLoading.set(false);
           fixture.detectChanges();
           expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
         });
@@ -247,14 +247,14 @@ describe('ThumbnailComponent', () => {
     describe('fallback', () => {
       describe('if there is a default image', () => {
         it('should display the default image', () => {
-          comp.src$.next('http://bit.stream');
+          comp.src.set('http://bit.stream');
           comp.defaultImage = 'http://default.img';
           comp.errorHandler();
-          expect(comp.src$.getValue()).toBe(comp.defaultImage);
+          expect(comp.src()).toBe(comp.defaultImage);
         });
 
         it('should include the alt text', () => {
-          comp.src$.next('http://bit.stream');
+          comp.src.set('http://bit.stream');
           comp.defaultImage = 'http://default.img';
           comp.errorHandler();
 
@@ -266,10 +266,10 @@ describe('ThumbnailComponent', () => {
 
       describe('if there is no default image', () => {
         it('should display the HTML placeholder', () => {
-          comp.src$.next('http://default.img');
+          comp.src.set('http://default.img');
           comp.defaultImage = null;
           comp.errorHandler();
-          expect(comp.src$.getValue()).toBe(null);
+          expect(comp.src()).toBe(null);
 
           fixture.detectChanges();
           const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
@@ -363,7 +363,7 @@ describe('ThumbnailComponent', () => {
         it('should show the default image', () => {
           comp.defaultImage = 'default/image.jpg';
           comp.ngOnChanges({});
-          expect(comp.src$.getValue()).toBe('default/image.jpg');
+          expect(comp.src()).toBe('default/image.jpg');
         });
       });
     });
@@ -419,7 +419,7 @@ describe('ThumbnailComponent', () => {
     });
 
     it('should start out with isLoading$ true', () => {
-      expect(comp.isLoading$.getValue()).toBeTrue();
+      expect(comp.isLoading()).toBeTrue();
       expect(de.query(By.css('ds-loading'))).toBeTruthy();
     });
 

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -8,10 +8,12 @@ import {
   Input,
   OnChanges,
   PLATFORM_ID,
+  signal,
   SimpleChanges,
+  WritableSignal,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { of as observableOf, BehaviorSubject } from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { AuthService } from '../core/auth/auth.service';
@@ -54,7 +56,7 @@ export class ThumbnailComponent implements OnChanges {
   /**
    * The src attribute used in the template to render the image.
    */
-  src$: BehaviorSubject<string> = new BehaviorSubject<string>(undefined);
+  src: WritableSignal<string> = signal(undefined);
 
   retriedWithToken = false;
 
@@ -77,7 +79,7 @@ export class ThumbnailComponent implements OnChanges {
    * Whether the thumbnail is currently loading
    * Start out as true to avoid flashing the alt text while a thumbnail is being loaded.
    */
-  isLoading$: BehaviorSubject<boolean> = new BehaviorSubject(true);
+  isLoading: WritableSignal<boolean> = signal(true);
 
   constructor(
     @Inject(PLATFORM_ID) private platformID: any,
@@ -96,8 +98,8 @@ export class ThumbnailComponent implements OnChanges {
       // every time the inputs change we need to start the loading animation again, as it's possible
       // that thumbnail is first set to null when the parent component initializes and then set to
       // the actual value
-      if (this.isLoading$.getValue() === false) {
-        this.isLoading$.next(true);
+      if (!this.isLoading()) {
+        this.isLoading.set(true);
       }
 
       if (hasNoValue(this.thumbnail)) {
@@ -140,7 +142,7 @@ export class ThumbnailComponent implements OnChanges {
    * Otherwise, fall back to the default image or a HTML placeholder
    */
   errorHandler() {
-    const src = this.src$.getValue();
+    const src = this.src();
     const thumbnail = this.bitstream;
     const thumbnailSrc = thumbnail?._links?.content?.href;
 
@@ -192,9 +194,9 @@ export class ThumbnailComponent implements OnChanges {
    * @param src
    */
   setSrc(src: string): void {
-    this.src$.next(src);
+    this.src.set(src);
     if (src === null) {
-      this.isLoading$.next(false);
+      this.isLoading.set(false);
     }
   }
 
@@ -202,6 +204,6 @@ export class ThumbnailComponent implements OnChanges {
    * Stop the loading animation once the thumbnail is successfully loaded
    */
   successHandler() {
-    this.isLoading$.next(false);
+    this.isLoading.set(false);
   }
 }


### PR DESCRIPTION
## References
* Fixes #4165

## Description
There was already a call to get a shortlivedtoken in the thumbnail component. The issue was that in prod mode, angular didn't detect that the image src had changed afterwards so it didn't rerender the image.

The solution was to use a signal for the src and the isLoading boolean

## Instructions for Reviewers
- Create a bitstream in the ORIGINAL bundle of an item
- Configure an embargo for that bitstream, with a date in the future
- Run `filter-media -f -i ${the item's handle}` on the item containing the bitstream
- Go to the item page as an admin, and verify that you can see that bitstream's thumbnail
- Go to the item page as an anonymous user, and verify that you see a placeholder instead

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
