### PR TITLE
Update dependabot to run monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,9 @@ updates:
   # So, only this first section can include "applies-to: security-updates"
   - package-ecosystem: "npm"
     directory: "/"
+    # Monthly dependency updates (NOTE: "schedule" doesn't apply to security updates)
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -169,7 +170,7 @@ updates:
     directory: "/"
     target-branch: dspace-9_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -264,7 +265,7 @@ updates:
     directory: "/"
     target-branch: dspace-8_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -358,7 +359,7 @@ updates:
     directory: "/"
     target-branch: dspace-7_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "05:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Description
This PR comes out of a Slack discussion between @alanorth , @kshepherd and I.  We were talking about ways to improve our dependabot configs to be less "noisy" (with PRs) and less "busywork" (minor updates that don't matter much).

So, this is the first attempt of just changing the `dependabot` schedule to only create dependency PRs once per month.

## Instructions for Reviewers
* No changes to DSpace.  This is only a change to dependabot.