### PR TITLE
Use ellipsis for truncatable parts

### DIFF
--- a/src/styles/_truncatable-part.component.scss
+++ b/src/styles/_truncatable-part.component.scss
@@ -4,24 +4,11 @@
     height: $lines * $height;
   }
   .content {
-    max-height: $lines * $height;
-    position: relative;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    line-height: $line-height;
-    overflow-wrap: break-word;
-    &:after {
-      content: "";
-      position: absolute;
-      padding-right: 15px;
-      top: ($lines - 1) * $height;
-      right: 0;
-      width: 30%;
-      min-width: 75px;
-      max-width: 150px;
-      height: $height;
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba($bg, 1) 70%);
-      pointer-events: none;
-    }
   }
 
 }


### PR DESCRIPTION
## References
* Fixes #1164 

## Description
Changed truncatable parts in order to use ellipsis instead of fading text, for a11y purposes.

## Instructions for Reviewers
I decided to use [webkit's line-clamp CSS rule](https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp) in order to achieve the same result as before, changing only how the truncated part happens to "fade away" - it was a fade to transparency before, it's an ellipsis now.

![image](https://github.com/user-attachments/assets/ae30e520-f783-4164-8f68-3eb489965ef9)

I think this is the best way to implement this feature, as it is now [widely supported](https://caniuse.com/css-line-clamp). Moreover, we can keep backwards compatibility by just changing the `clamp` mixin, since it's used in all truncatable-part css classes, except for the `clamp-none.fixedHeight.min-<1 to 15>`, which is just applying a `min-height`, so that's ok.

Another great upside of using `line-clamp` is that it behaves very well in containers that include different sizes of text, with no need to manually calculate `min-height`s. I still kept around the `clamp-with-titles` mixin for, again, backwards compatibility and use in combination with `fixedHeight`.

List of changes in this PR:
* Changed CSS rules in order to use line-clamp to ellipse truncatable parts.

The best way to test this PR is to play around with truncatable parts, and even better by including different types of text lines inside them.

Since this is a css-only PR, I have not created any test for it, also because the a11y issue raised on the linked issue has been detected via manual testing and not via automated testing, but I'm of course open to suggestions on that!

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
