### PR TITLE
Bitstream Metadata Required Notification for submissions

### DIFF
--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
@@ -157,10 +157,25 @@ export class SubmissionUploadFilesComponent implements OnChanges, OnDestroy {
                     .subscribe((isUpload) => {
                       if (isUpload) {
                         // Look for errors on upload
-                        if ((isEmpty(sectionErrors))) {
-                          this.notificationsService.success(null, this.translate.get('submission.sections.upload.upload-successful'));
+                        const hasOnlyPendingMetadataErrors = sectionErrors?.every(
+                          (error) => error.message === 'error.validation.metadata.pending'
+                        );
+
+                        if (isEmpty(sectionErrors)) {
+                          this.notificationsService.success(
+                            null,
+                            this.translate.get('submission.sections.upload.upload-successful')
+                          );
+                        } else if (hasOnlyPendingMetadataErrors) {
+                          this.notificationsService.warning(
+                            null,
+                            this.translate.get('submission.sections.upload.metadata-pending')
+                          );
                         } else {
-                          this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
+                          this.notificationsService.error(
+                            null,
+                            this.translate.get('submission.sections.upload.upload-failed')
+                          );
                         }
                       }
                     });

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
@@ -158,23 +158,23 @@ export class SubmissionUploadFilesComponent implements OnChanges, OnDestroy {
                       if (isUpload) {
                         // Look for errors on upload
                         const hasOnlyPendingMetadataErrors = sectionErrors?.every(
-                          (error) => error.message === 'error.validation.metadata.pending'
+                          (error) => error.message === 'error.validation.metadata.pending',
                         );
 
                         if (isEmpty(sectionErrors)) {
                           this.notificationsService.success(
                             null,
-                            this.translate.get('submission.sections.upload.upload-successful')
+                            this.translate.get('submission.sections.upload.upload-successful'),
                           );
                         } else if (hasOnlyPendingMetadataErrors) {
                           this.notificationsService.warning(
                             null,
-                            this.translate.get('submission.sections.upload.metadata-pending')
+                            this.translate.get('submission.sections.upload.metadata-pending'),
                           );
                         } else {
                           this.notificationsService.error(
                             null,
-                            this.translate.get('submission.sections.upload.upload-failed')
+                            this.translate.get('submission.sections.upload.upload-failed'),
                           );
                         }
                       }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5649,7 +5649,7 @@
   "submission.sections.upload.save-metadata": "Save metadata",
 
   "submission.sections.upload.undo": "Cancel",
-  
+
   "submission.sections.upload.metadata-pending": "Upload successful. There are required fields for the file. Scroll to the \"Upload files\" section to view and edit uploaded files.",
 
   "submission.sections.upload.upload-failed": "Upload failed",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5649,6 +5649,8 @@
   "submission.sections.upload.save-metadata": "Save metadata",
 
   "submission.sections.upload.undo": "Cancel",
+  
+  "submission.sections.upload.metadata-pending": "Upload successful. There are required fields for the file. Scroll to the \"Upload files\" section to view and edit uploaded files.",
 
   "submission.sections.upload.upload-failed": "Upload failed",
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Requires https://github.com/DSpace/DSpace/pull/10958

## Description
Enhances the submission form file upload with specifics about the upload metadata validation if the uploaded file requires metadata to be put into it.

## Instructions for Reviewers
 - Adjusts Submission-upload-file.component.ts adds a new i18n message to be sent when the upload detects that metadata is required.

Have a submission form whose uploadStep required metadata and then attempt to upload a file a new notifications should appear informing the user to edit the metadata of the file

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
