### PR TITLE
Enforce standalone components/directives/pipes via linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -160,6 +160,9 @@
             ]
           }
         ],
+        "@angular-eslint/prefer-standalone": [
+          "error"
+        ],
         "@angular-eslint/no-attribute-decorator": "error",
         "@angular-eslint/no-output-native": "warn",
         "@angular-eslint/no-output-on-prefix": "warn",

--- a/src/app/browse-by/browse-by-page/browse-by-page.component.spec.ts
+++ b/src/app/browse-by/browse-by-page/browse-by-page.component.spec.ts
@@ -20,6 +20,7 @@ import { BrowseByPageComponent } from './browse-by-page.component';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: '',
+  standalone: true,
   template: '<span id="BrowseByTestComponent"></span>',
 })
 class BrowseByTestComponent {

--- a/src/app/browse-by/browse-by-switcher/browse-by-switcher.component.spec.ts
+++ b/src/app/browse-by/browse-by-switcher/browse-by-switcher.component.spec.ts
@@ -20,6 +20,7 @@ import { BrowseBySwitcherComponent } from './browse-by-switcher.component';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: '',
+  standalone: true,
   template: '<span id="BrowseByTestComponent"></span>',
 })
 class BrowseByTestComponent {

--- a/src/app/process-page/form/process-parameters/parameter-value-input/value-input.component.ts
+++ b/src/app/process-page/form/process-parameters/parameter-value-input/value-input.component.ts
@@ -10,6 +10,7 @@ import {
  */
 @Component({
   selector: 'ds-value-input',
+  standalone: true,
   template: '',
 })
 export abstract class ValueInputComponent<T> {

--- a/src/app/shared/browse-by/browse-by.component.spec.ts
+++ b/src/app/shared/browse-by/browse-by.component.spec.ts
@@ -58,6 +58,7 @@ import { BrowseByComponent } from './browse-by.component';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ds-browse-entry-list-element',
+  standalone: true,
   template: '',
 })
 class MockThemedBrowseEntryListElementComponent {

--- a/src/app/shared/comcol/sections/comcol-browse-by/comcol-browse-by.component.spec.ts
+++ b/src/app/shared/comcol/sections/comcol-browse-by/comcol-browse-by.component.spec.ts
@@ -23,6 +23,7 @@ import { ComcolBrowseByComponent } from './comcol-browse-by.component';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: '',
+  standalone: true,
   template: '<span id="ComcolBrowseByComponent"></span>',
 })
 class BrowseByTestComponent {

--- a/src/app/shared/disabled-directive.spec.ts
+++ b/src/app/shared/disabled-directive.spec.ts
@@ -11,9 +11,13 @@ import { By } from '@angular/platform-browser';
 import { BtnDisabledDirective } from './btn-disabled.directive';
 
 @Component({
+  standalone: true,
   template: `
     <button [dsBtnDisabled]="isDisabled">Test Button</button>
   `,
+  imports: [
+    BtnDisabledDirective,
+  ],
 })
 class TestComponent {
   isDisabled = false;
@@ -26,8 +30,7 @@ describe('DisabledDirective', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BtnDisabledDirective],
-      declarations: [TestComponent],
+      imports: [BtnDisabledDirective, TestComponent],
     });
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.ts
@@ -34,6 +34,7 @@ export enum SelectorActionType {
  */
 @Component({
   selector: 'ds-dso-selector-modal',
+  standalone: true,
   template: '',
 })
 export abstract class DSOSelectorModalWrapperComponent implements OnInit {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
@@ -28,6 +28,7 @@ import { DsDynamicInputModel } from './ds-dynamic-input.model';
  */
 @Component({
   selector: 'ds-dynamic-vocabulary',
+  standalone: true,
   template: '',
 })
 export abstract class DsDynamicVocabularyComponent extends DynamicFormControlComponent {

--- a/src/app/shared/mydspace-actions/claimed-task/abstract/advanced-claimed-task-actions-abstract.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/abstract/advanced-claimed-task-actions-abstract.component.ts
@@ -27,6 +27,7 @@ import { ClaimedTaskActionsAbstractComponent } from './claimed-task-actions-abst
  */
 @Component({
   selector: 'ds-advanced-claimed-task-action-abstract',
+  standalone: true,
   template: '',
 })
 export abstract class AdvancedClaimedTaskActionsAbstractComponent extends ClaimedTaskActionsAbstractComponent implements OnInit {

--- a/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/abstract/claimed-task-actions-abstract.component.ts
@@ -31,6 +31,7 @@ import { MyDSpaceReloadableActionsComponent } from '../../mydspace-reloadable-ac
  */
 @Component({
   selector: 'ds-claimed-task-action-abstract',
+  standalone: true,
   template: '',
 })
 export abstract class ClaimedTaskActionsAbstractComponent extends MyDSpaceReloadableActionsComponent<ClaimedTask, ClaimedTaskDataService> implements OnDestroy {

--- a/src/app/shared/mydspace-actions/mydspace-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.ts
@@ -37,6 +37,7 @@ export interface MyDSpaceActionsResult {
  */
 @Component({
   selector: 'ds-mydspace-actions-abstract',
+  standalone: true,
   template: '',
 })
 export abstract class MyDSpaceActionsComponent<T extends DSpaceObject, TService extends IdentifiableDataService<T>> {

--- a/src/app/shared/mydspace-actions/mydspace-reloadable-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-reloadable-actions.ts
@@ -34,6 +34,7 @@ import { MyDSpaceActionsComponent } from './mydspace-actions';
  */
 @Component({
   selector: 'ds-mydspace-reloadable-actions',
+  standalone: true,
   template: '',
 })
 export abstract class MyDSpaceReloadableActionsComponent<T extends DSpaceObject, TService extends IdentifiableDataService<T>>

--- a/src/app/shared/object-select/object-select/object-select.component.ts
+++ b/src/app/shared/object-select/object-select/object-select.component.ts
@@ -30,6 +30,7 @@ import { ObjectSelectService } from '../object-select.service';
  */
 @Component({
   selector: 'ds-object-select-abstract',
+  standalone: true,
   template: '',
 })
 export abstract class ObjectSelectComponent<TDomain extends DSpaceObject> implements OnInit, OnDestroy {

--- a/src/app/shared/starts-with/starts-with-abstract.component.ts
+++ b/src/app/shared/starts-with/starts-with-abstract.component.ts
@@ -23,6 +23,7 @@ import { StartsWithType } from './starts-with-type';
  */
 @Component({
   selector: 'ds-start-with-abstract',
+  standalone: true,
   template: '',
 })
 export abstract class StartsWithAbstractComponent implements OnInit, OnDestroy {

--- a/src/app/shared/theme-support/test/custom/themed-test.component.spec.ts
+++ b/src/app/shared/theme-support/test/custom/themed-test.component.spec.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 // noinspection AngularMissingOrInvalidDeclarationInModule
 @Component({
   selector: 'ds-test-component',
+  standalone: true,
   template: '',
 })
 export class TestComponent {

--- a/src/app/shared/theme-support/test/test.component.spec.ts
+++ b/src/app/shared/theme-support/test/test.component.spec.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 // noinspection AngularMissingOrInvalidDeclarationInModule
 @Component({
   selector: 'ds-test-component',
+  standalone: true,
   template: '',
 })
 export class TestComponent {

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -37,6 +37,7 @@ import { ThemeService } from './theme.service';
 
 @Component({
   selector: 'ds-themed',
+  standalone: true,
   styleUrls: ['./themed.component.scss'],
   templateUrl: './themed.component.html',
 })

--- a/src/app/submission/sections/models/section.model.ts
+++ b/src/app/submission/sections/models/section.model.ts
@@ -29,6 +29,7 @@ export interface SectionDataModel {
  */
 @Component({
   selector: 'ds-section-model',
+  standalone: true,
   template: '',
 })
 export abstract class SectionModelComponent implements OnDestroy, OnInit, SectionDataModel {

--- a/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action/advanced-workflow-action.component.ts
+++ b/src/app/workflowitems-edit-page/advanced-workflow-action/advanced-workflow-action/advanced-workflow-action.component.ts
@@ -30,6 +30,7 @@ import { WorkflowItemActionPageDirective } from '../../workflow-item-action-page
  */
 @Component({
   selector: 'ds-advanced-workflow-action',
+  standalone: true,
   template: '',
 })
 export abstract class AdvancedWorkflowActionComponent extends WorkflowItemActionPageDirective implements OnInit {


### PR DESCRIPTION
## References
* Fixes #4328

## Description
Implemented the `@angular-eslint/prefer-standalone` rule to enforce using standalone components/directives/pipes.

## Instructions for Reviewers
You can test this linting rule by removing a `standalone: true` property from a component declaration.
Components that are now `standalone` are either abstract components or test components, so no functionality has been degraded.

List of changes in this PR:
* Added the @angular-eslint/prefer-standalone rule in `.eslintrc.json`;
* Fixed linting errors;
* Fixed tests that were declaring components (as now they have to import them).

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
