### PR TITLE
Remove stray comma from `config.example.yml` which makes example config invalid

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -27,7 +27,7 @@ ssr:
   # If the path match any of the regexes it will be served directly in CSR.
   # By default, excludes community and collection browse, global browse, global search, community list, statistics and various administrative tools.
   excludePathPatterns:
-    - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$",
+    - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
       flag: "i"
     - pattern: "^/collections/[a-f0-9-]{36}/browse(/.*)?$"
       flag: "i"


### PR DESCRIPTION
## References
* Reported in https://github.com/DSpace/dspace-angular/pull/4227#discussion_r2102805783

## Description
Tiny fix to `config.example.yml` to remove a stray comma which is invalid in YAML.