### PR TITLE
Fix auth method retrieval after Tomcat restart

### DIFF
--- a/src/app/core/auth/auth.actions.ts
+++ b/src/app/core/auth/auth.actions.ts
@@ -69,8 +69,16 @@ export class AuthenticatedAction implements Action {
   public type: string = AuthActionTypes.AUTHENTICATED;
   payload: AuthTokenInfo;
 
-  constructor(token: AuthTokenInfo) {
+  /**
+   * Whether we should consider the given authentication info final.
+   * If the backend restarted we may have a token that hasn't expired yet, but it will be invalid anyway.
+   * In this case we'll have to check twice.
+   */
+  checkAgain: boolean;
+
+  constructor(token: AuthTokenInfo, checkAgain = false) {
     this.payload = token;
+    this.checkAgain = checkAgain;
   }
 }
 

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -156,7 +156,7 @@ describe('AuthEffects', () => {
 
     describe('when token is valid', () => {
       it('should return a AUTHENTICATED_SUCCESS action in response to a AUTHENTICATED action', () => {
-        actions = hot('--a-', { a: { type: AuthActionTypes.AUTHENTICATED, payload: token } });
+        actions = hot('--a-', { a: new AuthenticatedAction(token) });
 
         const expected = cold('--b-', { b: new AuthenticatedSuccessAction(true, token, EPersonMock._links.self.href) });
 
@@ -164,13 +164,25 @@ describe('AuthEffects', () => {
       });
     });
 
-    describe('when token is not valid', () => {
+    describe('when token is expired', () => {
       it('should return a AUTHENTICATED_ERROR action in response to a AUTHENTICATED action', () => {
         spyOn((authEffects as any).authService, 'authenticatedUser').and.returnValue(observableThrow(new Error('Message Error test')));
 
-        actions = hot('--a-', { a: { type: AuthActionTypes.AUTHENTICATED, payload: token } });
+        actions = hot('--a-', { a: new AuthenticatedAction(token) });
 
         const expected = cold('--b-', { b: new AuthenticatedErrorAction(new Error('Message Error test')) });
+
+        expect(authEffects.authenticated$).toBeObservable(expected);
+      });
+    });
+
+    describe('when token is not valid but also not expired (~ cookie)', () => {
+      it('should return a AUTHENTICATED_ERROR action in response to a AUTHENTICATED action', () => {
+        spyOn((authEffects as any).authService, 'authenticatedUser').and.returnValue(observableThrow(new Error('Message Error test')));
+
+        actions = hot('--a-', { a: new AuthenticatedAction(token, true) });
+
+        const expected = cold('--b-', { b: new CheckAuthenticationTokenCookieAction() });
 
         expect(authEffects.authenticated$).toBeObservable(expected);
       });
@@ -210,7 +222,7 @@ describe('AuthEffects', () => {
 
         actions = hot('--a-', { a: { type: AuthActionTypes.CHECK_AUTHENTICATION_TOKEN } });
 
-        const expected = cold('--b-', { b: new AuthenticatedAction(token) });
+        const expected = cold('--b-', { b: new AuthenticatedAction(token, true) });
 
         expect(authEffects.checkToken$).toBeObservable(expected);
       });


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/dspace-angular/issues/4662
* Requires DSpace/DSpace#pr-number (if a REST API PR is required to test this)

## Description
This PR ensures that authentication methods are retrieved when the current authentication cookie hasn't expired yet, but it is invalid for other reasons (such as Tomcat having restarted)
- The `AuthenticatedAction` fired when a token appears valid is marked with `checkAgain: true`
- If the authentication status indicates that we aren't authenticated, we'll now fire a  `CheckAuthenticationTokenCookieAction`
- When we fire `AuthenticatedAction` after parsing an authentication response, we mark it with `checkAgain: false` to make sure that we don't keep re-checking the cookie forever

## Instructions for Reviewers
Confirm that the bug described in the linked issue can no longer be replicated.

Confirm that the following scenarios are still handled correctly:
- Opening the app without authenticating (no cookie)
- Logging in (with password, Shibboleth, ...)
- Refreshing while authenticated
- Logging out
- Getting logged out when the authentication token expires

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
