### PR TITLE
Bitstream upload failure during the workflow editing process when impersonating an editor

### DIFF
--- a/src/app/shared/upload/uploader/uploader-options.model.ts
+++ b/src/app/shared/upload/uploader/uploader-options.model.ts
@@ -23,6 +23,11 @@ export class UploaderOptions {
   maxFileNumber: number;
 
   /**
+   * Impersonating user uuid
+   */
+  impersonatingID: string;
+
+  /**
    * The request method to use for the file upload request
    */
   method: RestRequestMethod = RestRequestMethod.POST;

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -48,6 +48,11 @@ import { UploaderProperties } from './uploader-properties.model';
 export class UploaderComponent implements OnInit, AfterViewInit {
 
   /**
+   * Header key to impersonate a user
+   */
+  private readonly ON_BEHALF_HEADER = 'X-On-Behalf-Of';
+
+  /**
    * The message to show when drag files on the drop zone
    */
   @Input() dropMsg: string;
@@ -162,7 +167,13 @@ export class UploaderComponent implements OnInit, AfterViewInit {
         item.url = this.uploader.options.url;
       }
       // Ensure the current XSRF token is included in every upload request (token may change between items uploaded)
-      this.uploader.options.headers = [{ name: XSRF_REQUEST_HEADER, value: this.tokenExtractor.getToken() }];
+      // Ensure the behalf header is set if impersonating
+      this.uploader.options.headers = [
+        { name: XSRF_REQUEST_HEADER, value: this.tokenExtractor.getToken() },
+        ...(hasValue(this.uploadFilesOptions.impersonatingID)
+          ? [{ name: this.ON_BEHALF_HEADER, value: this.uploadFilesOptions.impersonatingID }]
+          : [])
+      ];
       this.onBeforeUpload();
       this.isOverDocumentDropZone = observableOf(false);
     };

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -170,10 +170,10 @@ export class UploaderComponent implements OnInit, AfterViewInit {
       // Ensure the behalf header is set if impersonating
       this.uploader.options.headers = [
         { name: XSRF_REQUEST_HEADER, value: this.tokenExtractor.getToken() },
-        ...(hasValue(this.uploadFilesOptions.impersonatingID)
-          ? [{ name: this.ON_BEHALF_HEADER, value: this.uploadFilesOptions.impersonatingID }]
-          : [])
       ];
+      if (hasValue(this.uploadFilesOptions.impersonatingID)) {
+        this.uploader.options.headers.push({ name: this.ON_BEHALF_HEADER, value: this.uploadFilesOptions.impersonatingID });
+      }
       this.onBeforeUpload();
       this.isOverDocumentDropZone = observableOf(false);
     };

--- a/src/app/submission/form/submission-form.component.ts
+++ b/src/app/submission/form/submission-form.component.ts
@@ -209,6 +209,7 @@ export class SubmissionFormComponent implements OnChanges, OnDestroy {
           distinctUntilChanged())
           .subscribe((endpointURL) => {
             this.uploadFilesOptions.authToken = this.authService.buildAuthHeader();
+            this.uploadFilesOptions.impersonatingID = this.authService.getImpersonateID();
             this.uploadFilesOptions.url = endpointURL.concat(`/${this.submissionId}`);
             this.definitionId = this.submissionDefinition.name;
             this.submissionService.dispatchInit(


### PR DESCRIPTION
## Description
Fix the bitstream upload failure during the workflow editing process when a admin  is impersonating an editor.

## Instructions for Reviewers
The issue was caused by the missing X-On-Behalf-Of header required to handle impersonation during the file upload process.

List of changes in this PR:
- Set the X-On-Behalf-Of header with the impersonatingID in the FileUploader class.
- Added a new field, impersonatingID, to the UploaderOptions 
- Updated UploaderOptions to include the impersonatingID parameter, ensuring it propagates correctly during the upload process.

### Steps to reproduce the bug this PR addresses:

1. Log in as an **admin**
2. Go to **Access Control > Person**
3. Impersonate a **Submitter** (e.g., `dspacedemo+submit@gmail.com`)
4. Deposit an item into a workflow-enabled collection
5. Stop impersonating the **Submitter**
6. Impersonate an **Editor** (e.g., `dspacedemo+acceptrejectedit@gmail.com`)
7. Go to **MyDSpace > Workflow tasks**
8. Edit the item submitted by the Submitter
9. Try to **add a bitstream** — this is where the issue occurs


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
