### PR TITLE
[DURACOM-326] fix possible issue on missing value for eperson patch

### DIFF
--- a/src/app/core/eperson/eperson-data.service.spec.ts
+++ b/src/app/core/eperson/eperson-data.service.spec.ts
@@ -31,6 +31,7 @@ import {
 import {
   EPersonMock,
   EPersonMock2,
+  EPersonMockWithNoName,
 } from '../../shared/testing/eperson.mock';
 import { GroupMock } from '../../shared/testing/group-mock';
 import { HALEndpointServiceStub } from '../../shared/testing/hal-endpoint-service.stub';
@@ -275,6 +276,37 @@ describe('EPersonDataService', () => {
         const operations = [
           { op: 'replace', path: '/eperson.lastname/0/value', value: newLastName },
           { op: 'replace', path: '/eperson.firstname/0/value', value: newFirstName }];
+        const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
+        expect(requestService.send).toHaveBeenCalledWith(expected);
+      });
+    });
+  });
+
+  describe('updateEPerson with non existing metadata', () => {
+    beforeEach(() => {
+      spyOn(service, 'findByHref').and.returnValue(createSuccessfulRemoteDataObject$(EPersonMockWithNoName));
+    });
+    describe('add name that was not previously set', () => {
+      beforeEach(() => {
+        const changedEPerson = Object.assign(new EPerson(), {
+          id: EPersonMock.id,
+          metadata: Object.assign(EPersonMock.metadata, {
+            'eperson.firstname': [
+              {
+                language: null,
+                value: 'User',
+              },
+            ],
+          }),
+          email: EPersonMock.email,
+          canLogIn: EPersonMock.canLogIn,
+          requireCertificate: EPersonMock.requireCertificate,
+          _links: EPersonMock._links,
+        });
+        service.updateEPerson(changedEPerson).subscribe();
+      });
+      it('should send PatchRequest with add email operation', () => {
+        const operations = [{ op: 'add', path: '/eperson.firstname', value: [{ language: null, value: 'User' }] }];
         const expected = new PatchRequest(requestService.generateRequestId(), epersonsEndpoint + '/' + EPersonMock.uuid, operations);
         expect(requestService.send).toHaveBeenCalledWith(expected);
       });

--- a/src/app/core/eperson/eperson-data.service.ts
+++ b/src/app/core/eperson/eperson-data.service.ts
@@ -269,7 +269,8 @@ export class EPersonDataService extends IdentifiableDataService<EPerson> impleme
    * @param newEPerson
    */
   private generateOperations(oldEPerson: EPerson, newEPerson: EPerson): Operation[] {
-    let operations = this.comparator.diff(oldEPerson, newEPerson).filter((operation: Operation) => operation.op === 'replace');
+    let operations = this.comparator.diff(oldEPerson, newEPerson)
+      .filter((operation: Operation) => ['replace', 'add'].includes(operation.op));
     if (hasValue(oldEPerson.email) && oldEPerson.email !== newEPerson.email) {
       operations = [...operations, {
         op: 'replace', path: '/email', value: newEPerson.email,

--- a/src/app/shared/testing/eperson.mock.ts
+++ b/src/app/shared/testing/eperson.mock.ts
@@ -91,3 +91,43 @@ export const EPersonMock2: EPerson = Object.assign(new EPerson(), {
     ],
   },
 });
+
+export const EPersonMockWithNoName: EPerson = Object.assign(new EPerson(), {
+  handle: null,
+  groups: [],
+  netid: 'test@test.com',
+  lastActive: '2018-05-14T12:25:42.411+0000',
+  canLogIn: true,
+  email: 'test@test.com',
+  requireCertificate: false,
+  selfRegistered: false,
+  _links: {
+    self: {
+      href: 'https://rest.api/dspace-spring-rest/api/eperson/epersons/testid',
+    },
+    groups: { href: 'https://rest.api/dspace-spring-rest/api/eperson/epersons/testid/groups' },
+  },
+  id: 'testid',
+  uuid: 'testid',
+  type: 'eperson',
+  metadata: {
+    'dc.title': [
+      {
+        language: null,
+        value: 'User Test',
+      },
+    ],
+    'eperson.lastname': [
+      {
+        language: null,
+        value: 'Test',
+      },
+    ],
+    'eperson.language': [
+      {
+        language: null,
+        value: 'en',
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## References
Fixes https://github.com/DSpace/dspace-angular/issues/4287

## Description

Improve patch for EPerson to allow "add" operation.

## Instructions for Reviewers

Inserted "add" operation as possible for EPerson  modification.
Implemented test to ensure presence of "add" operation, created mock.

To reproduce the bug the easiest way is to delete one of the metadata on the DB, e.g. lastname, for an EPerson, and then try to add that metadata via UI. (Step by step at https://github.com/DSpace/dspace-angular/issues/4287).

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
