### PR TITLE
Fixed broken Pagination of People/Groups on Edit Resource Policy page

### DIFF
--- a/src/app/shared/eperson-group-list/eperson-group-list.component.ts
+++ b/src/app/shared/eperson-group-list/eperson-group-list.component.ts
@@ -34,7 +34,7 @@ import { lazyDataService } from '../../core/lazy-data-service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
 import {
-  getFirstCompletedRemoteData,
+  getAllCompletedRemoteData,
   getRemoteDataPayload,
 } from '../../core/shared/operators';
 import { ResourceType } from '../../core/shared/resource-type';
@@ -177,7 +177,7 @@ export class EpersonGroupListComponent implements OnInit, OnDestroy {
           (this.dataService as EPersonDataService).searchByScope(scope, query, options) :
           (this.dataService as GroupDataService).searchGroups(query, options);
       }),
-      getFirstCompletedRemoteData(),
+      getAllCompletedRemoteData(),
       getRemoteDataPayload(),
     );
   }


### PR DESCRIPTION
## References
* Fixes #4303

## Description
Fixed broken pagination of of the People/Group section on the edit resource page introduced by #4290

## Instructions for Reviewers
List of changes in this PR:
* Updated the `EpersonGroupListComponent#updateList` to continue listening to pagination changes, to ensure the list automatically gets refershed when you switch to a different page

See #4303 on how to reproduce this bug

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
