### PR TITLE
Resolving item version page routing by using config `nameSpace` #4358

### DIFF
--- a/src/app/item-page/item-page-routing-paths.ts
+++ b/src/app/item-page/item-page-routing-paths.ts
@@ -4,48 +4,71 @@ import { isNotEmpty } from '../shared/empty.util';
 
 export const ITEM_MODULE_PATH = 'items';
 
-export function getItemModuleRoute() {
-  return `/${ITEM_MODULE_PATH}`;
-}
 
 export const ENTITY_MODULE_PATH = 'entities';
 
 /**
+ * Normalize a namespace by ensuring it starts with '/' and doesn't end with '/'
+ */
+function normalizeNamespace(namespace?: string): string {
+  if (!namespace || namespace === '/') {
+    return '';
+  }
+
+  let normalized = namespace;
+  if (!normalized.startsWith('/')) {
+    normalized = '/' + normalized;
+  }
+  if (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function getItemModuleRoute(namespace?: string) {
+  const normalizedNamespace = normalizeNamespace(namespace);
+  return `${normalizedNamespace}/${ITEM_MODULE_PATH}`;
+}
+
+/**
  * Get the route to an item's page
  * Depending on the item's entity type, the route will either start with /items or /entities
- * @param item  The item to retrieve the route for
+ * @param item      The item to retrieve the route for
+ * @param namespace Optional namespace to prepend to the route
  */
-export function getItemPageRoute(item: Item) {
+export function getItemPageRoute(item: Item, namespace?: string) {
   const type = item.firstMetadataValue('dspace.entity.type');
-  return getEntityPageRoute(type, item.uuid);
+  return getEntityPageRoute(type, item.uuid, namespace);
 }
 
-export function getItemEditRoute(item: Item) {
-  return new URLCombiner(getItemPageRoute(item), ITEM_EDIT_PATH).toString();
+export function getItemEditRoute(item: Item, namespace?: string) {
+  return new URLCombiner(getItemPageRoute(item, namespace), ITEM_EDIT_PATH).toString();
 }
 
-export function getItemEditVersionhistoryRoute(item: Item) {
-  return new URLCombiner(getItemPageRoute(item), ITEM_EDIT_PATH, ITEM_EDIT_VERSIONHISTORY_PATH).toString();
+export function getItemEditVersionhistoryRoute(item: Item, namespace?: string) {
+  return new URLCombiner(getItemPageRoute(item, namespace), ITEM_EDIT_PATH, ITEM_EDIT_VERSIONHISTORY_PATH).toString();
 }
 
-export function getEntityPageRoute(entityType: string, itemId: string) {
+export function getEntityPageRoute(entityType: string, itemId: string, namespace?: string) {
+  const normalizedNamespace = normalizeNamespace(namespace);
   if (isNotEmpty(entityType)) {
-    return new URLCombiner('/entities', encodeURIComponent(entityType.toLowerCase()), itemId).toString();
+    return new URLCombiner(`${normalizedNamespace}/entities`, encodeURIComponent(entityType.toLowerCase()), itemId).toString();
   } else {
-    return new URLCombiner(getItemModuleRoute(), itemId).toString();
+    return new URLCombiner(getItemModuleRoute(namespace), itemId).toString();
   }
 }
 
-export function getEntityEditRoute(entityType: string, itemId: string) {
-  return new URLCombiner(getEntityPageRoute(entityType, itemId), ITEM_EDIT_PATH).toString();
+export function getEntityEditRoute(entityType: string, itemId: string, namespace?: string) {
+  return new URLCombiner(getEntityPageRoute(entityType, itemId, namespace), ITEM_EDIT_PATH).toString();
 }
 
 /**
  * Get the route to an item's version
  * @param versionId the ID of the version for which the route will be retrieved
+ * @param namespace Optional namespace to prepend to the route
  */
-export function getItemVersionRoute(versionId: string) {
-  return new URLCombiner(getItemModuleRoute(), ITEM_VERSION_PATH, versionId).toString();
+export function getItemVersionRoute(versionId: string, namespace?: string) {
+  return new URLCombiner(getItemModuleRoute(namespace), ITEM_VERSION_PATH, versionId).toString();
 }
 
 export const ITEM_EDIT_PATH = 'edit';

--- a/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
@@ -11,6 +11,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
 
+import { APP_CONFIG } from '../../../../config/app-config.interface';
+import { environment } from '../../../../environments/environment';
 import { VersionHistoryDataService } from '../../../core/data/version-history-data.service';
 import { Item } from '../../../core/shared/item.model';
 import { Version } from '../../../core/shared/version.model';
@@ -64,7 +66,7 @@ describe('ItemVersionsNoticeComponent', () => {
 
   beforeEach(waitForAsync(() => {
 
-    TestBed.configureTestingModule({
+    void TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot(),
         RouterTestingModule.withRoutes([]),
@@ -73,6 +75,7 @@ describe('ItemVersionsNoticeComponent', () => {
       ],
       providers: [
         { provide: VersionHistoryDataService, useValue: versionHistoryServiceSpy },
+        { provide: APP_CONFIG, useValue: environment },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -1,6 +1,10 @@
-import { AsyncPipe } from '@angular/common';
+import {
+  AsyncPipe,
+  NgIf,
+} from '@angular/common';
 import {
   Component,
+  inject,
   Input,
   OnInit,
 } from '@angular/core';
@@ -16,6 +20,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import { APP_CONFIG } from '../../../../config/app-config.interface';
 import { RemoteData } from '../../../core/data/remote-data';
 import { VersionHistoryDataService } from '../../../core/data/version-history-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -39,8 +44,9 @@ import { getItemPageRoute } from '../../item-page-routing-paths';
   templateUrl: './item-versions-notice.component.html',
   standalone: true,
   imports: [
-    AlertComponent,
-    AsyncPipe,
+    NgIf, 
+    AlertComponent, 
+    AsyncPipe, 
     TranslateModule,
   ],
 })
@@ -84,6 +90,8 @@ export class ItemVersionsNoticeComponent implements OnInit {
    * @type {AlertType}
    */
   public AlertTypeEnum = AlertType;
+
+  private appConfig = inject(APP_CONFIG);
 
   constructor(private versionHistoryService: VersionHistoryDataService) {
   }
@@ -134,7 +142,7 @@ export class ItemVersionsNoticeComponent implements OnInit {
    */
   getItemPage(item: Item): string {
     if (hasValue(item)) {
-      return getItemPageRoute(item);
+      return getItemPageRoute(item, this.appConfig.ui.nameSpace);
     }
   }
 }

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -44,9 +44,9 @@ import { getItemPageRoute } from '../../item-page-routing-paths';
   templateUrl: './item-versions-notice.component.html',
   standalone: true,
   imports: [
-    NgIf, 
-    AlertComponent, 
-    AsyncPipe, 
+    AlertComponent,
+    AsyncPipe,
+    NgIf,
     TranslateModule,
   ],
 })


### PR DESCRIPTION
## References

* Fixes #4358 – More context found here

## Description
I included a way for Angular to retrieve the namespace from the configuration file, enabling users to traverse to the newest version of an item in a way that includes the site's subpath.

## Instructions for Reviewers

- Injects the frontend configuration into `src/app/item-page/versions/notice/item-versions-notice.component.ts` to use `ui.nameSpace` with `getItemPageRoute()`.
- Changed `src/app/item-page/item-page-routing-paths.ts` to include `ui.nameSpace` before the full item subpath when moving across item versions via the provided `here` link.
- 🚨 Crucial! Setting DSpace to a subpath requires configuring `server.servlet.context-path` at least in `local.cfg` e.g. in our case `server.servlet.context-path=/metadata/server`. I couldn't find this in the documentation; we discovered this by looking at `[dspace]/webapps/server/WEB-INF/classes/application.properties`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
