### PR TITLE
Fix for #8916 #8917 #8918 The Community Administrator should not be able to view all communities/collections in the create/edit community and collection sections. Previous PR #9814

### DIFF
--- a/src/app/core/data/community-data.service.ts
+++ b/src/app/core/data/community-data.service.ts
@@ -11,9 +11,11 @@ import { isNotEmpty } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { RequestParam } from '../cache/models/request-param.model';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { Community } from '../shared/community.model';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { getAllCompletedRemoteData } from '../shared/operators';
 import { BitstreamDataService } from './bitstream-data.service';
 import { ComColDataService } from './comcol-data.service';
 import { DSOChangeAnalyzer } from './dso-change-analyzer.service';
@@ -36,6 +38,32 @@ export class CommunityDataService extends ComColDataService<Community> {
     protected bitstreamDataService: BitstreamDataService,
   ) {
     super('communities', requestService, rdbService, objectCache, halService, comparator, notificationsService, bitstreamDataService);
+  }
+
+  /**
+   * Get all communities the user is authorized to submit to
+   *
+   * @param query                       limit the returned community to those with metadata values
+   *                                    matching the query terms.
+   * @param options                     The [[FindListOptions]] object
+   * @param useCachedVersionIfAvailable If this is true, the request will only be sent if there's
+   *                                    no valid cached version. Defaults to true
+   * @param reRequestOnStale            Whether or not the request should automatically be re-
+   *                                    requested after the response becomes stale
+   * @param linksToFollow               List of {@link FollowLinkConfig} that indicate which
+   *                                    {@link HALLink}s should be automatically resolved
+   * @return Observable<RemoteData<PaginatedList<Community>>>
+   *    community list
+   */
+  getAuthorizedCommunity(query: string, options: FindListOptions = {}, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<Community>[]): Observable<RemoteData<PaginatedList<Community>>> {
+    const searchHref = 'findAdminAuthorized';
+    options = Object.assign({}, options, {
+      searchParams: [new RequestParam('query', query)],
+    });
+
+    return this.searchBy(searchHref, options, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow).pipe(
+      getAllCompletedRemoteData(),
+    );
   }
 
   // this method is overridden in order to make it public

