### PR TITLE
Fix bitstream tables being duplicated

### DIFF
--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
@@ -244,8 +244,22 @@ export class ItemBitstreamsComponent extends AbstractItemUpdateComponent impleme
       ),
       map((bundlePage: PaginatedList<Bundle>) => bundlePage.page),
     ).subscribe((bundles: Bundle[]) => {
-      this.bundlesSubject.next([...this.bundlesSubject.getValue(), ...bundles]);
+      this.updateBundlesSubject(bundles);
     });
+  }
+
+  updateBundlesSubject(newBundles: Bundle[]) {
+    const currentBundles = this.bundlesSubject.getValue();
+    const bundlesToAdd: Bundle[] = [];
+
+    // Only add bundles to the bundle subject if they are not present yet
+    newBundles.forEach(newBundle => {
+      if (!currentBundles.some(currentBundle => currentBundle.id === newBundle.id)) {
+        bundlesToAdd.push(newBundle);
+      }
+    });
+
+    this.bundlesSubject.next([...currentBundles, ...bundlesToAdd]);
   }
 
 

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
@@ -249,14 +249,10 @@ export class ItemBitstreamsComponent extends AbstractItemUpdateComponent impleme
    */
   updateBundles(newBundlesPL: PaginatedList<Bundle>) {
     const currentBundles = this.bundlesSubject.getValue();
-    const bundlesToAdd: Bundle[] = [];
 
     // Only add bundles to the bundle subject if they are not present yet
-    newBundlesPL.page.forEach(newBundle => {
-      if (!currentBundles.some(currentBundle => currentBundle.id === newBundle.id)) {
-        bundlesToAdd.push(newBundle);
-      }
-    });
+    const bundlesToAdd = newBundlesPL.page
+      .filter(bundleToAdd => !currentBundles.some(currentBundle => currentBundle.id === bundleToAdd.id));
 
     const updatedBundles = [...currentBundles, ...bundlesToAdd];
 

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.ts
@@ -30,7 +30,6 @@ import {
   map,
   switchMap,
   take,
-  tap,
 } from 'rxjs/operators';
 import { AlertComponent } from 'src/app/shared/alert/alert.component';
 import { AlertType } from 'src/app/shared/alert/alert-type';
@@ -239,27 +238,30 @@ export class ItemBitstreamsComponent extends AbstractItemUpdateComponent impleme
     this.itemService.getBundles(this.item.id, new PaginatedSearchOptions({ pagination: this.bundlesOptions })).pipe(
       getFirstSucceededRemoteData(),
       getRemoteDataPayload(),
-      tap((bundlesPL: PaginatedList<Bundle>) =>
-        this.showLoadMoreLink$.next(bundlesPL.pageInfo.currentPage < bundlesPL.pageInfo.totalPages),
-      ),
-      map((bundlePage: PaginatedList<Bundle>) => bundlePage.page),
-    ).subscribe((bundles: Bundle[]) => {
-      this.updateBundlesSubject(bundles);
+    ).subscribe((bundles: PaginatedList<Bundle>) => {
+      this.updateBundles(bundles);
     });
   }
 
-  updateBundlesSubject(newBundles: Bundle[]) {
+  /**
+   * Update the subject containing the bundles with the provided bundles.
+   * Also updates the showLoadMoreLink observable so it does not show up when it is no longer necessary.
+   */
+  updateBundles(newBundlesPL: PaginatedList<Bundle>) {
     const currentBundles = this.bundlesSubject.getValue();
     const bundlesToAdd: Bundle[] = [];
 
     // Only add bundles to the bundle subject if they are not present yet
-    newBundles.forEach(newBundle => {
+    newBundlesPL.page.forEach(newBundle => {
       if (!currentBundles.some(currentBundle => currentBundle.id === newBundle.id)) {
         bundlesToAdd.push(newBundle);
       }
     });
 
-    this.bundlesSubject.next([...currentBundles, ...bundlesToAdd]);
+    const updatedBundles = [...currentBundles, ...bundlesToAdd];
+
+    this.showLoadMoreLink$.next(updatedBundles.length < newBundlesPL.totalElements);
+    this.bundlesSubject.next(updatedBundles);
   }
 
 


### PR DESCRIPTION
## References
- Fixes #4015
- dspace-8_x port #4280 
- dspace-7_x port #4281  

## Description
The problem was introduced with [#3694](https://github.com/DSpace/dspace-angular/pull/3694). When the pagination changes, bundles that were retrieved previously were retrieved again and added to the bundles array without checking whether they were already present.
I added checks so bundles are not added multiple times.
Also made some changes to make sure the 'load more' button only shows up when there actually are more bundles to load.

## Instructions for Reviewers
Same as described in #4015:
1. Go to edit item > Bitstreams tab
2. Upload enough dummy files to trigger pagination
3. Use pagination to change table pages


For the 'load more' button to show up, you have to make sure the Item has more than 10 bundles.

I only managed to reliably reproduce the issue on the 8_x and main branches, so I would appreciate it if @alanorth or @tantz001 could double check whether the fix also works for 7.6.3. (I would be surprised if it doesn't, but you never know...)

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
