### PR TITLE
Fix missing input fields for integer script parameters

### DIFF
--- a/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.html
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.html
@@ -1,0 +1,11 @@
+<input [attr.aria-label]="'process.new.parameter.label' | translate" required #integer="ngModel" type="number" step="1" name="integer-value-{{index}}" class="form-control" id="integer-value-{{index}}" [ngModel]="value" (ngModelChange)="setValue($event)"/>
+@if (integer.invalid && (integer.dirty || integer.touched)) {
+  <div
+    class="alert alert-danger validation-error mb-0">
+    @if (integer.errors.required) {
+      <div>
+        {{'process.new.parameter.integer.required' | translate}}
+      </div>
+    }
+  </div>
+}

--- a/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.scss
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--bs-spacer) / 2);
+}

--- a/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.spec.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.spec.ts
@@ -1,0 +1,81 @@
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import {
+  TranslateLoader,
+  TranslateModule,
+} from '@ngx-translate/core';
+
+import { TranslateLoaderMock } from '../../../../../shared/mocks/translate-loader.mock';
+import { IntegerValueInputComponent } from './integer-value-input.component';
+
+describe('IntegerValueInputComponent', () => {
+  let component: IntegerValueInputComponent;
+  let fixture: ComponentFixture<IntegerValueInputComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          },
+        }),
+        IntegerValueInputComponent,
+      ],
+      providers: [],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IntegerValueInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not show a validation error if the input field was left untouched but left empty', () => {
+    const validationError = fixture.debugElement.query(By.css('.validation-error'));
+    expect(validationError).toBeFalsy();
+  });
+
+  it('should show a validation error if the input field was touched but left empty', fakeAsync(() => {
+    component.value = undefined;
+    fixture.detectChanges();
+    tick();
+
+    const input = fixture.debugElement.query(By.css('input'));
+    input.triggerEventHandler('blur', null);
+
+    fixture.detectChanges();
+
+    const validationError = fixture.debugElement.query(By.css('.validation-error'));
+    expect(validationError).toBeTruthy();
+  }));
+
+  it('should not show a validation error if the input field was touched but not left empty', fakeAsync(() => {
+    component.value = 1;
+    fixture.detectChanges();
+    tick();
+
+    const input = fixture.debugElement.query(By.css('input'));
+    input.triggerEventHandler('blur', null);
+
+    fixture.detectChanges();
+
+    const validationError = fixture.debugElement.query(By.css('.validation-error'));
+    expect(validationError).toBeFalsy();
+  }));
+});

--- a/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/number-value-input/integer-value-input.component.ts
@@ -1,0 +1,49 @@
+import {
+  Component,
+  Input,
+  OnInit,
+  Optional,
+} from '@angular/core';
+import {
+  ControlContainer,
+  FormsModule,
+  NgForm,
+} from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { controlContainerFactory } from '../../../process-form-factory';
+import { ValueInputComponent } from '../value-input.component';
+
+/**
+ * Represents the user-inputted value of an integer parameter
+ */
+@Component({
+  selector: 'ds-integer-value-input',
+  templateUrl: './integer-value-input.component.html',
+  styleUrls: ['./integer-value-input.component.scss'],
+  viewProviders: [{ provide: ControlContainer,
+    useFactory: controlContainerFactory,
+    deps: [[new Optional(), NgForm]] }],
+  standalone: true,
+  imports: [FormsModule, TranslateModule],
+})
+export class IntegerValueInputComponent extends ValueInputComponent<number> implements OnInit {
+  /**
+   * The current value of the integer
+   */
+  value: number;
+
+  /**
+   * Initial value of the field
+   */
+  @Input() initialValue;
+
+  ngOnInit(): void {
+    this.value = this.initialValue;
+  }
+
+  setValue(value) {
+    this.value = value;
+    this.updateValue.emit(value);
+  }
+}

--- a/src/app/process-page/form/process-parameters/parameter-value-input/parameter-value-input.component.html
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/parameter-value-input.component.html
@@ -3,6 +3,9 @@
     @case (parameterTypes.STRING) {
       <ds-string-value-input [initialValue]="initialValue" (updateValue)="updateValue.emit($event)" [index]="index"></ds-string-value-input>
     }