--- a/src/app/shared/dso-selector/dso-selector/authorized-community-selector/authorized-community-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-community-selector/authorized-community-selector.component.spec.ts
@@ -1,0 +1,74 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { CommunityDataService } from '../../../../core/data/community-data.service';
+import { Community } from '../../../../core/shared/community.model';
+import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
+import { SearchService } from '../../../../core/shared/search/search.service';
+import { ThemedLoadingComponent } from '../../../loading/themed-loading.component';
+import { NotificationsService } from '../../../notifications/notifications.service';
+import { ListableObjectComponentLoaderComponent } from '../../../object-collection/shared/listable-object/listable-object-component-loader.component';
+import { createSuccessfulRemoteDataObject$ } from '../../../remote-data.utils';
+import { createPaginatedList } from '../../../testing/utils.test';
+import { VarDirective } from '../../../utils/var.directive';
+import { AuthorizedCommunitySelectorComponent } from './authorized-community-selector.component';
+
+describe('AuthorizedCommunitySelectorComponent', () => {
+  let component: AuthorizedCommunitySelectorComponent;
+  let fixture: ComponentFixture<AuthorizedCommunitySelectorComponent>;
+
+  let communityService;
+  let community;
+
+  let notificationsService: NotificationsService;
+
+  beforeEach(waitForAsync(() => {
+    community = Object.assign(new Community(), {
+      id: 'authorized-community',
+    });
+    communityService = jasmine.createSpyObj('communityService', {
+      getAuthorizedCommunity: createSuccessfulRemoteDataObject$(createPaginatedList([community])),
+    });
+    notificationsService = jasmine.createSpyObj('notificationsService', ['error']);
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), AuthorizedCommunitySelectorComponent, VarDirective],
+      providers: [
+        { provide: SearchService, useValue: {} },
+        { provide: CommunityDataService, useValue: communityService },
+        { provide: NotificationsService, useValue: notificationsService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(AuthorizedCommunitySelectorComponent, {
+        remove: { imports: [ListableObjectComponentLoaderComponent, ThemedLoadingComponent] },
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthorizedCommunitySelectorComponent);
+    component = fixture.componentInstance;
+    component.types = [DSpaceObjectType.COMMUNITY];
+    fixture.detectChanges();
+  });
+
+  describe('search', () => {
+    describe('when has no entity type', () => {
+      it('should call getAuthorizedCommunity and return the authorized community in a SearchResult', (done) => {
+        component.search('', 1).subscribe((resultRD) => {
+          expect(communityService.getAuthorizedCommunity).toHaveBeenCalled();
+          expect(resultRD.payload.page.length).toEqual(1);
+          expect(resultRD.payload.page[0].indexableObject).toEqual(community);
+          done();
+        });
+      });
+    });
+
+  });
+});

--- a/src/app/shared/dso-selector/dso-selector/authorized-community-selector/authorized-community-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-community-selector/authorized-community-selector.component.ts
@@ -1,0 +1,105 @@
+import {
+  AsyncPipe,
+  NgClass,
+} from '@angular/common';
+import { Component } from '@angular/core';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
+import { CommunityDataService } from '../../../../core/data/community-data.service';
+import { FindListOptions } from '../../../../core/data/find-list-options.model';
+import {
+  buildPaginatedList,
+  PaginatedList,
+} from '../../../../core/data/paginated-list.model';
+import { RemoteData } from '../../../../core/data/remote-data';
+import { Community } from '../../../../core/shared/community.model';
+import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
+import { getFirstCompletedRemoteData } from '../../../../core/shared/operators';
+import { SearchService } from '../../../../core/shared/search/search.service';
+import { hasValue } from '../../../empty.util';
+import { HoverClassDirective } from '../../../hover-class.directive';
+import { ThemedLoadingComponent } from '../../../loading/themed-loading.component';
+import { NotificationsService } from '../../../notifications/notifications.service';
+import { CommunitySearchResult } from '../../../object-collection/shared/community-search-result.model';
+import { ListableObjectComponentLoaderComponent } from '../../../object-collection/shared/listable-object/listable-object-component-loader.component';
+import { SearchResult } from '../../../search/models/search-result.model';
+import { followLink } from '../../../utils/follow-link-config.model';
+import { DSOSelectorComponent } from '../dso-selector.component';
+
+@Component({
+  selector: 'ds-authorized-community-selector',
+  styleUrls: ['../dso-selector.component.scss'],
+  templateUrl: '../dso-selector.component.html',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    FormsModule,
+    HoverClassDirective,
+    InfiniteScrollModule,
+    ListableObjectComponentLoaderComponent,
+    NgClass,
+    ReactiveFormsModule,
+    ThemedLoadingComponent,
+    TranslateModule,
+  ],
+})
+/**
+ * Component rendering a list of communities to select from
+ */
+export class AuthorizedCommunitySelectorComponent extends DSOSelectorComponent {
+  /**
+   * If present this value is used to filter community list by entity type
+   */
+
+  constructor(
+    protected searchService: SearchService,
+    protected communityDataService: CommunityDataService,
+    protected notifcationsService: NotificationsService,
+    protected translate: TranslateService,
+    protected dsoNameService: DSONameService,
+  ) {
+    super(searchService, notifcationsService, translate, dsoNameService);
+  }
+
+  /**
+   * Get a query to send for retrieving the current DSO
+   */
+  getCurrentDSOQuery(): string {
+    return this.currentDSOId;
+  }
+
+  /**
+   * Perform a search for authorized communities with the current query and page
+   * @param query Query to search objects for
+   * @param page  Page to retrieve
+   * @param useCache Whether or not to use the cache
+   */
+  search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
+    let searchListService$: Observable<RemoteData<PaginatedList<Community>>> = null;
+    const findOptions: FindListOptions = {
+      currentPage: page,
+      elementsPerPage: this.defaultPagination.pageSize,
+    };
+
+    searchListService$ = this.communityDataService
+      .getAuthorizedCommunity(query, findOptions, useCache, false, followLink('parentCommunity'));
+
+    return searchListService$.pipe(
+      getFirstCompletedRemoteData(),
+      map((rd) => Object.assign(new RemoteData(null, null, null, null), rd, {
+        payload: hasValue(rd.payload) ? buildPaginatedList(rd.payload.pageInfo, rd.payload.page.map((col) => Object.assign(new CommunitySearchResult(), { indexableObject: col }))) : null,
+      })),
+    );
+  }
+}

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.html
@@ -1,0 +1,14 @@
+<div>
+  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+    <button type="button" class="btn-close" (click)="close()" aria-label="Close">
+    </button>
+  </div>
+  <div class="modal-body">
+    @if (header) {
+      <span class="h5 px-2">{{header | translate}}</span>
+    }
+    <ds-authorized-community-selector [currentDSOId]="dsoRD?.payload.uuid"
+      [types]="selectorTypes"
+    (onSelect)="selectObject($event)"></ds-authorized-community-selector>
+  </div>
+</div>

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.spec.ts
@@ -18,7 +18,7 @@ import { Community } from '../../../../core/shared/community.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject } from '../../../remote-data.utils';
 import { RouterStub } from '../../../testing/router.stub';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import { CreateCollectionParentSelectorComponent } from './create-collection-parent-selector.component';
 
 describe('CreateCollectionParentSelectorComponent', () => {
@@ -64,7 +64,7 @@ describe('CreateCollectionParentSelectorComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
     })
       .overrideComponent(CreateCollectionParentSelectorComponent, {
-        remove: { imports: [DSOSelectorComponent] },
+        remove: { imports: [AuthorizedCommunitySelectorComponent] },
       })
       .compileComponents();
 

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../../core/cache/models/sort-options.model';
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import {
   DSOSelectorModalWrapperComponent,
   SelectorActionType,
@@ -34,10 +34,10 @@ import {
 
 @Component({
   selector: 'ds-base-create-collection-parent-selector',
-  templateUrl: '../dso-selector-modal-wrapper.component.html',
+  templateUrl: './create-collection-parent-selector.component.html',
   standalone: true,
   imports: [
-    DSOSelectorComponent,
+    AuthorizedCommunitySelectorComponent,
     TranslateModule,
   ],
 })

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -16,7 +16,9 @@
         </div>
       }
       <span class="h5 px-2">{{'dso-selector.create.community.sub-level' | translate}}</span>
-      <ds-dso-selector [currentDSOId]="dsoRD?.payload.uuid" [types]="selectorTypes" [sort]="defaultSort" (onSelect)="selectObject($event)"></ds-dso-selector>
+      <ds-authorized-community-selector [currentDSOId]="dsoRD?.payload.uuid"
+        [types]="selectorTypes"
+        (onSelect)="selectObject($event)"></ds-authorized-community-selector>
     </div>
   </div>
 

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.spec.ts
@@ -21,7 +21,7 @@ import { Community } from '../../../../core/shared/community.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject } from '../../../remote-data.utils';
 import { RouterStub } from '../../../testing/router.stub';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import { CreateCommunityParentSelectorComponent } from './create-community-parent-selector.component';
 
 describe('CreateCommunityParentSelectorComponent', () => {
@@ -69,7 +69,7 @@ describe('CreateCommunityParentSelectorComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
     })
       .overrideComponent(CreateCommunityParentSelectorComponent, {
-        remove: { imports: [DSOSelectorComponent] },
+        remove: { imports: [AuthorizedCommunitySelectorComponent] },
       })
       .compileComponents();
 

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
@@ -26,7 +26,7 @@ import { FeatureID } from '../../../../core/data/feature-authorization/feature-i
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
 import { hasValue } from '../../../empty.util';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import {
   DSOSelectorModalWrapperComponent,
   SelectorActionType,
@@ -46,7 +46,7 @@ import {
   standalone: true,
   imports: [
     AsyncPipe,
-    DSOSelectorComponent,
+    AuthorizedCommunitySelectorComponent,
     TranslateModule,
   ],
 })
@@ -62,7 +62,6 @@ export class CreateCommunityParentSelectorComponent extends DSOSelectorModalWrap
   }
 
   ngOnInit() {
-    super.ngOnInit();
     this.isAdmin$ = this.authorizationService.isAuthorized(FeatureID.AdministratorOf);
   }
 

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.html
@@ -1,0 +1,14 @@
+<div>
+  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+    <button type="button" class="btn-close" (click)="close()" aria-label="Close">
+    </button>
+  </div>
+  <div class="modal-body">
+    @if (header) {
+      <span class="h5 px-2">{{header | translate}}</span>
+    }
+    <ds-authorized-collection-selector [currentDSOId]="dsoRD?.payload.uuid"
+      [types]="selectorTypes"
+      (onSelect)="selectObject($event)"></ds-authorized-collection-selector>
+  </div>
+</div>

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.spec.ts
@@ -18,7 +18,7 @@ import { Collection } from '../../../../core/shared/collection.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject } from '../../../remote-data.utils';
 import { RouterStub } from '../../../testing/router.stub';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCollectionSelectorComponent } from '../../dso-selector/authorized-collection-selector/authorized-collection-selector.component';
 import { EditCollectionSelectorComponent } from './edit-collection-selector.component';
 
 describe('EditCollectionSelectorComponent', () => {
@@ -64,7 +64,7 @@ describe('EditCollectionSelectorComponent', () => {
     })
       .overrideComponent(EditCollectionSelectorComponent, {
         remove: {
-          imports: [DSOSelectorComponent],
+          imports: [AuthorizedCollectionSelectorComponent],
         },
       })
       .compileComponents();

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../core/cache/models/sort-options.model';
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCollectionSelectorComponent } from '../../dso-selector/authorized-collection-selector/authorized-collection-selector.component';
 import {
   DSOSelectorModalWrapperComponent,
   SelectorActionType,
@@ -30,10 +30,10 @@ import {
 
 @Component({
   selector: 'ds-base-edit-collection-selector',
-  templateUrl: '../dso-selector-modal-wrapper.component.html',
+  templateUrl: './edit-collection-selector.component.html',
   standalone: true,
   imports: [
-    DSOSelectorComponent,
+    AuthorizedCollectionSelectorComponent,
     TranslateModule,
   ],
 })

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.html
@@ -1,0 +1,14 @@
+<div>
+  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+    <button type="button" class="btn-close" (click)="close()" aria-label="Close">
+    </button>
+  </div>
+  <div class="modal-body">
+    @if (header) {
+      <span class="h5 px-2">{{header | translate}}</span>
+    }
+    <ds-authorized-community-selector [currentDSOId]="dsoRD?.payload.uuid"
+      [types]="selectorTypes"
+      (onSelect)="selectObject($event)"></ds-authorized-community-selector>
+  </div>
+</div>

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.spec.ts
@@ -18,7 +18,7 @@ import { Community } from '../../../../core/shared/community.model';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { createSuccessfulRemoteDataObject } from '../../../remote-data.utils';
 import { RouterStub } from '../../../testing/router.stub';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import { EditCommunitySelectorComponent } from './edit-community-selector.component';
 
 describe('EditCommunitySelectorComponent', () => {
@@ -64,7 +64,7 @@ describe('EditCommunitySelectorComponent', () => {
     })
       .overrideComponent(EditCommunitySelectorComponent, {
         remove: {
-          imports: [DSOSelectorComponent],
+          imports: [AuthorizedCommunitySelectorComponent],
         },
       })
       .compileComponents();

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../core/cache/models/sort-options.model';
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
-import { DSOSelectorComponent } from '../../dso-selector/dso-selector.component';
+import { AuthorizedCommunitySelectorComponent } from '../../dso-selector/authorized-community-selector/authorized-community-selector.component';
 import {
   DSOSelectorModalWrapperComponent,
   SelectorActionType,
@@ -30,10 +30,10 @@ import {
 
 @Component({
   selector: 'ds-base-edit-community-selector',
-  templateUrl: '../dso-selector-modal-wrapper.component.html',
+  templateUrl: './edit-community-selector.component.html',
   standalone: true,
   imports: [
-    DSOSelectorComponent,
+    AuthorizedCommunitySelectorComponent,
     TranslateModule,
   ],
 })

--- a/src/themes/custom/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
+++ b/src/themes/custom/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
@@ -1,8 +1,8 @@
 import { AsyncPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
+import { AuthorizedCommunitySelectorComponent } from 'src/app/shared/dso-selector/dso-selector/authorized-community-selector/authorized-community-selector.component';
 
-import { DSOSelectorComponent } from '../../../../../../../app/shared/dso-selector/dso-selector/dso-selector.component';
 import { CreateCommunityParentSelectorComponent as BaseComponent } from '../../../../../../../app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component';
 
 @Component({
@@ -14,7 +14,7 @@ import { CreateCommunityParentSelectorComponent as BaseComponent } from '../../.
   standalone: true,
   imports: [
     AsyncPipe,
-    DSOSelectorComponent,
+    AuthorizedCommunitySelectorComponent,
     TranslateModule,
   ],
 })


### PR DESCRIPTION
# References
* Fixes #8916 #8917 #8918 
* Previous PR #9814

# Description
The Community Administrator should not be able to view all communities/collections in the create/edit community and collection sections.

# Instructions for Reviewers
Currently, users can see all communities/collections in the create/edit community and collection sections. However, the expected behaviour is that only the communities/collections where the user is a community or collection admin should be displayed.

# List of changes in this PR:
•	Added new method getAuthorizedCommunity in community-data.service.ts to get all communities for the user is authorized to.
•	Added authorized-community-selector.component.ts wrapper to show the autocomplete results in community edit section instead of using common DSpace Object selector.
•	Updated create-collection-parent-selector.component.ts, create-community-parent-selector.component.ts, edit-community-selector.component.ts to get authorized communities list at the time of new collection & community creation.
•	Updated edit-collection-selector.component.ts to list out already existing collections in which the user authorized to inside edit collection module.
•	Updated src/themes/.../create-community-parent-selector.component.ts to list already existing authorized communities.
•	Updated wrapper dso selector create-community-parent-selector.component.html to select authorized communities only inside the create community module.
•	Added create-collection-parent-selector.component.html, edit-community-selector.component.html, edit-collection-selector.component.html to select authorized parent communities & collections only inside the create and edit community & collection module.
 •	Added authorized-community-selector.component.spec.ts against the new dso selector wrapper added to test the listing of all authorized communities and collections in edit and create section.
 •	Updated create-community-parent-selector.component.spec.ts, edit-community-selector.component.spec.ts, create-collection-parent-selector.component.spec.ts, edit-collection-selector.component.spec.ts to test the listing of all authorized communities & collections inside edit & create community and collection module.
 

# How to Test
1.	Make a user the admin of a few communities.
2.	Navigate to the “New” section and click on "Community" or “Collection”. Only the communities where the user is community admin should be displayed.
3.	For the Edit section:
o	Go to Edit > click “Community”. Again, only the communities where the user is an admin should be shown.
o	For collections, go to Edit > click “Collection”. Only the collections where the user is a collection or community admin should be listed. If the user is a community admin for a community, all collections within that community should also be shown.

Bug Reproduction Steps
1.	New Section:
o	Log in as a community admin, go to New > Community. Currently, all communities are shown in the list.
o	Similarly, for collections, go to the New section > click Collection. Here, all collections are shown in the list.
2.	Edit Section:
o	Log in as a community admin, go to Edit > Community. Currently, all communities are shown in the list.
o	Similarly, for collections, go to Edit > click Collection. Here, all collections are shown in the list.
