### PR TITLE
Fix unqualified metadata field validation in Edit Metadata tab by sorting fields in validation request

### DIFF
--- a/src/app/dso-shared/dso-edit-metadata/metadata-field-selector/metadata-field-selector.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/metadata-field-selector/metadata-field-selector.component.spec.ts
@@ -116,6 +116,14 @@ describe('MetadataFieldSelectorComponent', () => {
       });
     });
 
+    it('should sort the fields by name to ensure the one without a qualifier is first', () => {
+      component.mdField = 'dc.relation';
+
+      component.validate();
+
+      expect(registryService.queryMetadataFields).toHaveBeenCalledWith('dc.relation', { elementsPerPage: 20, sort: new SortOptions('fieldName', SortDirection.ASC), currentPage: 1 }, true, false, followLink('schema'));
+    });
+
     describe('when querying the metadata fields returns an error response', () => {
       beforeEach(() => {
         (registryService.queryMetadataFields as jasmine.Spy).and.returnValue(createFailedRemoteDataObject$('Failed'));

--- a/src/app/dso-shared/dso-edit-metadata/metadata-field-selector/metadata-field-selector.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/metadata-field-selector/metadata-field-selector.component.ts
@@ -43,6 +43,7 @@ import {
   SortDirection,
   SortOptions,
 } from '../../../core/cache/models/sort-options.model';
+import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { RegistryService } from '../../../core/registry/registry.service';
 import {
   getAllSucceededRemoteData,
@@ -153,7 +154,10 @@ export class MetadataFieldSelectorComponent implements OnInit, OnDestroy, AfterV
   /**
    * Default page option for this feature
    */
-  pageOptions = { elementsPerPage: 20, sort: new SortOptions('fieldName', SortDirection.ASC) };
+  pageOptions: FindListOptions = {
+    elementsPerPage: 20,
+    sort: new SortOptions('fieldName', SortDirection.ASC),
+  };
 
 
   constructor(protected registryService: RegistryService,
@@ -209,7 +213,7 @@ export class MetadataFieldSelectorComponent implements OnInit, OnDestroy, AfterV
    * Upon subscribing to the returned observable, the showInvalid flag is updated accordingly to show the feedback under the input
    */
   validate(): Observable<boolean> {
-    return this.registryService.queryMetadataFields(this.mdField, null, true, false, followLink('schema')).pipe(
+    return this.registryService.queryMetadataFields(this.mdField, Object.assign({}, this.pageOptions, { currentPage: 1 }), true, false, followLink('schema')).pipe(
       getFirstCompletedRemoteData(),
       switchMap((rd) => {
         if (rd.hasSucceeded) {
@@ -263,9 +267,7 @@ export class MetadataFieldSelectorComponent implements OnInit, OnDestroy, AfterV
    * @param useCache Whether or not to use the cache
    */
   search(query: string, page: number, useCache: boolean = true)  {
-    return this.registryService.queryMetadataFields(query,{
-      elementsPerPage: this.pageOptions.elementsPerPage, sort: this.pageOptions.sort,
-      currentPage: page }, useCache, false, followLink('schema'))
+    return this.registryService.queryMetadataFields(query, Object.assign({}, this.pageOptions, { currentPage: page }), useCache, false, followLink('schema'))
       .pipe(
         getAllSucceededRemoteData(),
         metadataFieldsToString(),


### PR DESCRIPTION
## References
* Fixes #4339

## Description
Fixed a validation issue that prevents you from submitting unqualified metadata fields, if the unqualified metadata field was added to the registry when 20 qualified fields with the same schema & element were already present in the DB

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/fb90c3fb-f7f5-45da-8a7b-c3250d6ea1fa" />

## Instructions for Reviewers
List of changes in this PR:
* Updated the `MetadataFieldSelectorComponent` to sort the field names during the `validate()` call. This ensures that the unqualified field is always present on the first page. I also reused the other `pageOptions` as well, this way if you type out the whole metadata field name correctly, the validate call won't send out an additional network request

**Guidance for how to test or review this PR:** See #4339

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
