### PR TITLE
.github/dependabot.yml: adjust rules for zone.js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,6 +142,13 @@ updates:
         update-types:
         - "minor"
         - "patch"
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      zonejs:
+        applies-to: version-updates
+        patterns:
+        - "zone.js"
+        update-types:
+        - "patch"
     ignore:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
@@ -220,6 +227,13 @@ updates:
         - "webpack*"
         update-types:
         - "minor"
+        - "patch"
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      zonejs:
+        applies-to: version-updates
+        patterns:
+        - "zone.js"
+        update-types:
         - "patch"
     ignore:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
@@ -300,6 +314,13 @@ updates:
         update-types:
         - "minor"
         - "patch"
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      zonejs:
+        applies-to: version-updates
+        patterns:
+        - "zone.js"
+        update-types:
+        - "patch"
     ignore:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
@@ -370,6 +391,13 @@ updates:
         - "sass*"
         update-types:
         - "minor"
+        - "patch"
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      zonejs:
+        applies-to: version-updates
+        patterns:
+        - "zone.js"
+        update-types:
         - "patch"
     ignore:
       # 7.x Cannot update Webpack past v5.76.1 as later versions not supported by Angular 15


### PR DESCRIPTION
## Description
As @angular/core uses the `~` specifier to pin zone.js to a patch version, dependabot should not try to update minor versions in DSpace. We need to use the same version to avoid peer dependency conflicts.

I think we never noticed this until we switched to npm in DSpace 9 because yarn does not complain about conflicts in peer dependencies.

See: https://github.com/angular/angular/blob/18.2.x/packages/core/package.json

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Adjust dependabot configuration to consider patch versions for zone.js

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
