### PR TITLE
Fix layout of ORCID settings on profile page

### DIFF
--- a/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.html
+++ b/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.html
@@ -45,7 +45,7 @@
                       name="syncPublications" id="publicationOption_{{option.value}}" [value]="option.value"
                       required>
                     <label for="publicationOption_{{option.value}}"
-                    class="ms-2 form-label">{{option.label | translate}}</label>
+                    class="form-label">{{option.label | translate}}</label>
                   </div>
                 }
               </div>

--- a/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.scss
+++ b/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.scss
@@ -1,3 +1,3 @@
-.form-check input{
+.form-check input, .form-check label{
   width: auto;
 }

--- a/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.scss
+++ b/src/app/item-page/orcid-page/orcid-sync-settings/orcid-sync-settings.component.scss
@@ -1,0 +1,3 @@
+.form-check input{
+  width: auto;
+}


### PR DESCRIPTION
## References
* Fixes #4302 

## Description
This PR introduces CSS changes to adjust the layout of checkbox elements in the profile settings of the ORCID page.

## Instructions for Reviewers
Please review the visual alignment and spacing of the checkboxes and labels on the ORCID settings page.

List of changes in this PR:
* Changed the `width` of the checkbox `input` and `label` from `100%` to `auto` to prevent full-width stretching.
* Removed the `ms-2` class from the `label` element, as it already includes appropriate left padding via other styles.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
