### PR TITLE
[Port dspace-8_x] Show restricted thumbnails to users with access rights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dspace-angular",
-  "version": "8.1.0-next",
+  "version": "8.1.0",
   "scripts": {
     "ng": "ng",
     "config:watch": "nodemon",

--- a/src/app/item-page/media-viewer/media-viewer.component.html
+++ b/src/app/item-page/media-viewer/media-viewer.component.html
@@ -16,12 +16,7 @@
     </ng-container>
   </div>
   <ng-template #showThumbnail>
-    <ds-media-viewer-image *ngIf="mediaOptions.image && mediaOptions.video"
-      [image]="(thumbnailsRD$ | async)?.payload?.page[0]?._links.content.href || thumbnailPlaceholder"
-      [preview]="false"
-    ></ds-media-viewer-image>
-    <ds-thumbnail *ngIf="!(mediaOptions.image && mediaOptions.video)"
-                  [thumbnail]="(thumbnailsRD$ | async)?.payload?.page[0]">
+    <ds-thumbnail [thumbnail]="(thumbnailsRD$ | async)?.payload?.page[0]">
     </ds-thumbnail>
   </ng-template>
 </ng-container>

--- a/src/app/item-page/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.spec.ts
@@ -1,4 +1,4 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, PLATFORM_ID } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -27,10 +27,17 @@ import { ThemeService } from '../../shared/theme-support/theme.service';
 import { FileSizePipe } from '../../shared/utils/file-size-pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { MediaViewerComponent } from './media-viewer.component';
