### PR TITLE
Main: Add paginated vocabulary search with 'Show previous/next results' controls in hierarchical browse

### DIFF
--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.html
@@ -139,3 +139,20 @@
     </cdk-tree-node>
   </cdk-tree>
 </div>
+<!-- Show previous/next results pagination -->
+@if ((showPreviousPage$ | async) || (showNextPage$ | async)) {
+  <div class="mb-3 d-flex gap-2">
+    @if (showPreviousPage$ | async) {
+      <button class="btn btn-outline-secondary"
+              (click)="loadPreviousPage()">
+        {{ 'browse.taxonomy.show_previous_results' | translate }}
+      </button>
+    }
+    @if (showNextPage$ | async) {
+      <button class="btn btn-outline-secondary"
+              (click)="loadNextPage()">
+        {{ 'browse.taxonomy.show_next_results' | translate }}
+      </button>
+    }
+  </div>
+}

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.component.ts
@@ -20,6 +20,7 @@ import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   Observable,
+  of,
   Subscription,
 } from 'rxjs';
 
@@ -158,6 +159,14 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
   private subs: Subscription[] = [];
 
   readonly AlertType = AlertType;
+
+  public showNextPage$ = this.vocabularyTreeviewService.showNextPageSubject
+    ? this.vocabularyTreeviewService.showNextPageSubject.asObservable()
+    : of(false);
+
+  public showPreviousPage$ = this.vocabularyTreeviewService.showPreviousPageSubject
+    ? this.vocabularyTreeviewService.showPreviousPageSubject.asObservable()
+    : of(false);
 
   /**
    * Initialize instance variables
@@ -311,6 +320,30 @@ export class VocabularyTreeviewComponent implements OnDestroy, OnInit, OnChanges
       }
       this.nodeMap = new Map<string, TreeviewFlatNode>();
       this.vocabularyTreeviewService.searchByQuery(this.searchText, this.getSelectedEntryIds());
+    }
+  }
+
+  /**
+   * Loads the next page of vocabulary search results.
+   * Increments the current page in the service and re-triggers the query with the same search term and selection.
+   */
+  loadNextPage(): void {
+    const svc = this.vocabularyTreeviewService;
+
+    if (svc.currentPage < svc.totalPages) {
+      svc.searchByQueryAndPage(svc.queryInProgress, [], svc.currentPage + 1);
+    }
+  }
+
+  /**
+   * Loads the previous page of vocabulary search results.
+   * Decrements the current page in the service and re-triggers the query with the same search term and selection.
+   */
+  loadPreviousPage(): void {
+    const svc = this.vocabularyTreeviewService;
+
+    if (svc.currentPage > 1) {
+      svc.searchByQueryAndPage(svc.queryInProgress, [], svc.currentPage - 1);
     }
   }
 

--- a/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.service.ts
+++ b/src/app/shared/form/vocabulary-treeview/vocabulary-treeview.service.ts
@@ -10,10 +10,13 @@ import {
   merge,
   mergeMap,
   scan,
+  tap,
 } from 'rxjs/operators';
 
 import { PaginatedList } from '../../../core/data/paginated-list.model';
+import { RemoteData } from '../../../core/data/remote-data';
 import {
+  getFirstSucceededRemoteData,
   getFirstSucceededRemoteDataPayload,
   getFirstSucceededRemoteListPayload,
 } from '../../../core/shared/operators';
