### PR TITLE
Fix matomo SSR error on bitstream download page

### DIFF
--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -60,7 +60,7 @@ export class FooterComponent implements OnInit {
   }
 
   showCookieSettings() {
-    if (hasValue(this.cookies)) {
+    if (hasValue(this.cookies) && this.cookies.showSettings instanceof Function) {
       this.cookies.showSettings();
     }
     return false;

--- a/src/app/shared/cookies/orejime.service.ts
+++ b/src/app/shared/cookies/orejime.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 /**
  * Abstract class representing a service for handling Orejime consent preferences and UI
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export abstract class OrejimeService {
   /**
    * Initializes the service

--- a/src/app/statistics/matomo.service.spec.ts
+++ b/src/app/statistics/matomo.service.spec.ts
@@ -1,4 +1,8 @@
 import {
+  Injector,
+  runInInjectionContext,
+} from '@angular/core';
+import {
   fakeAsync,
   TestBed,
   tick,
@@ -53,6 +57,7 @@ describe('MatomoService', () => {
         { provide: OrejimeService, useValue: orejimeService },
         { provide: NativeWindowService, useValue: nativeWindowService },
         { provide: ConfigurationDataService, useValue: configService },
+        { provide: Injector, useValue: TestBed },
       ],
     });
 
@@ -70,11 +75,13 @@ describe('MatomoService', () => {
   });
 
   it('should call setConsentGiven when consent is true', () => {
+    service.matomoTracker = matomoTracker;
     service.changeMatomoConsent(true);
     expect(matomoTracker.setConsentGiven).toHaveBeenCalled();
   });
 
   it('should call forgetConsentGiven when consent is false', () => {
+    service.matomoTracker = matomoTracker;
     service.changeMatomoConsent(false);
     expect(matomoTracker.forgetConsentGiven).toHaveBeenCalled();
   });
@@ -91,7 +98,10 @@ describe('MatomoService', () => {
     configService.findByPropertyName.withArgs(MATOMO_SITE_ID).and.returnValue(
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
     orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
-    service.init();
+
+    runInInjectionContext(TestBed, () => {
+      service.init();
+    });
 
     expect(matomoTracker.setConsentGiven).toHaveBeenCalled();
     expect(matomoInitializer.initializeTracker).toHaveBeenCalledWith({
@@ -100,7 +110,7 @@ describe('MatomoService', () => {
     });
   });
 
-  it('should initialize tracker with REST configuration correct parameters in production', () => {
+  it('should initialize tracker with REST configuration correct parameters in production', fakeAsync(() => {
     environment.production = true;
     environment.matomo = { trackerUrl: '' };
     configService.findByPropertyName.withArgs(MATOMO_TRACKER_URL).and.returnValue(
@@ -113,19 +123,25 @@ describe('MatomoService', () => {
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
     orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
 
-    service.init();
+    runInInjectionContext(TestBed, () => {
+      service.init();
+    });
+
+    tick();
 
     expect(matomoTracker.setConsentGiven).toHaveBeenCalled();
     expect(matomoInitializer.initializeTracker).toHaveBeenCalledWith({
       siteId: '1',
       trackerUrl: 'http://example.com',
     });
-  });
+  }));
 
   it('should not initialize tracker if not in production', () => {
     environment.production = false;
 
-    service.init();
+    runInInjectionContext(TestBed, () => {
+      service.init();
+    });
 
     expect(matomoInitializer.initializeTracker).not.toHaveBeenCalled();
   });
@@ -143,7 +159,9 @@ describe('MatomoService', () => {
       createSuccessfulRemoteDataObject$(Object.assign(new ConfigurationProperty(), { values: ['1'] })));
     orejimeService.getSavedPreferences.and.returnValue(of({ matomo: true }));
 
-    service.init();
+    runInInjectionContext(TestBed, () => {
+      service.init();
+    });
 
     expect(matomoInitializer.initializeTracker).not.toHaveBeenCalled();
   });
@@ -151,6 +169,7 @@ describe('MatomoService', () => {
   describe('with visitorId set', () => {
     beforeEach(() => {
       matomoTracker.getVisitorId.and.returnValue(Promise.resolve('12345'));
+      service.matomoTracker = matomoTracker;
     });
 
     it('should add trackerId parameter', fakeAsync(() => {

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -1,6 +1,8 @@
 import {
+  EnvironmentInjector,
   inject,
   Injectable,
+  runInInjectionContext,
 } from '@angular/core';
 import {
   MatomoInitializerService,
@@ -11,12 +13,10 @@ import {
   from as fromPromise,
   Observable,
   of,
-  switchMap,
 } from 'rxjs';
 import {
   map,
   take,
-  tap,
 } from 'rxjs/operators';
 
 import { environment } from '../../environments/environment';
@@ -47,10 +47,10 @@ export const MATOMO_ENABLED = 'matomo.enabled';
 export class MatomoService {
 
   /** Injects the MatomoInitializerService to initialize the Matomo tracker. */
-  matomoInitializer = inject(MatomoInitializerService);
+  matomoInitializer: MatomoInitializerService;
 
   /** Injects the MatomoTracker to manage Matomo tracking operations. */
-  matomoTracker = inject(MatomoTracker);
+  matomoTracker: MatomoTracker;
 
   /** Injects the OrejimeService to manage cookie consent preferences. */
   orejimeService = inject(OrejimeService);
@@ -60,6 +60,10 @@ export class MatomoService {
 
   /** Injects the ConfigurationService. */
   configService = inject(ConfigurationDataService);
+
+  constructor(private injector: EnvironmentInjector) {
+
+  }
 
   /**
    * Initializes the Matomo tracker if in production environment.
@@ -74,14 +78,15 @@ export class MatomoService {
     if (environment.production) {
       const preferences$ = this.orejimeService.getSavedPreferences();
 
-      preferences$
-        .pipe(
-          tap(preferences => this.changeMatomoConsent(preferences?.matomo)),
-          switchMap(_ => combineLatest([this.isMatomoEnabled$(), this.getSiteId$(), this.getTrackerUrl$()])),
-        )
-        .subscribe(([isMatomoEnabled, siteId, trackerUrl]) => {
+      combineLatest([preferences$, this.isMatomoEnabled$(), this.getSiteId$(), this.getTrackerUrl$()])
+        .subscribe(([preferences, isMatomoEnabled, siteId, trackerUrl]) => {
           if (isMatomoEnabled && siteId && trackerUrl) {
+            runInInjectionContext(this.injector, () => {
+              this.matomoTracker = inject(MatomoTracker);
+              this.matomoInitializer = inject(MatomoInitializerService);
+            });
             this.matomoInitializer.initializeTracker({ siteId, trackerUrl });
+            this.changeMatomoConsent(preferences?.matomo);
           }
         });
     }
@@ -93,9 +98,9 @@ export class MatomoService {
    */
   changeMatomoConsent = (consent: boolean) => {
     if (consent) {
-      this.matomoTracker.setConsentGiven();
+      this.matomoTracker?.setConsentGiven();
     } else {
-      this.matomoTracker.forgetConsentGiven();
+      this.matomoTracker?.forgetConsentGiven();
     }
   };
 
@@ -105,7 +110,7 @@ export class MatomoService {
    * @returns An Observable that emits the URL with the visitor ID appended.
    */
   appendVisitorId(url: string): Observable<string> {
-    return fromPromise(this.matomoTracker.getVisitorId())
+    return fromPromise(this.matomoTracker?.getVisitorId())
       .pipe(
         map(visitorId => this.appendTrackerId(url, visitorId)),
         take(1),


### PR DESCRIPTION
## References
* Fixes #4309

## Description
Changed the injection of `MatomoTracker` and `MatomoInitializerService` so that they are not injected before checking for all Matomo's necessary configuration values.

## Instructions for Reviewers
I tested this without a local Matomo instance: I used Chrome overrides to mimic the same behavior instead, and it seems fine enough. The most important part - except for making sure that the issue is fixed, of course - is checking that there is no regression on Matomo.

List of changes in this PR:
* Moved `MatomoTracker` and `MatomoInitializerService` injection after obtaining Matomo's configuration options from the REST config;
* Fixed tests and added a missing `providedIn: root`.

To test this PR:
* Open any `/bitstreams/<uuid>/download` page in SSR with Matomo disabled - there should be no error regarding Matomo's missing initialization on logs;
* Enable Matomo and make sure that there is no regression.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
