### PR TITLE
Fix back button behavior on roles page

### DIFF
--- a/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
@@ -38,6 +38,8 @@ import { NoContent } from '../../../core/shared/NoContent.model';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { DSONameServiceMock } from '../../../shared/mocks/dso-name.service.mock';
 import { ActivatedRouteStub } from '../../../shared/testing/active-router.stub';
+import { routeServiceStub } from '../../../shared/testing/route-service.stub';
+import { RouteService } from '../../../core/services/route.service';
 
 describe('GroupFormComponent', () => {
   let component: GroupFormComponent;
@@ -230,6 +232,7 @@ describe('GroupFormComponent', () => {
         { provide: ActivatedRoute, useValue: route },
         { provide: Router, useValue: router },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: RouteService, useValue: routeServiceStub },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/src/app/access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.ts
@@ -46,6 +46,7 @@ import { ValidateGroupExists } from './validators/group-exists.validator';
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { environment } from '../../../../environments/environment';
 import { getGroupEditRoute, getGroupsRoute } from '../../access-control-routing-paths';
+import { RouteService } from '../../../core/services/route.service';
 
 @Component({
   selector: 'ds-group-form',
@@ -155,6 +156,7 @@ export class GroupFormComponent implements OnInit, OnDestroy {
     public requestService: RequestService,
     protected changeDetectorRef: ChangeDetectorRef,
     public dsoNameService: DSONameService,
+    protected routeService: RouteService,
   ) {
   }
 
@@ -267,7 +269,11 @@ export class GroupFormComponent implements OnInit, OnDestroy {
   onCancel() {
     this.groupDataService.cancelEditGroup();
     this.cancelForm.emit();
-    void this.router.navigate([getGroupsRoute()]);
+    this.routeService.getPreviousUrl().pipe(
+      take(1),
+    ).subscribe((previousURL) => {
+      void this.router.navigate([previousURL && previousURL.trim().length > 0 ? previousURL : getGroupsRoute()]);
+    });
   }
 
   /**


### PR DESCRIPTION
## References
Fixes #4278 


## Description
The back button behavior was hardcoded and did not really take into account the previous route. This is now fixed. Raising this against 7_x as per the discussion on #4278.

## Instructions for Reviewers
Start from a community or collection page. Navigate to edit -> Assign roles. Create any role and click on it to navigate to edit group page. Pressing back will now take you back to the original page. 

List of changes in this PR:
* group-form.component  edited to consider the previous route in onCancel()
* group-form.component.spec edited to provide routeServiceStub to prevent tests from failing

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
