### PR TITLE
Prevent removal of already removed menu sections from throwing errors

### DIFF
--- a/src/app/shared/menu/menu.reducer.spec.ts
+++ b/src/app/shared/menu/menu.reducer.spec.ts
@@ -388,6 +388,13 @@ describe('menusReducer', () => {
     expect(newState[menuID].sectionToSubsectionIndex[parentID]).not.toContain(childID);
   });
 
+  it('should not throw an error when trying to remove an already removed section using the REMOVE_SECTION action', () => {
+    const state = dummyState;
+    const action = new RemoveMenuSectionAction(menuID, 'non-existing-id');
+    const newState = menusReducer(state, action);
+    expect(newState).toEqual(dummyState);
+  });
+
   it('should set active to true for the correct menu section in response to the ACTIVATE_SECTION action', () => {
     dummyState[menuID].sections[topSectionID].active = false;
     const state = dummyState;

--- a/src/app/shared/menu/menu.reducer.ts
+++ b/src/app/shared/menu/menu.reducer.ts
@@ -1,4 +1,7 @@
-import { hasValue } from '../empty.util';
+import {
+  hasNoValue,
+  hasValue,
+} from '../empty.util';
 import { initialMenusState } from './initial-menus-state';
 import {
   ActivateMenuSectionAction,
@@ -148,11 +151,14 @@ function removeSection(state: MenusState, action: RemoveMenuSectionAction) {
 /**
  * Remove a section from the index of a certain menu
  * @param {MenusState} state The initial state
- * @param {MenuSection} action The MenuSection of which the ID should be removed from the index
- * @param {MenuID} action The Menu ID to which the section belonged
+ * @param {MenuSection} section The MenuSection of which the ID should be removed from the index
+ * @param {MenuID} menuID The Menu ID to which the section belonged
  * @returns {MenusState} The new reduced state
  */
 function removeFromIndex(state: MenusState, section: MenuSection, menuID: MenuID) {
+  if (hasNoValue(section)) {
+    return state;
+  }
   const sectionID = section.id;
   const parentID = section.parentID;
   if (hasValue(parentID)) {


### PR DESCRIPTION
## Description
Fixed an issue where the menu reducer could throw an error when you tried to delete an already deleted menu section. This can occur when you remove all the menu sections individually, and the parent section gets deleted before all its child sections are removed. This is because the deletion of a parent menu also removes all it's child sections (see `menu.reducer.ts#removeFromIndex`), and when you try to remove an already deleted menu section, an error will be thrown.

## Instructions for Reviewers
List of changes in this PR:
* Simply added an `hasNoValue` check to prevent the `menu.reducer.ts#removeFromIndex` from throwing an error when a section doesn't exist anymore

**Guidance for how to review this PR.**
This error is not directly reproducible in default DSpace but it's a nice safeguard. To review, simply verify that the regular menu providers are not affected by this new condition, and that the new test succeeds

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
