### PR TITLE
Fix scripts dropdown not loading new elements while being zoomed in or out

### DIFF
--- a/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
@@ -109,4 +109,86 @@ describe('ScriptsSelectComponent', () => {
     const validationError = fixture.debugElement.query(By.css('.validation-error'));
     expect(validationError).toBeFalsy();
   }));
+
+  it('should load more scripts when scrolled to the bottom', fakeAsync(() => {
+    spyOn(component, 'loadScripts');
+    const event = {
+      target: {
+        scrollTop: 100,
+        clientHeight: 200,
+        scrollHeight: 300,
+      },
+    };
+
+    component.onScroll(event);
+    tick();
+
+    expect(component.loadScripts).toHaveBeenCalled();
+  }));
+
+  it('should load more scripts when scrolled almost to the bottom', fakeAsync(() => {
+    spyOn(component, 'loadScripts');
+    const event = {
+      target: {
+        scrollTop: 99,
+        clientHeight: 200,
+        scrollHeight: 300,
+      },
+    };
+
+    component.onScroll(event);
+    tick();
+
+    expect(component.loadScripts).toHaveBeenCalled();
+  }));
+
+  it('should not load more scripts if already loading', fakeAsync(() => {
+    spyOn(component, 'loadScripts');
+    component.isLoading$.next(true);
+    const event = {
+      target: {
+        scrollTop: 100,
+        clientHeight: 200,
+        scrollHeight: 300,
+      },
+    };
+
+    component.onScroll(event);
+    tick();
+
+    expect(component.loadScripts).not.toHaveBeenCalled();
+  }));
+
+  it('should not load more scripts if it is the last page', fakeAsync(() => {
+    spyOn(component, 'loadScripts');
+    (component as any)._isLastPage = true;
+    const event = {
+      target: {
+        scrollTop: 100,
+        clientHeight: 200,
+        scrollHeight: 300,
+      },
+    };
+
+    component.onScroll(event);
+    tick();
+
+    expect(component.loadScripts).not.toHaveBeenCalled();
+  }));
+
+  it('should not load more scripts if not scrolled to the bottom', fakeAsync(() => {
+    spyOn(component, 'loadScripts');
+    const event = {
+      target: {
+        scrollTop: 50,
+        clientHeight: 200,
+        scrollHeight: 300,
+      },
+    };
+
+    component.onScroll(event);
+    tick();
+
+    expect(component.loadScripts).not.toHaveBeenCalled();
+  }));
 });

--- a/src/app/process-page/form/scripts-select/scripts-select.component.ts
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.ts
@@ -131,7 +131,9 @@ export class ScriptsSelectComponent implements OnInit, OnDestroy {
    * @param event The scroll event
    */
   onScroll(event: any) {
-    if (event.target.scrollTop + event.target.clientHeight >= event.target.scrollHeight) {
+    // offset to fix issues with zooming in or out in the browser
+    const offset = 5;
+    if (event.target.scrollTop + event.target.clientHeight + offset >= event.target.scrollHeight) {
       if (!this.isLoading$.value && !this._isLastPage) {
         this.scriptOptions.currentPage++;
         this.loadScripts();


### PR DESCRIPTION
## References
* Fixes #4577 

## Description
Added a small offset in order to fix issues regarding floating-point multiplications with non-integer pixel values, caused by the browser being zoomed in or out.

## Instructions for Reviewers

List of changes in this PR:
* Added a small offset to avoid issues with non-integer values not being calculated correctly;
* Added tests.

The issue can be reproduced thanks to the instructions found on #4577.


https://github.com/user-attachments/assets/1fb6c854-213f-4f09-a115-2b16c67ee7c5



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