+import {
+  AuthorizationDataService
+} from '../../core/data/feature-authorization/authorization-data.service';
+import { FileService } from '../../core/shared/file.service';
 
 describe('MediaViewerComponent', () => {
   let comp: MediaViewerComponent;
   let fixture: ComponentFixture<MediaViewerComponent>;
+  let authService;
+  let authorizationService;
+  let fileService;
 
   const mockBitstream: Bitstream = Object.assign(new Bitstream(), {
     sizeBytes: 10201,
@@ -73,6 +80,15 @@ describe('MediaViewerComponent', () => {
   );
 
   beforeEach(waitForAsync(() => {
+    authService = jasmine.createSpyObj('AuthService', {
+      isAuthenticated: observableOf(true),
+    });
+    authorizationService = jasmine.createSpyObj('AuthorizationService', {
+      isAuthorized: observableOf(true),
+    });
+    fileService = jasmine.createSpyObj('FileService', {
+      retrieveFileDownloadLink: null,
+    });
     return TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot({
@@ -88,6 +104,10 @@ describe('MediaViewerComponent', () => {
         MetadataFieldWrapperComponent,
       ],
       providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: FileService, useValue: fileService },
+        { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: BitstreamDataService, useValue: bitstreamDataService },
         { provide: ThemeService, useValue: getMockThemeService() },
         { provide: AuthService, useValue: new AuthServiceMock() },

--- a/src/app/item-page/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.spec.ts
@@ -55,7 +55,7 @@ describe('MediaViewerComponent', () => {
       'dc.title': [
         {
           language: null,
-          value: 'test_word.docx',
+          value: 'test_image.jpg',
         },
       ],
     },
@@ -150,9 +150,9 @@ describe('MediaViewerComponent', () => {
       expect(mediaItem.thumbnail).toBe(null);
     });
 
-    it('should display a default, thumbnail', () => {
+    it('should display a default thumbnail', () => {
       const defaultThumbnail = fixture.debugElement.query(
-        By.css('ds-media-viewer-image'),
+        By.css('ds-thumbnail')
       );
       expect(defaultThumbnail.nativeElement).toBeDefined();
     });

--- a/src/app/item-page/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.spec.ts
@@ -1,4 +1,7 @@
-import { NO_ERRORS_SCHEMA, PLATFORM_ID } from '@angular/core';
+import {
+  NO_ERRORS_SCHEMA,
+  PLATFORM_ID,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -14,7 +17,9 @@ import { of as observableOf } from 'rxjs';
 
 import { AuthService } from '../../core/auth/auth.service';
 import { BitstreamDataService } from '../../core/data/bitstream-data.service';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { Bitstream } from '../../core/shared/bitstream.model';
+import { FileService } from '../../core/shared/file.service';
 import { MediaViewerItem } from '../../core/shared/media-viewer-item.model';
 import { MetadataFieldWrapperComponent } from '../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
 import { AuthServiceMock } from '../../shared/mocks/auth.service.mock';
@@ -27,10 +32,6 @@ import { ThemeService } from '../../shared/theme-support/theme.service';
 import { FileSizePipe } from '../../shared/utils/file-size-pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { MediaViewerComponent } from './media-viewer.component';
-import {
-  AuthorizationDataService
-} from '../../core/data/feature-authorization/authorization-data.service';
-import { FileService } from '../../core/shared/file.service';
 
 describe('MediaViewerComponent', () => {
   let comp: MediaViewerComponent;
@@ -172,7 +173,7 @@ describe('MediaViewerComponent', () => {
 
     it('should display a default thumbnail', () => {
       const defaultThumbnail = fixture.debugElement.query(
-        By.css('ds-thumbnail')
+        By.css('ds-thumbnail'),
       );
       expect(defaultThumbnail.nativeElement).toBeDefined();
     });

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -97,13 +97,6 @@ export class ThumbnailComponent implements OnChanges {
    */
   ngOnChanges(changes: SimpleChanges): void {
     if (isPlatformBrowser(this.platformID)) {
-      // every time the inputs change we need to start the loading animation again, as it's possible
-      // that thumbnail is first set to null when the parent component initializes and then set to
-      // the actual value
-      if (this.isLoading$.getValue() === false) {
-        this.isLoading$.next(true);
-      }
-
       if (hasNoValue(this.thumbnail)) {
         this.setSrc(this.defaultImage);
         return;
@@ -196,9 +189,22 @@ export class ThumbnailComponent implements OnChanges {
    * @param src
    */
   setSrc(src: string): void {
-    this.src$.next(src);
-    if (src === null) {
-      this.isLoading$.next(false);
+    // only update the src if it has changed (the parent component may fire the same one multiple times
+    if (this.src$.getValue() !== src) {
+      // every time the src changes we need to start the loading animation again, as it's possible
+      // that it is first set to null when the parent component initializes and then set to
+      // the actual value
+      //
+      // isLoading$ will be set to false by the error or success handler afterwards, except in the
+      // case where src is null, then we have to set it manually here (because those handlers won't
+      // trigger)
+      if (this.isLoading$.getValue() === false) {
+        this.isLoading$.next(true);
+      }
+      this.src$.next(src);
+      if (src === null) {
+        this.isLoading$.next(false);
+      }
     }
   }
 

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -198,11 +198,11 @@ export class ThumbnailComponent implements OnChanges {
       // isLoading$ will be set to false by the error or success handler afterwards, except in the
       // case where src is null, then we have to set it manually here (because those handlers won't
       // trigger)
-      if (this.isLoading$.getValue() === false) {
+      if (src !== null && this.isLoading$.getValue() === false) {
         this.isLoading$.next(true);
       }
       this.src$.next(src);
-      if (src === null) {
+      if (src === null && this.isLoading$.getValue() === true) {
         this.isLoading$.next(false);
       }
     }


### PR DESCRIPTION
## References
* 8.x version of https://github.com/DSpace/dspace-angular/pull/4249

## Description
There was already a call to get a shortlivedtoken in the thumbnail component. The issue was that in prod mode, angular didn't detect that the image src had changed afterwards so it didn't rerender the image.

The solution was to use a BehaviorSubject for the src and the isLoading boolean

## Instructions for Reviewers
- Create a bitstream in the ORIGINAL bundle of an item
- Configure an embargo for that bitstream, with a date in the future
- Run `filter-media -f -i ${the item's handle}` on the item containing the bitstream
- Go to the item page as an admin, and verify that you can see that bitstream's thumbnail
- Go to the item page as an anonymous user, and verify that you see a placeholder instead

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes [ESLint](https://eslint.org/) validation using `yarn lint`
- [x] My PR doesn't introduce circular dependencies (verified via `yarn check-circ-deps`)
- [x] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
