### PR TITLE
Fix submission footer wrapping on medium screens

### DIFF
--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -1,6 +1,6 @@
 @if (!!submissionId) {
-  <div class="row">
-    <div class="col">
+  <div class="d-flex flex-row gap-1 justify-content-between">
+    <div class="flex-grow-0">
       @if ((showDepositAndDiscard | async)) {
         <button
           type="button"
@@ -13,7 +13,7 @@
         </button>
       }
     </div>
-    <div class="col text-end d-flex justify-content-end align-items-center">
+    <div class="text-end d-flex justify-content-end align-items-center">
       @if ((hasUnsavedModification | async) !== true && (processingSaveStatus | async) !== true && (processingDepositStatus | async) !== true) {
         <span>
           <i class="fas fa-check-circle"></i> {{'submission.general.info.saved' | translate}}


### PR DESCRIPTION
## References
* Fixes #4275

## Description
Used a flexbox approach instead of bootstrap columns to improve the UI behavior on medium screens.

## Instructions for Reviewers
To test this PR:
1. Start the project pointing at sandbox, log in;
2. Open a new submission and resize the page. The footer buttons now should be way more responsive.

![image](https://github.com/user-attachments/assets/c5b6a749-79d8-449e-8387-d7efc60fa544)

List of changes in this PR:
* Changed the template of the submission footer. No tests have been written since it's a template-only change.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
