### PR TITLE
Inspect event key characters, not keyCodes on tag keyUp for dynamic tag input

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/tag/dynamic-tag.component.ts
@@ -219,13 +219,15 @@ export class DsDynamicTagComponent extends DsDynamicVocabularyComponent implemen
   }
 
   /**
-   * Add a new tag with typed text when typing 'Enter' or ',' or ';'
+   * Add a new tag with typed text when typing 'Enter' or ','
+   * Tests the key rather than keyCode as keyCodes can vary
+   * based on keyboard layout (and do not consider Shift mod)
    * @param event the keyUp event
    */
   onKeyUp(event) {
-    if (event.keyCode === 13 || event.keyCode === 188) {
+    if (event.key === 'Enter' || event.key === ',') {
       event.preventDefault();
-      // Key: 'Enter' or ',' or ';'
+      // Key: 'Enter' or ','
       this.addTagsToChips();
       event.stopPropagation();
     }


### PR DESCRIPTION
## Description
The `keyUp` handling in `dynamic-tag.component.ts` inspects only event keyCode when deciding to create a new tag/chip from the current input text. It is supposed to do this on enter or comma (and split futher on semi-colon in the `addTagsToChips` function), but it actually will do this on *any* keyCode 188 which may not be simply `,` comma but also `<` (`Shift+,`) or any combination of keys that include the comma. It also could differ even further in other keyboard layouts.

One unexpected side-effect of this, in addition to splitting on `<`, is splitting tags on the character `و` in Persian keyboard layouts.

List of changes in this PR:
* The event key checks now check for the characters: `event.key === 'Enter' || event.key === ','` instead of the keyCodes
* The references to checking / splitting on `;` in this outer `keyUp` function in the jsdoc and other comments are removed -- the keycode or char was never checked in this function, instead it performs a secondary split in the `addTagsToChips()` function. (so, for example, one may type "one;two:three" and then on a comma or enter keyUp, those three tags would be added at once. If this behaviour is not desired we can work on that, but all I'm doing in this PR is making the docs and inline comments accurate)

**How to test**

To reproduce:
* Use a standard submission form which will use suggest and SRSC for subject keywords, for example. (you may use the DSpace Demo server to reproduce this problem, too)
* Enter some characters, followed by a comma and note the behaviour
* Repeat this with enter
* Now repeat this with a comma, or any other key combo (`Alt+,` etc) that includes a comma, and note that it also splits the tag

To test the PR, repeat the steps above with this small change applied. You may like to log `event.keyCode` and `event.key` to the console to see what's going on under the hood.

## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.