### PR TITLE
Replaced removed col-xs-_ bootstrap 3 classes with the equivalent col-_ classes

### DIFF
--- a/src/app/browse-by/browse-by-metadata/browse-by-metadata.component.html
+++ b/src/app/browse-by/browse-by-metadata/browse-by-metadata.component.html
@@ -2,7 +2,7 @@
   <section class="comcol-page-browse-section">
     <div class="browse-by-metadata w-100">
       @if ((loading$ | async) !== true) {
-        <ds-browse-by class="col-xs-12 w-100"
+        <ds-browse-by class="col-12 w-100"
                          title="{{'browse.title' | translate:{
                            field: 'browse.metadata.' + browseId | translate,
                            startsWith: (startsWith)? ('browse.startsWith' | translate: { startsWith: '&quot;' + startsWith + '&quot;' }) : '',

--- a/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-issue/journal-issue.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
@@ -32,7 +32,7 @@
       [label]="'journalissue.page.journal-issn'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-6">
+  <div class="col-12 col-md-6">
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isJournalVolumeOfIssue'"

--- a/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal-volume/journal-volume.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
@@ -20,7 +20,7 @@
       [label]="'journalvolume.page.issuedate'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-6">
+  <div class="col-12 col-md-6">
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isJournalOfVolume'"

--- a/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
+++ b/src/app/entity-groups/journal-entities/item-pages/journal/journal.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
     </ds-metadata-field-wrapper>
@@ -24,7 +24,7 @@
       [label]="'journal.page.editor'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-6">
+  <div class="col-12 col-md-6">
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isVolumeOfJournal'"

--- a/src/app/entity-groups/research-entities/item-pages/org-unit/org-unit.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/org-unit/org-unit.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail [thumbnail]="object?.thumbnail | async"
         [defaultImage]="'assets/images/orgunit-placeholder.svg'"
@@ -33,7 +33,7 @@
       [label]="'orgunit.page.id'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-7">
+  <div class="col-12 col-md-7">
     <ds-item-page-img-field
       [fields]="['organization.identifier.ror']"
       [img]="{

--- a/src/app/entity-groups/research-entities/item-pages/person/person.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/person/person.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail [thumbnail]="object?.thumbnail | async"
         [defaultImage]="'assets/images/person-placeholder.svg'"
@@ -24,7 +24,7 @@
       [label]="'person.page.birthdate'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-7">
+  <div class="col-12 col-md-7">
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isProjectOfPerson'"

--- a/src/app/entity-groups/research-entities/item-pages/project/project.component.html
+++ b/src/app/entity-groups/research-entities/item-pages/project/project.component.html
@@ -7,7 +7,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
       <ds-thumbnail
         [thumbnail]="object?.thumbnail | async"
@@ -39,7 +39,7 @@
   <!--[label]="'project.page.expectedcompletion'">-->
 <!--</ds-generic-item-page-field>-->
 </div>
-<div class="col-xs-12 col-md-7">
+<div class="col-12 col-md-7">
   <ds-related-items
     [parentItem]="object"
     [relationType]="'isPersonOfProject'"

--- a/src/app/info/feedback/feedback-form/feedback-form.component.html
+++ b/src/app/info/feedback/feedback-form/feedback-form.component.html
@@ -1,5 +1,5 @@
 <div class="row row-offcanvas row-offcanvas-right">
-  <div class="col-xs-12 col-sm-12 col-md-9">
+  <div class="col-12 col-sm-12 col-md-9">
     <h1>{{ 'info.feedback.head' | translate }}</h1>
     <p>{{ 'info.feedback.info' | translate }}</p>
     <form [formGroup]="feedbackForm" (ngSubmit)="createFeedback()" class="col p-0">

--- a/src/app/item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/item-page/simple/item-types/publication/publication.component.html
@@ -18,7 +18,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     @if (!(mediaViewer.image || mediaViewer.video)) {
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
         <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
@@ -54,7 +54,7 @@
       [label]="'publication.page.publisher'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-7">
+  <div class="col-12 col-md-7">
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isProjectOfPublication'"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -19,7 +19,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     @if (!(mediaViewer.image || mediaViewer.video)) {
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
         <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
@@ -55,7 +55,7 @@
       [label]="'item.page.publisher'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-6">
+  <div class="col-12 col-md-6">
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -39,7 +39,7 @@
 
     </div>
     @if (model.languageCodes && model.languageCodes.length > 0) {
-      <div class="col-xs-2" >
+      <div class="col-2" >
         <select
           #language="ngModel"
           [disabled]="model.readOnly"

--- a/src/app/shared/form/form.component.html
+++ b/src/app/shared/form/form.component.html
@@ -15,7 +15,7 @@
         <!--Array with repeatable items-->
         @if ((!context.notRepeatable) && !isVirtual(context, index) && group.context.groups.length !== 1 && !isItemReadOnly(context, index)) {
           <div
-            class="col-xs-2 d-flex flex-column justify-content-sm-start align-items-end">
+            class="col-2 d-flex flex-column justify-content-sm-start align-items-end">
             <button type="button" class="btn btn-secondary" role="button"
               title="{{'form.remove' | translate}}"
               [attr.aria-label]="'form.remove' | translate"
@@ -40,7 +40,7 @@
         <!--Array with non repeatable items - Only discard button-->
         @if (context.notRepeatable && context.showButtons && group.context.groups.length > 1) {
           <div
-            class="col-xs-2 d-flex flex-column justify-content-sm-start align-items-end">
+            class="col-2 d-flex flex-column justify-content-sm-start align-items-end">
             <div class="btn-group" role="button">
               <button type="button" class="btn btn-secondary"
                 title="{{'form.discard' | translate}}"

--- a/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
+++ b/src/app/shared/object-detail/my-dspace-result-detail-element/item-detail-preview/item-detail-preview.component.html
@@ -6,7 +6,7 @@
         <ds-item-page-title-field [item]="item">
         </ds-item-page-title-field>
         <div class="row mb-1">
-          <div class="col-xs-12 col-md-4">
+          <div class="col-12 col-md-4">
             <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
               <ds-thumbnail [thumbnail]="item?.thumbnail | async"></ds-thumbnail>
             </ds-metadata-field-wrapper>
@@ -45,7 +45,7 @@
                                           [placeholder]="('mydspace.results.no-authors' | translate)">
             </ds-item-detail-preview-field>
           </div>
-          <div class="col-xs-12 col-md-6">
+          <div class="col-12 col-md-6">
             <ds-item-detail-preview-field [item]="item"
                                           [object]="object"
                                           [label]="('item.page.abstract' | translate)"


### PR DESCRIPTION
## References

## Description
With the migration to bootstrap version 4 came a small change to the grid system: The old `.col-xs-_` classes were replace through the corresponding `.col-_` and became deprecated (See [bootstrap 4 migration guide](https://getbootstrap.com/docs/4.0/migration/#grid-system)) . With the migration to bootstrap 5 these old `.col-xs-_` classes were now removed completely. In the DSpace-Angular context this change didn't attracted much attention because the `.col-xs-_` tag was mostly used as `.col-xs-12`. There are only two components where `.col-xs-2` occurs: one of which is the [_dynamic-form-control-container.component.html_](https://github.com/DSpace/dspace-angular/blob/main/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html#L42): The language-select for a metadata field is currently placed underneath  the metadata field in a new line, because the column information is not taken into account.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Replaced all occurrences of `col-xs-_` through the equivalent `col-_` class.

**Include guidance for how to test or review your PR.** 

To check, if the new layout works, you can for example add a language field to a submission-workflow step and check, if it is displayed in the same row as the metadata field.

For an easier way to check, if the bootstrap classes are correctly set, go to the browse-by-author page, open the browser-inspector tools and check, if it recognizes the `.col-12` class.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
