### PR TITLE
[Port dspace-8_x] Make the default tab for browsing communities and collections configurable in DSpace 8

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -367,12 +367,20 @@ item:
 
 # Community Page Config
 community:
+  # Default tab to be shown when browsing a Community. Valid values are: comcols, search, or browse_<field>
+  # <field> must be any of the configured "browse by" fields, e.g., dateissued, author, title, or subject
+  # When the default tab is not the 'search' tab, the search tab is moved to the last position
+  defaultBrowseTab: search
   # Search tab config
   searchSection:
     showSidebar: true
 
 # Collection Page Config
 collection:
+  # Default tab to be shown when browsing a Collection. Valid values are: search, or browse_<field>
+  # <field> must be any of the configured "browse by" fields, e.g., dateissued, author, title, or subject
+  # When the default tab is not the 'search' tab, the search tab is moved to the last position
+  defaultBrowseTab: search
   # Search tab config
   searchSection:
     showSidebar: true

--- a/src/app/collection-page/collection-page-routes.ts
+++ b/src/app/collection-page/collection-page-routes.ts
@@ -94,6 +94,15 @@ export const ROUTES: Route[] = [
             component: ComcolSearchSectionComponent,
           },
           {
+            path: 'search',
+            pathMatch: 'full',
+            component: ComcolSearchSectionComponent,
+            resolve: {
+              breadcrumb: i18nBreadcrumbResolver,
+            },
+            data: { breadcrumbKey: 'collection.search' },
+          },
+          {
             path: 'browse/:id',
             pathMatch: 'full',
             component: ComcolBrowseByComponent,

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -81,6 +81,15 @@ export const ROUTES: Route[] = [
             component: ComcolSearchSectionComponent,
           },
           {
+            path: 'search',
+            pathMatch: 'full',
+            component: ComcolSearchSectionComponent,
+            resolve: {
+              breadcrumb: i18nBreadcrumbResolver,
+            },
+            data: { breadcrumbKey: 'community.search' },
+          },
+          {
             path: 'subcoms-cols',
             pathMatch: 'full',
             component: SubComColSectionComponent,

--- a/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
+++ b/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
@@ -143,7 +143,7 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
     } else if (this.contentType === 'community') {
       comColRoute = getCommunityPageRoute(this.id);
     }
-    
+
     this.subs.push(combineLatest([
       this.allOptions$,
       this.router.events.pipe(
@@ -157,7 +157,7 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
         if (url?.split('?')[0] === comColRoute && option.id === this.appConfig[this.contentType].defaultBrowseTab) {
           void this.router.navigate([option.routerLink], { queryParams: option.params });
           break;
-        } else if (option.routerLink === url?.split('?')[0]) {  
+        } else if (option.routerLink === url?.split('?')[0]) {
           this.currentOption$.next(option);
           break;
         }

--- a/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
+++ b/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -33,6 +34,10 @@ import {
   take,
 } from 'rxjs/operators';
 
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../../config/app-config.interface';
 import { getCollectionPageRoute } from '../../../collection-page/collection-page-routing-paths';
 import { getCommunityPageRoute } from '../../../community-page/community-page-routing-paths';
 import { BrowseService } from '../../../core/browse/browse.service';
@@ -82,6 +87,7 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
   subs: Subscription[] = [];
 
   constructor(
+    @Inject(APP_CONFIG) public appConfig: AppConfig,
     public router: Router,
     private browseService: BrowseService,
   ) {
@@ -99,14 +105,14 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
             allOptions.push({
               id: 'search',
               label: 'collection.page.browse.search.head',
-              routerLink: comColRoute,
+              routerLink: `${comColRoute}/search`,
             });
           } else if (this.contentType === 'community') {
             comColRoute = getCommunityPageRoute(this.id);
             allOptions.push({
               id: 'search',
               label: 'collection.page.browse.search.head',
-              routerLink: comColRoute,
+              routerLink: `${comColRoute}/search`,
             });
             allOptions.push({
               id: 'comcols',
@@ -120,11 +126,24 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
             label: `browse.comcol.by.${config.id}`,
             routerLink: `${comColRoute}/browse/${config.id}`,
           })));
+
+          // When the default tab is not the "search" tab, the "search" tab is moved
+          // at the end of the tabs ribbon for aesthetics purposes.
+          if (this.appConfig[this.contentType].defaultBrowseTab !== 'search') {
+            allOptions.push(allOptions.shift());
+          }
         }
         return allOptions;
       }),
     );
 
