### PR TITLE
Fix infinite loading for embargoed image in ImageViewer

### DIFF
--- a/src/app/item-page/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.spec.ts
@@ -29,6 +29,8 @@ import { ThemeService } from '../../shared/theme-support/theme.service';
 import { FileSizePipe } from '../../shared/utils/file-size-pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { MediaViewerComponent } from './media-viewer.component';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { AuthorizationDataServiceStub } from '../../shared/testing/authorization-service.stub';
 
 describe('MediaViewerComponent', () => {
   let comp: MediaViewerComponent;
@@ -94,6 +96,7 @@ describe('MediaViewerComponent', () => {
         { provide: ThemeService, useValue: getMockThemeService() },
         { provide: AuthService, useValue: new AuthServiceMock() },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
+        { provide: AuthorizationDataService, useClass: AuthorizationDataServiceStub },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/src/app/item-page/media-viewer/media-viewer.component.spec.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.spec.ts
@@ -15,6 +15,7 @@ import { of as observableOf } from 'rxjs';
 
 import { AuthService } from '../../core/auth/auth.service';
 import { BitstreamDataService } from '../../core/data/bitstream-data.service';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
 import { Bitstream } from '../../core/shared/bitstream.model';
 import { MediaViewerItem } from '../../core/shared/media-viewer-item.model';
 import { MetadataFieldWrapperComponent } from '../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
@@ -24,13 +25,12 @@ import { getMockThemeService } from '../../shared/mocks/theme-service.mock';
 import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { ActivatedRouteStub } from '../../shared/testing/active-router.stub';
+import { AuthorizationDataServiceStub } from '../../shared/testing/authorization-service.stub';
 import { createPaginatedList } from '../../shared/testing/utils.test';
 import { ThemeService } from '../../shared/theme-support/theme.service';
 import { FileSizePipe } from '../../shared/utils/file-size-pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
 import { MediaViewerComponent } from './media-viewer.component';
-import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
-import { AuthorizationDataServiceStub } from '../../shared/testing/authorization-service.stub';
 
 describe('MediaViewerComponent', () => {
   let comp: MediaViewerComponent;

--- a/src/app/item-page/media-viewer/media-viewer.component.ts
+++ b/src/app/item-page/media-viewer/media-viewer.component.ts
@@ -10,11 +10,16 @@ import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   BehaviorSubject,
+  combineLatest,
+  forkJoin,
   Observable,
+  of as observableOf,
   Subscription,
+  switchMap,
 } from 'rxjs';
 import {
   filter,
+  map,
   take,
 } from 'rxjs/operators';
 
@@ -101,45 +106,68 @@ export class MediaViewerComponent implements OnDestroy, OnInit {
       ...(this.mediaOptions.video ? ['audio', 'video'] : []),
     ];
     this.thumbnailsRD$ = this.loadRemoteData('THUMBNAIL');
-    this.subs.push(this.loadRemoteData('ORIGINAL')
-      .subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {
-        if (bitstreamsRD.payload.page.length === 0) {
-          this.isLoading = false;
-          this.mediaList$.next([]);
-        } else {
-          this.subs.push(this.thumbnailsRD$.subscribe((thumbnailsRD: RemoteData<PaginatedList<Bitstream>>) => {
-            for (
-              let index = 0;
-              index < bitstreamsRD.payload.page.length;
-              index++
-            ) {
-              this.subs.push(this.isAuthorized(bitstreamsRD.payload.page[index]).subscribe(
-                isAuthorize => {
-                  if (isAuthorize) {
-                    this.subs.push(bitstreamsRD.payload.page[index].format
-                      .pipe(getFirstSucceededRemoteDataPayload())
-                      .subscribe((format: BitstreamFormat) => {
-                        const mediaItem = this.createMediaViewerItem(
-                          bitstreamsRD.payload.page[index],
-                          format,
-                          thumbnailsRD.payload && thumbnailsRD.payload.page[index],
-                        );
-                        if (types.includes(mediaItem.format)) {
-                          this.mediaList$.next([...this.mediaList$.getValue(), mediaItem]);
-                        } else if (format.mimetype === 'text/vtt') {
-                          this.captions$.next([...this.captions$.getValue(), bitstreamsRD.payload.page[index]]);
-                        }
-                      }));
-                  }
-                },
-              ));
-            }
-            this.isLoading = false;
-            this.changeDetectorRef.detectChanges();
-          }));
-        }
-      }));
+    this.isLoading = true;
 
+    const bitstreams$ = this.loadRemoteData('ORIGINAL').pipe(
+      filter(rd => rd.hasSucceeded),
+      map(rd => rd.payload.page),
+    );
+
+    const thumbnails$ = this.thumbnailsRD$.pipe(
+      filter(rd => rd.hasSucceeded),
+      map(rd => rd.payload.page),
+    );
+
+    this.subs.push(
+      combineLatest([bitstreams$, thumbnails$]).pipe(
+        switchMap(([bitstreams, thumbnails]) => {
+          if (bitstreams.length === 0) {
+            this.mediaList$.next([]);
+            return observableOf([]);
+          }
+
+          const mediaObservables = bitstreams.map((bitstream, index) =>
+            this.isAuthorized(bitstream).pipe(
+              switchMap(isAuth => {
+                if (!isAuth) {
+                  return observableOf(null);
+                }
+                return bitstream.format.pipe(
+                  getFirstSucceededRemoteDataPayload(),
+                  map((format: BitstreamFormat) => {
+                    const mediaItem = this.createMediaViewerItem(
+                      bitstream,
+                      format,
+                      thumbnails[index],
+                    );
+                    return { mediaItem, format, bitstream };
+                  }),
+                );
+              }),
+            ),
+          );
+          return forkJoin(mediaObservables);
+        }),
+      ).subscribe(results => {
+        const mediaItems = [];
+        const captions = [];
+
+        results.forEach(res => {
+          if (res) {
+            if (types.includes(res.mediaItem.format)) {
+              mediaItems.push(res.mediaItem);
+            } else if (res.format.mimetype === 'text/vtt') {
+              captions.push(res.bitstream);
+            }
+          }
+        });
+
+        this.mediaList$.next(mediaItems);
+        this.captions$.next(captions);
+        this.isLoading = false;
+        this.changeDetectorRef.detectChanges();
+      }),
+    );
   }
 
   /**


### PR DESCRIPTION
Hi @tdonohue, I'am @jtimal partner, I like to share this PR with you.


## References

* Fixes #4213

## Description
In order to avoid the error of loading embargoed or restricted bitstream multimedia in the viewer. It was validated within the multimedia component to list these files

## Instructions for Reviewers

Steps to reproduce:
1.  Start a submission and attach two images
2. Set the embargo on the second image
3. Deposit the item
4. Visit the same item as anonymous
5. Open the image viewer by clicking on the image preview box
6. Display the first non-embargoed image
7. Click on "Next" arrow to display the second embargoed image


List of changes in this PR:
1. I added a function to check if an image can be downloaded.
2. I modified the way bitstreams are added in the image viewer so that only the ones that can be consulted are added.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
