### PR TITLE
Add dependabot configuration for dspace-9_x. 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
     # Group together Angular package upgrades
@@ -146,6 +147,85 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   #####################
+  ## dspace-9_x branch
+  #####################
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: dspace-9_x
+    schedule:
+      interval: "weekly"
+      time: "05:00"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together Angular package upgrades
+    groups:
+      # Group together all patch version updates for Angular in a single PR
+      angular:
+        applies-to: version-updates
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all minor/patch version updates for NgRx in a single PR
+      ngrx:
+        applies-to: version-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all patch version updates for eslint in a single PR
+      eslint:
+        applies-to: version-updates
+        patterns:
+        - "@typescript-eslint*"
+        - "eslint*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any testing related version updates
+      testing:
+        applies-to: version-updates
+        patterns:
+        - "@cypress*"
+        - "axe-*"
+        - "cypress*"
+        - "jasmine*"
+        - "karma*"
+        - "ng-mocks"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any postcss related version updates
+      postcss:
+        applies-to: version-updates
+        patterns:
+        - "postcss*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any sass related version updates
+      sass:
+        applies-to: version-updates
+        patterns:
+        - "sass*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any webpack related version updates
+      webpack:
+        applies-to: version-updates
+        patterns:
+        - "webpack*"
+        update-types:
+        - "minor"
+        - "patch"
+    ignore:
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  #####################
   ## dspace-8_x branch
   #####################
   - package-ecosystem: "npm"
@@ -153,6 +233,7 @@ updates:
     target-branch: dspace-8_x
     schedule:
       interval: "weekly"
+      time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
     # Group together Angular package upgrades
@@ -231,6 +312,7 @@ updates:
     target-branch: dspace-7_x
     schedule:
       interval: "weekly"
+      time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
     # Group together Angular package upgrades


### PR DESCRIPTION
## Description
Equivalent of DSpace/DSpace#10785 for `dspace-angular`.  This is just adding a new configuration to dependabot for `dspace-9_x` branch.  Additionally, it makes a minor modification to each configuration to have them run at the same `time`.  This is just for convenience, so we get all the dependabot PRs at once instead of on different days/times.