+    let comColRoute: string;
+    if (this.contentType === 'collection') {
+      comColRoute = getCollectionPageRoute(this.id);
+    } else if (this.contentType === 'community') {
+      comColRoute = getCommunityPageRoute(this.id);
+    }
+    
     this.subs.push(combineLatest([
       this.allOptions$,
       this.router.events.pipe(
@@ -135,11 +154,29 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
       ),
     ]).subscribe(([navOptions, url]: [ComColPageNavOption[], string]) => {
       for (const option of navOptions) {
-        if (option.routerLink === url?.split('?')[0]) {
+        if (url?.split('?')[0] === comColRoute && option.id === this.appConfig[this.contentType].defaultBrowseTab) {
+          void this.router.navigate([option.routerLink], { queryParams: option.params });
+          break;
+        } else if (option.routerLink === url?.split('?')[0]) {  
           this.currentOption$.next(option);
+          break;
         }
       }
     }));
+
+    if (this.router.url?.split('?')[0] === comColRoute) {
+      this.allOptions$.pipe(
+        take(1),
+      ).subscribe((allOptions: ComColPageNavOption[]) => {
+        for (const option of allOptions) {
+          if (option.id === this.appConfig[this.contentType].defaultBrowseTab) {
+            this.currentOption$.next(option[0]);
+            void this.router.navigate([option.routerLink], { queryParams: option.params });
+            break;
+          }
+        }
+      });
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.spec.ts
+++ b/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.spec.ts
@@ -18,6 +18,7 @@ describe('ComcolSearchSectionComponent', () => {
 
   beforeEach(async () => {
     route = new ActivatedRouteStub();
+    route.parent = new ActivatedRouteStub();
 
     await TestBed.configureTestingModule({
       imports: [ComcolSearchSectionComponent],

--- a/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.ts
+++ b/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.ts
@@ -55,7 +55,7 @@ export class ComcolSearchSectionComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.comcol$ = this.route.data.pipe(
+    this.comcol$ = this.route.parent.data.pipe(
       map((data: Data) => (data.dso as RemoteData<Community | Collection>).payload),
     );
     this.showSidebar$ = this.comcol$.pipe(

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1323,6 +1323,8 @@
 
   "collection.page.news": "News",
 
+  "collection.search.breadcrumbs": "Search",
+
   "collection.search.results.head": "Search Results",
 
   "collection.select.confirm": "Confirm selected",
@@ -1560,6 +1562,8 @@
   "community.page.news": "News",
 
   "community.all-lists.head": "Subcommunities and Collections",
+
+  "community.search.breadcrumbs": "Search",
 
   "community.search.results.head": "Search Results",
 

--- a/src/config/collection-page-config.interface.ts
+++ b/src/config/collection-page-config.interface.ts
@@ -4,6 +4,7 @@ import { Config } from './config.interface';
  * Collection Page Config
  */
 export interface CollectionPageConfig extends Config {
+  defaultBrowseTab: string;
   searchSection: CollectionSearchSectionConfig;
   edit: {
     undoTimeout: number;

--- a/src/config/community-page-config.interface.ts
+++ b/src/config/community-page-config.interface.ts
@@ -4,6 +4,7 @@ import { Config } from './config.interface';
  * Community Page Config
  */
 export interface CommunityPageConfig extends Config {
+  defaultBrowseTab: string;
   searchSection: CommunitySearchSectionConfig;
 }
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -334,6 +334,7 @@ export class DefaultAppConfig implements AppConfig {
 
   // Community Page Config
   community: CommunityPageConfig = {
+    defaultBrowseTab: 'search',
     searchSection: {
       showSidebar: true,
     },
@@ -341,6 +342,7 @@ export class DefaultAppConfig implements AppConfig {
 
   // Collection Page Config
   collection: CollectionPageConfig = {
+    defaultBrowseTab: 'search',
     searchSection: {
       showSidebar: true,
     },

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -290,11 +290,13 @@ export const environment: BuildConfig = {
     },
   },
   community: {
+    defaultBrowseTab: 'search',
     searchSection: {
       showSidebar: true,
     },
   },
   collection: {
+    defaultBrowseTab: 'search',
     searchSection: {
       showSidebar: true,
     },


### PR DESCRIPTION
## Description
This is a manual port of https://github.com/DSpace/dspace-angular/pull/3164 by @abelgomez. It would be great to get this improvement into the 8.x codebase. It doesn't require https://github.com/DSpace/dspace-angular/pull/4138 because https://github.com/DSpace/dspace-angular/pull/3994 wasn't backported to 8.x.

## Instructions for Reviewers
You can follow the instructions for reviewers in the original pull request: https://github.com/DSpace/dspace-angular/pull/3164.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
