### PR TITLE
Improved geospatial map bounds & scroll behaviour

### DIFF
--- a/src/app/shared/geospatial-map/geospatial-map.component.ts
+++ b/src/app/shared/geospatial-map/geospatial-map.component.ts
@@ -150,13 +150,19 @@ export class GeospatialMapComponent implements AfterViewInit, OnInit, OnDestroy 
     this.map = L.map(el, {
       center: this.DEFAULT_CENTRE_POINT,
       zoom: 11,
+      worldCopyJump: true,
+      maxBoundsViscosity: 1.0,
+      maxBounds: [
+        [-85, -Infinity],
+        [85, Infinity],
+      ],
     });
     const tileProviders = environment.geospatialMapViewer.tileProviders;
     for (let i = 0; i < tileProviders.length; i++) {
       // Add tiles to the map
       const tiles = L.tileLayer.provider(tileProviders[i], {
         maxZoom: 18,
-        minZoom: 3,
+        minZoom: 1,
       });
       tiles.addTo(this.map);
     }


### PR DESCRIPTION
## References
- Related to #3540

## Description
Minor improvements regarding the geospatial map zoom & scroll behaviour.

I updated the zoom level in order to be able to zoom out more, this way you can see the whole map. Also blocked users from scrolling above the north pole and below the south pole. I also ensured that when you scroll vertically, that the points are rendered on those maps as well

## Instructions for Reviewers
List of changes in this PR:
* Updated the `minZoom` to 1 (this way you can zoom out completely, but I coudl see the point to set it to 1.5 to prevent duplicate continents from being shown)
* Added `maxBounds` & enforced them using `maxBoundsViscosity` to prevent scrolling out of the map
* Enabled `worldCopyJump` to copy the points to neighbouring maps when you scroll too far to the left/right

**Guidance for how to test or review this PR.**
- Enable the map on the search page by setting `geospatialMapViewer.enableSearchViewMode` to `true`
- Add a `dcterms.spatial` field with the value `Point ( +008.660000 +047.336111 )` to a random item
- Search for that item and verify the point is copied over to the neighbouring map and that the zoom functionality works as described above

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
