### PR TITLE
Add basic automated tests to ensure common HTTP Return Codes do not break

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,37 @@ jobs:
           echo "$result"
           echo "$result" | grep -oE "<meta name=\"title\" [^>]*>" | grep "Environmental &amp; Architectural Phenomenology Vol. 28, No. 1"
 
+      # Verify 301 Handle redirect behavior
+      # Note: /handle/123456789/260 is the same test Publication used by our e2e tests
+      - name: Verify 301 redirect from '/handle' URLs
+        run: |
+          result=$(wget --server-response --quiet http://127.0.0.1:4000/handle/123456789/260 2>&1 | head -1 | awk '{print $2}')
+          echo "$result"
+          [[ "$result" -eq "301" ]]
+
+      # Verify 403 error code behavior
+      - name: Verify 403 error code from '/403'
+        run: |
+          result=$(wget --server-response --quiet http://127.0.0.1:4000/403 2>&1 | head -1 | awk '{print $2}')
+          echo "$result"
+          [[ "$result" -eq "403" ]]
+
+      # Verify 404 error code behavior
+      - name: Verify 404 error code from '/404' and on invalid pages
+        run: |
+          result=$(wget --server-response --quiet http://127.0.0.1:4000/404 2>&1 | head -1 | awk '{print $2}')
+          echo "$result"
+          result2=$(wget --server-response --quiet http://127.0.0.1:4000/invalidurl 2>&1 | head -1 | awk '{print $2}')
+          echo "$result2"
+          [[ "$result" -eq "404" && "$result2" -eq "404" ]]
+
+      # Verify 500 error code behavior
+      - name: Verify 500 error code from '/500'
+        run: |
+          result=$(wget --server-response --quiet http://127.0.0.1:4000/500 2>&1 | head -1 | awk '{print $2}')
+          echo "$result"
+          [[ "$result" -eq "500" ]]
+
       - name: Stop running app
         run: kill -9 $(lsof -t -i:4000)
 


### PR DESCRIPTION
## References
* Inspired by trying to **avoid** seeing tickets like #4042 and #4132 occur again.

## Description
This small PR adds basic, (Bash) command-line tests into our GitHub build process to verify the following HTTP response codes occur:
* 301 redirect occurs for `/handle/[prefix]/[suffix]` URLs
* 403 error occurs for the `/403` error page
* 404 error occurs for the `/404` error page and an invalid URL
* 500 error occurs for the `/500` error page.

## Instructions for Reviewers
* This PR contains no new DSpace code.  It just adds some Bash commandline tests on to the end of our Build process which verify proper error codes are returned from the DSpace UI as described above. 