### PR TITLE
fixed flash and translate problems on statistics

### DIFF
--- a/src/app/core/statistics/models/usage-report.model.ts
+++ b/src/app/core/statistics/models/usage-report.model.ts
@@ -32,7 +32,7 @@ export class UsageReport extends HALResource {
   id: string;
 
   @autoserializeAs('report-type')
-    reportType: string;
+  reportType: string;
 
   @autoserialize
   points: Point[];

--- a/src/app/statistics-page/statistics-table/statistics-table.component.html
+++ b/src/app/statistics-page/statistics-table/statistics-table.component.html
@@ -11,7 +11,7 @@
           @for (header of headers; track header) {
             <th scope="col"
               class="{{header}}-header">
-              {{ header }}
+              {{ 'statistics.table.header.' + header | translate  }}
             </th>
           }
         </tr>
@@ -19,7 +19,7 @@
           <tr
             class="{{point.id}}-data">
             <th scope="row" data-test="statistics-label">
-              {{ getLabel(point) | async }}
+              {{ point.label }}
             </th>
             @for (header of headers; track header) {
               <td

--- a/src/app/statistics-page/statistics-table/statistics-table.component.spec.ts
+++ b/src/app/statistics-page/statistics-table/statistics-table.component.spec.ts
@@ -83,9 +83,9 @@ describe('StatisticsTableComponent', () => {
       expect(de.query(By.css('table'))).toBeTruthy();
 
       expect(de.query(By.css('th.views-header')).nativeElement.innerText)
-        .toEqual('views');
+        .toEqual('statistics.table.header.views');
       expect(de.query(By.css('th.downloads-header')).nativeElement.innerText)
-        .toEqual('downloads');
+        .toEqual('statistics.table.header.downloads');
 
       expect(de.query(By.css('td.item_1-views-data')).nativeElement.innerText)
         .toEqual('7');

--- a/src/app/statistics-page/statistics-table/statistics-table.component.ts
+++ b/src/app/statistics-page/statistics-table/statistics-table.component.ts
@@ -4,27 +4,11 @@ import {
   Input,
   OnInit,
 } from '@angular/core';
-import {
-  TranslateModule,
-  TranslateService,
-} from '@ngx-translate/core';
-import {
-  Observable,
-  of,
-} from 'rxjs';
-import { map } from 'rxjs/operators';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { DSpaceObjectDataService } from '../../core/data/dspace-object-data.service';
-import {
-  getFinishedRemoteData,
-  getRemoteDataPayload,
-} from '../../core/shared/operators';
-import {
-  Point,
-  UsageReport,
-} from '../../core/statistics/models/usage-report.model';
-import { isEmpty } from '../../shared/empty.util';
+import { UsageReport } from '../../core/statistics/models/usage-report.model';
 
 /**
  * Component representing a statistics table for a given usage report.
@@ -57,7 +41,6 @@ export class StatisticsTableComponent implements OnInit {
   constructor(
     protected dsoService: DSpaceObjectDataService,
     protected nameService: DSONameService,
-    private translateService: TranslateService,
   ) {
 
   }
@@ -66,25 +49,6 @@ export class StatisticsTableComponent implements OnInit {
     this.hasData = this.report.points.length > 0;
     if (this.hasData) {
       this.headers = Object.keys(this.report.points[0].values);
-    }
-  }
-
-  /**
-   * Get the row label to display for a statistics point.
-   * @param point the statistics point to get the label for
-   */
-  getLabel(point: Point): Observable<string> {
-    switch (this.report.reportType) {
-      case 'TotalVisits':
-        return this.dsoService.findById(point.id).pipe(
-          getFinishedRemoteData(),
-          getRemoteDataPayload(),
-          map((item) => !isEmpty(item) ?  this.nameService.getName(item) : this.translateService.instant('statistics.table.no-name')),
-        );
-      case 'TopCities':
-      case 'topCountries':
-      default:
-        return of(point.label);
     }
   }
 }


### PR DESCRIPTION
Hi @tdonohue I have taken a look at this issue and generated this PR:

## References
* Fixes #4204 

## Description
This PR resolves a blink that occurs on the site statistics page and some translation issues related to the page.

## Instructions for Reviewers
When you enter to [dspace.site.url]/statistics, the table should load without blink, also the "views" header must be translated if you change the language (before always sets as views)

List of changes in this PR:
* Removed an unnecessary request for each point in the statistics table (only site statistics made this request, however the information this request obtained is already included in the report itself)
* Fixed header translation
* Fixed unit tests and e2e tests.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