@@ -89,6 +92,12 @@ export class VocabularyTreeviewService {
    * An observable to change the loading status
    */
   private hideSearchingWhenUnsubscribed$ = new Observable(() => () => this.loading.next(false));
+
+  public currentPage = 1;
+  public totalPages = 1;
+  public queryInProgress = '';
+  public showNextPageSubject = new BehaviorSubject<boolean>(false);
+  public showPreviousPageSubject = new BehaviorSubject<boolean>(false);
 
   /**
    * Initialize instance variables
@@ -197,10 +206,28 @@ export class VocabularyTreeviewService {
   }
 
   /**
-   * Perform a search operation by query
+   * Initiates a vocabulary search using the provided query term and selection, starting from the first page.
+   *
+   * @param query - The text input to search for within the vocabulary.
+   * @param selectedItems - Currently selected vocabulary item IDs to retain in the result.
    */
   searchByQuery(query: string, selectedItems: string[]) {
+    this.searchByQueryAndPage(query, selectedItems, 1);
+  }
+
+  /**
+   * Executes a paginated vocabulary search with the given query, selection, and page number.
+   * Updates pagination state, loading indicators, and triggers the vocabulary tree rebuild.
+   *
+   * @param query - The search term to filter vocabulary entries.
+   * @param selectedItems - IDs of items currently selected in the tree.
+   * @param page - The page number to fetch (1-based index).
+   */
+  searchByQueryAndPage(query: string, selectedItems: string[], page: number = 1) {
     this.loading.next(true);
+    this.queryInProgress = query;
+    this.currentPage = page;
+
     if (isEmpty(this.storedNodes)) {
       this.storedNodes = this.dataChange.value;
       this.storedNodeMap = this.nodeMap;
@@ -208,9 +235,22 @@ export class VocabularyTreeviewService {
     this.nodeMap = new Map<string, TreeviewNode>();
     this.dataChange.next([]);
 
-    this.vocabularyService.getVocabularyEntriesByValue(query, false, this.vocabularyOptions, new PageInfo()).pipe(
+    const pageInfo = new PageInfo({
+      elementsPerPage: 20,
+      currentPage: page,
+      totalElements: 0,
+      totalPages: 0,
+    });
+
+    this.vocabularyService.getVocabularyEntriesByValue(query, false, this.vocabularyOptions, pageInfo).pipe(
+      getFirstSucceededRemoteData(),
+      tap((rd: RemoteData<PaginatedList<VocabularyEntry>>) => {
+        this.totalPages = rd.payload.pageInfo.totalPages;
+        this.showPreviousPageSubject.next(rd.payload.pageInfo.currentPage > 1);
+        this.showNextPageSubject.next(rd.payload.pageInfo.currentPage < this.totalPages);
+      }),
       getFirstSucceededRemoteListPayload(),
-      mergeMap((result: VocabularyEntry[]) => (result.length > 0) ? result : of(null)),
+      mergeMap((result: VocabularyEntry[]) => result.length > 0 ? result : of(null)),
       mergeMap((entry: VocabularyEntry) =>
         this.vocabularyService.findEntryDetailById(entry.otherInformation.id, this.vocabularyName).pipe(
           getFirstSucceededRemoteDataPayload(),

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1127,6 +1127,10 @@
 
   "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}",
 
+  "browse.taxonomy.show_next_results": "Show next results",
+
+  "browse.taxonomy.show_previous_results": "Show previous results",
+
   "browse.title.page": "Browsing by {{ field }} {{ value }}",
 
   "search.browse.item-back": "Back to Results",


### PR DESCRIPTION
## References
* Fixes #4500

## Description
Added paging state management to the vocabulary treeview service, updating after each query based on whether previous or next pages exist; this state is exposed to the component to conditionally render navigation buttons in the hierarchical vocabulary browse.

## Instructions for Reviewers
List of changes in this PR:
* First, added `currentPage`, `totalPages`, `showNextPageSubject`, and `showPreviousPageSubject` to the `vocabulary-treeview.service` to manage and expose pagination state.
* Second, created a new method `searchByQueryAndPage(query, selectedItems, page)` to support page-specific vocabulary search requests. The existing `searchByQuery` method was updated to call this with page `1` by default.
* Third, updated `searchByQueryAndPage` to extract pagination info from the search response and update the `showNextPageSubject` and `showPreviousPageSubject` based on whether more pages are available.
* Fourth, exposed `showNextPage$` and `showPreviousPage$` in the component, derived from `showNextPageSubject`, and `showPreviousPageSubject`, to reactively control the display of pagination buttons.
* Fifth, added conditional rendering of “**Show next results**” and “**Show previous results**” buttons in the template, along with `loadNextPage` and `loadPreviousPage to trigger paging behavior.

**To test this PR:**
1. Create a custom vocabulary XML file containing more than 20 nodes. Example: nodes with `label="label1"` through `label="label100"` and corresponding values like `"value test 1"` to `"value test 100"`.
2. Deploy the vocabulary to your backend instance.
3. Navigate to the hierarchical browse interface in the UI (e.g., `/browse/srsc`).
4. Enter the query `label`.

**Expected behavior after applying this PR:**
- Only the first 20 matching entries are displayed initially.
- A “_Show next results_” button appears below the filtered tree.
- Clicking it displays the next 20 results and replaces the tree content.
- When on subsequent pages, a “_Show previous results_” button also appears to navigate back.
- On the final page, only the “_Show previous results_” button should be visible (no “Show next”).
- On the first page, only the “_Show next results_” button should be visible.

**First page:**
<img width="901" alt="image" src="https://github.com/user-attachments/assets/33aa0b36-c01e-4ba2-9f20-9bc0daa1066a" />

**Intermediate page:**
<img width="901" alt="image" src="https://github.com/user-attachments/assets/a6e27c23-adc0-4f9c-a047-5ce2f7d72b32" />

**Last page:**
<img width="901" alt="image" src="https://github.com/user-attachments/assets/9e06b0ed-dba2-48aa-9ac4-1adbd55043e8" />

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
