### PR TITLE
[Dependabot] Move zone.js and typescript rules into "ignore" settings and ignore major/minor versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -145,21 +145,13 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
-      zonejs:
-        applies-to: version-updates
-        patterns:
-        - "zone.js"
-        update-types:
-        - "patch"
-      # Restrict typescript updates to patch level because that's what our package.json says
-      typescript:
-        applies-to: version-updates
-        patterns:
-        - "typescript"
-        update-types:
-        - "patch"
     ignore:
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Restrict typescript updates to patch level because that's what our package.json says
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -240,21 +232,13 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
-      zonejs:
-        applies-to: version-updates
-        patterns:
-        - "zone.js"
-        update-types:
-        - "patch"
-      # Restrict typescript updates to patch level because that's what our package.json says
-      typescript:
-        applies-to: version-updates
-        patterns:
-        - "typescript"
-        update-types:
-        - "patch"
     ignore:
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Restrict typescript updates to patch level because that's what our package.json says
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -334,21 +318,13 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
-      zonejs:
-        applies-to: version-updates
-        patterns:
-        - "zone.js"
-        update-types:
-        - "patch"
-      # Restrict typescript updates to patch level because that's what our package.json says
-      typescript:
-        applies-to: version-updates
-        patterns:
-        - "typescript"
-        update-types:
-        - "patch"
     ignore:
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Restrict typescript updates to patch level because that's what our package.json says
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -420,24 +396,16 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
-      zonejs:
-        applies-to: version-updates
-        patterns:
-        - "zone.js"
-        update-types:
-        - "patch"
-      # Restrict typescript updates to patch level because that's what our package.json says
-      typescript:
-        applies-to: version-updates
-        patterns:
-        - "typescript"
-        update-types:
-        - "patch"
     ignore:
       # 7.x Cannot update Webpack past v5.76.1 as later versions not supported by Angular 15
       # See also https://github.com/DSpace/dspace-angular/pull/3283#issuecomment-2372488489
       - dependency-name: "webpack"
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Restrict typescript updates to patch level because that's what our package.json says
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## References
Refactors code added in these two PRs:
* #4483 
* #4424 
 
## Description
Since merging #4424 and #4483, it appears that dependabot has been having issues with our configuration.  We're seeing this error everytime dependabot attempts to run on dependencies:

```
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+----------------------------------------------------------------------------------------------------+
|                                   Dependencies failed to update                                    |
+------------+--------------------------------+------------------------------------------------------+
| Dependency | Error Type                     | Error Details                                        |
+------------+--------------------------------+------------------------------------------------------+
| typescript | dependency_file_not_resolvable | {                                                    |
|            |                                |   "message": "Error while updating peer dependency." |
|            |                                | }                                                    |
+------------+--------------------------------+------------------------------------------------------+
```

As best I can tell, it appears that dependabot doesn't like the syntax we used to "ignore" the minor upgrades for typescript (and possibly also zonejs).  These errors started only after merging the above PRs, so I *think* they are the cause.

So, this PR is just moving those settings to the `ignore` section and specifically ignoring major & minor upgrades of those dependencies.  Hopefully, this will help fix things for dependabot.