### PR TITLE
Create .browserslistrc for browser support configuration

### DIFF
--- a/..browserslistrc
+++ b/..browserslistrc
@@ -1,0 +1,17 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
+# For additional information regarding the format and rule options, please see:
+# https://github.com/browserslist/browserslist#queries
+
+# For the full list of supported browsers by the Angular framework, please see:
+# https://angular.dev/reference/versions#browser-support
+
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
+last 2 Chrome versions
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+last 2 Android major versions
+Firefox ESR


### PR DESCRIPTION
## Description

This PR adds a `.browserslistrc` configuration file to the project (which was removed in DSpace 7.6 in conjunction with the Angular 15 update), specifying which browsers should be supported by the build system.

`.browserslistrc` defines the list of browsers that the CSS and JS output should support, including recent versions of Chrome, Firefox, Edge, Safari, iOS, Android, and Firefox ESR.

The background of this PR is that in DSpace 7.5, Safari 17.x was still supported (included in the output of `npx browserslist`), whereas in newer DSpace versions only the last two Safari versions (18.4, 18.5-18.6) are supported. The Angular CLI documentation states that Angular 19 supports the last two **major** Safari versions (including 17.x). However, this does not match the output of `npx browserslist`.

By adding the `.browserslistrc` file through this PR, the output of `npx browserslist` now also includes Safari 17.x, which is the expected behavior. The Angular documentation may not be entirely precise at this point. Therefore, an issue has also been created in the Angular project: https://github.com/angular/angular/issues/63600