+    @case (parameterTypes.INTEGER) {
+      <ds-integer-value-input [initialValue]="initialValue" (updateValue)="updateValue.emit($event)" [index]="index"></ds-integer-value-input>
+    }
     @case (parameterTypes.OUTPUT) {
       <ds-string-value-input [initialValue]="initialValue" (updateValue)="updateValue.emit($event)" [index]="index"></ds-string-value-input>
     }

--- a/src/app/process-page/form/process-parameters/parameter-value-input/parameter-value-input.component.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/parameter-value-input.component.ts
@@ -17,6 +17,7 @@ import { controlContainerFactory } from '../../process-form-factory';
 import { BooleanValueInputComponent } from './boolean-value-input/boolean-value-input.component';
 import { DateValueInputComponent } from './date-value-input/date-value-input.component';
 import { FileValueInputComponent } from './file-value-input/file-value-input.component';
+import { IntegerValueInputComponent } from './number-value-input/integer-value-input.component';
 import { StringValueInputComponent } from './string-value-input/string-value-input.component';
 
 /**
@@ -30,7 +31,7 @@ import { StringValueInputComponent } from './string-value-input/string-value-inp
     useFactory: controlContainerFactory,
     deps: [[new Optional(), NgForm]] }],
   standalone: true,
-  imports: [StringValueInputComponent, DateValueInputComponent, FileValueInputComponent, BooleanValueInputComponent],
+  imports: [StringValueInputComponent, DateValueInputComponent, FileValueInputComponent, BooleanValueInputComponent, IntegerValueInputComponent],
 })
 export class ParameterValueInputComponent {
   @Input() index: number;

--- a/src/app/process-page/scripts/script-parameter-type.model.ts
+++ b/src/app/process-page/scripts/script-parameter-type.model.ts
@@ -3,6 +3,7 @@
  */
 export enum ScriptParameterType {
   STRING = 'String',
+  INTEGER = 'Integer',
   DATE = 'date',
   BOOLEAN = 'boolean',
   FILE = 'InputStream',

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -6045,6 +6045,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "يرجى تحديد ملف",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "قيمة المتغير مطلوبة",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "قيمة المتغير مطلوبة",
 

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -6525,6 +6525,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "দয়াকরে একটি ফাইল নির্বাচন করুন",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "পরামিতির মান প্রয়োজন",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "পরামিতির মান প্রয়োজন",
 

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -5850,6 +5850,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Si us plau seleccioneu un fitxer",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Es requereix el valor del paràmetre",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Es requereix el valor del paràmetre",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -6223,6 +6223,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Vyberte prosím soubor",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Hodnota parametru je povinná",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Hodnota parametru je povinná",
 

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -5861,6 +5861,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Bitte wählen Sie eine Datei aus",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Parameterwert ist erforderlich",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Parameterwert ist erforderlich",
 

--- a/src/assets/i18n/el.json5
+++ b/src/assets/i18n/el.json5
@@ -6444,6 +6444,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Επιλέξτε ένα αρχείο",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Απαιτείται τιμή παραμέτρου",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Απαιτείται τιμή παραμέτρου",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3858,6 +3858,8 @@
 
   "process.new.parameter.file.required": "Please select a file",
 
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   "process.new.parameter.string.required": "Parameter value is required",
 
   "process.new.parameter.type.value": "value",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -5848,6 +5848,10 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Por favor seleccione un archivo",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Se requiere el valor del parámetro",
+
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Se requiere el valor del parámetro",
 

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -6223,6 +6223,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Valitse tiedosto, ole hyvä",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Parametrin arvo on pakollinen tieto",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Parametrin arvo on pakollinen tieto",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -6281,6 +6281,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Veuillez sélectionner un fichier",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Veuillez spécifier un paramètre",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Veuillez spécifier un paramètre",
 

--- a/src/assets/i18n/gd.json5
+++ b/src/assets/i18n/gd.json5
@@ -6588,6 +6588,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Tagh faidhle",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Feum air luach parameatair",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Feum air luach parameatair",
 

--- a/src/assets/i18n/hi.json5
+++ b/src/assets/i18n/hi.json5
@@ -6440,6 +6440,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "कृपया एक फ़ाइल चुनें",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "पैरामीटर मान आवश्यक है",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "पैरामीटर मान आवश्यक है",
 

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -6667,6 +6667,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Kérem válasszon egy fájlt",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Szüséges egy paraméter érték",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Szüséges egy paraméter érték",
 

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -6256,6 +6256,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Seleziona un file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Il valore del parametro è obbligatorio",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Il valore del parametro è obbligatorio",
 

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -7714,6 +7714,10 @@
   // TODO New key - Add a translation
   "process.new.parameter.file.required": "Please select a file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  // TODO New key - Add a translation
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   // TODO New key - Add a translation
   "process.new.parameter.string.required": "Parameter value is required",

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -6444,6 +6444,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Файлды таңдаңыз",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Параметр мәні қажет",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Параметр мәні қажет",
 

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -6958,6 +6958,10 @@
   // TODO New key - Add a translation
   "process.new.parameter.file.required": "Please select a file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  // TODO New key - Add a translation
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   // TODO New key - Add a translation
   "process.new.parameter.string.required": "Parameter value is required",

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -7200,6 +7200,10 @@
   // TODO New key - Add a translation
   "process.new.parameter.file.required": "Please select a file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  // TODO New key - Add a translation
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   // TODO New key - Add a translation
   "process.new.parameter.string.required": "Parameter value is required",

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -5786,6 +5786,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Proszę wybrać plik",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Wartość parametru jest wymagana",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Wartość parametru jest wymagana",
 

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -5869,6 +5869,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Por favor, selecione um arquivo",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Valor do parâmetro é obrigatório",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Valor do parâmetro é obrigatório",
 

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -5904,6 +5904,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Selecione um ficheiro",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "É necessário um valor no parâmetro",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "É necessário um valor no parâmetro",
 

--- a/src/assets/i18n/sr-cyr.json5
+++ b/src/assets/i18n/sr-cyr.json5
@@ -6255,6 +6255,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Молимо изаберите фајл",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Вредност параметра је обавезна",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Вредност параметра је обавезна",
 

--- a/src/assets/i18n/sr-lat.json5
+++ b/src/assets/i18n/sr-lat.json5
@@ -6253,6 +6253,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Molimo izaberite fajl",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Vrednost parametra je obavezna",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Vrednost parametra je obavezna",
 

--- a/src/assets/i18n/sv.json5
+++ b/src/assets/i18n/sv.json5
@@ -6596,6 +6596,10 @@
   // TODO New key - Add a translation
   "process.new.parameter.file.required": "Please select a file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  // TODO New key - Add a translation
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   // TODO New key - Add a translation
   "process.new.parameter.string.required": "Parameter value is required",

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -7714,6 +7714,10 @@
   // TODO New key - Add a translation
   "process.new.parameter.file.required": "Please select a file",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  // TODO New key - Add a translation
+  "process.new.parameter.integer.required": "Parameter value is required",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   // TODO New key - Add a translation
   "process.new.parameter.string.required": "Parameter value is required",

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -6740,6 +6740,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Lütfen dosya seçiniz.",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Parametre değeri gerekli",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Parametre değeri gerekli",
 

--- a/src/assets/i18n/uk.json5
+++ b/src/assets/i18n/uk.json5
@@ -6768,6 +6768,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Виберіть файл",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Цей параметр є обв'язковим",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Цей параметр є обв'язковим",
 

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -6344,6 +6344,9 @@
   // "process.new.parameter.file.required": "Please select a file",
   "process.new.parameter.file.required": "Vui lòng chọn một tệp tin",
 
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Giá trị tham số là bắt buộc",
+
   // "process.new.parameter.string.required": "Parameter value is required",
   "process.new.parameter.string.required": "Giá trị tham số là bắt buộc",
 


### PR DESCRIPTION
## References
* Fixes #4093

## Description
Created a new component called `ds-integer-value-input` to use alongside the other ones, and mapped it to `Integer` type script parameters.

## Instructions for Reviewers
You can test this PR by starting it up, pointing to the `sandbox` environment, logging in and creating a new `import-loader-suggestions` script. By adding a `--max` parameter, now the input field should be visible.

![image](https://github.com/user-attachments/assets/3205039a-6bfd-4906-a9c1-f752c33b387d)

List of changes in this PR:
* Added a new component for integer type parameters;
* Added i18n strings;
* Added tests.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
