### PR TITLE
Fix matomo downloading its .js even if it's disabled

### DIFF
--- a/src/app/statistics/matomo.service.spec.ts
+++ b/src/app/statistics/matomo.service.spec.ts
@@ -23,6 +23,7 @@ import {
   createSuccessfulRemoteDataObject$,
 } from '../shared/remote-data.utils';
 import {
+  MATOMO_ENABLED,
   MATOMO_SITE_ID,
   MATOMO_TRACKER_URL,
   MatomoService,
@@ -84,6 +85,9 @@ describe('MatomoService', () => {
     configService.findByPropertyName.withArgs(MATOMO_TRACKER_URL).and.returnValue(
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['http://matomo'] })),
     );
+    configService.findByPropertyName.withArgs(MATOMO_ENABLED).and.returnValue(
+      createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['true'] })),
+    );
     configService.findByPropertyName.withArgs(MATOMO_SITE_ID).and.returnValue(
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
     orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
@@ -102,6 +106,9 @@ describe('MatomoService', () => {
     configService.findByPropertyName.withArgs(MATOMO_TRACKER_URL).and.returnValue(
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['http://example.com'] })),
     );
+    configService.findByPropertyName.withArgs(MATOMO_ENABLED).and.returnValue(
+      createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['true'] })),
+    );
     configService.findByPropertyName.withArgs(MATOMO_SITE_ID).and.returnValue(
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
     orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
@@ -117,6 +124,24 @@ describe('MatomoService', () => {
 
   it('should not initialize tracker if not in production', () => {
     environment.production = false;
+
+    service.init();
+
+    expect(matomoInitializer.initializeTracker).not.toHaveBeenCalled();
+  });
+
+  it('should not initialize tracker if matomo is disabled', () => {
+    environment.production = true;
+    environment.matomo = { trackerUrl: '' };
+    configService.findByPropertyName.withArgs(MATOMO_TRACKER_URL).and.returnValue(
+      createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['http://example.com'] })),
+    );
+    configService.findByPropertyName.withArgs(MATOMO_ENABLED).and.returnValue(
+      createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(),{ values: ['false'] })),
+    );
+    configService.findByPropertyName.withArgs(MATOMO_SITE_ID).and.returnValue(
+      createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
+    orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
 
     service.init();
 

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -77,10 +77,10 @@ export class MatomoService {
       preferences$
         .pipe(
           tap(preferences => this.changeMatomoConsent(preferences?.matomo)),
-          switchMap(_ => combineLatest([this.getSiteId$(), this.getTrackerUrl$()])),
+          switchMap(_ => combineLatest([this.isMatomoEnabled$(), this.getSiteId$(), this.getTrackerUrl$()])),
         )
-        .subscribe(([siteId, trackerUrl]) => {
-          if (siteId && trackerUrl) {
+        .subscribe(([isMatomoEnabled, siteId, trackerUrl]) => {
+          if (isMatomoEnabled && siteId && trackerUrl) {
             this.matomoInitializer.initializeTracker({ siteId, trackerUrl });
           }
         });


### PR DESCRIPTION
## References
* Fixes #4128

## Description
DSpace was checking for the Matomo `matomo.request.siteid` and `matomo.tracker.url` configuration properties in order to start configuring Matomo, but it should check for `matomo.enabled` too. This PR solves the issue.

## Instructions for Reviewers
This PR can be tested by starting up the environment in SSR, pointing at the sandbox environment. There should not be any call to `matomo.js`, since `matomo.enabled` is `false` on sandbox. Setting it as `true` correctly starts up matomo.

List of changes in this PR:
* Added a check for `matomo.enabled` in `matomo.service.ts`;
* Changed previously set tests and added a new one to cover the new behavior.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
