### PR TITLE
Adding all missing Arabic translations

### DIFF
--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -51,8 +51,7 @@
   "error-page.orcid.generic-error": "حدث خطأ أثناء تسجيل الدخول عبر أوركيد. يرجى التأكد من أنك قمت بمشاركة عنوان البريد الإلكتروني الخاص بحساب أوركيد الخاص بك مع دي سبيس. إذا استمر الخطأ، فاتصل بالمسؤول",
 
   // "listelement.badge.access-status": "Access status:",
-  // TODO New key - Add a translation
-  "listelement.badge.access-status": "Access status:",
+  "listelement.badge.access-status": "حالة الوصول:",
 
   // "access-status.embargo.listelement.badge": "Embargo",
   "access-status.embargo.listelement.badge": "حظر",
@@ -460,20 +459,16 @@
   "admin.access-control.epeople.table.edit.buttons.remove": "حذف \"{{name}}\"",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Delete Group \"{{ dsoName }}\"",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "حذف المجموعة \"{{ dsoName }}\"",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "هل أنت متأكد أنك تريد حذف المجموعة \"{{ dsoName }}\" وجميع السياسات المرتبطة بها؟",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Cancel",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "إلغاء",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Delete",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Delete",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "حذف",
 
   // "admin.access-control.epeople.no-items": "No EPeople to show.",
   "admin.access-control.epeople.no-items": "لا يوجد أشخاص إلكترونيين للعرض.",
@@ -668,8 +663,7 @@
   "admin.access-control.groups.form.delete-group.modal.header": "حذف المجموعة \"{{ dsoName }}\"",
 
   // "admin.access-control.groups.form.delete-group.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO Source message changed - Revise the translation
-  "admin.access-control.groups.form.delete-group.modal.info": "هل أنت متأكد من أنك ترغب في حذف المجموعة \"{{ dsoName }}\"",
+  "admin.access-control.groups.form.delete-group.modal.info": "هل أنت متأكد أنك تريد حذف المجموعة \"{{ dsoName }}\" وجميع السياسات المرتبطة بها؟",
 
   // "admin.access-control.groups.form.delete-group.modal.cancel": "Cancel",
   "admin.access-control.groups.form.delete-group.modal.cancel": "إلغاء",
@@ -834,400 +828,301 @@
   "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "لإضافة مجموعة فرعية إلى هذه المجموعة أو إزالتها منها، قم بالنقر على زر 'استعراض الكل' أو قم باستخدام شريط البحث أدناه للبحث عن المجموعات. ثم قم بالنقر على أيقونة زائد لكل مجموعة ترغب في إضافتها في القائمة أدناه، أو أيقونة سلة المهملات لكل مجموعة ترغب في إزالتها. قد تحتوي القائمة أدناه على عدة صفحات: استخدم عناصر التحكم في الصفحة الموجودة أسفل القائمة للانتقال إلى الصفحات التالية.",
 
   // "admin.reports.collections.title": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.title": "Collection Filter Report",
+  "admin.reports.collections.title": "تقرير تصفية الحاويات",
 
   // "admin.reports.collections.breadcrumbs": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.breadcrumbs": "Collection Filter Report",
+  "admin.reports.collections.breadcrumbs": "تقرير تصفية الحاويات",
 
   // "admin.reports.collections.head": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.head": "Collection Filter Report",
+  "admin.reports.collections.head": "تقرير تصفية الحاويات",
 
   // "admin.reports.button.show-collections": "Show Collections",
-  // TODO New key - Add a translation
-  "admin.reports.button.show-collections": "Show Collections",
+  "admin.reports.button.show-collections": "عرض الحاويات",
 
   // "admin.reports.collections.collections-report": "Collection Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.collections-report": "Collection Report",
+  "admin.reports.collections.collections-report": "تقرير الحاويات",
 
   // "admin.reports.collections.item-results": "Item Results",
-  // TODO New key - Add a translation
-  "admin.reports.collections.item-results": "Item Results",
+  "admin.reports.collections.item-results": "نتائج المواد",
 
   // "admin.reports.collections.community": "Community",
-  // TODO New key - Add a translation
-  "admin.reports.collections.community": "Community",
+  "admin.reports.collections.community": "المجتمع",
 
   // "admin.reports.collections.collection": "Collection",
-  // TODO New key - Add a translation
-  "admin.reports.collections.collection": "Collection",
+  "admin.reports.collections.collection": "الحاوية",
 
   // "admin.reports.collections.nb_items": "Nb. Items",
-  // TODO New key - Add a translation
-  "admin.reports.collections.nb_items": "Nb. Items",
+  "admin.reports.collections.nb_items": "عدد المواد",
 
   // "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
-  // TODO New key - Add a translation
-  "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
+  "admin.reports.collections.match_all_selected_filters": "مطابقة جميع عوامل التصفية المحددة",
 
   // "admin.reports.items.breadcrumbs": "Metadata Query Report",
-  // TODO New key - Add a translation
-  "admin.reports.items.breadcrumbs": "Metadata Query Report",
+  "admin.reports.items.breadcrumbs": "تقرير استعلام البيانات الوصفية",
 
   // "admin.reports.items.head": "Metadata Query Report",
-  // TODO New key - Add a translation
-  "admin.reports.items.head": "Metadata Query Report",
+  "admin.reports.items.head": "تقرير استعلام البيانات الوصفية",
 
   // "admin.reports.items.run": "Run Item Query",
-  // TODO New key - Add a translation
-  "admin.reports.items.run": "Run Item Query",
+  "admin.reports.items.run": "تشغيل استعلام المواد",
 
   // "admin.reports.items.section.collectionSelector": "Collection Selector",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.collectionSelector": "Collection Selector",
+  "admin.reports.items.section.collectionSelector": "محدد الحاويات",
 
   // "admin.reports.items.section.metadataFieldQueries": "Metadata Field Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.metadataFieldQueries": "Metadata Field Queries",
+  "admin.reports.items.section.metadataFieldQueries": "استعلامات حقول البيانات الوصفية",
 
   // "admin.reports.items.predefinedQueries": "Predefined Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.predefinedQueries": "Predefined Queries",
+  "admin.reports.items.predefinedQueries": "استعلامات محددة مسبقًا",
 
   // "admin.reports.items.section.limitPaginateQueries": "Limit/Paginate Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.limitPaginateQueries": "Limit/Paginate Queries",
+  "admin.reports.items.section.limitPaginateQueries": "تحديد/تقسيم صفحات الاستعلامات",
 
   // "admin.reports.items.limit": "Limit/",
-  // TODO New key - Add a translation
-  "admin.reports.items.limit": "Limit/",
+  "admin.reports.items.limit": "حد/",
 
   // "admin.reports.items.offset": "Offset",
-  // TODO New key - Add a translation
-  "admin.reports.items.offset": "Offset",
+  "admin.reports.items.offset": "إزاحة",
 
   // "admin.reports.items.wholeRepo": "Whole Repository",
-  // TODO New key - Add a translation
-  "admin.reports.items.wholeRepo": "Whole Repository",
+  "admin.reports.items.wholeRepo": "المستودع بأكمله",
 
   // "admin.reports.items.anyField": "Any field",
-  // TODO New key - Add a translation
-  "admin.reports.items.anyField": "Any field",
+  "admin.reports.items.anyField": "أي حقل",
 
   // "admin.reports.items.predicate.exists": "exists",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.exists": "exists",
+  "admin.reports.items.predicate.exists": "موجود",
 
   // "admin.reports.items.predicate.doesNotExist": "does not exist",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotExist": "does not exist",
+  "admin.reports.items.predicate.doesNotExist": "غير موجود",
 
   // "admin.reports.items.predicate.equals": "equals",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.equals": "equals",
+  "admin.reports.items.predicate.equals": "يساوي",
 
   // "admin.reports.items.predicate.doesNotEqual": "does not equal",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotEqual": "does not equal",
+  "admin.reports.items.predicate.doesNotEqual": "لا يساوي",
 
   // "admin.reports.items.predicate.like": "like",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.like": "like",
+  "admin.reports.items.predicate.like": "يشبه",
 
   // "admin.reports.items.predicate.notLike": "not like",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.notLike": "not like",
+  "admin.reports.items.predicate.notLike": "لا يشبه",
 
   // "admin.reports.items.predicate.contains": "contains",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.contains": "contains",
+  "admin.reports.items.predicate.contains": "يحتوي",
 
   // "admin.reports.items.predicate.doesNotContain": "does not contain",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotContain": "does not contain",
+  "admin.reports.items.predicate.doesNotContain": "لا يحتوي",
 
   // "admin.reports.items.predicate.matches": "matches",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.matches": "matches",
+  "admin.reports.items.predicate.matches": "يطابق",
 
   // "admin.reports.items.predicate.doesNotMatch": "does not match",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotMatch": "does not match",
+  "admin.reports.items.predicate.doesNotMatch": "لا يطابق",
 
   // "admin.reports.items.preset.new": "New Query",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.new": "New Query",
+  "admin.reports.items.preset.new": "استعلام جديد",
 
   // "admin.reports.items.preset.hasNoTitle": "Has No Title",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNoTitle": "Has No Title",
+  "admin.reports.items.preset.hasNoTitle": "بدون عنوان",
 
   // "admin.reports.items.preset.hasNoIdentifierUri": "Has No dc.identifier.uri",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNoIdentifierUri": "Has No dc.identifier.uri",
+  "admin.reports.items.preset.hasNoIdentifierUri": "لا يحتوي على dc.identifier.uri",
 
   // "admin.reports.items.preset.hasCompoundSubject": "Has compound subject",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundSubject": "Has compound subject",
+  "admin.reports.items.preset.hasCompoundSubject": "يحتوي على موضوع مركب",
 
   // "admin.reports.items.preset.hasCompoundAuthor": "Has compound dc.contributor.author",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundAuthor": "Has compound dc.contributor.author",
+  "admin.reports.items.preset.hasCompoundAuthor": "يحتوي على dc.contributor.author مركب",
 
   // "admin.reports.items.preset.hasCompoundCreator": "Has compound dc.creator",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundCreator": "Has compound dc.creator",
+  "admin.reports.items.preset.hasCompoundCreator": "يحتوي على dc.creator مركب",
 
   // "admin.reports.items.preset.hasUrlInDescription": "Has URL in dc.description",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasUrlInDescription": "Has URL in dc.description",
+  "admin.reports.items.preset.hasUrlInDescription": "يحتوي على رابط في dc.description",
 
   // "admin.reports.items.preset.hasFullTextInProvenance": "Has full text in dc.description.provenance",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasFullTextInProvenance": "Has full text in dc.description.provenance",
+  "admin.reports.items.preset.hasFullTextInProvenance": "يحتوي على نص كامل في dc.description.provenance",
 
   // "admin.reports.items.preset.hasNonFullTextInProvenance": "Has non-full text in dc.description.provenance",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNonFullTextInProvenance": "Has non-full text in dc.description.provenance",
+  "admin.reports.items.preset.hasNonFullTextInProvenance": "يحتوي على نص غير كامل في dc.description.provenance",
 
   // "admin.reports.items.preset.hasEmptyMetadata": "Has empty metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasEmptyMetadata": "Has empty metadata",
+  "admin.reports.items.preset.hasEmptyMetadata": "يحتوي على بيانات وصفية فارغة",
 
   // "admin.reports.items.preset.hasUnbreakingDataInDescription": "Has unbreaking metadata in description",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasUnbreakingDataInDescription": "Has unbreaking metadata in description",
+  "admin.reports.items.preset.hasUnbreakingDataInDescription": "يحتوي على بيانات وصفية غير قابلة للكسر في الوصف",
 
   // "admin.reports.items.preset.hasXmlEntityInMetadata": "Has XML entity in metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasXmlEntityInMetadata": "Has XML entity in metadata",
+  "admin.reports.items.preset.hasXmlEntityInMetadata": "يحتوي على كيان XML في البيانات الوصفية",
 
   // "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Has non-ascii character in metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Has non-ascii character in metadata",
+  "admin.reports.items.preset.hasNonAsciiCharInMetadata": "يحتوي على محرف غير ASCII في البيانات الوصفية",
 
   // "admin.reports.items.number": "No.",
-  // TODO New key - Add a translation
-  "admin.reports.items.number": "No.",
+  "admin.reports.items.number": "رقم.",
 
   // "admin.reports.items.id": "UUID",
-  // TODO New key - Add a translation
-  "admin.reports.items.id": "UUID",
+  "admin.reports.items.id": "المعرف UUID",
 
   // "admin.reports.items.collection": "Collection",
-  // TODO New key - Add a translation
-  "admin.reports.items.collection": "Collection",
+  "admin.reports.items.collection": "الحاوية",
 
   // "admin.reports.items.handle": "URI",
-  // TODO New key - Add a translation
-  "admin.reports.items.handle": "URI",
+  "admin.reports.items.handle": "المعرف URI",
 
   // "admin.reports.items.title": "Title",
-  // TODO New key - Add a translation
-  "admin.reports.items.title": "Title",
+  "admin.reports.items.title": "العنوان",
 
   // "admin.reports.commons.filters": "Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters": "Filters",
+  "admin.reports.commons.filters": "عوامل التصفية",
 
   // "admin.reports.commons.additional-data": "Additional data to return",
-  // TODO New key - Add a translation
-  "admin.reports.commons.additional-data": "Additional data to return",
+  "admin.reports.commons.additional-data": "بيانات إضافية للإرجاع",
 
   // "admin.reports.commons.previous-page": "Prev Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.previous-page": "Prev Page",
+  "admin.reports.commons.previous-page": "الصفحة السابقة",
 
   // "admin.reports.commons.next-page": "Next Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.next-page": "Next Page",
+  "admin.reports.commons.next-page": "الصفحة التالية",
 
   // "admin.reports.commons.page": "Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.page": "Page",
+  "admin.reports.commons.page": "الصفحة",
 
   // "admin.reports.commons.of": "of",
-  // TODO New key - Add a translation
-  "admin.reports.commons.of": "of",
+  "admin.reports.commons.of": "من",
 
   // "admin.reports.commons.export": "Export for Metadata Update",
-  // TODO New key - Add a translation
-  "admin.reports.commons.export": "Export for Metadata Update",
+  "admin.reports.commons.export": "تصدير لتحديث البيانات الوصفية",
 
   // "admin.reports.commons.filters.deselect_all": "Deselect all filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.deselect_all": "Deselect all filters",
+  "admin.reports.commons.filters.deselect_all": "إلغاء تحديد جميع عوامل التصفية",
 
   // "admin.reports.commons.filters.select_all": "Select all filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.select_all": "Select all filters",
+  "admin.reports.commons.filters.select_all": "تحديد جميع عوامل التصفية",
 
   // "admin.reports.commons.filters.matches_all": "Matches all specified filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.matches_all": "Matches all specified filters",
+  "admin.reports.commons.filters.matches_all": "يطابق جميع عوامل التصفية المحددة",
 
   // "admin.reports.commons.filters.property": "Item Property Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property": "Item Property Filters",
+  "admin.reports.commons.filters.property": "عوامل تصفية خصائص المادة",
 
   // "admin.reports.commons.filters.property.is_item": "Is Item - always true",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_item": "Is Item - always true",
+  "admin.reports.commons.filters.property.is_item": "هو مادة - دائماً صحيح",
 
   // "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
+  "admin.reports.commons.filters.property.is_withdrawn": "مواد مسحوبة",
 
   // "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
+  "admin.reports.commons.filters.property.is_not_withdrawn": "مواد متاحة - غير مسحوبة",
 
   // "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
+  "admin.reports.commons.filters.property.is_discoverable": "مواد قابلة للاكتشاف - غير خاصة",
 
   // "admin.reports.commons.filters.property.is_not_discoverable": "Not Discoverable - Private Item",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_not_discoverable": "Not Discoverable - Private Item",
+  "admin.reports.commons.filters.property.is_not_discoverable": "غير قابل للاكتشاف - مادة خاصة",
 
   // "admin.reports.commons.filters.bitstream": "Basic Bitstream Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream": "Basic Bitstream Filters",
+  "admin.reports.commons.filters.bitstream": "عوامل تصفية تدفق البت الأساسية",
 
   // "admin.reports.commons.filters.bitstream.has_multiple_originals": "Item has Multiple Original Bitstreams",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_multiple_originals": "Item has Multiple Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_multiple_originals": "تحتوي المادة على عدة تدفقات بت أصلية",
 
   // "admin.reports.commons.filters.bitstream.has_no_originals": "Item has No Original Bitstreams",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_no_originals": "Item has No Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_no_originals": "لا تحتوي المادة على أي تدفقات بت أصلية",
 
   // "admin.reports.commons.filters.bitstream.has_one_original": "Item has One Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_one_original": "Item has One Original Bitstream",
+  "admin.reports.commons.filters.bitstream.has_one_original": "تحتوي المادة على تدفق بت أصلي واحد",
 
   // "admin.reports.commons.filters.bitstream_mime": "Bitstream Filters by MIME Type",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime": "Bitstream Filters by MIME Type",
+  "admin.reports.commons.filters.bitstream_mime": "عوامل تصفية تدفق البت حسب نوع MIME",
 
   // "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Item has a Doc Original Bitstream (PDF, Office, Text, HTML, XML, etc)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Item has a Doc Original Bitstream (PDF, Office, Text, HTML, XML, etc)",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_original": "تحتوي المادة على تدفق بت أصلي للوثائق (PDF، أوفيس، نص، HTML، XML، إلخ)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_image_original": "Item has an Image Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_image_original": "Item has an Image Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_image_original": "تحتوي المادة على تدفق بت أصلي للصورة",
 
   // "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Has Other Bitstream Types (not Doc or Image)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Has Other Bitstream Types (not Doc or Image)",
+  "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "توجد أنواع أخرى من تدفق البت (ليست وثائق أو صور)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Item has multiple types of Original Bitstreams (Doc, Image, Other)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Item has multiple types of Original Bitstreams (Doc, Image, Other)",
+  "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "تحتوي المادة على عدة أنواع من تدفقات البت الأصلية (وثائق، صور، أخرى)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Item has a PDF Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Item has a PDF Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "تحتوي المادة على تدفق بت أصلي بصيغة PDF",
 
   // "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Item has JPG Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Item has JPG Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "تحتوي المادة على تدفق بت أصلي بصيغة JPG",
 
   // "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Has unusually small PDF",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Has unusually small PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "يحتوي على PDF صغير بشكل غير معتاد",
 
   // "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Has unusually large PDF",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Has unusually large PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "يحتوي على PDF كبير بشكل غير معتاد",
 
   // "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Has document bitstream without TEXT item",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Has document bitstream without TEXT item",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "يحتوي على تدفق بت لوثيقة بدون عنصر نص",
 
   // "admin.reports.commons.filters.mime": "Supported MIME Type Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime": "Supported MIME Type Filters",
+  "admin.reports.commons.filters.mime": "عوامل تصفية أنواع MIME المدعومة",
 
   // "admin.reports.commons.filters.mime.has_only_supp_image_type": "Item Image Bitstreams are Supported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_only_supp_image_type": "Item Image Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_image_type": "تدفقات بت الصور للمادة مدعومة",
 
   // "admin.reports.commons.filters.mime.has_unsupp_image_type": "Item has Image Bitstream that is Unsupported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_unsupp_image_type": "Item has Image Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_image_type": "تحتوي المادة على تدفق بت للصورة غير مدعوم",
 
   // "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Item Document Bitstreams are Supported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Item Document Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_doc_type": "تدفقات بت وثائق المادة مدعومة",
 
   // "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Item has Document Bitstream that is Unsupported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Item has Document Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_doc_type": "تحتوي المادة على تدفق بت لوثيقة غير مدعوم",
 
   // "admin.reports.commons.filters.bundle": "Bitstream Bundle Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle": "Bitstream Bundle Filters",
+  "admin.reports.commons.filters.bundle": "عوامل تصفية حزم تدفق البت",
 
   // "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Has bitstream in an unsupported bundle",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Has bitstream in an unsupported bundle",
+  "admin.reports.commons.filters.bundle.has_unsupported_bundle": "يوجد تدفق بت في حزمة غير مدعومة",
 
   // "admin.reports.commons.filters.bundle.has_small_thumbnail": "Has unusually small thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_small_thumbnail": "Has unusually small thumbnail",
+  "admin.reports.commons.filters.bundle.has_small_thumbnail": "توجد صورة مصغرة صغيرة بشكل غير معتاد",
 
   // "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Has original bitstream without thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Has original bitstream without thumbnail",
+  "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "يوجد تدفق بت أصلي بدون صورة مصغرة",
 
   // "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Has invalid thumbnail name (assumes one thumbnail for each original)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Has invalid thumbnail name (assumes one thumbnail for each original)",
+  "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "يوجد اسم صورة مصغرة غير صالح (يفترض وجود صورة مصغرة واحدة لكل أصل)",
 
   // "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Has non-generated thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Has non-generated thumbnail",
+  "admin.reports.commons.filters.bundle.has_non_generated_thumb": "توجد صورة مصغرة غير مُنشأة",
 
   // "admin.reports.commons.filters.bundle.no_license": "Doesn't have a license",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.no_license": "Doesn't have a license",
+  "admin.reports.commons.filters.bundle.no_license": "لا يحتوي على ترخيص",
 
   // "admin.reports.commons.filters.bundle.has_license_documentation": "Has documentation in the license bundle",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_license_documentation": "Has documentation in the license bundle",
+  "admin.reports.commons.filters.bundle.has_license_documentation": "توجد وثائق في حزمة الترخيص",
 
   // "admin.reports.commons.filters.permission": "Permission Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission": "Permission Filters",
+  "admin.reports.commons.filters.permission": "عوامل تصفية الأذونات",
 
   // "admin.reports.commons.filters.permission.has_restricted_original": "Item has Restricted Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_original": "Item has Restricted Original Bitstream",
+  "admin.reports.commons.filters.permission.has_restricted_original": "تحتوي المادة على تدفق بت أصلي مقيد",
 
   // "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Item has at least one original bitstream that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Item has at least one original bitstream that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "تحتوي المادة على تدفق بت أصلي واحد على الأقل غير متاح للمستخدم المجهول",
 
   // "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Item has Restricted Thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Item has Restricted Thumbnail",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail": "تحتوي المادة على صورة مصغرة مقيدة",
 
   // "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Item has at least one thumbnail that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Item has at least one thumbnail that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "تحتوي المادة على صورة مصغرة واحدة على الأقل غير متاحة للمستخدم المجهول",
 
   // "admin.reports.commons.filters.permission.has_restricted_metadata": "Item has Restricted Metadata",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_metadata": "Item has Restricted Metadata",
+  "admin.reports.commons.filters.permission.has_restricted_metadata": "تحتوي المادة على بيانات وصفية مقيدة",
 
   // "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Item has metadata that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Item has metadata that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "تحتوي المادة على بيانات وصفية غير متاحة للمستخدم المجهول",
 
   // "admin.search.breadcrumbs": "Administrative Search",
   "admin.search.breadcrumbs": "بحث إداري",
@@ -1614,28 +1509,22 @@
   "bitstream-request-a-copy.submit.error": "حدث خطأ ما أثناء تقديم طلب المادة.",
 
   // "bitstream-request-a-copy.access-by-token.warning": "You are viewing this item with the secure access link provided to you by the author or repository staff. It is important not to share this link to unauthorised users.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.warning": "You are viewing this item with the secure access link provided to you by the author or repository staff. It is important not to share this link to unauthorised users.",
+  "bitstream-request-a-copy.access-by-token.warning": "أنت تشاهد هذه المادة عبر رابط وصول آمن قدمه لك المؤلف أو فريق المستودع. من المهم عدم مشاركة هذا الرابط مع مستخدمين غير مخولين.",
 
   // "bitstream-request-a-copy.access-by-token.expiry-label": "Access provided by this link will expire on",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.expiry-label": "Access provided by this link will expire on",
+  "bitstream-request-a-copy.access-by-token.expiry-label": "سيَنتهي الوصول الممنوح عبر هذا الرابط في",
 
   // "bitstream-request-a-copy.access-by-token.expired": "Access provided by this link is no longer possible. Access expired on",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.expired": "Access provided by this link is no longer possible. Access expired on",
+  "bitstream-request-a-copy.access-by-token.expired": "لم يَعُد الوصول الممنوح عبر هذا الرابط ممكناً. انتهى الوصول في",
 
   // "bitstream-request-a-copy.access-by-token.not-granted": "Access provided by this link is not possible. Access has either not been granted, or has been revoked.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.not-granted": "Access provided by this link is not possible. Access has either not been granted, or has been revoked.",
+  "bitstream-request-a-copy.access-by-token.not-granted": "الوصول عبر هذا الرابط غير ممكن. لم يتم منح الوصول بعد أو تم إلغاؤه.",
 
   // "bitstream-request-a-copy.access-by-token.re-request": "Follow restricted download links to submit a new request for access.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.re-request": "Follow restricted download links to submit a new request for access.",
+  "bitstream-request-a-copy.access-by-token.re-request": "اتبع روابط التنزيل المقيدة لتقديم طلب جديد للوصول.",
 
   // "bitstream-request-a-copy.access-by-token.alt-text": "Access to this item is provided by a secure token",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.alt-text": "Access to this item is provided by a secure token",
+  "bitstream-request-a-copy.access-by-token.alt-text": "يتم توفير الوصول إلى هذه المادة عبر رمز آمن",
 
   // "browse.back.all-results": "All browse results",
   "browse.back.all-results": "جميع نتائج الاستعراض",
@@ -1692,30 +1581,25 @@
   "browse.metadata.srsc.breadcrumbs": "استعراض حسب فئة الموضوع",
 
   // "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
-  // TODO New key - Add a translation
-  "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
+  "browse.metadata.srsc.tree.description": "حدد موضوعاً لإضافته كعامل تصفية للبحث",
 
   // "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
   "browse.metadata.nsi.breadcrumbs": "استعراض حسب فهرس العلوم النرويجي",
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
-  // TODO New key - Add a translation
-  "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
+  "browse.metadata.nsi.tree.description": "حدد فهرساً لإضافته كعامل تصفية للبحث",
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "استعراض حسب العنوان",
 
   // "browse.metadata.map": "Browse by Geolocation",
-  // TODO New key - Add a translation
-  "browse.metadata.map": "Browse by Geolocation",
+  "browse.metadata.map": "استعراض حسب الموقع الجغرافي",
 
   // "browse.metadata.map.breadcrumbs": "Browse by Geolocation",
-  // TODO New key - Add a translation
-  "browse.metadata.map.breadcrumbs": "Browse by Geolocation",
+  "browse.metadata.map.breadcrumbs": "استعراض حسب الموقع الجغرافي",
 
   // "browse.metadata.map.count.items": "items",
-  // TODO New key - Add a translation
-  "browse.metadata.map.count.items": "items",
+  "browse.metadata.map.count.items": "عناصر",
 
   // "pagination.next.button": "Next",
   "pagination.next.button": "التالي",
@@ -1727,8 +1611,7 @@
   "pagination.next.button.disabled.tooltip": "لا مزيد من الصفحات من النتائج",
 
   // "pagination.page-number-bar": "Control bar for page navigation, relative to element with ID: ",
-  // TODO New key - Add a translation
-  "pagination.page-number-bar": "Control bar for page navigation, relative to element with ID: ",
+  "pagination.page-number-bar": "شريط التحكم للتنقل بين الصفحات، بالنسبة للعنصر ذو المعرف: ",
 
   // "browse.startsWith": ", starting with {{ startsWith }}",
   "browse.startsWith": ", يبدأ بـ {{ startsWith }}",
@@ -1827,8 +1710,7 @@
   "claimed-declined-task-search-result-list-element.title": "تم الرفض، وتمت الإعادة إلى سير عمل مدير المراجعة",
 
   // "collection.create.breadcrumbs": "Create collection",
-  // TODO New key - Add a translation
-  "collection.create.breadcrumbs": "Create collection",
+  "collection.create.breadcrumbs": "إنشاء حاوية",
 
   // "collection.browse.logo": "Browse for a collection logo",
   "collection.browse.logo": "استعراض للحصول على شعار للحاوية",
@@ -2131,8 +2013,7 @@
   "collection.logo": "شعار الحاوية",
 
   // "collection.page.browse.search.head": "Search",
-  // TODO New key - Add a translation
-  "collection.page.browse.search.head": "Search",
+  "collection.page.browse.search.head": "بحث",
 
   // "collection.page.edit": "Edit this collection",
   "collection.page.edit": "تحرير هذه الحاوية",
@@ -2147,16 +2028,13 @@
   "collection.page.news": "الأخبار",
 
   // "collection.page.options": "Options",
-  // TODO New key - Add a translation
-  "collection.page.options": "Options",
+  "collection.page.options": "خيارات",
 
   // "collection.search.breadcrumbs": "Search",
-  // TODO New key - Add a translation
-  "collection.search.breadcrumbs": "Search",
+  "collection.search.breadcrumbs": "بحث",
 
   // "collection.search.results.head": "Search Results",
-  // TODO New key - Add a translation
-  "collection.search.results.head": "Search Results",
+  "collection.search.results.head": "نتائج البحث",
 
   // "collection.select.confirm": "Confirm selected",
   "collection.select.confirm": "تأكيد المحدد",
@@ -2273,12 +2151,10 @@
   "community.browse.logo": "استعراض للحصول على شعار المجتمع",
 
   // "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
-  // TODO New key - Add a translation
-  "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
+  "community.subcoms-cols.breadcrumbs": "المجتمعات الفرعية والحاويات",
 
   // "community.create.breadcrumbs": "Create Community",
-  // TODO New key - Add a translation
-  "community.create.breadcrumbs": "Create Community",
+  "community.create.breadcrumbs": "إنشاء مجتمع",
 
   // "community.create.head": "Create a Community",
   "community.create.head": "إنشاء مجتمع",
@@ -2326,15 +2202,13 @@
   "community.edit.logo.delete.title": "حذف الشعار",
 
   // "community-collection.edit.logo.delete.title": "Confirm deletion",
-  // TODO New key - Add a translation
-  "community-collection.edit.logo.delete.title": "Confirm deletion",
+  "community-collection.edit.logo.delete.title": "تأكيد الحذف",
 
   // "community.edit.logo.delete-undo.title": "Undo delete",
   "community.edit.logo.delete-undo.title": "التراجع عن الحذف",
 
   // "community-collection.edit.logo.delete-undo.title": "Undo delete",
-  // TODO New key - Add a translation
-  "community-collection.edit.logo.delete-undo.title": "Undo delete",
+  "community-collection.edit.logo.delete-undo.title": "التراجع عن الحذف",
 
   // "community.edit.logo.label": "Community logo",
   "community.edit.logo.label": "شعار المجتمع",
@@ -2364,7 +2238,6 @@
   "community.edit.notifications.unauthorized": "ليس لديك امتيازات لإجراء هذا التغيير",
 
   // "community.edit.notifications.error": "An error occurred while editing the community",
-  // TODO Source message changed - Revise the translation
   "community.edit.notifications.error": "حدث خطأ أثناء تحرير المجتمع",
 
   // "community.edit.return": "Back",
@@ -2425,20 +2298,16 @@
   "comcol-role.edit.delete.error.title": "فشل حذف مجموعة الدور '{{ role }}'",
 
   // "comcol-role.edit.delete.modal.header": "Delete Group \"{{ dsoName }}\"",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "comcol-role.edit.delete.modal.header": "حذف المجموعة \"{{ dsoName }}\"",
 
   // "comcol-role.edit.delete.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "comcol-role.edit.delete.modal.info": "هل أنت متأكد أنك تريد حذف المجموعة \"{{ dsoName }}\" وجميع السياسات المرتبطة بها؟",
 
   // "comcol-role.edit.delete.modal.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.cancel": "Cancel",
+  "comcol-role.edit.delete.modal.cancel": "إلغاء",
 
   // "comcol-role.edit.delete.modal.confirm": "Delete",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.confirm": "Delete",
+  "comcol-role.edit.delete.modal.confirm": "حذف",
 
   // "comcol-role.edit.community-admin.name": "Administrators",
   "comcol-role.edit.community-admin.name": "المسؤولون",
@@ -2531,19 +2400,16 @@
   "community.page.news": "الأخبار",
 
   // "community.page.options": "Options",
-  // TODO New key - Add a translation
-  "community.page.options": "Options",
+  "community.page.options": "خيارات",
 
   // "community.all-lists.head": "Subcommunities and Collections",
   "community.all-lists.head": "المجتمعات الفرعية والحاويات",
 
   // "community.search.breadcrumbs": "Search",
-  // TODO New key - Add a translation
-  "community.search.breadcrumbs": "Search",
+  "community.search.breadcrumbs": "بحث",
 
   // "community.search.results.head": "Search Results",
-  // TODO New key - Add a translation
-  "community.search.results.head": "Search Results",
+  "community.search.results.head": "نتائج البحث",
 
   // "community.sub-collection-list.head": "Collections in this community",
   "community.sub-collection-list.head": "حاويات هذا المجتمع",
@@ -2582,8 +2448,7 @@
   "cookies.consent.decline": "رفض",
 
   // "cookies.consent.decline-all": "Decline all",
-  // TODO New key - Add a translation
-  "cookies.consent.decline-all": "Decline all",
+  "cookies.consent.decline-all": "رفض الكل",
 
   // "cookies.consent.ok": "That's ok",
   "cookies.consent.ok": "لا بأس",
@@ -2592,8 +2457,7 @@
   "cookies.consent.save": "حفظ",
 
   // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
-  // TODO Source message changed - Revise the translation
-  "cookies.consent.content-notice.description": "نقوم بجمع ومعالجة معلوماتك الشخصية للأغراض التالية: الاستيثاق، والتفضيلات، والإقرار، والإحصائيات.  لمعرفة المزيد، يرجى قراءة {privacyPolicy}.",
+  "cookies.consent.content-notice.description": "نقوم بجمع ومعالجة معلوماتك الشخصية للأغراض التالية: {purposes}.<br/>لمعرفة المزيد، يرجى قراءة {privacyPolicy}.",
 
   // "cookies.consent.content-notice.learnMore": "Customize",
   "cookies.consent.content-notice.learnMore": "تخصيص",
@@ -2608,19 +2472,16 @@
   "cookies.consent.content-modal.privacy-policy.text": "لمعرفة المزيد، يرجى قراءة {privacyPolicy}.",
 
   // "cookies.consent.content-modal.no-privacy-policy.text": "",
-  // TODO New key - Add a translation
   "cookies.consent.content-modal.no-privacy-policy.text": "",
 
   // "cookies.consent.content-modal.title": "Information that we collect",
   "cookies.consent.content-modal.title": "المعلومات التي نقوم بجمعها",
 
   // "cookies.consent.app.title.accessibility": "Accessibility Settings",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.accessibility": "Accessibility Settings",
+  "cookies.consent.app.title.accessibility": "إعدادات إمكانية الوصول",
 
   // "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
+  "cookies.consent.app.description.accessibility": "مطلوب لحفظ إعدادات إمكانية الوصول الخاصة بك محليًا",
 
   // "cookies.consent.app.title.authentication": "Authentication",
   "cookies.consent.app.title.authentication": "استيثاق",
@@ -2629,12 +2490,10 @@
   "cookies.consent.app.description.authentication": "مطلوب لتسجيل دخولك",
 
   // "cookies.consent.app.title.correlation-id": "Correlation ID",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.correlation-id": "Correlation ID",
+  "cookies.consent.app.title.correlation-id": "معرّف الترابط",
 
   // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
+  "cookies.consent.app.description.correlation-id": "يسمح لنا بتتبع جلستك في سجلات الواجهة الخلفية لأغراض الدعم/تصحيح الأخطاء",
 
   // "cookies.consent.app.title.preferences": "Preferences",
   "cookies.consent.app.title.preferences": "التفضيلات",
@@ -2658,16 +2517,13 @@
   "cookies.consent.app.title.google-recaptcha": "جوجل ريكابتشا",
 
   // "cookies.consent.app.description.google-recaptcha": "We use google reCAPTCHA service during registration and password recovery",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.google-recaptcha": "We use google reCAPTCHA service during registration and password recovery",
+  "cookies.consent.app.description.google-recaptcha": "نستخدم خدمة Google reCAPTCHA أثناء التسجيل واستعادة كلمة المرور",
 
   // "cookies.consent.app.title.matomo": "Matomo",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.matomo": "Matomo",
+  "cookies.consent.app.title.matomo": "ماتومو",
 
   // "cookies.consent.app.description.matomo": "Allows us to track statistical data",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.matomo": "Allows us to track statistical data",
+  "cookies.consent.app.description.matomo": "يسمح لنا بتتبع البيانات الإحصائية",
 
   // "cookies.consent.purpose.functional": "Functional",
   "cookies.consent.purpose.functional": "وظيفي",
@@ -2721,7 +2577,6 @@
   "curation.form.submit.error.head": "فشل تشغيل مهمة الأكرتة",
 
   // "curation.form.submit.error.content": "An error occurred when trying to start the curation task.",
-  // TODO Source message changed - Revise the translation
   "curation.form.submit.error.content": "حدث خطأ أثناء محاولة بدء مهمة الأكرتة.",
 
   // "curation.form.submit.error.invalid-handle": "Couldn't determine the handle for this object",
@@ -2752,16 +2607,13 @@
   "deny-request-copy.success": "تم رفض طلب المادة بنجاح",
 
   // "dynamic-list.load-more": "Load more",
-  // TODO New key - Add a translation
-  "dynamic-list.load-more": "Load more",
+  "dynamic-list.load-more": "تحميل المزيد",
 
   // "dropdown.clear": "Clear selection",
-  // TODO New key - Add a translation
-  "dropdown.clear": "Clear selection",
+  "dropdown.clear": "مسح التحديد",
 
   // "dropdown.clear.tooltip": "Clear the selected option",
-  // TODO New key - Add a translation
-  "dropdown.clear.tooltip": "Clear the selected option",
+  "dropdown.clear.tooltip": "مسح الخيار المحدد",
 
   // "dso.name.untitled": "Untitled",
   "dso.name.untitled": "بدون عنوان",
@@ -2824,16 +2676,13 @@
   "dso-selector.placeholder": "بحث عن {{ type }}",
 
   // "dso-selector.placeholder.type.community": "community",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.community": "community",
+  "dso-selector.placeholder.type.community": "مجتمع",
 
   // "dso-selector.placeholder.type.collection": "collection",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.collection": "collection",
+  "dso-selector.placeholder.type.collection": "حاوية",
 
   // "dso-selector.placeholder.type.item": "item",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.item": "مادة",
 
   // "dso-selector.select.collection.head": "Select a collection",
   "dso-selector.select.collection.head": "تحديد حاوية",
@@ -2941,8 +2790,7 @@
   "confirmation-modal.delete-eperson.confirm": "حذف",
 
   // "confirmation-modal.delete-community-collection-logo.info": "Are you sure you want to delete the logo?",
-  // TODO New key - Add a translation
-  "confirmation-modal.delete-community-collection-logo.info": "Are you sure you want to delete the logo?",
+  "confirmation-modal.delete-community-collection-logo.info": "هل أنت متأكد من أنك تريد حذف الشعار؟",
 
   // "confirmation-modal.delete-profile.header": "Delete Profile",
   "confirmation-modal.delete-profile.header": "حذف الملف الشخصي",
@@ -2969,24 +2817,19 @@
   "confirmation-modal.delete-subscription.confirm": "حذف",
 
   // "confirmation-modal.review-account-info.header": "Save the changes",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.header": "Save the changes",
+  "confirmation-modal.review-account-info.header": "حفظ التغييرات",
 
   // "confirmation-modal.review-account-info.info": "Are you sure you want to save the changes to your profile",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.info": "Are you sure you want to save the changes to your profile",
+  "confirmation-modal.review-account-info.info": "هل أنت متأكد أنك تريد حفظ التغييرات في ملفك الشخصي",
 
   // "confirmation-modal.review-account-info.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.cancel": "Cancel",
+  "confirmation-modal.review-account-info.cancel": "إلغاء",
 
   // "confirmation-modal.review-account-info.confirm": "Confirm",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.confirm": "Confirm",
+  "confirmation-modal.review-account-info.confirm": "تأكيد",
 
   // "confirmation-modal.review-account-info.save": "Save",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.save": "Save",
+  "confirmation-modal.review-account-info.save": "حفظ",
 
   // "error.bitstream": "Error fetching bitstream",
   "error.bitstream": "حدث خطأ أثناء جلب تدفق البت",
@@ -3022,8 +2865,7 @@
   "error.recent-submissions": "حدث خطأ أثناء جلب أحدث التقديمات",
 
   // "error.profile-groups": "Error retrieving profile groups",
-  // TODO New key - Add a translation
-  "error.profile-groups": "Error retrieving profile groups",
+  "error.profile-groups": "حدث خطأ أثناء استرجاع مجموعات الملف الشخصي",
 
   // "error.search-results": "Error fetching search results",
   "error.search-results": "حدث خطأ أثناء جلب نتائج البحث",
@@ -3047,8 +2889,7 @@
   "error.validation.license.notgranted": "يجب عليك منح هذا الترخيص لإكمال عملية التقديم الخاصة بك. إذا لم تتمكن من منح هذا الترخيص في هذا الوقت، يمكنك حفظ عملك والعودة لاحقاً أو إزالة التقديم.",
 
   // "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
-  // TODO New key - Add a translation
-  "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
+  "error.validation.cclicense.required": "يجب عليك منح رخصة المشاع الإبداعي هذه لإكمال تقديمك. إذا لم تتمكن من منح الرخصة في هذا الوقت، يمكنك حفظ عملك والعودة لاحقًا أو إزالة التقديم.",
 
   // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
   "error.validation.pattern": "هذا الإدخال مقيد بالنمط الحالي: {{ pattern }}.",
@@ -3096,8 +2937,7 @@
   "file-download-link.restricted": "دفق البت المقيد",
 
   // "file-download-link.secure-access": "Restricted bitstream available via secure access token",
-  // TODO New key - Add a translation
-  "file-download-link.secure-access": "Restricted bitstream available via secure access token",
+  "file-download-link.secure-access": "تدفق بت مقيد متاح عبر رمز وصول آمن",
 
   // "file-section.error.header": "Error obtaining files for this item",
   "file-section.error.header": "حدث خطأ أثناء الحصول على ملفات لهذه المادة",
@@ -3106,11 +2946,10 @@
   "footer.copyright": "حقوق النشر © 2002-{{ year }}",
 
   // "footer.link.accessibility": "Accessibility settings",
-  // TODO New key - Add a translation
-  "footer.link.accessibility": "Accessibility settings",
+  "footer.link.accessibility": "إعدادات إمكانية الوصول",
 
   // "footer.link.dspace": "DSpace software",
-  "footer.link.dspace": "برنامج دي سبيس",
+  "footer.link.dspace": "المستودع الإلكتروني",
 
   // "footer.link.lyrasis": "LYRASIS",
   "footer.link.lyrasis": "ليراسيس",
@@ -3128,8 +2967,7 @@
   "footer.link.feedback": "إرسال الملاحظات",
 
   // "footer.link.coar-notify-support": "COAR Notify",
-  // TODO New key - Add a translation
-  "footer.link.coar-notify-support": "COAR Notify",
+  "footer.link.coar-notify-support": "دعم COAR Notify",
 
   // "forgot-email.form.header": "Forgot Password",
   "forgot-email.form.header": "هل نسيت كلمة المرور",
@@ -3162,8 +3000,7 @@
   "forgot-email.form.error.head": "حدث خطأ أثناء محاولة إعادة تعيين كلمة المرور",
 
   // "forgot-email.form.error.content": "An error occurred when attempting to reset the password for the account associated with the following email address: {{ email }}",
-  // TODO New key - Add a translation
-  "forgot-email.form.error.content": "An error occurred when attempting to reset the password for the account associated with the following email address: {{ email }}",
+  "forgot-email.form.error.content": "حدث خطأ عند محاولة إعادة تعيين كلمة المرور للحساب المرتبط بعنوان البريد الإلكتروني التالي: {{ email }}",
 
   // "forgot-password.title": "Forgot Password",
   "forgot-password.title": "نسيت كلمة المرور",
@@ -3316,12 +3153,10 @@
   "form.repeatable.sort.tip": "قم بإسقاط المادة في الموضع الجديد",
 
   // "grant-deny-request-copy.deny": "Deny access request",
-  // TODO Source message changed - Revise the translation
-  "grant-deny-request-copy.deny": "لا تقم بإرسال نسخة",
+  "grant-deny-request-copy.deny": "رفض طلب الوصول",
 
   // "grant-deny-request-copy.revoke": "Revoke access",
-  // TODO New key - Add a translation
-  "grant-deny-request-copy.revoke": "Revoke access",
+  "grant-deny-request-copy.revoke": "إلغاء الوصول",
 
   // "grant-deny-request-copy.email.back": "Back",
   "grant-deny-request-copy.email.back": "رجوع",
@@ -3348,8 +3183,7 @@
   "grant-deny-request-copy.email.subject.empty": "يرجى إدخال موضوع",
 
   // "grant-deny-request-copy.grant": "Grant access request",
-  // TODO Source message changed - Revise the translation
-  "grant-deny-request-copy.grant": "إرسال نسخة",
+  "grant-deny-request-copy.grant": "منح طلب الوصول",
 
   // "grant-deny-request-copy.header": "Document copy request",
   "grant-deny-request-copy.header": "طلب نسخة من الوثيقة",
@@ -3364,8 +3198,7 @@
   "grant-deny-request-copy.intro2": "بعد اختيار أحد الخيارات، سيُعرض عليك رسالة رد مقترحة بالبريد الإلكتروني يمكنك تحريرها.",
 
   // "grant-deny-request-copy.previous-decision": "This request was previously granted with a secure access token. You may revoke this access now to immediately invalidate the access token",
-  // TODO New key - Add a translation
-  "grant-deny-request-copy.previous-decision": "This request was previously granted with a secure access token. You may revoke this access now to immediately invalidate the access token",
+  "grant-deny-request-copy.previous-decision": "تمت الموافقة على هذا الطلب سابقًا بواسطة رمز وصول آمن. يمكنك إلغاء هذا الوصول الآن لإبطال رمز الوصول فورًا.",
 
   // "grant-deny-request-copy.processed": "This request has already been processed. You can use the button below to get back to the home page.",
   "grant-deny-request-copy.processed": "تمت معالجة هذا الطلب بالفعل. يمكنك استخدام الزر أدناه للعودة إلى الصفحة الرئيسية.",
@@ -3380,43 +3213,34 @@
   "grant-request-copy.header": "طلب منح نسخة من الوثيقة",
 
   // "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
-  // TODO New key - Add a translation
-  "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
+  "grant-request-copy.intro.attachment": "سيتم إرسال رسالة إلى مقدم الطلب. سيتم إرفاق الوثيقة/الوثائق المطلوبة.",
 
   // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
-  // TODO New key - Add a translation
-  "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
+  "grant-request-copy.intro.link": "سيتم إرسال رسالة إلى مقدم الطلب. سيتم إرفاق رابط آمن يتيح الوصول إلى الوثيقة/الوثائق المطلوبة. سيوفر الرابط الوصول للفترة الزمنية المحددة في قائمة \"فترة الوصول\" أدناه.",
 
   // "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
-  // TODO New key - Add a translation
-  "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
+  "grant-request-copy.intro.link.preview": "فيما يلي معاينة للرابط الذي سيتم إرساله إلى مقدم الطلب:",
 
   // "grant-request-copy.success": "Successfully granted item request",
   "grant-request-copy.success": "تم منح طلب المادة بنجاح",
 
   // "grant-request-copy.access-period.header": "Access period",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.header": "Access period",
+  "grant-request-copy.access-period.header": "فترة الوصول",
 
   // "grant-request-copy.access-period.+1DAY": "1 day",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+1DAY": "1 day",
+  "grant-request-copy.access-period.+1DAY": "يوم واحد",
 
   // "grant-request-copy.access-period.+7DAYS": "1 week",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+7DAYS": "1 week",
+  "grant-request-copy.access-period.+7DAYS": "أسبوع واحد",
 
   // "grant-request-copy.access-period.+1MONTH": "1 month",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+1MONTH": "1 month",
+  "grant-request-copy.access-period.+1MONTH": "شهر واحد",
 
   // "grant-request-copy.access-period.+3MONTHS": "3 months",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+3MONTHS": "3 months",
+  "grant-request-copy.access-period.+3MONTHS": "ثلاثة أشهر",
 
   // "grant-request-copy.access-period.FOREVER": "Forever",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.FOREVER": "Forever",
+  "grant-request-copy.access-period.FOREVER": "إلى الأبد",
 
   // "health.breadcrumbs": "Health",
   "health.breadcrumbs": "كشف الصحة",
@@ -3497,80 +3321,61 @@
   "home.top-level-communities.help": "قم بتحديد مجتمع لاستعراض حاوياته.",
 
   // "info.accessibility-settings.breadcrumbs": "Accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.breadcrumbs": "Accessibility settings",
+  "info.accessibility-settings.breadcrumbs": "إعدادات إمكانية الوصول",
 
   // "info.accessibility-settings.cookie-warning": "Saving the accessibility settings is currently not possible. Either log in to save the settings in user data, or accept the 'Accessibility Settings' cookie using the 'Cookie Settings' menu at the bottom of the page. Once the cookie has been accepted, you can reload the page to remove this message.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.cookie-warning": "Saving the accessibility settings is currently not possible. Either log in to save the settings in user data, or accept the 'Accessibility Settings' cookie using the 'Cookie Settings' menu at the bottom of the page. Once the cookie has been accepted, you can reload the page to remove this message.",
+  "info.accessibility-settings.cookie-warning": "حفظ إعدادات إمكانية الوصول غير ممكن حالياً. إما أن تقوم بتسجيل الدخول لحفظ الإعدادات في بيانات المستخدم، أو تقبل ملف تعريف الارتباط 'إعدادات إمكانية الوصول' باستخدام قائمة 'إعدادات ملفات تعريف الارتباط' أسفل الصفحة. بعد قبول ملف تعريف الارتباط، يمكنك إعادة تحميل الصفحة لإزالة هذه الرسالة.",
 
   // "info.accessibility-settings.disableNotificationTimeOut.label": "Automatically close notifications after time out",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.disableNotificationTimeOut.label": "Automatically close notifications after time out",
+  "info.accessibility-settings.disableNotificationTimeOut.label": "إغلاق الإشعارات تلقائيًا بعد انتهاء المهلة",
 
   // "info.accessibility-settings.disableNotificationTimeOut.hint": "When this toggle is activated, notifications will close automatically after the time out passes. When deactivated, notifications will remain open untill manually closed.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.disableNotificationTimeOut.hint": "When this toggle is activated, notifications will close automatically after the time out passes. When deactivated, notifications will remain open untill manually closed.",
+  "info.accessibility-settings.disableNotificationTimeOut.hint": "عند تفعيل هذا التبديل، ستُغلق الإشعارات تلقائيًا بعد انتهاء المهلة. عند تعطيله، ستظل الإشعارات مفتوحة حتى يتم إغلاقها يدويًا.",
 
   // "info.accessibility-settings.failed-notification": "Failed to save accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.failed-notification": "Failed to save accessibility settings",
+  "info.accessibility-settings.failed-notification": "فشل حفظ إعدادات إمكانية الوصول",
 
   // "info.accessibility-settings.invalid-form-notification": "Did not save. The form contains invalid values.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.invalid-form-notification": "Did not save. The form contains invalid values.",
+  "info.accessibility-settings.invalid-form-notification": "لم يتم الحفظ. يحتوي النموذج على قيم غير صالحة.",
 
   // "info.accessibility-settings.liveRegionTimeOut.label": "ARIA Live region time out (in seconds)",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.label": "ARIA Live region time out (in seconds)",
+  "info.accessibility-settings.liveRegionTimeOut.label": "مهلة منطقة ARIA الحية (بالثواني)",
 
   // "info.accessibility-settings.liveRegionTimeOut.hint": "The duration after which a message in the ARIA live region disappears. ARIA live regions are not visible on the page, but provide announcements of notifications (or other actions) to screen readers.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.hint": "The duration after which a message in the ARIA live region disappears. ARIA live regions are not visible on the page, but provide announcements of notifications (or other actions) to screen readers.",
+  "info.accessibility-settings.liveRegionTimeOut.hint": "المدة التي تختفي بعدها الرسالة في منطقة ARIA الحية. مناطق ARIA الحية غير مرئية على الصفحة، لكنها توفر إعلانات عن الإشعارات (أو الإجراءات الأخرى) لقارئات الشاشة.",
 
   // "info.accessibility-settings.liveRegionTimeOut.invalid": "Live region time out must be greater than 0",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.invalid": "Live region time out must be greater than 0",
+  "info.accessibility-settings.liveRegionTimeOut.invalid": "يجب أن تكون مهلة المنطقة الحية أكبر من 0",
 
   // "info.accessibility-settings.notificationTimeOut.label": "Notification time out (in seconds)",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.label": "Notification time out (in seconds)",
+  "info.accessibility-settings.notificationTimeOut.label": "مهلة الإشعار (بالثواني)",
 
   // "info.accessibility-settings.notificationTimeOut.hint": "The duration after which a notification disappears.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.hint": "The duration after which a notification disappears.",
+  "info.accessibility-settings.notificationTimeOut.hint": "المدة التي تختفي بعدها الإشعار.",
 
   // "info.accessibility-settings.notificationTimeOut.invalid": "Notification time out must be greater than 0",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.invalid": "Notification time out must be greater than 0",
+  "info.accessibility-settings.notificationTimeOut.invalid": "يجب أن تكون مهلة الإشعار أكبر من 0",
 
   // "info.accessibility-settings.save-notification.cookie": "Successfully saved settings locally.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.save-notification.cookie": "Successfully saved settings locally.",
+  "info.accessibility-settings.save-notification.cookie": "تم حفظ الإعدادات محليًا بنجاح.",
 
   // "info.accessibility-settings.save-notification.metadata": "Successfully saved settings on the user profile.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.save-notification.metadata": "Successfully saved settings on the user profile.",
+  "info.accessibility-settings.save-notification.metadata": "تم حفظ الإعدادات في ملف المستخدم بنجاح.",
 
   // "info.accessibility-settings.reset-failed": "Failed to reset. Either log in or accept the 'Accessibility Settings' cookie.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset-failed": "Failed to reset. Either log in or accept the 'Accessibility Settings' cookie.",
+  "info.accessibility-settings.reset-failed": "فشل في إعادة التعيين. إما أن تسجّل الدخول أو تقبل ملف تعريف الارتباط 'إعدادات إمكانية الوصول'.",
 
   // "info.accessibility-settings.reset-notification": "Successfully reset settings.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset-notification": "Successfully reset settings.",
+  "info.accessibility-settings.reset-notification": "تمت إعادة تعيين الإعدادات بنجاح.",
 
   // "info.accessibility-settings.reset": "Reset accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset": "Reset accessibility settings",
+  "info.accessibility-settings.reset": "إعادة تعيين إعدادات إمكانية الوصول",
 
   // "info.accessibility-settings.submit": "Save accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.submit": "Save accessibility settings",
+  "info.accessibility-settings.submit": "حفظ إعدادات إمكانية الوصول",
 
   // "info.accessibility-settings.title": "Accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.title": "Accessibility settings",
+  "info.accessibility-settings.title": "إعدادات إمكانية الوصول",
 
   // "info.end-user-agreement.accept": "I have read and I agree to the End User Agreement",
   "info.end-user-agreement.accept": "لقد قمت بقراءة اتفاقية المستخدم النهائي وأوافق عليها",
@@ -3648,12 +3453,10 @@
   "info.feedback.page_help": "الصفحة ذات الصلة بملاحظاتك",
 
   // "info.coar-notify-support.title": "COAR Notify Support",
-  // TODO New key - Add a translation
-  "info.coar-notify-support.title": "COAR Notify Support",
+  "info.coar-notify-support.title": "دعم COAR Notify",
 
   // "info.coar-notify-support.breadcrumbs": "COAR Notify Support",
-  // TODO New key - Add a translation
-  "info.coar-notify-support.breadcrumbs": "COAR Notify Support",
+  "info.coar-notify-support.breadcrumbs": "دعم COAR Notify",
 
   // "item.alerts.private": "This item is non-discoverable",
   "item.alerts.private": "هذه المادة غير قابلة للاكتشاف",
@@ -3662,12 +3465,10 @@
   "item.alerts.withdrawn": "تم سحب هذه المادة",
 
   // "item.alerts.reinstate-request": "Request reinstate",
-  // TODO New key - Add a translation
-  "item.alerts.reinstate-request": "Request reinstate",
+  "item.alerts.reinstate-request": "طلب إعادة التفعيل",
 
   // "quality-assurance.event.table.person-who-requested": "Requested by",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.person-who-requested": "Requested by",
+  "quality-assurance.event.table.person-who-requested": "طُلِب بواسطة",
 
   // "item.edit.authorizations.heading": "With this editor you can view and alter the policies of an item, plus alter policies of individual item components: bundles and bitstreams. Briefly, an item is a container of bundles, and bundles are containers of bitstreams. Containers usually have ADD/REMOVE/READ/WRITE policies, while bitstreams only have READ/WRITE policies.",
   "item.edit.authorizations.heading": "باستخدام هذا المحرر ، يمكنك عرض وتغيير سياسات مادة ما، بالإضافة إلى تغيير سياسات مكونات المادة الفردية: الحزم وتدفق البت. باختصار، المادة عبارة عن حاوية من الحزم، والحزم عبارة عن حاويات لتدفقات البت. للحاويات في المعتاد سياسات ADD/REMOVE/READ/WRITE ، بينما يكون لتدفقات البت سياسات READ/WRITE فقط.",
@@ -3676,8 +3477,7 @@
   "item.edit.authorizations.title": "تحرير سياسات المادة",
 
   // "item.badge.status": "Item status:",
-  // TODO New key - Add a translation
-  "item.badge.status": "Item status:",
+  "item.badge.status": "حالة المادة:",
 
   // "item.badge.private": "Non-discoverable",
   "item.badge.private": "غير قابل للاكتشاف",
@@ -3734,12 +3534,10 @@
   "item.edit.bitstreams.bundle.name": "الحزمة: {{ name }}",
 
   // "item.edit.bitstreams.bundle.table.aria-label": "Bitstreams in the  {{ bundle }} Bundle",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.bundle.table.aria-label": "Bitstreams in the  {{ bundle }} Bundle",
+  "item.edit.bitstreams.bundle.table.aria-label": "تدفقات البت في الحزمة {{ bundle }}",
 
   // "item.edit.bitstreams.bundle.tooltip": "You can move a bitstream to a different page by dropping it on the page number.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.bundle.tooltip": "You can move a bitstream to a different page by dropping it on the page number.",
+  "item.edit.bitstreams.bundle.tooltip": "يمكنك نقل تدفق بت إلى صفحة أخرى عبر إسقاطه على رقم الصفحة.",
 
   // "item.edit.bitstreams.discard-button": "Discard",
   "item.edit.bitstreams.discard-button": "تجاهل",
@@ -3760,31 +3558,25 @@
   "item.edit.bitstreams.edit.buttons.undo": "التراجع عن التغييرات",
 
   // "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} was returned to position {{ toIndex }} and is no longer selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} was returned to position {{ toIndex }} and is no longer selected.",
+  "item.edit.bitstreams.edit.live.cancel": "تمت إعادة {{ bitstream }} إلى الموضع {{ toIndex }} ولم يعد محددًا.",
 
   // "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} is no longer selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} is no longer selected.",
+  "item.edit.bitstreams.edit.live.clear": "لم يعد {{ bitstream }} محددًا.",
 
   // "item.edit.bitstreams.edit.live.loading": "Waiting for move to complete.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.loading": "Waiting for move to complete.",
+  "item.edit.bitstreams.edit.live.loading": "بانتظار اكتمال عملية النقل.",
 
   // "item.edit.bitstreams.edit.live.select": "{{ bitstream }} is selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.select": "{{ bitstream }} is selected.",
+  "item.edit.bitstreams.edit.live.select": "تم تحديد {{ bitstream }}.",
 
   // "item.edit.bitstreams.edit.live.move": "{{ bitstream }} is now in position {{ toIndex }}.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.move": "{{ bitstream }} is now in position {{ toIndex }}.",
+  "item.edit.bitstreams.edit.live.move": "تم نقل {{ bitstream }} الآن إلى الموضع {{ toIndex }}.",
 
   // "item.edit.bitstreams.empty": "This item doesn't contain any bitstreams. Click the upload button to create one.",
   "item.edit.bitstreams.empty": "لا تحتوي هذه المادة على أية تدفقات بت. انقر على زر التحميل لإنشاء واحد.",
 
   // "item.edit.bitstreams.info-alert": "Bitstreams can be reordered within their bundles by holding the drag handle and moving the mouse. Alternatively, bitstreams can be moved using the keyboard in the following way: Select the bitstream by pressing enter when the bitstream's drag handle is in focus. Move the bitstream up or down using the arrow keys. Press enter again to confirm the current position of the bitstream.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.info-alert": "Bitstreams can be reordered within their bundles by holding the drag handle and moving the mouse. Alternatively, bitstreams can be moved using the keyboard in the following way: Select the bitstream by pressing enter when the bitstream's drag handle is in focus. Move the bitstream up or down using the arrow keys. Press enter again to confirm the current position of the bitstream.",
+  "item.edit.bitstreams.info-alert": "يمكن إعادة ترتيب تدفقات البت داخل حزمها عبر سحب مقبض السحب وتحريك الفأرة. بدلاً من ذلك، يمكن نقل تدفقات البت بلوحة المفاتيح كما يلي: حدد تدفق البت بالضغط على Enter عندما يكون مقبض السحب في التركيز. حرّك تدفق البت لأعلى أو لأسفل باستخدام مفاتيح الأسهم. اضغط Enter مرة أخرى لتأكيد الموضع الحالي لتدفق البت.",
 
   // "item.edit.bitstreams.headers.actions": "Actions",
   "item.edit.bitstreams.headers.actions": "إجراءات",
@@ -3841,8 +3633,7 @@
   "item.edit.bitstreams.upload-button": "تحميل",
 
   // "item.edit.bitstreams.load-more.link": "Load more",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.load-more.link": "Load more",
+  "item.edit.bitstreams.load-more.link": "تحميل المزيد",
 
   // "item.edit.delete.cancel": "Cancel",
   "item.edit.delete.cancel": "إلغاء",
@@ -4007,16 +3798,13 @@
   "item.edit.metadata.edit.value": "تحرير القيمة",
 
   // "item.edit.metadata.edit.authority.key": "Edit authority key",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.authority.key": "Edit authority key",
+  "item.edit.metadata.edit.authority.key": "تحرير مفتاح الاستناد",
 
   // "item.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
+  "item.edit.metadata.edit.buttons.enable-free-text-editing": "تمكين تحرير النص الحر",
 
   // "item.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
+  "item.edit.metadata.edit.buttons.disable-free-text-editing": "تعطيل تحرير النص الحر",
 
   // "item.edit.metadata.edit.buttons.confirm": "Confirm",
   "item.edit.metadata.edit.buttons.confirm": "تأكيد",
@@ -4100,16 +3888,13 @@
   "item.edit.metadata.save-button": "حفظ",
 
   // "item.edit.metadata.authority.label": "Authority: ",
-  // TODO New key - Add a translation
-  "item.edit.metadata.authority.label": "Authority: ",
+  "item.edit.metadata.authority.label": "الاستناد: ",
 
   // "item.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.open-authority-edition": "فتح قيمة مفتاح الاستناد للتحرير اليدوي",
 
   // "item.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.close-authority-edition": "قفل قيمة مفتاح الاستناد للتحرير اليدوي",
 
   // "item.edit.modify.overview.field": "Field",
   "item.edit.modify.overview.field": "حقل",
@@ -4412,29 +4197,25 @@
   "item.page.description": "الوصف",
 
   // "item.page.org-unit": "Organizational Unit",
-  // TODO New key - Add a translation
-  "item.page.org-unit": "Organizational Unit",
+  "item.page.org-unit": "وحدة مؤسسية",
 
   // "item.page.org-units": "Organizational Units",
   "item.page.org-units": "وحدات مؤسسية",
 
   // "item.page.project": "Research Project",
-  // TODO New key - Add a translation
-  "item.page.project": "Research Project",
+  "item.page.project": "مشروع بحثي",
 
   // "item.page.projects": "Research Projects",
   "item.page.projects": "مشاريع البحث",
 
   // "item.page.publication": "Publications",
-  // TODO New key - Add a translation
-  "item.page.publication": "Publications",
+  "item.page.publication": "منشورات",
 
   // "item.page.publications": "Publications",
   "item.page.publications": "منشورات",
 
   // "item.page.article": "Article",
-  // TODO New key - Add a translation
-  "item.page.article": "Article",
+  "item.page.article": "مقالة",
 
   // "item.page.articles": "Articles",
   "item.page.articles": "مقالات",
@@ -4443,8 +4224,7 @@
   "item.page.journal": "الدورية",
 
   // "item.page.journals": "Journals",
-  // TODO New key - Add a translation
-  "item.page.journals": "Journals",
+  "item.page.journals": "الدوريات",
 
   // "item.page.journal-issue": "Journal Issue",
   "item.page.journal-issue": "عدد الدورية",
@@ -4474,8 +4254,7 @@
   "item.page.volume-title": "عنوان المجلد",
 
   // "item.page.dcterms.spatial": "Geospatial point",
-  // TODO New key - Add a translation
-  "item.page.dcterms.spatial": "Geospatial point",
+  "item.page.dcterms.spatial": "نقطة جغرافية",
 
   // "item.search.results.head": "Item Search Results",
   "item.search.results.head": "نتائج بحث المواد",
@@ -4490,20 +4269,16 @@
   "item.truncatable-part.show-less": "طي",
 
   // "item.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
-  "item.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "item.qa-event-notification.check.notification-info": "هناك {{num}} اقتراحات قيد الانتظار مرتبطة بحسابك",
 
   // "item.qa-event-notification-info.check.button": "View",
-  // TODO New key - Add a translation
-  "item.qa-event-notification-info.check.button": "View",
+  "item.qa-event-notification-info.check.button": "عرض",
 
   // "mydspace.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
-  "mydspace.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "mydspace.qa-event-notification.check.notification-info": "هناك {{num}} اقتراحات قيد الانتظار مرتبطة بحسابك",
 
   // "mydspace.qa-event-notification-info.check.button": "View",
-  // TODO New key - Add a translation
-  "mydspace.qa-event-notification-info.check.button": "View",
+  "mydspace.qa-event-notification-info.check.button": "عرض",
 
   // "workflow-item.search.result.delete-supervision.modal.header": "Delete Supervision Order",
   "workflow-item.search.result.delete-supervision.modal.header": "حذف أمر الإشراف",
@@ -4530,47 +4305,37 @@
   "workflow-item.search.result.list.element.supervised.remove-tooltip": "إزالة مجموعة الإشراف",
 
   // "confidence.indicator.help-text.accepted": "This authority value has been confirmed as accurate by an interactive user",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.accepted": "This authority value has been confirmed as accurate by an interactive user",
+  "confidence.indicator.help-text.accepted": "تم تأكيد دقة قيمة الاستناد هذه بواسطة مستخدم تفاعلي",
 
   // "confidence.indicator.help-text.uncertain": "Value is singular and valid but has not been seen and accepted by a human so it is still uncertain",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.uncertain": "Value is singular and valid but has not been seen and accepted by a human so it is still uncertain",
+  "confidence.indicator.help-text.uncertain": "القيمة مفردة وصحيحة ولكن لم يطلع عليها إنسان ويقبلها بعد، لذا فهي غير مؤكدة",
 
   // "confidence.indicator.help-text.ambiguous": "There are multiple matching authority values of equal validity",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.ambiguous": "There are multiple matching authority values of equal validity",
+  "confidence.indicator.help-text.ambiguous": "توجد قيم استناد مطابقة متعددة بنفس الدرجة من الصلاحية",
 
   // "confidence.indicator.help-text.notfound": "There are no matching answers in the authority",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.notfound": "There are no matching answers in the authority",
+  "confidence.indicator.help-text.notfound": "لا توجد إجابات مطابقة في الاستناد",
 
   // "confidence.indicator.help-text.failed": "The authority encountered an internal failure",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.failed": "The authority encountered an internal failure",
+  "confidence.indicator.help-text.failed": "واجه نظام الاستناد خطأً داخليًا",
 
   // "confidence.indicator.help-text.rejected": "The authority recommends this submission be rejected",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.rejected": "The authority recommends this submission be rejected",
+  "confidence.indicator.help-text.rejected": "يوصي نظام الاستناد برفض هذا التقديم",
 
   // "confidence.indicator.help-text.novalue": "No reasonable confidence value was returned from the authority",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.novalue": "No reasonable confidence value was returned from the authority",
+  "confidence.indicator.help-text.novalue": "لم تُرجع خدمة الاستناد قيمة ثقة معقولة لهذه القيمة",
 
   // "confidence.indicator.help-text.unset": "Confidence was never recorded for this value",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.unset": "Confidence was never recorded for this value",
+  "confidence.indicator.help-text.unset": "لم تُسجل قيمة الثقة لهذه القيمة",
 
   // "confidence.indicator.help-text.unknown": "Unknown confidence value",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.unknown": "Unknown confidence value",
+  "confidence.indicator.help-text.unknown": "قيمة ثقة غير معروفة",
 
   // "item.page.abstract": "Abstract",
   "item.page.abstract": "خلاصة",
 
   // "item.page.author": "Author",
-  // TODO New key - Add a translation
-  "item.page.author": "Author",
+  "item.page.author": "المؤلف",
 
   // "item.page.authors": "Authors",
   "item.page.authors": "المؤلفين",
@@ -4621,8 +4386,7 @@
   "item.page.link.simple": "صفحة المادة البسيطة",
 
   // "item.page.options": "Options",
-  // TODO New key - Add a translation
-  "item.page.options": "Options",
+  "item.page.options": "خيارات",
 
   // "item.page.orcid.title": "ORCID",
   "item.page.orcid.title": "أوركيد",
@@ -4664,8 +4428,7 @@
   "item.page.bitstreams.collapse": "طي",
 
   // "item.page.bitstreams.primary": "Primary",
-  // TODO New key - Add a translation
-  "item.page.bitstreams.primary": "Primary",
+  "item.page.bitstreams.primary": "رئيسي",
 
   // "item.page.filesection.original.bundle": "Original bundle",
   "item.page.filesection.original.bundle": "الحزمة الرئيسية",
@@ -4680,16 +4443,13 @@
   "item.page.version.create": "إنشاء إصدارة جديدة",
 
   // "item.page.withdrawn": "Request a withdrawal for this item",
-  // TODO New key - Add a translation
-  "item.page.withdrawn": "Request a withdrawal for this item",
+  "item.page.withdrawn": "طلب سحب هذه المادة",
 
   // "item.page.reinstate": "Request reinstatement",
-  // TODO New key - Add a translation
-  "item.page.reinstate": "Request reinstatement",
+  "item.page.reinstate": "طلب إعادة تفعيل المادة",
 
   // "item.page.version.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
-  "item.page.version.hasDraft": "لا يمكن إنشاء إصدارة جديدة نظراً لوجود تقديم قيد التقدم في سجل الإصدارة",
+  "item.page.version.hasDraft": "لا يمكن إنشاء إصدارة جديدة نظرًا لوجود تقديم قيد المعالجة في سجل الإصدارات",
 
   // "item.page.claim.button": "Claim",
   "item.page.claim.button": "مطالبة",
@@ -4710,8 +4470,7 @@
   "item.preview.dc.date.issued": "تاريخ النشر:",
 
   // "item.preview.dc.description": "Description:",
-  // TODO New key - Add a translation
-  "item.preview.dc.description": "Description:",
+  "item.preview.dc.description": "الوصف:",
 
   // "item.preview.dc.description.abstract": "Abstract:",
   "item.preview.dc.description.abstract": "مستخلص:",
@@ -4732,8 +4491,7 @@
   "item.preview.dc.type": "النوع:",
 
   // "item.preview.oaire.version": "Version",
-  // TODO New key - Add a translation
-  "item.preview.oaire.version": "Version",
+  "item.preview.oaire.version": "الإصدارة",
 
   // "item.preview.oaire.citation.issue": "Issue",
   "item.preview.oaire.citation.issue": "العدد",
@@ -4742,32 +4500,25 @@
   "item.preview.oaire.citation.volume": "المجلد",
 
   // "item.preview.oaire.citation.title": "Citation container",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.title": "Citation container",
+  "item.preview.oaire.citation.title": "حاوية الاستشهاد",
 
   // "item.preview.oaire.citation.startPage": "Citation start page",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.startPage": "Citation start page",
+  "item.preview.oaire.citation.startPage": "صفحة بداية الاستشهاد",
 
   // "item.preview.oaire.citation.endPage": "Citation end page",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.endPage": "Citation end page",
+  "item.preview.oaire.citation.endPage": "صفحة نهاية الاستشهاد",
 
   // "item.preview.dc.relation.hasversion": "Has version",
-  // TODO New key - Add a translation
-  "item.preview.dc.relation.hasversion": "Has version",
+  "item.preview.dc.relation.hasversion": "يحتوي على إصدارة",
 
   // "item.preview.dc.relation.ispartofseries": "Is part of series",
-  // TODO New key - Add a translation
-  "item.preview.dc.relation.ispartofseries": "Is part of series",
+  "item.preview.dc.relation.ispartofseries": "جزء من سلسلة",
 
   // "item.preview.dc.rights": "Rights",
-  // TODO New key - Add a translation
-  "item.preview.dc.rights": "Rights",
+  "item.preview.dc.rights": "الحقوق",
 
   // "item.preview.dc.identifier.other": "Other Identifier",
-  // TODO Source message changed - Revise the translation
-  "item.preview.dc.identifier.other": "معرف آخر:",
+  "item.preview.dc.identifier.other": "معرف آخر",
 
   // "item.preview.dc.relation.issn": "ISSN",
   "item.preview.dc.relation.issn": "ISSN",
@@ -4797,8 +4548,7 @@
   "item.preview.person.identifier.orcid": "أوركيد:",
 
   // "item.preview.person.affiliation.name": "Affiliations:",
-  // TODO New key - Add a translation
-  "item.preview.person.affiliation.name": "Affiliations:",
+  "item.preview.person.affiliation.name": "الانتماءات:",
 
   // "item.preview.project.funder.name": "Funder:",
   "item.preview.project.funder.name": "الممول:",
@@ -4807,8 +4557,7 @@
   "item.preview.project.funder.identifier": "معرف الممول:",
 
   // "item.preview.project.investigator": "Project Investigator",
-  // TODO New key - Add a translation
-  "item.preview.project.investigator": "Project Investigator",
+  "item.preview.project.investigator": "المحقق في المشروع",
 
   // "item.preview.oaire.awardNumber": "Funding ID:",
   "item.preview.oaire.awardNumber": "معرف التمويل:",
@@ -4832,8 +4581,7 @@
   "item.preview.organization.foundingDate": "تاريخ التأسيس",
 
   // "item.preview.organization.identifier.crossrefid": "Crossref ID",
-  // TODO Source message changed - Revise the translation
-  "item.preview.organization.identifier.crossrefid": "CrossRef معرف",
+  "item.preview.organization.identifier.crossrefid": "معرّف Crossref",
 
   // "item.preview.organization.identifier.isni": "ISNI",
   "item.preview.organization.identifier.isni": "ISNI",
@@ -4845,28 +4593,22 @@
   "item.preview.organization.legalName": "الاسم القانوني",
 
   // "item.preview.dspace.entity.type": "Entity Type:",
-  // TODO New key - Add a translation
-  "item.preview.dspace.entity.type": "Entity Type:",
+  "item.preview.dspace.entity.type": "نوع الكينونة:",
 
   // "item.preview.creativework.publisher": "Publisher",
-  // TODO New key - Add a translation
-  "item.preview.creativework.publisher": "Publisher",
+  "item.preview.creativework.publisher": "الناشر",
 
   // "item.preview.creativeworkseries.issn": "ISSN",
-  // TODO New key - Add a translation
   "item.preview.creativeworkseries.issn": "ISSN",
 
   // "item.preview.dc.identifier.issn": "ISSN",
-  // TODO New key - Add a translation
   "item.preview.dc.identifier.issn": "ISSN",
 
   // "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
-  // TODO New key - Add a translation
-  "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
+  "item.preview.dc.identifier.openalex": "معرّف OpenAlex",
 
   // "item.preview.dc.description": "Description",
-  // TODO New key - Add a translation
-  "item.preview.dc.description": "Description",
+  "item.preview.dc.description": "الوصف",
 
   // "item.select.confirm": "Confirm selected",
   "item.select.confirm": "تأكيد المحدد",
@@ -4950,8 +4692,7 @@
   "item.version.history.table.action.deleteVersion": "حذف الإصدارة",
 
   // "item.version.history.table.action.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
-  "item.version.history.table.action.hasDraft": "لا يمكن إنشاء إصدارة جديدة نظراً لوجود تقديم قيد التقدم في سجل الإصدارة",
+  "item.version.history.table.action.hasDraft": "لا يمكن إنشاء إصدارة جديدة نظرًا لوجود تقديم قيد المعالجة في سجل الإصدارات",
 
   // "item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
   "item.version.notice": "هذه ليست آخر إصدارة من هذه المادة. يمكن العثور على آخر إصدارة من <a href='{{destination}}'>هنا</a>.",
@@ -4960,16 +4701,13 @@
   "item.version.create.modal.header": "إصدارة جديدة",
 
   // "item.qa.withdrawn.modal.header": "Request withdrawal",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn.modal.header": "Request withdrawal",
+  "item.qa.withdrawn.modal.header": "طلب سحب",
 
   // "item.qa.reinstate.modal.header": "Request reinstate",
-  // TODO New key - Add a translation
-  "item.qa.reinstate.modal.header": "Request reinstate",
+  "item.qa.reinstate.modal.header": "طلب إعادة التفعيل",
 
   // "item.qa.reinstate.create.modal.header": "New version",
-  // TODO New key - Add a translation
-  "item.qa.reinstate.create.modal.header": "New version",
+  "item.qa.reinstate.create.modal.header": "إصدارة جديدة",
 
   // "item.version.create.modal.text": "Create a new version for this item",
   "item.version.create.modal.text": "إنشاء إصدارة جديدة لهذه المادة",
@@ -4984,75 +4722,61 @@
   "item.version.create.modal.button.confirm.tooltip": "إنشاء إصدارة جديدة",
 
   // "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Send request",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Send request",
+  "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "إرسال الطلب",
 
   // "qa-withdrown.create.modal.button.confirm": "Withdraw",
-  // TODO New key - Add a translation
-  "qa-withdrown.create.modal.button.confirm": "Withdraw",
+  "qa-withdrown.create.modal.button.confirm": "سحب",
 
   // "qa-reinstate.create.modal.button.confirm": "Reinstate",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.button.confirm": "Reinstate",
+  "qa-reinstate.create.modal.button.confirm": "إعادة التفعيل",
 
   // "item.version.create.modal.button.cancel": "Cancel",
   "item.version.create.modal.button.cancel": "إلغاء",
 
   // "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Cancel",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel": "إلغاء",
 
   // "item.version.create.modal.button.cancel.tooltip": "Do not create new version",
   "item.version.create.modal.button.cancel.tooltip": "لا تقم بإنشاء إصدارة جديدة",
 
   // "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Do not send request",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Do not send request",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "عدم إرسال الطلب",
 
   // "item.version.create.modal.form.summary.label": "Summary",
   "item.version.create.modal.form.summary.label": "الملخص",
 
   // "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
-  // TODO New key - Add a translation
-  "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
+  "qa-withdrawn.create.modal.form.summary.label": "أنت تطلب سحب هذه المادة",
 
   // "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
-  // TODO New key - Add a translation
-  "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
+  "qa-withdrawn.create.modal.form.summary2.label": "يرجى إدخال سبب السحب",
 
   // "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
+  "qa-reinstate.create.modal.form.summary.label": "أنت تطلب إعادة تفعيل هذه المادة",
 
   // "qa-reinstate.create.modal.form.summary2.label": "Please enter the reason for the reinstatment",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.form.summary2.label": "Please enter the reason for the reinstatment",
+  "qa-reinstate.create.modal.form.summary2.label": "يرجى إدخال سبب إعادة التفعيل",
 
   // "item.version.create.modal.form.summary.placeholder": "Insert the summary for the new version",
   "item.version.create.modal.form.summary.placeholder": "قم بإدخال ملخص الإصدارة الجديدة",
 
   // "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
-  // TODO New key - Add a translation
-  "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
+  "qa-withdrown.modal.form.summary.placeholder": "أدخل سبب السحب",
 
   // "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
-  // TODO New key - Add a translation
-  "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
+  "qa-reinstate.modal.form.summary.placeholder": "أدخل سبب إعادة التفعيل",
 
   // "item.version.create.modal.submitted.header": "Creating new version...",
   "item.version.create.modal.submitted.header": "إنشاء إصدارة جديدة...",
 
   // "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
+  "item.qa.withdrawn.modal.submitted.header": "جاري إرسال طلب السحب...",
 
   // "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
-  // TODO New key - Add a translation
-  "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
+  "correction-type.manage-relation.action.notification.reinstate": "تم إرسال طلب إعادة التفعيل.",
 
   // "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
-  // TODO New key - Add a translation
-  "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
+  "correction-type.manage-relation.action.notification.withdrawn": "تم إرسال طلب السحب.",
 
   // "item.version.create.modal.submitted.text": "The new version is being created. This may take some time if the item has a lot of relationships.",
   "item.version.create.modal.submitted.text": "جاري إنشاء الإصدارة الجديدة. قد يستغرق هذا بعض الوقت إذا كان لهذه المادة الكثير من العلاقات.",
@@ -5064,8 +4788,7 @@
   "item.version.create.notification.failure": "لم يتم إنشاء إصدارة جديدة",
 
   // "item.version.create.notification.inProgress": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
-  "item.version.create.notification.inProgress": "لا يمكن إنشاء إصدارة جديدة نظراً لوجود تقديم قيد التقدم في سجل الإصدارة",
+  "item.version.create.notification.inProgress": "لا يمكن إنشاء إصدارة جديدة نظرًا لوجود تقديم قيد المعالجة في سجل الإصدارات",
 
   // "item.version.delete.modal.header": "Delete version",
   "item.version.delete.modal.header": "حذف الإصدارة",
@@ -5206,8 +4929,7 @@
   "journal.page.publisher": "الناشر",
 
   // "journal.page.options": "Options",
-  // TODO New key - Add a translation
-  "journal.page.options": "Options",
+  "journal.page.options": "خيارات",
 
   // "journal.page.titleprefix": "Journal: ",
   "journal.page.titleprefix": "الدورية: ",
@@ -5246,8 +4968,7 @@
   "journalissue.page.number": "رقم",
 
   // "journalissue.page.options": "Options",
-  // TODO New key - Add a translation
-  "journalissue.page.options": "Options",
+  "journalissue.page.options": "خيارات",
 
   // "journalissue.page.titleprefix": "Journal Issue: ",
   "journalissue.page.titleprefix": "عدد الدورية: ",
@@ -5268,8 +4989,7 @@
   "journalvolume.page.issuedate": "تاريخ الإصدار",
 
   // "journalvolume.page.options": "Options",
-  // TODO New key - Add a translation
-  "journalvolume.page.options": "Options",
+  "journalvolume.page.options": "خيارات",
 
   // "journalvolume.page.titleprefix": "Journal Volume: ",
   "journalvolume.page.titleprefix": "مجلد دورية: ",
@@ -5389,8 +5109,7 @@
   "login.form.password": "كلمة المرور",
 
   // "login.form.saml": "Log in with SAML",
-  // TODO New key - Add a translation
-  "login.form.saml": "Log in with SAML",
+  "login.form.saml": "تسجيل الدخول باستخدام SAML",
 
   // "login.form.shibboleth": "Log in with Shibboleth",
   "login.form.shibboleth": "تسجيل الدخول باستخدام Shibboleth",
@@ -5414,8 +5133,7 @@
   "logout.title": "خروج",
 
   // "menu.header.nav.description": "Admin navigation bar",
-  // TODO New key - Add a translation
-  "menu.header.nav.description": "Admin navigation bar",
+  "menu.header.nav.description": "شريط تنقل المسؤول",
 
   // "menu.header.admin": "Management",
   "menu.header.admin": "إدارة",
@@ -5442,16 +5160,13 @@
   "menu.section.access_control_people": "أشخاص",
 
   // "menu.section.reports": "Reports",
-  // TODO New key - Add a translation
-  "menu.section.reports": "Reports",
+  "menu.section.reports": "تقارير",
 
   // "menu.section.reports.collections": "Filtered Collections",
-  // TODO New key - Add a translation
-  "menu.section.reports.collections": "Filtered Collections",
+  "menu.section.reports.collections": "حاويات مُفلترة",
 
   // "menu.section.reports.queries": "Metadata Query",
-  // TODO New key - Add a translation
-  "menu.section.reports.queries": "Metadata Query",
+  "menu.section.reports.queries": "استعلام البيانات الوصفية",
 
   // "menu.section.admin_search": "Admin Search",
   "menu.section.admin_search": "بحث إداري",
@@ -5469,7 +5184,7 @@
   "menu.section.browse_community_by_title": "حسب العنوان",
 
   // "menu.section.browse_global": "All of DSpace",
-  "menu.section.browse_global": "كل دي سبيس",
+  "menu.section.browse_global": "كل الدي سبيس",
 
   // "menu.section.browse_global_by_author": "By Author",
   "menu.section.browse_global_by_author": "حسب المؤلف",
@@ -5493,8 +5208,7 @@
   "menu.section.browse_global_communities_and_collections": "المجتمعات والحاويات",
 
   // "menu.section.browse_global_geospatial_map": "By Geolocation (Map)",
-  // TODO New key - Add a translation
-  "menu.section.browse_global_geospatial_map": "By Geolocation (Map)",
+  "menu.section.browse_global_geospatial_map": "حسب الموقع الجغرافي (خريطة)",
 
   // "menu.section.control_panel": "Control Panel",
   "menu.section.control_panel": "لوحة التحكم",
@@ -5536,8 +5250,7 @@
   "menu.section.icon.access_control": "قسم قائمة التحكم في الوصول",
 
   // "menu.section.icon.reports": "Reports menu section",
-  // TODO New key - Add a translation
-  "menu.section.icon.reports": "Reports menu section",
+  "menu.section.icon.reports": "قسم قائمة التقارير",
 
   // "menu.section.icon.admin_search": "Admin search menu section",
   "menu.section.icon.admin_search": "قسم قائمة البحث الإداري",
@@ -5609,8 +5322,7 @@
   "menu.section.quality-assurance": "ضمان الجودة",
 
   // "menu.section.notifications_publication-claim": "Publication Claim",
-  // TODO New key - Add a translation
-  "menu.section.notifications_publication-claim": "Publication Claim",
+  "menu.section.notifications_publication-claim": "مطالبة بمنشور",
 
   // "menu.section.pin": "Pin sidebar",
   "menu.section.pin": "تدبيس الشريط الجانبي",
@@ -5643,8 +5355,7 @@
   "menu.section.toggle.access_control": "قسم التحكم في الوصول للبدل",
 
   // "menu.section.toggle.reports": "Toggle Reports section",
-  // TODO New key - Add a translation
-  "menu.section.toggle.reports": "Toggle Reports section",
+  "menu.section.toggle.reports": "تبديل قسم التقارير",
 
   // "menu.section.toggle.control_panel": "Toggle Control Panel section",
   "menu.section.toggle.control_panel": "قسم لوحة التحكم في البدل",
@@ -5779,8 +5490,7 @@
   "mydspace.show.supervisedWorkspace": "مواد تحت الإشراف",
 
   // "mydspace.status": "My DSpace status:",
-  // TODO New key - Add a translation
-  "mydspace.status": "My DSpace status:",
+  "mydspace.status": "حالة ماي دي سبيس:",
 
   // "mydspace.status.mydspaceArchived": "Archived",
   "mydspace.status.mydspaceArchived": "في الأرشيف",
@@ -5816,23 +5526,19 @@
   "mydspace.view-btn": "عرض",
 
   // "nav.expandable-navbar-section-suffix": "(submenu)",
-  // TODO New key - Add a translation
-  "nav.expandable-navbar-section-suffix": "(submenu)",
+  "nav.expandable-navbar-section-suffix": "(قائمة فرعية)",
 
   // "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
-  // TODO New key - Add a translation
-  "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
+  "notification.suggestion": "لقد وجدنا <b>{{count}} منشوراً</b> في {{source}} تبدو ذات صلة بملفك الشخصي.<br>",
 
   // "notification.suggestion.review": "review the suggestions",
-  // TODO New key - Add a translation
-  "notification.suggestion.review": "review the suggestions",
+  "notification.suggestion.review": "مراجعة المقترحات",
 
   // "notification.suggestion.please": "Please",
-  // TODO New key - Add a translation
-  "notification.suggestion.please": "Please",
+  "notification.suggestion.please": "يرجى",
 
   // "nav.browse.header": "All of DSpace",
-  "nav.browse.header": "كل دي سبيس",
+  "nav.browse.header": "تصفح",
 
   // "nav.community-browse.header": "By Community",
   "nav.community-browse.header": "حسب المجتمع",
@@ -5883,19 +5589,16 @@
   "nav.user.description": "شريط ملف تعريف المستخدم",
 
   // "listelement.badge.dso-type": "Item type:",
-  // TODO New key - Add a translation
-  "listelement.badge.dso-type": "Item type:",
+  "listelement.badge.dso-type": "نوع المادة:",
 
   // "none.listelement.badge": "Item",
   "none.listelement.badge": "المادة",
 
   // "publication-claim.title": "Publication claim",
-  // TODO New key - Add a translation
-  "publication-claim.title": "Publication claim",
+  "publication-claim.title": "مطالبة بمنشور",
 
   // "publication-claim.source.description": "Below you can see all the sources.",
-  // TODO New key - Add a translation
-  "publication-claim.source.description": "Below you can see all the sources.",
+  "publication-claim.source.description": "يمكنك أدناه رؤية جميع المصادر.",
 
   // "quality-assurance.title": "Quality Assurance",
   "quality-assurance.title": "ضمان الجودة",
@@ -5925,12 +5628,10 @@
   "quality-assurance.table.actions": "إجراءات",
 
   // "quality-assurance.source-list.button.detail": "Show topics for {{param}}",
-  // TODO New key - Add a translation
-  "quality-assurance.source-list.button.detail": "Show topics for {{param}}",
+  "quality-assurance.source-list.button.detail": "عرض المواضيع لـ {{param}}",
 
   // "quality-assurance.topics-list.button.detail": "Show suggestions for {{param}}",
-  // TODO New key - Add a translation
-  "quality-assurance.topics-list.button.detail": "Show suggestions for {{param}}",
+  "quality-assurance.topics-list.button.detail": "عرض الاقتراحات لـ {{param}}",
 
   // "quality-assurance.noTopics": "No topics found.",
   "quality-assurance.noTopics": "لم يتم العثور على مواضيع.",
@@ -5969,8 +5670,7 @@
   "quality-assurance.event.table.project-details": "تفاصيل المشروع",
 
   // "quality-assurance.event.table.reasons": "Reasons",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.reasons": "Reasons",
+  "quality-assurance.event.table.reasons": "الأسباب",
 
   // "quality-assurance.event.table.actions": "Actions",
   "quality-assurance.event.table.actions": "إجراءات",
@@ -5982,8 +5682,7 @@
   "quality-assurance.event.action.ignore": "تجاهل الاقتراح",
 
   // "quality-assurance.event.action.undo": "Delete",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.undo": "Delete",
+  "quality-assurance.event.action.undo": "حذف",
 
   // "quality-assurance.event.action.reject": "Reject suggestion",
   "quality-assurance.event.action.reject": "رفض الاقتراح",
@@ -6028,8 +5727,7 @@
   "quality-assurance.events.back": "رجوع إلى المواضيع",
 
   // "quality-assurance.events.back-to-sources": "Back to sources",
-  // TODO New key - Add a translation
-  "quality-assurance.events.back-to-sources": "Back to sources",
+  "quality-assurance.events.back-to-sources": "الرجوع إلى المصادر",
 
   // "quality-assurance.event.table.less": "Show less",
   "quality-assurance.event.table.less": "عرض أقل",
@@ -6050,8 +5748,7 @@
   "quality-assurance.event.ignore.description": "لا يمكن التراجع عن هذه العملية. تجاهل هذا الاقتراح؟",
 
   // "quality-assurance.event.undo.description": "This operation can't be undone!",
-  // TODO New key - Add a translation
-  "quality-assurance.event.undo.description": "This operation can't be undone!",
+  "quality-assurance.event.undo.description": "لا يمكن التراجع عن هذه العملية!",
 
   // "quality-assurance.event.reject.description": "This operation can't be undone. Reject this suggestion?",
   "quality-assurance.event.reject.description": "لا يمكن التراجع عن هذه العملية. هل ترفض هذا الاقتراح؟",
@@ -6138,8 +5835,7 @@
   "orgunit.page.id": "المعرف",
 
   // "orgunit.page.options": "Options",
-  // TODO New key - Add a translation
-  "orgunit.page.options": "Options",
+  "orgunit.page.options": "خيارات",
 
   // "orgunit.page.titleprefix": "Organizational Unit: ",
   "orgunit.page.titleprefix": "الوحدة المؤسسية: ",
@@ -6181,8 +5877,7 @@
   "person.page.email": "عنوان البريد الإلكتروني",
 
   // "person.page.firstname": "First Name",
-  // TODO New key - Add a translation
-  "person.page.firstname": "First Name",
+  "person.page.firstname": "الاسم الأول",
 
   // "person.page.jobtitle": "Job Title",
   "person.page.jobtitle": "المسمي الوظيفي",
@@ -6197,8 +5892,7 @@
   "person.page.link.full": "عرض كل الميتاداتا",
 
   // "person.page.options": "Options",
-  // TODO New key - Add a translation
-  "person.page.options": "Options",
+  "person.page.options": "خيارات",
 
   // "person.page.orcid": "ORCID",
   "person.page.orcid": "أوركيد",
@@ -6363,28 +6057,22 @@
   "process.detail.delete.error": "حدث خطأ ما أثناء حذف العملية",
 
   // "process.detail.refreshing": "Auto-refreshing…",
-  // TODO New key - Add a translation
-  "process.detail.refreshing": "Auto-refreshing…",
+  "process.detail.refreshing": "تحديث تلقائي…",
 
   // "process.overview.table.completed.info": "Finish time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.completed.info": "Finish time (UTC)",
+  "process.overview.table.completed.info": "وقت الانتهاء (التوقيت العالمي)",
 
   // "process.overview.table.completed.title": "Succeeded processes",
-  // TODO New key - Add a translation
-  "process.overview.table.completed.title": "Succeeded processes",
+  "process.overview.table.completed.title": "عمليات ناجحة",
 
   // "process.overview.table.empty": "No matching processes found.",
-  // TODO New key - Add a translation
-  "process.overview.table.empty": "No matching processes found.",
+  "process.overview.table.empty": "لم يتم العثور على عمليات مطابقة.",
 
   // "process.overview.table.failed.info": "Finish time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.failed.info": "Finish time (UTC)",
+  "process.overview.table.failed.info": "وقت الانتهاء (التوقيت العالمي)",
 
   // "process.overview.table.failed.title": "Failed processes",
-  // TODO New key - Add a translation
-  "process.overview.table.failed.title": "Failed processes",
+  "process.overview.table.failed.title": "عمليات فاشلة",
 
   // "process.overview.table.finish": "Finish time (UTC)",
   "process.overview.table.finish": "وقت الانتهاء (التوقيت العالمي)",
@@ -6396,20 +6084,16 @@
   "process.overview.table.name": "الاسم",
 
   // "process.overview.table.running.info": "Start time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.running.info": "Start time (UTC)",
+  "process.overview.table.running.info": "وقت البدء (التوقيت العالمي)",
 
   // "process.overview.table.running.title": "Running processes",
-  // TODO New key - Add a translation
-  "process.overview.table.running.title": "Running processes",
+  "process.overview.table.running.title": "عمليات قيد التشغيل",
 
   // "process.overview.table.scheduled.info": "Creation time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.scheduled.info": "Creation time (UTC)",
+  "process.overview.table.scheduled.info": "وقت الإنشاء (التوقيت العالمي)",
 
   // "process.overview.table.scheduled.title": "Scheduled processes",
-  // TODO New key - Add a translation
-  "process.overview.table.scheduled.title": "Scheduled processes",
+  "process.overview.table.scheduled.title": "عمليات مجدولة",
 
   // "process.overview.table.start": "Start time (UTC)",
   "process.overview.table.start": "وقت البدء (التوقيت العالمي)",
@@ -6451,8 +6135,7 @@
   "process.overview.delete.header": "حذف العمليات",
 
   // "process.overview.unknown.user": "Unknown",
-  // TODO New key - Add a translation
-  "process.overview.unknown.user": "Unknown",
+  "process.overview.unknown.user": "غير معروف",
 
   // "process.bulk.delete.error.head": "Error on deleteing process",
   "process.bulk.delete.error.head": "خطأ في عملية الحذف",
@@ -6467,16 +6150,13 @@
   "profile.breadcrumbs": "تحديث الملف الشخصي",
 
   // "profile.card.accessibility.content": "Accessibility settings can be configured on the accessibility settings page.",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.content": "Accessibility settings can be configured on the accessibility settings page.",
+  "profile.card.accessibility.content": "يمكن تهيئة إعدادات إمكانية الوصول في صفحة إعدادات إمكانية الوصول.",
 
   // "profile.card.accessibility.header": "Accessibility",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.header": "Accessibility",
+  "profile.card.accessibility.header": "إمكانية الوصول",
 
   // "profile.card.accessibility.link": "Go to Accessibility Settings Page",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.link": "Go to Accessibility Settings Page",
+  "profile.card.accessibility.link": "اذهب إلى صفحة إعدادات إمكانية الوصول",
 
   // "profile.card.identify": "Identify",
   "profile.card.identify": "تعريف",
@@ -6590,8 +6270,7 @@
   "project.page.keyword": "كلمات رئيسية",
 
   // "project.page.options": "Options",
-  // TODO New key - Add a translation
-  "project.page.options": "Options",
+  "project.page.options": "خيارات",
 
   // "project.page.status": "Status",
   "project.page.status": "الحالة",
@@ -6624,8 +6303,7 @@
   "publication.page.publisher": "الناشر",
 
   // "publication.page.options": "Options",
-  // TODO New key - Add a translation
-  "publication.page.options": "Options",
+  "publication.page.options": "خيارات",
 
   // "publication.page.titleprefix": "Publication: ",
   "publication.page.titleprefix": "المنشور: ",
@@ -6652,139 +6330,105 @@
   "media-viewer.playlist": "قائمة التشغيل",
 
   // "suggestion.loading": "Loading ...",
-  // TODO New key - Add a translation
-  "suggestion.loading": "Loading ...",
+  "suggestion.loading": "جاري التحميل ...",
 
   // "suggestion.title": "Publication Claim",
-  // TODO New key - Add a translation
-  "suggestion.title": "Publication Claim",
+  "suggestion.title": "مطالبة بمنشور",
 
   // "suggestion.title.breadcrumbs": "Publication Claim",
-  // TODO New key - Add a translation
-  "suggestion.title.breadcrumbs": "Publication Claim",
+  "suggestion.title.breadcrumbs": "مطالبة بمنشور",
 
   // "suggestion.targets.description": "Below you can see all the suggestions ",
-  // TODO New key - Add a translation
-  "suggestion.targets.description": "Below you can see all the suggestions ",
+  "suggestion.targets.description": "أدناه يمكنك رؤية جميع الاقتراحات ",
 
   // "suggestion.targets": "Current Suggestions",
-  // TODO New key - Add a translation
-  "suggestion.targets": "Current Suggestions",
+  "suggestion.targets": "الاقتراحات الحالية",
 
   // "suggestion.table.name": "Researcher Name",
-  // TODO New key - Add a translation
-  "suggestion.table.name": "Researcher Name",
+  "suggestion.table.name": "اسم الباحث",
 
   // "suggestion.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "suggestion.table.actions": "Actions",
+  "suggestion.table.actions": "إجراءات",
 
   // "suggestion.button.review": "Review {{ total }} suggestion(s)",
-  // TODO New key - Add a translation
-  "suggestion.button.review": "Review {{ total }} suggestion(s)",
+  "suggestion.button.review": "مراجعة {{ total }} اقتراح",
 
   // "suggestion.button.review.title": "Review {{ total }} suggestion(s) for ",
-  // TODO New key - Add a translation
-  "suggestion.button.review.title": "Review {{ total }} suggestion(s) for ",
+  "suggestion.button.review.title": "مراجعة {{ total }} اقتراح لـ ",
 
   // "suggestion.noTargets": "No target found.",
-  // TODO New key - Add a translation
-  "suggestion.noTargets": "No target found.",
+  "suggestion.noTargets": "لم يتم العثور على هدف.",
 
   // "suggestion.target.error.service.retrieve": "An error occurred while loading the Suggestion targets",
-  // TODO New key - Add a translation
-  "suggestion.target.error.service.retrieve": "An error occurred while loading the Suggestion targets",
+  "suggestion.target.error.service.retrieve": "حدث خطأ أثناء تحميل أهداف الاقتراحات",
 
   // "suggestion.evidence.type": "Type",
-  // TODO New key - Add a translation
-  "suggestion.evidence.type": "Type",
+  "suggestion.evidence.type": "النوع",
 
   // "suggestion.evidence.score": "Score",
-  // TODO New key - Add a translation
-  "suggestion.evidence.score": "Score",
+  "suggestion.evidence.score": "النتيجة",
 
   // "suggestion.evidence.notes": "Notes",
-  // TODO New key - Add a translation
-  "suggestion.evidence.notes": "Notes",
+  "suggestion.evidence.notes": "ملاحظات",
 
   // "suggestion.approveAndImport": "Approve & import",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport": "Approve & import",
+  "suggestion.approveAndImport": "الموافقة والاستيراد",
 
   // "suggestion.approveAndImport.success": "The suggestion has been imported successfully. <a href='{{ url }}'>View.</a>",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.success": "The suggestion has been imported successfully. <a href='{{ url }}'>View.</a>",
+  "suggestion.approveAndImport.success": "تم استيراد الاقتراح بنجاح. <a href='{{ url }}'>عرض.</a>",
 
   // "suggestion.approveAndImport.bulk": "Approve & import Selected",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk": "Approve & import Selected",
+  "suggestion.approveAndImport.bulk": "الموافقة والاستيراد للمحدد",
 
   // "suggestion.approveAndImport.bulk.success": "{{ count }} suggestions have been imported successfully ",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk.success": "{{ count }} suggestions have been imported successfully ",
+  "suggestion.approveAndImport.bulk.success": "{{ count }} من المقترحات تم استيرادها بنجاح ",
 
   // "suggestion.approveAndImport.bulk.error": "{{ count }} suggestions haven't been imported due to unexpected server errors",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk.error": "{{ count }} suggestions haven't been imported due to unexpected server errors",
+  "suggestion.approveAndImport.bulk.error": "{{ count }} من المقترحات لم يتم استيرادها بسبب أخطاء غير متوقعة في الخادم",
 
   // "suggestion.ignoreSuggestion": "Ignore Suggestion",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion": "Ignore Suggestion",
+  "suggestion.ignoreSuggestion": "تجاهل الاقتراح",
 
   // "suggestion.ignoreSuggestion.success": "The suggestion has been discarded",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.success": "The suggestion has been discarded",
+  "suggestion.ignoreSuggestion.success": "تم تجاهل الاقتراح",
 
   // "suggestion.ignoreSuggestion.bulk": "Ignore Suggestion Selected",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk": "Ignore Suggestion Selected",
+  "suggestion.ignoreSuggestion.bulk": "تجاهل المقترحات المحددة",
 
   // "suggestion.ignoreSuggestion.bulk.success": "{{ count }} suggestions have been discarded ",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk.success": "{{ count }} suggestions have been discarded ",
+  "suggestion.ignoreSuggestion.bulk.success": "{{ count }} من المقترحات تم تجاهلها ",
 
   // "suggestion.ignoreSuggestion.bulk.error": "{{ count }} suggestions haven't been discarded due to unexpected server errors",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk.error": "{{ count }} suggestions haven't been discarded due to unexpected server errors",
+  "suggestion.ignoreSuggestion.bulk.error": "{{ count }} من المقترحات لم يتم تجاهلها بسبب أخطاء غير متوقعة في الخادم",
 
   // "suggestion.seeEvidence": "See evidence",
-  // TODO New key - Add a translation
-  "suggestion.seeEvidence": "See evidence",
+  "suggestion.seeEvidence": "عرض الأدلة",
 
   // "suggestion.hideEvidence": "Hide evidence",
-  // TODO New key - Add a translation
-  "suggestion.hideEvidence": "Hide evidence",
+  "suggestion.hideEvidence": "إخفاء الأدلة",
 
   // "suggestion.suggestionFor": "Suggestions for",
-  // TODO New key - Add a translation
-  "suggestion.suggestionFor": "Suggestions for",
+  "suggestion.suggestionFor": "اقتراحات لـ",
 
   // "suggestion.suggestionFor.breadcrumb": "Suggestions for {{ name }}",
-  // TODO New key - Add a translation
-  "suggestion.suggestionFor.breadcrumb": "Suggestions for {{ name }}",
+  "suggestion.suggestionFor.breadcrumb": "اقتراحات لـ {{ name }}",
 
   // "suggestion.source.openaire": "OpenAIRE Graph",
-  // TODO New key - Add a translation
   "suggestion.source.openaire": "OpenAIRE Graph",
 
   // "suggestion.source.openalex": "OpenAlex",
-  // TODO New key - Add a translation
   "suggestion.source.openalex": "OpenAlex",
 
   // "suggestion.from.source": "from the ",
-  // TODO New key - Add a translation
-  "suggestion.from.source": "from the ",
+  "suggestion.from.source": "من ",
 
   // "suggestion.count.missing": "You have no publication claims left",
-  // TODO New key - Add a translation
-  "suggestion.count.missing": "You have no publication claims left",
+  "suggestion.count.missing": "ليس لديك أي مطالبات منشورات متبقية",
 
   // "suggestion.totalScore": "Total Score",
-  // TODO New key - Add a translation
-  "suggestion.totalScore": "Total Score",
+  "suggestion.totalScore": "النتيجة الإجمالية",
 
   // "suggestion.type.openaire": "OpenAIRE",
-  // TODO New key - Add a translation
   "suggestion.type.openaire": "OpenAIRE",
 
   // "register-email.title": "New user registration",
@@ -6884,8 +6528,7 @@
   "register-page.registration.error.head": "خطأ أثناء محاولة تسجيل البريد الإلكتروني",
 
   // "register-page.registration.error.content": "An error occurred when registering the following email address: {{ email }}",
-  // TODO New key - Add a translation
-  "register-page.registration.error.content": "An error occurred when registering the following email address: {{ email }}",
+  "register-page.registration.error.content": "حدث خطأ عند تسجيل عنوان البريد الإلكتروني التالي: {{ email }}",
 
   // "register-page.registration.error.recaptcha": "Error when trying to authenticate with recaptcha",
   "register-page.registration.error.recaptcha": "حدث خطأ أثناء محاولة الاستيثاق باستخدام recaptcha",
@@ -6951,8 +6594,7 @@
   "relationships.Person.isOrgUnitOfPerson.OrgUnit": "وحدات مؤسسية",
 
   // "relationships.Person.isPublicationOfContributor.Publication": "Publications (contributor to)",
-  // TODO Source message changed - Revise the translation
-  "relationships.Person.isPublicationOfContributor.Publication": "منشورات",
+  "relationships.Person.isPublicationOfContributor.Publication": "منشورات (مساهم فيها)",
 
   // "relationships.Project.isPublicationOfProject.Publication": "Publications",
   "relationships.Project.isPublicationOfProject.Publication": "منشورات",
@@ -6979,12 +6621,10 @@
   "relationships.OrgUnit.isPublicationOfAuthor.Publication": "منشورات مؤلفة",
 
   // "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publications (contributor to)",
-  // TODO Source message changed - Revise the translation
-  "relationships.OrgUnit.isPublicationOfContributor.Publication": "منشورات",
+  "relationships.OrgUnit.isPublicationOfContributor.Publication": "منشورات (مساهم فيها)",
 
   // "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Research Projects (funder of)",
-  // TODO Source message changed - Revise the translation
-  "relationships.OrgUnit.isProjectOfFundingAgency.Project": "مشروعات البحث",
+  "relationships.OrgUnit.isProjectOfFundingAgency.Project": "مشاريع البحث (ممول لها)",
 
   // "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "Journal Volume",
   "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "مجلد الدورية",
@@ -7128,8 +6768,7 @@
   "resource-policies.form.name.label": "الاسم",
 
   // "resource-policies.form.name.hint": "Max 30 characters",
-  // TODO New key - Add a translation
-  "resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "بحد أقصى 30 محرفًا",
 
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "حدد نوع السياسة",
@@ -7219,8 +6858,7 @@
   "search.filters.remove": "إزالة المنقح من النوع {{ type }} بقيمة {{ value }}",
 
   // "search.filters.applied.f.title": "Title",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.title": "Title",
+  "search.filters.applied.f.title": "العنوان",
 
   // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "المؤلف",
@@ -7244,15 +6882,12 @@
   "search.filters.applied.f.has_content_in_original_bundle": "بها ملفات",
 
   // "search.filters.applied.f.original_bundle_filenames": "File name",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.original_bundle_filenames": "File name",
+  "search.filters.applied.f.original_bundle_filenames": "اسم الملف",
 
   // "search.filters.applied.f.original_bundle_descriptions": "File description",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.original_bundle_descriptions": "File description",
+  "search.filters.applied.f.original_bundle_descriptions": "وصف الملف",
   // "search.filters.applied.f.has_geospatial_metadata": "Has geographical location",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.has_geospatial_metadata": "Has geographical location",
+  "search.filters.applied.f.has_geospatial_metadata": "يحتوي على موقع جغرافي",
 
   // "search.filters.applied.f.itemtype": "Type",
   "search.filters.applied.f.itemtype": "النوع",
@@ -7282,48 +6917,37 @@
   "search.filters.applied.f.withdrawn": "مسحوب",
 
   // "search.filters.applied.operator.equals": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.equals": "",
 
   // "search.filters.applied.operator.notequals": " not equals",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notequals": " not equals",
+  "search.filters.applied.operator.notequals": " لا يساوي",
 
   // "search.filters.applied.operator.authority": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.authority": "",
 
   // "search.filters.applied.operator.notauthority": " not authority",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notauthority": " not authority",
+  "search.filters.applied.operator.notauthority": " ليس استنادًا",
 
   // "search.filters.applied.operator.contains": " contains",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.contains": " contains",
+  "search.filters.applied.operator.contains": " يحتوي",
 
   // "search.filters.applied.operator.notcontains": " not contains",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notcontains": " not contains",
+  "search.filters.applied.operator.notcontains": " لا يحتوي",
 
   // "search.filters.applied.operator.query": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.query": "",
 
   // "search.filters.applied.f.point": "Coordinates",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.point": "Coordinates",
+  "search.filters.applied.f.point": "إحداثيات",
 
   // "search.filters.filter.title.head": "Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.head": "Title",
+  "search.filters.filter.title.head": "العنوان",
 
   // "search.filters.filter.title.placeholder": "Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.placeholder": "Title",
+  "search.filters.filter.title.placeholder": "العنوان",
 
   // "search.filters.filter.title.label": "Search Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.label": "Search Title",
+  "search.filters.filter.title.label": "بحث العنوان",
 
   // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "المؤلف",
@@ -7356,12 +6980,10 @@
   "search.filters.filter.creativeDatePublished.label": "بحث تاريخ النشر",
 
   // "search.filters.filter.creativeDatePublished.min.label": "Start",
-  // TODO New key - Add a translation
-  "search.filters.filter.creativeDatePublished.min.label": "Start",
+  "search.filters.filter.creativeDatePublished.min.label": "البداية",
 
   // "search.filters.filter.creativeDatePublished.max.label": "End",
-  // TODO New key - Add a translation
-  "search.filters.filter.creativeDatePublished.max.label": "End",
+  "search.filters.filter.creativeDatePublished.max.label": "النهاية",
 
   // "search.filters.filter.creativeWorkEditor.head": "Editor",
   "search.filters.filter.creativeWorkEditor.head": "المحرر",
@@ -7436,32 +7058,25 @@
   "search.filters.filter.has_content_in_original_bundle.head": "بها ملفات",
 
   // "search.filters.filter.original_bundle_filenames.head": "File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.head": "File name",
+  "search.filters.filter.original_bundle_filenames.head": "اسم الملف",
 
   // "search.filters.filter.has_geospatial_metadata.head": "Has geographical location",
-  // TODO New key - Add a translation
-  "search.filters.filter.has_geospatial_metadata.head": "Has geographical location",
+  "search.filters.filter.has_geospatial_metadata.head": "يحتوي على موقع جغرافي",
 
   // "search.filters.filter.original_bundle_filenames.placeholder": "File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.placeholder": "File name",
+  "search.filters.filter.original_bundle_filenames.placeholder": "اسم الملف",
 
   // "search.filters.filter.original_bundle_filenames.label": "Search File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.label": "Search File name",
+  "search.filters.filter.original_bundle_filenames.label": "بحث اسم الملف",
 
   // "search.filters.filter.original_bundle_descriptions.head": "File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.head": "File description",
+  "search.filters.filter.original_bundle_descriptions.head": "وصف الملف",
 
   // "search.filters.filter.original_bundle_descriptions.placeholder": "File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.placeholder": "File description",
+  "search.filters.filter.original_bundle_descriptions.placeholder": "وصف الملف",
 
   // "search.filters.filter.original_bundle_descriptions.label": "Search File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.label": "Search File description",
+  "search.filters.filter.original_bundle_descriptions.label": "بحث وصف الملف",
 
   // "search.filters.filter.itemtype.head": "Type",
   "search.filters.filter.itemtype.head": "النوع",
@@ -7536,12 +7151,10 @@
   "search.filters.filter.organizationFoundingDate.label": "بحث تاريخ التأسيس",
 
   // "search.filters.filter.organizationFoundingDate.min.label": "Start",
-  // TODO New key - Add a translation
-  "search.filters.filter.organizationFoundingDate.min.label": "Start",
+  "search.filters.filter.organizationFoundingDate.min.label": "البداية",
 
   // "search.filters.filter.organizationFoundingDate.max.label": "End",
-  // TODO New key - Add a translation
-  "search.filters.filter.organizationFoundingDate.max.label": "End",
+  "search.filters.filter.organizationFoundingDate.max.label": "النهاية",
 
   // "search.filters.filter.scope.head": "Scope",
   "search.filters.filter.scope.head": "النطاق",
@@ -7595,16 +7208,13 @@
   "search.filters.filter.supervisedBy.label": "البحث تحت إشراف",
 
   // "search.filters.filter.access_status.head": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.head": "Access type",
+  "search.filters.filter.access_status.head": "نوع الوصول",
 
   // "search.filters.filter.access_status.placeholder": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.placeholder": "Access type",
+  "search.filters.filter.access_status.placeholder": "نوع الوصول",
 
   // "search.filters.filter.access_status.label": "Search by access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.label": "Search by access type",
+  "search.filters.filter.access_status.label": "ابحث بواسطة نوع الوصول",
 
   // "search.filters.entityType.JournalIssue": "Journal Issue",
   "search.filters.entityType.JournalIssue": "عدد الدورية",
@@ -7616,16 +7226,13 @@
   "search.filters.entityType.OrgUnit": "وحدة مؤسسية",
 
   // "search.filters.entityType.Person": "Person",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Person": "Person",
+  "search.filters.entityType.Person": "شخص",
 
   // "search.filters.entityType.Project": "Project",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Project": "Project",
+  "search.filters.entityType.Project": "مشروع",
 
   // "search.filters.entityType.Publication": "Publication",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Publication": "Publication",
+  "search.filters.entityType.Publication": "منشور",
 
   // "search.filters.has_content_in_original_bundle.true": "Yes",
   "search.filters.has_content_in_original_bundle.true": "نعم",
@@ -7634,12 +7241,10 @@
   "search.filters.has_content_in_original_bundle.false": "لا",
 
   // "search.filters.has_geospatial_metadata.true": "Yes",
-  // TODO New key - Add a translation
-  "search.filters.has_geospatial_metadata.true": "Yes",
+  "search.filters.has_geospatial_metadata.true": "نعم",
 
   // "search.filters.has_geospatial_metadata.false": "No",
-  // TODO New key - Add a translation
-  "search.filters.has_geospatial_metadata.false": "No",
+  "search.filters.has_geospatial_metadata.false": "لا",
 
   // "search.filters.discoverable.true": "No",
   "search.filters.discoverable.true": "لا",
@@ -7678,32 +7283,25 @@
   "search.filters.search.submit": "تقديم",
 
   // "search.filters.operator.equals.text": "Equals",
-  // TODO New key - Add a translation
-  "search.filters.operator.equals.text": "Equals",
+  "search.filters.operator.equals.text": "يساوي",
 
   // "search.filters.operator.notequals.text": "Not Equals",
-  // TODO New key - Add a translation
-  "search.filters.operator.notequals.text": "Not Equals",
+  "search.filters.operator.notequals.text": "لا يساوي",
 
   // "search.filters.operator.authority.text": "Authority",
-  // TODO New key - Add a translation
-  "search.filters.operator.authority.text": "Authority",
+  "search.filters.operator.authority.text": "استناد",
 
   // "search.filters.operator.notauthority.text": "Not Authority",
-  // TODO New key - Add a translation
-  "search.filters.operator.notauthority.text": "Not Authority",
+  "search.filters.operator.notauthority.text": "ليس استنادًا",
 
   // "search.filters.operator.contains.text": "Contains",
-  // TODO New key - Add a translation
-  "search.filters.operator.contains.text": "Contains",
+  "search.filters.operator.contains.text": "يحتوي",
 
   // "search.filters.operator.notcontains.text": "Not Contains",
-  // TODO New key - Add a translation
-  "search.filters.operator.notcontains.text": "Not Contains",
+  "search.filters.operator.notcontains.text": "لا يحتوي",
 
   // "search.filters.operator.query.text": "Query",
-  // TODO New key - Add a translation
-  "search.filters.operator.query.text": "Query",
+  "search.filters.operator.query.text": "استعلام",
 
   // "search.form.search": "Search",
   "search.form.search": "بحث",
@@ -7727,8 +7325,7 @@
   "search.results.empty": "لم يسفر بحثك عن أي نتائج.",
 
   // "search.results.geospatial-map.empty": "No results on this page with geospatial locations",
-  // TODO New key - Add a translation
-  "search.results.geospatial-map.empty": "No results on this page with geospatial locations",
+  "search.results.geospatial-map.empty": "لا توجد نتائج على هذه الصفحة بمواقع جغرافية",
 
   // "search.results.view-result": "View",
   "search.results.view-result": "عرض",
@@ -7740,8 +7337,7 @@
   "default.search.results.head": "نتائج البحث",
 
   // "default-relationships.search.results.head": "Search Results",
-  // TODO New key - Add a translation
-  "default-relationships.search.results.head": "Search Results",
+  "default-relationships.search.results.head": "نتائج البحث",
 
   // "search.sidebar.close": "Back to results",
   "search.sidebar.close": "العودة إلى النتائج",
@@ -7762,24 +7358,19 @@
   "search.sidebar.settings.sort-by": "فرز حسب",
 
   // "search.sidebar.advanced-search.title": "Advanced Search",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.title": "Advanced Search",
+  "search.sidebar.advanced-search.title": "بحث متقدم",
 
   // "search.sidebar.advanced-search.filter-by": "Filter by",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.filter-by": "Filter by",
+  "search.sidebar.advanced-search.filter-by": "تصفية حسب",
 
   // "search.sidebar.advanced-search.filters": "Filters",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.filters": "Filters",
+  "search.sidebar.advanced-search.filters": "عوامل التصفية",
 
   // "search.sidebar.advanced-search.operators": "Operators",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.operators": "Operators",
+  "search.sidebar.advanced-search.operators": "العوامل",
 
   // "search.sidebar.advanced-search.add": "Add",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.add": "Add",
+  "search.sidebar.advanced-search.add": "إضافة",
 
   // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "الإعدادات",
@@ -7794,8 +7385,7 @@
   "search.view-switch.show-list": "عرض كقائمة",
 
   // "search.view-switch.show-geospatialMap": "Show as map",
-  // TODO New key - Add a translation
-  "search.view-switch.show-geospatialMap": "Show as map",
+  "search.view-switch.show-geospatialMap": "عرض كخريطة",
 
   // "selectable-list-item-control.deselect": "Deselect item",
   "selectable-list-item-control.deselect": "إلغاء تحديد المادة",
@@ -7840,28 +7430,22 @@
   "sorting.lastModified.DESC": "آخر تعديل تنازلياً",
 
   // "sorting.person.familyName.ASC": "Surname Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.familyName.ASC": "Surname Ascending",
+  "sorting.person.familyName.ASC": "الكنية تصاعدياً",
 
   // "sorting.person.familyName.DESC": "Surname Descending",
-  // TODO New key - Add a translation
-  "sorting.person.familyName.DESC": "Surname Descending",
+  "sorting.person.familyName.DESC": "الكنية تنازلياً",
 
   // "sorting.person.givenName.ASC": "Name Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.givenName.ASC": "Name Ascending",
+  "sorting.person.givenName.ASC": "الاسم تصاعدياً",
 
   // "sorting.person.givenName.DESC": "Name Descending",
-  // TODO New key - Add a translation
-  "sorting.person.givenName.DESC": "Name Descending",
+  "sorting.person.givenName.DESC": "الاسم تنازلياً",
 
   // "sorting.person.birthDate.ASC": "Birth Date Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.birthDate.ASC": "Birth Date Ascending",
+  "sorting.person.birthDate.ASC": "تاريخ الميلاد تصاعدياً",
 
   // "sorting.person.birthDate.DESC": "Birth Date Descending",
-  // TODO New key - Add a translation
-  "sorting.person.birthDate.DESC": "Birth Date Descending",
+  "sorting.person.birthDate.DESC": "تاريخ الميلاد تنازلياً",
 
   // "statistics.title": "Statistics",
   "statistics.title": "الاحصائيات",
@@ -7930,8 +7514,7 @@
   "submission.general.discard.submit": "تجاهل",
 
   // "submission.general.back.submit": "Back",
-  // TODO New key - Add a translation
-  "submission.general.back.submit": "Back",
+  "submission.general.back.submit": "رجوع",
 
   // "submission.general.info.saved": "Saved",
   "submission.general.info.saved": "محفوظ",
@@ -8003,18 +7586,15 @@
   "submission.import-external.source.cinii": "CiNii",
 
   // "submission.import-external.source.crossref": "Crossref",
-  // TODO Source message changed - Revise the translation
-  "submission.import-external.source.crossref": "كروس ريف",
+  "submission.import-external.source.crossref": "Crossref",
 
   // "submission.import-external.source.datacite": "DataCite",
   "submission.import-external.source.datacite": "داتاسايت",
 
   // "submission.import-external.source.dataciteProject": "DataCite",
-  // TODO New key - Add a translation
-  "submission.import-external.source.dataciteProject": "DataCite",
+  "submission.import-external.source.dataciteProject": "داتاسايت",
 
   // "submission.import-external.source.doi": "DOI",
-  // TODO New key - Add a translation
   "submission.import-external.source.doi": "DOI",
 
   // "submission.import-external.source.scielo": "SciELO",
@@ -8048,16 +7628,13 @@
   "submission.import-external.source.sherpaPublisher": "ناشري شيربا",
 
   // "submission.import-external.source.openaire": "OpenAIRE Search by Authors",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaire": "OpenAIRE Search by Authors",
+  "submission.import-external.source.openaire": "OpenAIRE بحث حسب المؤلفين",
 
   // "submission.import-external.source.openaireTitle": "OpenAIRE Search by Title",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaireTitle": "OpenAIRE Search by Title",
+  "submission.import-external.source.openaireTitle": "OpenAIRE بحث حسب العنوان",
 
   // "submission.import-external.source.openaireFunding": "OpenAIRE Search by Funder",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaireFunding": "OpenAIRE Search by Funder",
+  "submission.import-external.source.openaireFunding": "OpenAIRE بحث حسب جهة التمويل",
 
   // "submission.import-external.source.orcid": "ORCID",
   "submission.import-external.source.orcid": "أوركيد",
@@ -8075,36 +7652,28 @@
   "submission.import-external.source.ror": "سجل المؤسسات البحثية (ROR)",
 
   // "submission.import-external.source.openalexPublication": "OpenAlex Search by Title",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublication": "OpenAlex Search by Title",
+  "submission.import-external.source.openalexPublication": "OpenAlex بحث حسب العنوان",
 
   // "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex Search by Author ID",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex Search by Author ID",
+  "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex بحث حسب مُعرّف المؤلف",
 
   // "submission.import-external.source.openalexPublicationByDOI": "OpenAlex Search by DOI",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublicationByDOI": "OpenAlex Search by DOI",
+  "submission.import-external.source.openalexPublicationByDOI": "OpenAlex بحث حسب DOI",
 
   // "submission.import-external.source.openalexPerson": "OpenAlex Search by name",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPerson": "OpenAlex Search by name",
+  "submission.import-external.source.openalexPerson": "OpenAlex بحث حسب الاسم",
 
   // "submission.import-external.source.openalexJournal": "OpenAlex Journals",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexJournal": "OpenAlex Journals",
+  "submission.import-external.source.openalexJournal": "دوريات OpenAlex",
 
   // "submission.import-external.source.openalexInstitution": "OpenAlex Institutions",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexInstitution": "OpenAlex Institutions",
+  "submission.import-external.source.openalexInstitution": "مؤسسات OpenAlex",
 
   // "submission.import-external.source.openalexPublisher": "OpenAlex Publishers",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublisher": "OpenAlex Publishers",
+  "submission.import-external.source.openalexPublisher": "ناشرو OpenAlex",
 
   // "submission.import-external.source.openalexFunder": "OpenAlex Funders",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexFunder": "OpenAlex Funders",
+  "submission.import-external.source.openalexFunder": "ممولو OpenAlex",
 
   // "submission.import-external.preview.title": "Item Preview",
   "submission.import-external.preview.title": "معاينة المادة",
@@ -8230,16 +7799,13 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "استيراد من أوركيد",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "الاستيراد من OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "الاستيراد من OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "الاستيراد من OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Importing from Sherpa Journal",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "استيراد من دورية شيربا",
@@ -8359,8 +7925,7 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "أعداد الدوريات المحلية ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Local Journal Volumes ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Local Journal Volumes ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "مجلدات الدوريات المحلية ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Local Journal Volumes ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "مجلدات الدوريات المحلية ({{ count }})",
@@ -8393,46 +7958,37 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcidWorks": "أوركيد ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "Crossref ({{ count }})",
-  // TODO Source message changed - Revise the translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "CrossRef ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE بحث حسب المؤلفين ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE Search by Title ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE Search by Title ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE بحث حسب العنوان ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE Search by Funder ({{ count }})",
-  // TODO Source message changed - Revise the translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "تمويل OpenAIRE ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE بحث حسب جهة التمويل ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "Sherpa Journals by ISSN ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "دوريات شيربا حسب ISSN ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex بحث حسب المؤسسة ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex Search by Publisher ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex Search by Publisher ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex بحث حسب الناشر ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex Search by Funder ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex Search by Funder ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex بحث حسب الممول ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite Search by Project ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite Search by Project ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite بحث حسب المشروع ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Search for Funding Agencies",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "البحث عن وكالات ممولة",
@@ -8465,8 +8021,7 @@
   "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "ممول المشروع",
 
   // "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Person of the Project",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Person of the Project",
+  "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "شخص المشروع",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Search...",
   "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "بحث...",
@@ -8484,8 +8039,7 @@
   "submission.sections.describe.relationship-lookup.title.JournalIssue": "أعداد الدورية",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Journal Volumes",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Journal Volumes",
+  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "مجلدات الدورية",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Journal Volumes",
   "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "مجلدات الدورية",
@@ -8551,8 +8105,7 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalOfPublication": "الدوريات المحددة",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Selected Journal Volume",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Selected Journal Volume",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "مجلد الدورية المحدد",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Selected Journal Volume",
   "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "مجلد الدورية المحدد",
@@ -8609,16 +8162,13 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.orcidv2": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "نتائج البحث",
@@ -8648,24 +8198,19 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "نتائج البحث",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title": "نتائج البحث",
@@ -8785,8 +8330,7 @@
   "submission.sections.submit.progressbar.describe.steptwo": "وصف",
 
   // "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
+  "submission.sections.submit.progressbar.duplicates": "تكرارات محتملة",
 
   // "submission.sections.submit.progressbar.identifiers": "Identifiers",
   "submission.sections.submit.progressbar.identifiers": "المعرفات",
@@ -8843,12 +8387,10 @@
   "submission.sections.toggle.aria.close": "طي قسم {{sectionHeader}}",
 
   // "submission.sections.upload.primary.make": "Make {{fileName}} the primary bitstream",
-  // TODO New key - Add a translation
-  "submission.sections.upload.primary.make": "Make {{fileName}} the primary bitstream",
+  "submission.sections.upload.primary.make": "اجعل {{fileName}} تدفق البت الرئيسي",
 
   // "submission.sections.upload.primary.remove": "Remove {{fileName}} as the primary bitstream",
-  // TODO New key - Add a translation
-  "submission.sections.upload.primary.remove": "Remove {{fileName}} as the primary bitstream",
+  "submission.sections.upload.primary.remove": "أزل {{fileName}} كتدفق البت الرئيسي",
 
   // "submission.sections.upload.delete.confirm.cancel": "Cancel",
   "submission.sections.upload.delete.confirm.cancel": "إلغاء",
@@ -8986,20 +8528,16 @@
   "submission.sections.accesses.form.until-placeholder": "حتى",
 
   // "submission.sections.duplicates.none": "No duplicates were detected.",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.none": "No duplicates were detected.",
+  "submission.sections.duplicates.none": "لم يتم الكشف عن تكرارات.",
 
   // "submission.sections.duplicates.detected": "Potential duplicates were detected. Please review the list below.",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.detected": "Potential duplicates were detected. Please review the list below.",
+  "submission.sections.duplicates.detected": "تم اكتشاف تكرارات محتملة. يرجى مراجعة القائمة أدناه.",
 
   // "submission.sections.duplicates.in-workspace": "This item is in workspace",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.in-workspace": "This item is in workspace",
+  "submission.sections.duplicates.in-workspace": "هذه المادة في مساحة العمل",
 
   // "submission.sections.duplicates.in-workflow": "This item is in workflow",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.in-workflow": "This item is in workflow",
+  "submission.sections.duplicates.in-workflow": "هذه المادة في سير العمل",
 
   // "submission.sections.license.granted-label": "I confirm the license above",
   "submission.sections.license.granted-label": "أؤكد الترخيص أعلاه",
@@ -9191,8 +8729,7 @@
   "submission.workflow.tasks.pool.show-detail": "عرض التفاصيل",
 
   // "submission.workflow.tasks.duplicates": "potential duplicates were detected for this item. Claim and edit this item to see details.",
-  // TODO New key - Add a translation
-  "submission.workflow.tasks.duplicates": "potential duplicates were detected for this item. Claim and edit this item to see details.",
+  "submission.workflow.tasks.duplicates": "تم اكتشاف تكرارات محتملة لهذه المادة. يرجى المطالبة بالمادة وتحريرها للاطلاع على التفاصيل.",
 
   // "submission.workspace.generic.view": "View",
   "submission.workspace.generic.view": "عرض",
@@ -9234,8 +8771,7 @@
   "subscriptions.tooltip": "اشتراك",
 
   // "subscriptions.unsubscribe": "Unsubscribe",
-  // TODO New key - Add a translation
-  "subscriptions.unsubscribe": "Unsubscribe",
+  "subscriptions.unsubscribe": "إلغاء الاشتراك",
 
   // "subscriptions.modal.title": "Subscriptions",
   "subscriptions.modal.title": "الاشتراكات",
@@ -9925,12 +9461,10 @@
   "person.orcid.registry.auth": "تصاريح أوركيد",
 
   // "person.orcid-tooltip.authenticated": "{{orcid}}",
-  // TODO New key - Add a translation
   "person.orcid-tooltip.authenticated": "{{orcid}}",
 
   // "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
-  // TODO New key - Add a translation
-  "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
+  "person.orcid-tooltip.not-authenticated": "{{orcid}} (غير مؤكد)",
 
   // "home.recent-submissions.head": "Recent Submissions",
   "home.recent-submissions.head": "أحدث التقديمات",
@@ -10011,8 +9545,7 @@
   "admin.system-wide-alert.title": "تنبيهات على مستوى النظام",
 
   // "discover.filters.head": "Discover",
-  // TODO New key - Add a translation
-  "discover.filters.head": "Discover",
+  "discover.filters.head": "اكتشف",
 
   // "item-access-control-title": "This form allows you to perform changes to the access conditions of the item's metadata or its bitstreams.",
   "item-access-control-title": "يتيح لك هذا النموذج إجراء تغييرات على شروط الوصول إلى ميتاداتا المادة أو تدفقات البت الخاصة بها.",
@@ -10111,1675 +9644,1230 @@
   "vocabulary-treeview.search.form.add": "إضافة",
 
   // "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
-  // TODO New key - Add a translation
-  "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
+  "admin.notifications.publicationclaim.breadcrumbs": "مطالبة بمنشور",
 
   // "admin.notifications.publicationclaim.page.title": "Publication Claim",
-  // TODO New key - Add a translation
-  "admin.notifications.publicationclaim.page.title": "Publication Claim",
+  "admin.notifications.publicationclaim.page.title": "مطالبة بمنشور",
 
   // "coar-notify-support.title": "COAR Notify Protocol",
-  // TODO New key - Add a translation
-  "coar-notify-support.title": "COAR Notify Protocol",
+  "coar-notify-support.title": "بروتوكول COAR Notify",
 
   // "coar-notify-support-title.content": "Here, we fully support the COAR Notify protocol, which is designed to enhance the communication between repositories. To learn more about the COAR Notify protocol, visit the <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">COAR Notify website</a>.",
-  // TODO New key - Add a translation
-  "coar-notify-support-title.content": "Here, we fully support the COAR Notify protocol, which is designed to enhance the communication between repositories. To learn more about the COAR Notify protocol, visit the <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">COAR Notify website</a>.",
+  "coar-notify-support-title.content": "نحن هنا ندعم بشكل كامل بروتوكول COAR Notify المصمم لتعزيز التواصل بين المستودعات. لمعرفة المزيد عن بروتوكول COAR Notify، تفضّل بزيارة <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">موقع COAR Notify</a>.",
 
   // "coar-notify-support.ldn-inbox.title": "LDN InBox",
-  // TODO New key - Add a translation
-  "coar-notify-support.ldn-inbox.title": "LDN InBox",
+  "coar-notify-support.ldn-inbox.title": "صندوق وارد LDN",
 
   // "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
-  // TODO New key - Add a translation
-  "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
+  "coar-notify-support.ldn-inbox.content": "لتسهيل الأمر عليك، يمكن الوصول إلى صندوق وارد LDN (إشعارات البيانات المترابطة) لدينا بسهولة على {{ ldnInboxUrl }}. يتيح صندوق الوارد LDN تواصلاً سلساً وتبادلاً للبيانات بما يضمن تعاوناً فعالاً ومثمراً.",
 
   // "coar-notify-support.message-moderation.title": "Message Moderation",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.title": "Message Moderation",
+  "coar-notify-support.message-moderation.title": "إشراف الرسائل",
 
   // "coar-notify-support.message-moderation.content": "To ensure a secure and productive environment, all incoming LDN messages are moderated. If you are planning to exchange information with us, kindly reach out via our dedicated",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.content": "To ensure a secure and productive environment, all incoming LDN messages are moderated. If you are planning to exchange information with us, kindly reach out via our dedicated",
+  "coar-notify-support.message-moderation.content": "لضمان بيئة آمنة ومنتجة، يتم الإشراف على جميع رسائل LDN الواردة. إذا كنت تخطط لتبادل المعلومات معنا، يُرجى التواصل عبر",
 
   // "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
+  "coar-notify-support.message-moderation.feedback-form": " نموذج الملاحظات.",
 
   // "service.overview.delete.header": "Delete Service",
-  // TODO New key - Add a translation
-  "service.overview.delete.header": "Delete Service",
+  "service.overview.delete.header": "حذف الخدمة",
 
   // "ldn-registered-services.title": "Registered Services",
-  // TODO New key - Add a translation
-  "ldn-registered-services.title": "Registered Services",
+  "ldn-registered-services.title": "الخدمات المسجّلة",
   // "ldn-registered-services.table.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.name": "Name",
+  "ldn-registered-services.table.name": "الاسم",
   // "ldn-registered-services.table.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.description": "Description",
+  "ldn-registered-services.table.description": "الوصف",
   // "ldn-registered-services.table.status": "Status",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.status": "Status",
+  "ldn-registered-services.table.status": "الحالة",
   // "ldn-registered-services.table.action": "Action",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.action": "Action",
+  "ldn-registered-services.table.action": "إجراء",
   // "ldn-registered-services.new": "NEW",
-  // TODO New key - Add a translation
-  "ldn-registered-services.new": "NEW",
+  "ldn-registered-services.new": "جديد",
   // "ldn-registered-services.new.breadcrumbs": "Registered Services",
-  // TODO New key - Add a translation
-  "ldn-registered-services.new.breadcrumbs": "Registered Services",
+  "ldn-registered-services.new.breadcrumbs": "الخدمات المسجّلة",
 
   // "ldn-service.overview.table.enabled": "Enabled",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.enabled": "Enabled",
+  "ldn-service.overview.table.enabled": "مفعل",
   // "ldn-service.overview.table.disabled": "Disabled",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.disabled": "Disabled",
+  "ldn-service.overview.table.disabled": "معطّل",
   // "ldn-service.overview.table.clickToEnable": "Click to enable",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.clickToEnable": "Click to enable",
+  "ldn-service.overview.table.clickToEnable": "انقر للتفعيل",
   // "ldn-service.overview.table.clickToDisable": "Click to disable",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.clickToDisable": "Click to disable",
+  "ldn-service.overview.table.clickToDisable": "انقر للتعطيل",
 
   // "ldn-edit-registered-service.title": "Edit Service",
-  // TODO New key - Add a translation
-  "ldn-edit-registered-service.title": "Edit Service",
+  "ldn-edit-registered-service.title": "تحرير الخدمة",
   // "ldn-create-service.title": "Create service",
-  // TODO New key - Add a translation
-  "ldn-create-service.title": "Create service",
+  "ldn-create-service.title": "إنشاء خدمة",
   // "service.overview.create.modal": "Create Service",
-  // TODO New key - Add a translation
-  "service.overview.create.modal": "Create Service",
+  "service.overview.create.modal": "إنشاء خدمة",
   // "service.overview.create.body": "Please confirm the creation of this service.",
-  // TODO New key - Add a translation
-  "service.overview.create.body": "Please confirm the creation of this service.",
+  "service.overview.create.body": "يرجى تأكيد إنشاء هذه الخدمة.",
   // "ldn-service-status": "Status",
-  // TODO New key - Add a translation
-  "ldn-service-status": "Status",
+  "ldn-service-status": "الحالة",
   // "service.confirm.create": "Create",
-  // TODO New key - Add a translation
-  "service.confirm.create": "Create",
+  "service.confirm.create": "إنشاء",
   // "service.refuse.create": "Cancel",
-  // TODO New key - Add a translation
-  "service.refuse.create": "Cancel",
+  "service.refuse.create": "إلغاء",
   // "ldn-register-new-service.title": "Register a new service",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.title": "Register a new service",
+  "ldn-register-new-service.title": "تسجيل خدمة جديدة",
   // "ldn-new-service.form.label.submit": "Save",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.submit": "Save",
+  "ldn-new-service.form.label.submit": "حفظ",
   // "ldn-new-service.form.label.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.name": "Name",
+  "ldn-new-service.form.label.name": "الاسم",
   // "ldn-new-service.form.label.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.description": "Description",
+  "ldn-new-service.form.label.description": "الوصف",
   // "ldn-new-service.form.label.url": "Service URL",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.url": "Service URL",
+  "ldn-new-service.form.label.url": "رابط الخدمة",
   // "ldn-new-service.form.label.ip-range": "Service IP range",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ip-range": "Service IP range",
+  "ldn-new-service.form.label.ip-range": "نطاق عناوين IP للخدمة",
   // "ldn-new-service.form.label.score": "Level of trust",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.score": "Level of trust",
+  "ldn-new-service.form.label.score": "مستوى الثقة",
   // "ldn-new-service.form.label.ldnUrl": "LDN Inbox URL",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-new-service.form.label.ldnUrl": "عنوان URL لصندوق وارد LDN",
   // "ldn-new-service.form.placeholder.name": "Please provide service name",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.name": "Please provide service name",
+  "ldn-new-service.form.placeholder.name": "يرجى إدخال اسم الخدمة",
   // "ldn-new-service.form.placeholder.description": "Please provide a description regarding your service",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.description": "Please provide a description regarding your service",
+  "ldn-new-service.form.placeholder.description": "يرجى تقديم وصف لخدمتك",
   // "ldn-new-service.form.placeholder.url": "Please input the URL for users to check out more information about the service",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.url": "Please input the URL for users to check out more information about the service",
+  "ldn-new-service.form.placeholder.url": "يرجى إدخال رابط يتيح للمستخدمين معرفة المزيد عن الخدمة",
   // "ldn-new-service.form.placeholder.lowerIp": "IPv4 range lower bound",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.lowerIp": "IPv4 range lower bound",
+  "ldn-new-service.form.placeholder.lowerIp": "الحد الأدنى لنطاق IPv4",
   // "ldn-new-service.form.placeholder.upperIp": "IPv4 range upper bound",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.upperIp": "IPv4 range upper bound",
+  "ldn-new-service.form.placeholder.upperIp": "الحد الأقصى لنطاق IPv4",
   // "ldn-new-service.form.placeholder.ldnUrl": "Please specify the URL of the LDN Inbox",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.ldnUrl": "Please specify the URL of the LDN Inbox",
+  "ldn-new-service.form.placeholder.ldnUrl": "يرجى تحديد عنوان URL لصندوق وارد LDN",
   // "ldn-new-service.form.placeholder.score": "Please enter a value between 0 and 1. Use the “.” as decimal separator",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.score": "Please enter a value between 0 and 1. Use the “.” as decimal separator",
+  "ldn-new-service.form.placeholder.score": "يرجى إدخال قيمة بين 0 و1. استخدم '.' كفاصل عشري",
   // "ldn-service.form.label.placeholder.default-select": "Select a pattern",
-  // TODO New key - Add a translation
-  "ldn-service.form.label.placeholder.default-select": "Select a pattern",
+  "ldn-service.form.label.placeholder.default-select": "اختر نمطاً",
 
   // "ldn-service.form.pattern.ack-accept.label": "Acknowledge and Accept",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.label": "Acknowledge and Accept",
+  "ldn-service.form.pattern.ack-accept.label": "إقرار وقبول",
   // "ldn-service.form.pattern.ack-accept.description": "This pattern is used to acknowledge and accept a request (offer). It implies an intention to act on the request.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.description": "This pattern is used to acknowledge and accept a request (offer). It implies an intention to act on the request.",
+  "ldn-service.form.pattern.ack-accept.description": "يُستخدم هذا النمط للإقرار وقبول طلب (عرض). يفيد بنية اتخاذ إجراء على الطلب.",
   // "ldn-service.form.pattern.ack-accept.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-accept.category": "إقرارات",
 
   // "ldn-service.form.pattern.ack-reject.label": "Acknowledge and Reject",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.label": "Acknowledge and Reject",
+  "ldn-service.form.pattern.ack-reject.label": "إقرار ورفض",
   // "ldn-service.form.pattern.ack-reject.description": "This pattern is used to acknowledge and reject a request (offer). It signifies no further action regarding the request.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.description": "This pattern is used to acknowledge and reject a request (offer). It signifies no further action regarding the request.",
+  "ldn-service.form.pattern.ack-reject.description": "يُستخدم هذا النمط للإقرار ورفض طلب (عرض). يفيد بعدم اتخاذ أي إجراء إضافي بخصوص الطلب.",
   // "ldn-service.form.pattern.ack-reject.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-reject.category": "إقرارات",
 
   // "ldn-service.form.pattern.ack-tentative-accept.label": "Acknowledge and Tentatively Accept",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.label": "Acknowledge and Tentatively Accept",
+  "ldn-service.form.pattern.ack-tentative-accept.label": "إقرار وقبول مبدئي",
   // "ldn-service.form.pattern.ack-tentative-accept.description": "This pattern is used to acknowledge and tentatively accept a request (offer). It implies an intention to act, which may change.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.description": "This pattern is used to acknowledge and tentatively accept a request (offer). It implies an intention to act, which may change.",
+  "ldn-service.form.pattern.ack-tentative-accept.description": "يُستخدم هذا النمط للإقرار والقبول المبدئي لطلب (عرض). يفيد بنية اتخاذ إجراء، وقد تتغير.",
   // "ldn-service.form.pattern.ack-tentative-accept.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-accept.category": "إقرارات",
 
   // "ldn-service.form.pattern.ack-tentative-reject.label": "Acknowledge and Tentatively Reject",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.label": "Acknowledge and Tentatively Reject",
+  "ldn-service.form.pattern.ack-tentative-reject.label": "إقرار ورفض مبدئي",
   // "ldn-service.form.pattern.ack-tentative-reject.description": "This pattern is used to acknowledge and tentatively reject a request (offer). It signifies no further action, subject to change.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.description": "This pattern is used to acknowledge and tentatively reject a request (offer). It signifies no further action, subject to change.",
+  "ldn-service.form.pattern.ack-tentative-reject.description": "يُستخدم هذا النمط للإقرار والرفض المبدئي لطلب (عرض). يفيد بعدم اتخاذ إجراء إضافي، وقابل للتغيير.",
   // "ldn-service.form.pattern.ack-tentative-reject.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-reject.category": "إقرارات",
 
   // "ldn-service.form.pattern.announce-endorsement.label": "Announce Endorsement",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.label": "Announce Endorsement",
+  "ldn-service.form.pattern.announce-endorsement.label": "الإعلان عن تأييد",
   // "ldn-service.form.pattern.announce-endorsement.description": "This pattern is used to announce the existence of an endorsement, referencing the endorsed resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.description": "This pattern is used to announce the existence of an endorsement, referencing the endorsed resource.",
+  "ldn-service.form.pattern.announce-endorsement.description": "يُستخدم هذا النمط للإعلان عن وجود تأييد، مع الإشارة إلى المورد المُؤيَّد.",
   // "ldn-service.form.pattern.announce-endorsement.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.category": "Announcements",
+  "ldn-service.form.pattern.announce-endorsement.category": "إعلانات",
 
   // "ldn-service.form.pattern.announce-ingest.label": "Announce Ingest",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.label": "Announce Ingest",
+  "ldn-service.form.pattern.announce-ingest.label": "الإعلان عن إدخال",
   // "ldn-service.form.pattern.announce-ingest.description": "This pattern is used to announce that a resource has been ingested.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.description": "This pattern is used to announce that a resource has been ingested.",
+  "ldn-service.form.pattern.announce-ingest.description": "يُستخدم هذا النمط للإعلان عن أنه قد تم إدخال مورد.",
   // "ldn-service.form.pattern.announce-ingest.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.category": "Announcements",
+  "ldn-service.form.pattern.announce-ingest.category": "إعلانات",
 
   // "ldn-service.form.pattern.announce-relationship.label": "Announce Relationship",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.label": "Announce Relationship",
+  "ldn-service.form.pattern.announce-relationship.label": "الإعلان عن علاقة",
   // "ldn-service.form.pattern.announce-relationship.description": "This pattern is used to announce a relationship between two resources.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.description": "This pattern is used to announce a relationship between two resources.",
+  "ldn-service.form.pattern.announce-relationship.description": "يُستخدم هذا النمط للإعلان عن علاقة بين موردين.",
   // "ldn-service.form.pattern.announce-relationship.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.category": "Announcements",
+  "ldn-service.form.pattern.announce-relationship.category": "إعلانات",
 
   // "ldn-service.form.pattern.announce-review.label": "Announce Review",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.label": "Announce Review",
+  "ldn-service.form.pattern.announce-review.label": "الإعلان عن مراجعة",
   // "ldn-service.form.pattern.announce-review.description": "This pattern is used to announce the existence of a review, referencing the reviewed resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.description": "This pattern is used to announce the existence of a review, referencing the reviewed resource.",
+  "ldn-service.form.pattern.announce-review.description": "يُستخدم هذا النمط للإعلان عن وجود مراجعة، مع الإشارة إلى المورد المُراجع.",
   // "ldn-service.form.pattern.announce-review.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.category": "Announcements",
+  "ldn-service.form.pattern.announce-review.category": "إعلانات",
 
   // "ldn-service.form.pattern.announce-service-result.label": "Announce Service Result",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.label": "Announce Service Result",
+  "ldn-service.form.pattern.announce-service-result.label": "الإعلان عن نتيجة خدمة",
   // "ldn-service.form.pattern.announce-service-result.description": "This pattern is used to announce the existence of a 'service result', referencing the relevant resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.description": "This pattern is used to announce the existence of a 'service result', referencing the relevant resource.",
+  "ldn-service.form.pattern.announce-service-result.description": "يُستخدم هذا النمط للإعلان عن وجود 'نتيجة خدمة'، مع الإشارة إلى المورد ذي الصلة.",
   // "ldn-service.form.pattern.announce-service-result.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.category": "Announcements",
+  "ldn-service.form.pattern.announce-service-result.category": "إعلانات",
 
   // "ldn-service.form.pattern.request-endorsement.label": "Request Endorsement",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.label": "Request Endorsement",
+  "ldn-service.form.pattern.request-endorsement.label": "طلب تأييد",
   // "ldn-service.form.pattern.request-endorsement.description": "This pattern is used to request endorsement of a resource owned by the origin system.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.description": "This pattern is used to request endorsement of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-endorsement.description": "يُستخدم هذا النمط لطلب تأييد مورد يملكه نظام المصدر.",
   // "ldn-service.form.pattern.request-endorsement.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.category": "Requests",
+  "ldn-service.form.pattern.request-endorsement.category": "طلبات",
 
   // "ldn-service.form.pattern.request-ingest.label": "Request Ingest",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.label": "Request Ingest",
+  "ldn-service.form.pattern.request-ingest.label": "طلب إدخال",
   // "ldn-service.form.pattern.request-ingest.description": "This pattern is used to request that the target system ingest a resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.description": "This pattern is used to request that the target system ingest a resource.",
+  "ldn-service.form.pattern.request-ingest.description": "يُستخدم هذا النمط لطلب أن يقوم النظام الهدف بإدخال مورد.",
   // "ldn-service.form.pattern.request-ingest.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.category": "Requests",
+  "ldn-service.form.pattern.request-ingest.category": "طلبات",
 
   // "ldn-service.form.pattern.request-review.label": "Request Review",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.label": "Request Review",
+  "ldn-service.form.pattern.request-review.label": "طلب مراجعة",
   // "ldn-service.form.pattern.request-review.description": "This pattern is used to request a review of a resource owned by the origin system.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.description": "This pattern is used to request a review of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-review.description": "يُستخدم هذا النمط لطلب مراجعة مورد يملكه نظام المصدر.",
   // "ldn-service.form.pattern.request-review.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.category": "Requests",
+  "ldn-service.form.pattern.request-review.category": "طلبات",
 
   // "ldn-service.form.pattern.undo-offer.label": "Undo Offer",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.label": "Undo Offer",
+  "ldn-service.form.pattern.undo-offer.label": "تراجع عن العرض",
   // "ldn-service.form.pattern.undo-offer.description": "This pattern is used to undo (retract) an offer previously made.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.description": "This pattern is used to undo (retract) an offer previously made.",
+  "ldn-service.form.pattern.undo-offer.description": "يُستخدم هذا النمط للتراجع (سحب) عن عرض تم تقديمه سابقاً.",
   // "ldn-service.form.pattern.undo-offer.category": "Undo",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.category": "Undo",
+  "ldn-service.form.pattern.undo-offer.category": "تراجع",
 
   // "ldn-new-service.form.label.placeholder.selectedItemFilter": "No Item Filter Selected",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.placeholder.selectedItemFilter": "No Item Filter Selected",
+  "ldn-new-service.form.label.placeholder.selectedItemFilter": "لا يوجد مُرشّح عناصر محدد",
   // "ldn-new-service.form.label.ItemFilter": "Item Filter",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ItemFilter": "Item Filter",
+  "ldn-new-service.form.label.ItemFilter": "مرشّح العناصر",
   // "ldn-new-service.form.label.automatic": "Automatic",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.automatic": "Automatic",
+  "ldn-new-service.form.label.automatic": "تلقائي",
   // "ldn-new-service.form.error.name": "Name is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.name": "Name is required",
+  "ldn-new-service.form.error.name": "الاسم مطلوب",
   // "ldn-new-service.form.error.url": "URL is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.url": "URL is required",
+  "ldn-new-service.form.error.url": "عنوان URL مطلوب",
   // "ldn-new-service.form.error.ipRange": "Please enter a valid IP range",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.ipRange": "Please enter a valid IP range",
+  "ldn-new-service.form.error.ipRange": "يرجى إدخال نطاق IP صالح",
   // "ldn-new-service.form.hint.ipRange": "Please enter a valid IpV4 in both range bounds (note: for single IP, please enter the same value in both fields)",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.hint.ipRange": "Please enter a valid IpV4 in both range bounds (note: for single IP, please enter the same value in both fields)",
+  "ldn-new-service.form.hint.ipRange": "يرجى إدخال IPv4 صالح في حدّي النطاق (ملاحظة: لعنوان IP واحد، أدخل نفس القيمة في الحقلين)",
   // "ldn-new-service.form.error.ldnurl": "LDN URL is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.ldnurl": "LDN URL is required",
+  "ldn-new-service.form.error.ldnurl": "عنوان URL الخاص بـ LDN مطلوب",
   // "ldn-new-service.form.error.patterns": "At least a pattern is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.patterns": "At least a pattern is required",
+  "ldn-new-service.form.error.patterns": "مطلوب نمط واحد على الأقل",
   // "ldn-new-service.form.error.score": "Please enter a valid score (between 0 and 1). Use the “.” as decimal separator",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.score": "Please enter a valid score (between 0 and 1). Use the “.” as decimal separator",
+  "ldn-new-service.form.error.score": "يرجى إدخال قيمة صحيحة (بين 0 و1). استخدم '.' كفاصل عشري",
 
   // "ldn-new-service.form.label.inboundPattern": "Supported Pattern",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.inboundPattern": "Supported Pattern",
+  "ldn-new-service.form.label.inboundPattern": "النمط المدعوم",
   // "ldn-new-service.form.label.addPattern": "+ Add more",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.addPattern": "+ Add more",
+  "ldn-new-service.form.label.addPattern": "+ إضافة المزيد",
   // "ldn-new-service.form.label.removeItemFilter": "Remove",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.removeItemFilter": "Remove",
+  "ldn-new-service.form.label.removeItemFilter": "إزالة",
   // "ldn-register-new-service.breadcrumbs": "New Service",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.breadcrumbs": "New Service",
+  "ldn-register-new-service.breadcrumbs": "خدمة جديدة",
   // "service.overview.delete.body": "Are you sure you want to delete this service?",
-  // TODO New key - Add a translation
-  "service.overview.delete.body": "Are you sure you want to delete this service?",
+  "service.overview.delete.body": "هل أنت متأكد أنك تريد حذف هذه الخدمة؟",
   // "service.overview.edit.body": "Do you confirm the changes?",
-  // TODO New key - Add a translation
-  "service.overview.edit.body": "Do you confirm the changes?",
+  "service.overview.edit.body": "هل تؤكد إجراء التغييرات؟",
   // "service.overview.edit.modal": "Edit Service",
-  // TODO New key - Add a translation
-  "service.overview.edit.modal": "Edit Service",
+  "service.overview.edit.modal": "تحرير الخدمة",
   // "service.detail.update": "Confirm",
-  // TODO New key - Add a translation
-  "service.detail.update": "Confirm",
+  "service.detail.update": "تأكيد",
   // "service.detail.return": "Cancel",
-  // TODO New key - Add a translation
-  "service.detail.return": "Cancel",
+  "service.detail.return": "إلغاء",
   // "service.overview.reset-form.body": "Are you sure you want to discard the changes and leave?",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.body": "Are you sure you want to discard the changes and leave?",
+  "service.overview.reset-form.body": "هل أنت متأكد أنك تريد تجاهل التغييرات والمغادرة؟",
   // "service.overview.reset-form.modal": "Discard Changes",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.modal": "Discard Changes",
+  "service.overview.reset-form.modal": "تجاهل التغييرات",
   // "service.overview.reset-form.reset-confirm": "Discard",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.reset-confirm": "Discard",
+  "service.overview.reset-form.reset-confirm": "تجاهل",
   // "admin.registries.services-formats.modify.success.head": "Successful Edit",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.success.head": "Successful Edit",
+  "admin.registries.services-formats.modify.success.head": "تم التحرير بنجاح",
   // "admin.registries.services-formats.modify.success.content": "The service has been edited",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.success.content": "The service has been edited",
+  "admin.registries.services-formats.modify.success.content": "تم تحرير الخدمة",
   // "admin.registries.services-formats.modify.failure.head": "Failed Edit",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.failure.head": "Failed Edit",
+  "admin.registries.services-formats.modify.failure.head": "فشل التحرير",
   // "admin.registries.services-formats.modify.failure.content": "The service has not been edited",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.failure.content": "The service has not been edited",
+  "admin.registries.services-formats.modify.failure.content": "لم يتم تحرير الخدمة",
   // "ldn-service-notification.created.success.title": "Successful Create",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.success.title": "Successful Create",
+  "ldn-service-notification.created.success.title": "تم الإنشاء بنجاح",
   // "ldn-service-notification.created.success.body": "The service has been created",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.success.body": "The service has been created",
+  "ldn-service-notification.created.success.body": "تم إنشاء الخدمة",
   // "ldn-service-notification.created.failure.title": "Failed Create",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.failure.title": "Failed Create",
+  "ldn-service-notification.created.failure.title": "فشل الإنشاء",
   // "ldn-service-notification.created.failure.body": "The service has not been created",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.failure.body": "The service has not been created",
+  "ldn-service-notification.created.failure.body": "لم يتم إنشاء الخدمة",
   // "ldn-service-notification.created.warning.title": "Please select at least one Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.warning.title": "Please select at least one Inbound Pattern",
+  "ldn-service-notification.created.warning.title": "يرجى اختيار نمط وارد واحد على الأقل",
   // "ldn-enable-service.notification.success.title": "Successful status updated",
-  // TODO New key - Add a translation
-  "ldn-enable-service.notification.success.title": "Successful status updated",
+  "ldn-enable-service.notification.success.title": "تم تحديث الحالة بنجاح",
   // "ldn-enable-service.notification.success.content": "The service status has been updated",
-  // TODO New key - Add a translation
-  "ldn-enable-service.notification.success.content": "The service status has been updated",
+  "ldn-enable-service.notification.success.content": "تم تحديث حالة الخدمة",
   // "ldn-service-delete.notification.success.title": "Successful Deletion",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.success.title": "Successful Deletion",
+  "ldn-service-delete.notification.success.title": "تم الحذف بنجاح",
   // "ldn-service-delete.notification.success.content": "The service has been deleted",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.success.content": "The service has been deleted",
+  "ldn-service-delete.notification.success.content": "تم حذف الخدمة",
   // "ldn-service-delete.notification.error.title": "Failed Deletion",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.error.title": "Failed Deletion",
+  "ldn-service-delete.notification.error.title": "فشل الحذف",
   // "ldn-service-delete.notification.error.content": "The service has not been deleted",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.error.content": "The service has not been deleted",
+  "ldn-service-delete.notification.error.content": "لم يتم حذف الخدمة",
   // "service.overview.reset-form.reset-return": "Cancel",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.reset-return": "Cancel",
+  "service.overview.reset-form.reset-return": "إلغاء",
   // "service.overview.delete": "Delete service",
-  // TODO New key - Add a translation
-  "service.overview.delete": "Delete service",
+  "service.overview.delete": "حذف الخدمة",
   // "ldn-edit-service.title": "Edit service",
-  // TODO New key - Add a translation
-  "ldn-edit-service.title": "Edit service",
+  "ldn-edit-service.title": "تحرير الخدمة",
   // "ldn-edit-service.form.label.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.name": "Name",
+  "ldn-edit-service.form.label.name": "الاسم",
   // "ldn-edit-service.form.label.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.description": "Description",
+  "ldn-edit-service.form.label.description": "الوصف",
   // "ldn-edit-service.form.label.url": "Service URL",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.url": "Service URL",
+  "ldn-edit-service.form.label.url": "رابط الخدمة",
   // "ldn-edit-service.form.label.ldnUrl": "LDN Inbox URL",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-edit-service.form.label.ldnUrl": "عنوان URL لصندوق وارد LDN",
   // "ldn-edit-service.form.label.inboundPattern": "Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.inboundPattern": "Inbound Pattern",
+  "ldn-edit-service.form.label.inboundPattern": "النمط الوارد",
   // "ldn-edit-service.form.label.noInboundPatternSelected": "No Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.noInboundPatternSelected": "No Inbound Pattern",
+  "ldn-edit-service.form.label.noInboundPatternSelected": "لا يوجد نمط وارد",
   // "ldn-edit-service.form.label.selectedItemFilter": "Selected Item Filter",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.selectedItemFilter": "Selected Item Filter",
+  "ldn-edit-service.form.label.selectedItemFilter": "مرشّح العناصر المحدد",
   // "ldn-edit-service.form.label.selectItemFilter": "No Item Filter",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.selectItemFilter": "No Item Filter",
+  "ldn-edit-service.form.label.selectItemFilter": "لا يوجد مرشّح عناصر",
   // "ldn-edit-service.form.label.automatic": "Automatic",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.automatic": "Automatic",
+  "ldn-edit-service.form.label.automatic": "تلقائي",
   // "ldn-edit-service.form.label.addInboundPattern": "+ Add more",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.addInboundPattern": "+ Add more",
+  "ldn-edit-service.form.label.addInboundPattern": "+ إضافة المزيد",
   // "ldn-edit-service.form.label.submit": "Save",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.submit": "Save",
+  "ldn-edit-service.form.label.submit": "حفظ",
   // "ldn-edit-service.breadcrumbs": "Edit Service",
-  // TODO New key - Add a translation
-  "ldn-edit-service.breadcrumbs": "Edit Service",
+  "ldn-edit-service.breadcrumbs": "تحرير الخدمة",
   // "ldn-service.control-constaint-select-none": "Select none",
-  // TODO New key - Add a translation
-  "ldn-service.control-constaint-select-none": "Select none",
+  "ldn-service.control-constaint-select-none": "عدم التحديد",
 
   // "ldn-register-new-service.notification.error.title": "Error",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.error.title": "Error",
+  "ldn-register-new-service.notification.error.title": "خطأ",
   // "ldn-register-new-service.notification.error.content": "An error occurred while creating this process",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.error.content": "An error occurred while creating this process",
+  "ldn-register-new-service.notification.error.content": "حدث خطأ أثناء إنشاء هذه العملية",
   // "ldn-register-new-service.notification.success.title": "Success",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.success.title": "Success",
+  "ldn-register-new-service.notification.success.title": "نجاح",
   // "ldn-register-new-service.notification.success.content": "The process was successfully created",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.success.content": "The process was successfully created",
+  "ldn-register-new-service.notification.success.content": "تم إنشاء العملية بنجاح",
 
   // "submission.sections.notify.info": "The selected service is compatible with the item according to its current status. {{ service.name }}: {{ service.description }}",
-  // TODO New key - Add a translation
-  "submission.sections.notify.info": "The selected service is compatible with the item according to its current status. {{ service.name }}: {{ service.description }}",
+  "submission.sections.notify.info": "الخدمة المحددة متوافقة مع المادة وفق حالتها الحالية. {{ service.name }}: {{ service.description }}",
 
   // "item.page.endorsement": "Endorsement",
-  // TODO New key - Add a translation
-  "item.page.endorsement": "Endorsement",
+  "item.page.endorsement": "تأييد",
 
   // "item.page.places": "Related places",
-  // TODO New key - Add a translation
-  "item.page.places": "Related places",
+  "item.page.places": "أماكن ذات صلة",
 
   // "item.page.review": "Review",
-  // TODO New key - Add a translation
-  "item.page.review": "Review",
+  "item.page.review": "مراجعة",
 
   // "item.page.referenced": "Referenced By",
-  // TODO New key - Add a translation
-  "item.page.referenced": "Referenced By",
+  "item.page.referenced": "مشار إليه بواسطة",
 
   // "item.page.supplemented": "Supplemented By",
-  // TODO New key - Add a translation
-  "item.page.supplemented": "Supplemented By",
+  "item.page.supplemented": "مدعوم بواسطة",
 
   // "menu.section.icon.ldn_services": "LDN Services overview",
-  // TODO New key - Add a translation
-  "menu.section.icon.ldn_services": "LDN Services overview",
+  "menu.section.icon.ldn_services": "نظرة عامة على خدمات LDN",
 
   // "menu.section.services": "LDN Services",
-  // TODO New key - Add a translation
-  "menu.section.services": "LDN Services",
+  "menu.section.services": "خدمات LDN",
 
   // "menu.section.services_new": "LDN Service",
-  // TODO New key - Add a translation
-  "menu.section.services_new": "LDN Service",
+  "menu.section.services_new": "خدمة LDN",
 
   // "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
-  // TODO New key - Add a translation
-  "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
+  "quality-assurance.topics.description-with-target": "أدناه يمكنك رؤية جميع المواضيع الواردة من الاشتراكات في {{source}} والمتعلقة بـ",
   // "quality-assurance.events.description": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b>.",
   "quality-assurance.events.description": "توجد أدناه القائمة التي تحتوي على كافة الاقتراحات للموضوع المحدد.",
 
   // "quality-assurance.events.description-with-topic-and-target": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b> and ",
-  // TODO New key - Add a translation
-  "quality-assurance.events.description-with-topic-and-target": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b> and ",
+  "quality-assurance.events.description-with-topic-and-target": "أدناه قائمة بجميع الاقتراحات للموضوع المحدد <b>{{topic}}</b>، المتعلقة بـ <b>{{source}}</b> و ",
 
   // "quality-assurance.event.table.event.message.serviceUrl": "Actor:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.event.message.serviceUrl": "Actor:",
+  "quality-assurance.event.table.event.message.serviceUrl": "الجهة الفاعلة:",
 
   // "quality-assurance.event.table.event.message.link": "Link:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.event.message.link": "Link:",
+  "quality-assurance.event.table.event.message.link": "رابط:",
 
   // "service.detail.delete.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "service.detail.delete.cancel": "Cancel",
+  "service.detail.delete.cancel": "إلغاء",
 
   // "service.detail.delete.button": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.button": "Delete service",
+  "service.detail.delete.button": "حذف الخدمة",
 
   // "service.detail.delete.header": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.header": "Delete service",
+  "service.detail.delete.header": "حذف الخدمة",
 
   // "service.detail.delete.body": "Are you sure you want to delete the current service?",
-  // TODO New key - Add a translation
-  "service.detail.delete.body": "Are you sure you want to delete the current service?",
+  "service.detail.delete.body": "هل أنت متأكد أنك تريد حذف الخدمة الحالية؟",
 
   // "service.detail.delete.confirm": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.confirm": "Delete service",
+  "service.detail.delete.confirm": "حذف الخدمة",
 
   // "service.detail.delete.success": "The service was successfully deleted.",
-  // TODO New key - Add a translation
-  "service.detail.delete.success": "The service was successfully deleted.",
+  "service.detail.delete.success": "تم حذف الخدمة بنجاح.",
 
   // "service.detail.delete.error": "Something went wrong when deleting the service",
-  // TODO New key - Add a translation
-  "service.detail.delete.error": "Something went wrong when deleting the service",
+  "service.detail.delete.error": "حدث خطأ أثناء حذف الخدمة",
 
   // "service.overview.table.id": "Services ID",
-  // TODO New key - Add a translation
-  "service.overview.table.id": "Services ID",
+  "service.overview.table.id": "معرف الخدمة",
 
   // "service.overview.table.name": "Name",
-  // TODO New key - Add a translation
-  "service.overview.table.name": "Name",
+  "service.overview.table.name": "الاسم",
 
   // "service.overview.table.start": "Start time (UTC)",
-  // TODO New key - Add a translation
-  "service.overview.table.start": "Start time (UTC)",
+  "service.overview.table.start": "وقت البدء (التوقيت العالمي)",
 
   // "service.overview.table.status": "Status",
-  // TODO New key - Add a translation
-  "service.overview.table.status": "Status",
+  "service.overview.table.status": "الحالة",
 
   // "service.overview.table.user": "User",
-  // TODO New key - Add a translation
-  "service.overview.table.user": "User",
+  "service.overview.table.user": "المستخدم",
 
   // "service.overview.title": "Services Overview",
-  // TODO New key - Add a translation
-  "service.overview.title": "Services Overview",
+  "service.overview.title": "نظرة عامة على الخدمات",
 
   // "service.overview.breadcrumbs": "Services Overview",
-  // TODO New key - Add a translation
-  "service.overview.breadcrumbs": "Services Overview",
+  "service.overview.breadcrumbs": "نظرة عامة على الخدمات",
 
   // "service.overview.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "service.overview.table.actions": "Actions",
+  "service.overview.table.actions": "إجراءات",
 
   // "service.overview.table.description": "Description",
-  // TODO New key - Add a translation
-  "service.overview.table.description": "Description",
+  "service.overview.table.description": "الوصف",
 
   // "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
+  "submission.sections.submit.progressbar.coarnotify": "إشعار COAR",
 
   // "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
+  "submission.section.section-coar-notify.control.request-review.label": "يمكنك طلب مراجعة من إحدى الخدمات التالية",
 
   // "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
+  "submission.section.section-coar-notify.control.request-endorsement.label": "يمكنك طلب تأييد إلى إحدى الدوريات التراكمية التالية",
 
   // "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
+  "submission.section.section-coar-notify.control.request-ingest.label": "يمكنك طلب إدخال نسخة من تقديمك إلى إحدى الخدمات التالية",
 
   // "submission.section.section-coar-notify.dropdown.no-data": "No data available",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.dropdown.no-data": "No data available",
+  "submission.section.section-coar-notify.dropdown.no-data": "لا توجد بيانات متاحة",
 
   // "submission.section.section-coar-notify.dropdown.select-none": "Select none",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.dropdown.select-none": "Select none",
+  "submission.section.section-coar-notify.dropdown.select-none": "عدم التحديد",
 
   // "submission.section.section-coar-notify.small.notification": "Select a service for {{ pattern }} of this item",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.small.notification": "Select a service for {{ pattern }} of this item",
+  "submission.section.section-coar-notify.small.notification": "حدد خدمة لـ {{ pattern }} لهذه المادة",
 
   // "submission.section.section-coar-notify.selection.description": "Selected service's description:",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.selection.description": "Selected service's description:",
+  "submission.section.section-coar-notify.selection.description": "وصف الخدمة المحددة:",
 
   // "submission.section.section-coar-notify.selection.no-description": "No further information is available",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.selection.no-description": "No further information is available",
+  "submission.section.section-coar-notify.selection.no-description": "لا تتوفر معلومات إضافية",
 
   // "submission.section.section-coar-notify.notification.error": "The selected service is not suitable for the current item. Please check the description for details about which record can be managed by this service.",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.notification.error": "The selected service is not suitable for the current item. Please check the description for details about which record can be managed by this service.",
+  "submission.section.section-coar-notify.notification.error": "الخدمة المحددة غير مناسبة لهذه المادة. يرجى مراجعة الوصف لمعرفة السجلات التي يمكن لهذه الخدمة معالجتها.",
 
   // "submission.section.section-coar-notify.info.no-pattern": "No configurable patterns found.",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.info.no-pattern": "No configurable patterns found.",
+  "submission.section.section-coar-notify.info.no-pattern": "لم يتم العثور على أنماط قابلة للتهيئة.",
 
   // "error.validation.coarnotify.invalidfilter": "Invalid filter, try to select another service or none.",
-  // TODO New key - Add a translation
-  "error.validation.coarnotify.invalidfilter": "Invalid filter, try to select another service or none.",
+  "error.validation.coarnotify.invalidfilter": "مرشح غير صالح، حاول اختيار خدمة أخرى أو عدم اختيار أي خدمة.",
 
   // "request-status-alert-box.accepted": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been taken in charge.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.accepted": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been taken in charge.",
+  "request-status-alert-box.accepted": "تم استلام {{ offerType }} المطلوبة لـ <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> ومعالجتها.",
 
   // "request-status-alert-box.rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been rejected.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been rejected.",
+  "request-status-alert-box.rejected": "تم رفض {{ offerType }} المطلوبة لـ <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a>.",
 
   // "request-status-alert-box.tentative_rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been tentatively rejected. Revisions are required",
-  // TODO New key - Add a translation
-  "request-status-alert-box.tentative_rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been tentatively rejected. Revisions are required",
+  "request-status-alert-box.tentative_rejected": "تم رفض {{ offerType }} المطلوبة لـ <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> بشكل مبدئي. التعديلات مطلوبة",
 
   // "request-status-alert-box.requested": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> is pending.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.requested": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> is pending.",
+  "request-status-alert-box.requested": "{{ offerType }} المطلوبة لـ <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> قيد الانتظار.",
 
   // "ldn-service-button-mark-inbound-deletion": "Mark supported pattern for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-button-mark-inbound-deletion": "Mark supported pattern for deletion",
+  "ldn-service-button-mark-inbound-deletion": "وَسْم النمط المدعوم للحذف",
 
   // "ldn-service-button-unmark-inbound-deletion": "Unmark supported pattern for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-button-unmark-inbound-deletion": "Unmark supported pattern for deletion",
+  "ldn-service-button-unmark-inbound-deletion": "إلغاء وَسْم النمط المدعوم للحذف",
 
   // "ldn-service-input-inbound-item-filter-dropdown": "Select Item filter for the pattern",
-  // TODO New key - Add a translation
-  "ldn-service-input-inbound-item-filter-dropdown": "Select Item filter for the pattern",
+  "ldn-service-input-inbound-item-filter-dropdown": "حدد مُرشِّح المواد للنمط",
 
   // "ldn-service-input-inbound-pattern-dropdown": "Select a pattern for service",
-  // TODO New key - Add a translation
-  "ldn-service-input-inbound-pattern-dropdown": "Select a pattern for service",
+  "ldn-service-input-inbound-pattern-dropdown": "حدد نمطاً للخدمة",
 
   // "ldn-service-overview-select-delete": "Select service for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-overview-select-delete": "Select service for deletion",
+  "ldn-service-overview-select-delete": "حدد خدمة للحذف",
 
   // "ldn-service-overview-select-edit": "Edit LDN service",
-  // TODO New key - Add a translation
-  "ldn-service-overview-select-edit": "Edit LDN service",
+  "ldn-service-overview-select-edit": "تحرير خدمة LDN",
 
   // "ldn-service-overview-close-modal": "Close modal",
-  // TODO New key - Add a translation
-  "ldn-service-overview-close-modal": "Close modal",
+  "ldn-service-overview-close-modal": "إغلاق نافذة الحوار",
 
   // "ldn-service-usesActorEmailId": "Requires actor email in notifications",
-  // TODO New key - Add a translation
-  "ldn-service-usesActorEmailId": "Requires actor email in notifications",
+  "ldn-service-usesActorEmailId": "يتطلب بريد الجهة الفاعلة في الإشعارات",
 
   // "ldn-service-usesActorEmailId-description": "If enabled, initial notifications sent will include the submitter email rather than the repository URL. This is usually the case for endorsement or review services.",
-  // TODO New key - Add a translation
-  "ldn-service-usesActorEmailId-description": "If enabled, initial notifications sent will include the submitter email rather than the repository URL. This is usually the case for endorsement or review services.",
+  "ldn-service-usesActorEmailId-description": "إذا تم التفعيل، ستتضمن الإشعارات الأولية المرسلة بريد مقدم الطلب بدلاً من عنوان مستودع الويب. يحدث ذلك عادةً مع خدمات التأييد أو المراجعة.",
 
   // "a-common-or_statement.label": "Item type is Journal Article or Dataset",
-  // TODO New key - Add a translation
-  "a-common-or_statement.label": "Item type is Journal Article or Dataset",
+  "a-common-or_statement.label": "نوع المادة هو مقالة دورية أو مجموعة بيانات",
 
   // "always_true_filter.label": "Always true",
-  // TODO New key - Add a translation
-  "always_true_filter.label": "Always true",
+  "always_true_filter.label": "صحيح دائماً",
 
   // "automatic_processing_collection_filter_16.label": "Automatic processing",
-  // TODO New key - Add a translation
-  "automatic_processing_collection_filter_16.label": "Automatic processing",
+  "automatic_processing_collection_filter_16.label": "معالجة تلقائية",
 
   // "dc-identifier-uri-contains-doi_condition.label": "URI contains DOI",
-  // TODO New key - Add a translation
-  "dc-identifier-uri-contains-doi_condition.label": "URI contains DOI",
+  "dc-identifier-uri-contains-doi_condition.label": "يحتوي المعرّف URI على DOI",
 
   // "doi-filter.label": "DOI filter",
-  // TODO New key - Add a translation
-  "doi-filter.label": "DOI filter",
+  "doi-filter.label": "مرشح DOI",
 
   // "driver-document-type_condition.label": "Document type equals driver",
-  // TODO New key - Add a translation
-  "driver-document-type_condition.label": "Document type equals driver",
+  "driver-document-type_condition.label": "نوع المستند يساوي driver",
 
   // "has-at-least-one-bitstream_condition.label": "Has at least one Bitstream",
-  // TODO New key - Add a translation
-  "has-at-least-one-bitstream_condition.label": "Has at least one Bitstream",
+  "has-at-least-one-bitstream_condition.label": "يحتوي على تدفق بت واحد على الأقل",
 
   // "has-bitstream_filter.label": "Has Bitstream",
-  // TODO New key - Add a translation
-  "has-bitstream_filter.label": "Has Bitstream",
+  "has-bitstream_filter.label": "يحتوي على تدفق بت",
 
   // "has-one-bitstream_condition.label": "Has one Bitstream",
-  // TODO New key - Add a translation
-  "has-one-bitstream_condition.label": "Has one Bitstream",
+  "has-one-bitstream_condition.label": "يحتوي على تدفق بت واحد",
 
   // "is-archived_condition.label": "Is archived",
-  // TODO New key - Add a translation
-  "is-archived_condition.label": "Is archived",
+  "is-archived_condition.label": "مؤرشف",
 
   // "is-withdrawn_condition.label": "Is withdrawn",
-  // TODO New key - Add a translation
-  "is-withdrawn_condition.label": "Is withdrawn",
+  "is-withdrawn_condition.label": "مسحوب",
 
   // "item-is-public_condition.label": "Item is public",
-  // TODO New key - Add a translation
-  "item-is-public_condition.label": "Item is public",
+  "item-is-public_condition.label": "العنصر متاح للعامة",
 
   // "journals_ingest_suggestion_collection_filter_18.label": "Journals ingest",
-  // TODO New key - Add a translation
-  "journals_ingest_suggestion_collection_filter_18.label": "Journals ingest",
+  "journals_ingest_suggestion_collection_filter_18.label": "إدخال الدوريات",
 
   // "title-starts-with-pattern_condition.label": "Title starts with pattern",
-  // TODO New key - Add a translation
-  "title-starts-with-pattern_condition.label": "Title starts with pattern",
+  "title-starts-with-pattern_condition.label": "العنوان يبدأ بالنمط",
 
   // "type-equals-dataset_condition.label": "Type equals Dataset",
-  // TODO New key - Add a translation
-  "type-equals-dataset_condition.label": "Type equals Dataset",
+  "type-equals-dataset_condition.label": "النوع يساوي مجموعة بيانات",
 
   // "type-equals-journal-article_condition.label": "Type equals Journal Article",
-  // TODO New key - Add a translation
-  "type-equals-journal-article_condition.label": "Type equals Journal Article",
+  "type-equals-journal-article_condition.label": "النوع يساوي مقالة دورية",
 
   // "ldn.no-filter.label": "None",
-  // TODO New key - Add a translation
-  "ldn.no-filter.label": "None",
+  "ldn.no-filter.label": "لا شيء",
 
   // "admin.notify.dashboard": "Dashboard",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard": "Dashboard",
+  "admin.notify.dashboard": "لوحة التحكم",
 
   // "menu.section.notify_dashboard": "Dashboard",
-  // TODO New key - Add a translation
-  "menu.section.notify_dashboard": "Dashboard",
+  "menu.section.notify_dashboard": "لوحة التحكم",
 
   // "menu.section.coar_notify": "COAR Notify",
-  // TODO New key - Add a translation
   "menu.section.coar_notify": "COAR Notify",
 
   // "admin-notify-dashboard.title": "Notify Dashboard",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.title": "Notify Dashboard",
+  "admin-notify-dashboard.title": "لوحة إشعارات COAR Notify",
 
   // "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
+  "admin-notify-dashboard.description": "تُراقب لوحة إشعار COAR Notify الاستخدام العام لبروتوكول COAR Notify عبر المستودع. في تبويب \"المقاييس\" توجد إحصاءات حول استخدام البروتوكول. وفي تبويبي \"السجلات/الوارد\" و\"السجلات/الصادر\" يمكن البحث والتحقق من الحالة الفردية لكل رسالة LDN سواء كانت مستلمة أو مُرسلة.",
 
   // "admin-notify-dashboard.metrics": "Metrics",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.metrics": "Metrics",
+  "admin-notify-dashboard.metrics": "المقاييس",
 
   // "admin-notify-dashboard.received-ldn": "Number of received LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.received-ldn": "Number of received LDN",
+  "admin-notify-dashboard.received-ldn": "عدد رسائل LDN المستلمة",
 
   // "admin-notify-dashboard.generated-ldn": "Number of generated LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.generated-ldn": "Number of generated LDN",
+  "admin-notify-dashboard.generated-ldn": "عدد رسائل LDN المُولدة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.accepted": "Accepted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.accepted": "Accepted",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted": "مقبول",
 
   // "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Accepted inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Accepted inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "إشعارات واردة مقبولة",
 
   // "admin-notify-logs.NOTIFY.incoming.accepted": "Currently displaying: Accepted notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.accepted": "Currently displaying: Accepted notifications",
+  "admin-notify-logs.NOTIFY.incoming.accepted": "المعروض حالياً: إشعارات مقبولة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.processed": "Processed LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.processed": "Processed LDN",
+  "admin-notify-dashboard.NOTIFY.incoming.processed": "LDN مُعالجة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Processed inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Processed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.processed.description": "إشعارات واردة مُعالجة",
 
   // "admin-notify-logs.NOTIFY.incoming.processed": "Currently displaying: Processed LDN",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.processed": "Currently displaying: Processed LDN",
+  "admin-notify-logs.NOTIFY.incoming.processed": "المعروض حالياً: LDN مُعالجة",
 
   // "admin-notify-logs.NOTIFY.incoming.failure": "Currently displaying: Failed notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.incoming.failure": "المعروض حالياً: إشعارات فاشلة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.failure": "Failure",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.incoming.failure": "فشل",
 
   // "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Failed inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Failed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.failure.description": "إشعارات واردة فاشلة",
 
   // "admin-notify-logs.NOTIFY.outgoing.failure": "Currently displaying: Failed notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.outgoing.failure": "المعروض حالياً: إشعارات فاشلة",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.failure": "Failure",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure": "فشل",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Failed outbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Failed outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "إشعارات صادرة فاشلة",
 
   // "admin-notify-logs.NOTIFY.incoming.untrusted": "Currently displaying: Untrusted notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.untrusted": "Currently displaying: Untrusted notifications",
+  "admin-notify-logs.NOTIFY.incoming.untrusted": "المعروض حالياً: إشعارات غير موثوقة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Untrusted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Untrusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted": "غير موثوق",
 
   // "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Inbound notifications not trusted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Inbound notifications not trusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "إشعارات واردة غير موثوقة",
 
   // "admin-notify-logs.NOTIFY.incoming.delivered": "Currently displaying: Delivered notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.incoming.delivered": "المعروض حالياً: إشعارات تم تسليمها",
 
   // "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Inbound notifications successfully delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Inbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "إشعارات واردة تم تسليمها بنجاح",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered": "تم التسليم",
 
   // "admin-notify-logs.NOTIFY.outgoing.delivered": "Currently displaying: Delivered notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.outgoing.delivered": "المعروض حالياً: إشعارات تم تسليمها",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Outbound notifications successfully delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Outbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "إشعارات صادرة تم تسليمها بنجاح",
 
   // "admin-notify-logs.NOTIFY.outgoing.queued": "Currently displaying: Queued notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.queued": "Currently displaying: Queued notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued": "المعروض حالياً: إشعارات في قائمة الانتظار",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Notifications currently queued",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Notifications currently queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "إشعارات موجودة حالياً في قائمة الانتظار",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued": "Queued",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued": "Queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued": "في قائمة الانتظار",
 
   // "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Currently displaying: Queued for retry notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Currently displaying: Queued for retry notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "المعروض حالياً: إشعارات في قائمة الانتظار لإعادة المحاولة",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Queued for retry",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "في قائمة الانتظار لإعادة المحاولة",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Notifications currently queued for retry",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Notifications currently queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "إشعارات موجودة حالياً في قائمة الانتظار لإعادة المحاولة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Items involved",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "العناصر المشاركة",
 
   // "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Items related to inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Items related to inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "عناصر مرتبطة بالإشعارات الواردة",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Items involved",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "العناصر المشاركة",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Items related to outbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Items related to outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "عناصر مرتبطة بالإشعارات الصادرة",
 
   // "admin.notify.dashboard.breadcrumbs": "Dashboard",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.breadcrumbs": "Dashboard",
+  "admin.notify.dashboard.breadcrumbs": "لوحة التحكم",
 
   // "admin.notify.dashboard.inbound": "Inbound messages",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.inbound": "Inbound messages",
+  "admin.notify.dashboard.inbound": "رسائل واردة",
 
   // "admin.notify.dashboard.inbound-logs": "Logs/Inbound",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.inbound-logs": "Logs/Inbound",
+  "admin.notify.dashboard.inbound-logs": "السجلات/الوارد",
 
   // "admin.notify.dashboard.filter": "Filter: ",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.filter": "Filter: ",
+  "admin.notify.dashboard.filter": "عامل التصفية: ",
 
   // "search.filters.applied.f.relateditem": "Related items",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.relateditem": "Related items",
+  "search.filters.applied.f.relateditem": "عناصر ذات صلة",
 
   // "search.filters.applied.f.ldn_service": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.ldn_service": "LDN Service",
+  "search.filters.applied.f.ldn_service": "خدمة LDN",
 
   // "search.filters.applied.f.notifyReview": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyReview": "Notify Review",
+  "search.filters.applied.f.notifyReview": "إشعار المراجعة",
 
   // "search.filters.applied.f.notifyEndorsement": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyEndorsement": "Notify Endorsement",
+  "search.filters.applied.f.notifyEndorsement": "إشعار التأييد",
 
   // "search.filters.applied.f.notifyRelation": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyRelation": "Notify Relation",
+  "search.filters.applied.f.notifyRelation": "إشعار العلاقة",
 
   // "search.filters.applied.f.access_status": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.access_status": "Access type",
+  "search.filters.applied.f.access_status": "نوع الوصول",
 
   // "search.filters.filter.queue_last_start_time.head": "Last processing time ",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.head": "Last processing time ",
+  "search.filters.filter.queue_last_start_time.head": "آخر وقت معالجة ",
 
   // "search.filters.filter.queue_last_start_time.min.label": "Min range",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.min.label": "Min range",
+  "search.filters.filter.queue_last_start_time.min.label": "الحد الأدنى للنطاق",
 
   // "search.filters.filter.queue_last_start_time.max.label": "Max range",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.max.label": "Max range",
+  "search.filters.filter.queue_last_start_time.max.label": "الحد الأقصى للنطاق",
 
   // "search.filters.applied.f.queue_last_start_time.min": "Min range",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_last_start_time.min": "Min range",
+  "search.filters.applied.f.queue_last_start_time.min": "الحد الأدنى للنطاق",
 
   // "search.filters.applied.f.queue_last_start_time.max": "Max range",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_last_start_time.max": "Max range",
+  "search.filters.applied.f.queue_last_start_time.max": "الحد الأقصى للنطاق",
 
   // "admin.notify.dashboard.outbound": "Outbound messages",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.outbound": "Outbound messages",
+  "admin.notify.dashboard.outbound": "رسائل صادرة",
 
   // "admin.notify.dashboard.outbound-logs": "Logs/Outbound",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.outbound-logs": "Logs/Outbound",
+  "admin.notify.dashboard.outbound-logs": "السجلات/الصادر",
 
   // "NOTIFY.incoming.search.results.head": "Incoming",
-  // TODO New key - Add a translation
-  "NOTIFY.incoming.search.results.head": "Incoming",
+  "NOTIFY.incoming.search.results.head": "وارد",
 
   // "search.filters.filter.relateditem.head": "Related item",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.head": "Related item",
+  "search.filters.filter.relateditem.head": "عنصر ذو صلة",
 
   // "search.filters.filter.origin.head": "Origin",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.head": "Origin",
+  "search.filters.filter.origin.head": "المصدر",
 
   // "search.filters.filter.ldn_service.head": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.head": "LDN Service",
+  "search.filters.filter.ldn_service.head": "خدمة LDN",
 
   // "search.filters.filter.target.head": "Target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.head": "Target",
+  "search.filters.filter.target.head": "الهدف",
 
   // "search.filters.filter.queue_status.head": "Queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.head": "Queue status",
+  "search.filters.filter.queue_status.head": "حالة قائمة الانتظار",
 
   // "search.filters.filter.activity_stream_type.head": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.head": "Activity stream type",
+  "search.filters.filter.activity_stream_type.head": "نوع تيار النشاط",
 
   // "search.filters.filter.coar_notify_type.head": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.head": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.head": "نوع COAR Notify",
 
   // "search.filters.filter.notification_type.head": "Notification type",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.head": "Notification type",
+  "search.filters.filter.notification_type.head": "نوع الإشعار",
 
   // "search.filters.filter.relateditem.label": "Search related items",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.label": "Search related items",
+  "search.filters.filter.relateditem.label": "بحث العناصر ذات الصلة",
 
   // "search.filters.filter.queue_status.label": "Search queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.label": "Search queue status",
+  "search.filters.filter.queue_status.label": "بحث حالة قائمة الانتظار",
 
   // "search.filters.filter.target.label": "Search target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.label": "Search target",
+  "search.filters.filter.target.label": "بحث الهدف",
 
   // "search.filters.filter.activity_stream_type.label": "Search activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.label": "Search activity stream type",
+  "search.filters.filter.activity_stream_type.label": "بحث نوع تيار النشاط",
 
   // "search.filters.applied.f.queue_status": "Queue Status",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_status": "Queue Status",
+  "search.filters.applied.f.queue_status": "حالة قائمة الانتظار",
 
   // "search.filters.queue_status.0,authority": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.0,authority": "Untrusted Ip",
+  "search.filters.queue_status.0,authority": "عنوان IP غير موثوق",
 
   // "search.filters.queue_status.1,authority": "Queued",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.1,authority": "Queued",
+  "search.filters.queue_status.1,authority": "في قائمة الانتظار",
 
   // "search.filters.queue_status.2,authority": "Processing",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.2,authority": "Processing",
+  "search.filters.queue_status.2,authority": "جارٍ المعالجة",
 
   // "search.filters.queue_status.3,authority": "Processed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.3,authority": "Processed",
+  "search.filters.queue_status.3,authority": "تمت معالجته",
 
   // "search.filters.queue_status.4,authority": "Failed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.4,authority": "Failed",
+  "search.filters.queue_status.4,authority": "فشل",
 
   // "search.filters.queue_status.5,authority": "Untrusted",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.5,authority": "Untrusted",
+  "search.filters.queue_status.5,authority": "غير موثوق",
 
   // "search.filters.queue_status.6,authority": "Unmapped Action",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.6,authority": "Unmapped Action",
+  "search.filters.queue_status.6,authority": "إجراء غير معين",
 
   // "search.filters.queue_status.7,authority": "Queued for retry",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.7,authority": "Queued for retry",
+  "search.filters.queue_status.7,authority": "في قائمة الانتظار لإعادة المحاولة",
 
   // "search.filters.applied.f.activity_stream_type": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.activity_stream_type": "Activity stream type",
+  "search.filters.applied.f.activity_stream_type": "نوع تيار النشاط",
 
   // "search.filters.applied.f.coar_notify_type": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.coar_notify_type": "COAR Notify type",
+  "search.filters.applied.f.coar_notify_type": "نوع COAR Notify",
 
   // "search.filters.applied.f.notification_type": "Notification type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notification_type": "Notification type",
+  "search.filters.applied.f.notification_type": "نوع الإشعار",
 
   // "search.filters.filter.coar_notify_type.label": "Search COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.label": "Search COAR Notify type",
+  "search.filters.filter.coar_notify_type.label": "بحث نوع COAR Notify",
 
   // "search.filters.filter.notification_type.label": "Search notification type",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.label": "Search notification type",
+  "search.filters.filter.notification_type.label": "بحث نوع الإشعار",
 
   // "search.filters.filter.relateditem.placeholder": "Related items",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.placeholder": "Related items",
+  "search.filters.filter.relateditem.placeholder": "عناصر ذات صلة",
 
   // "search.filters.filter.target.placeholder": "Target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.placeholder": "Target",
+  "search.filters.filter.target.placeholder": "الهدف",
 
   // "search.filters.filter.origin.label": "Search source",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.label": "Search source",
+  "search.filters.filter.origin.label": "بحث المصدر",
 
   // "search.filters.filter.origin.placeholder": "Source",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.placeholder": "Source",
+  "search.filters.filter.origin.placeholder": "المصدر",
 
   // "search.filters.filter.ldn_service.label": "Search LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.label": "Search LDN Service",
+  "search.filters.filter.ldn_service.label": "بحث خدمة LDN",
 
   // "search.filters.filter.ldn_service.placeholder": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.placeholder": "LDN Service",
+  "search.filters.filter.ldn_service.placeholder": "خدمة LDN",
 
   // "search.filters.filter.queue_status.placeholder": "Queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.placeholder": "Queue status",
+  "search.filters.filter.queue_status.placeholder": "حالة قائمة الانتظار",
 
   // "search.filters.filter.activity_stream_type.placeholder": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.placeholder": "Activity stream type",
+  "search.filters.filter.activity_stream_type.placeholder": "نوع تيار النشاط",
 
   // "search.filters.filter.coar_notify_type.placeholder": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.placeholder": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.placeholder": "نوع COAR Notify",
 
   // "search.filters.filter.notification_type.placeholder": "Notification",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.placeholder": "Notification",
+  "search.filters.filter.notification_type.placeholder": "إشعار",
 
   // "search.filters.filter.notifyRelation.head": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.head": "Notify Relation",
+  "search.filters.filter.notifyRelation.head": "إشعار العلاقة",
 
   // "search.filters.filter.notifyRelation.label": "Search Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.label": "Search Notify Relation",
+  "search.filters.filter.notifyRelation.label": "بحث إشعار العلاقة",
 
   // "search.filters.filter.notifyRelation.placeholder": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.placeholder": "Notify Relation",
+  "search.filters.filter.notifyRelation.placeholder": "إشعار العلاقة",
 
   // "search.filters.filter.notifyReview.head": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.head": "Notify Review",
+  "search.filters.filter.notifyReview.head": "إشعار المراجعة",
 
   // "search.filters.filter.notifyReview.label": "Search Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.label": "Search Notify Review",
+  "search.filters.filter.notifyReview.label": "بحث إشعار المراجعة",
 
   // "search.filters.filter.notifyReview.placeholder": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.placeholder": "Notify Review",
+  "search.filters.filter.notifyReview.placeholder": "إشعار المراجعة",
 
   // "search.filters.coar_notify_type.coar-notify:ReviewAction": "Review action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:ReviewAction": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction": "إجراء المراجعة",
 
   // "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Review action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "إجراء المراجعة",
 
   // "notify-detail-modal.coar-notify:ReviewAction": "Review action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:ReviewAction": "Review action",
+  "notify-detail-modal.coar-notify:ReviewAction": "إجراء المراجعة",
 
   // "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Endorsement action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction": "إجراء التأييد",
 
   // "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Endorsement action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "إجراء التأييد",
 
   // "notify-detail-modal.coar-notify:EndorsementAction": "Endorsement action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:EndorsementAction": "Endorsement action",
+  "notify-detail-modal.coar-notify:EndorsementAction": "إجراء التأييد",
 
   // "search.filters.coar_notify_type.coar-notify:IngestAction": "Ingest action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:IngestAction": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction": "إجراء الإدخال",
 
   // "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Ingest action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "إجراء الإدخال",
 
   // "notify-detail-modal.coar-notify:IngestAction": "Ingest action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:IngestAction": "Ingest action",
+  "notify-detail-modal.coar-notify:IngestAction": "إجراء الإدخال",
 
   // "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Relationship action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction": "إجراء العلاقة",
 
   // "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Relationship action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "إجراء العلاقة",
 
   // "notify-detail-modal.coar-notify:RelationshipAction": "Relationship action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:RelationshipAction": "Relationship action",
+  "notify-detail-modal.coar-notify:RelationshipAction": "إجراء العلاقة",
 
   // "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Queued",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Queued",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED": "في قائمة الانتظار",
 
   // "notify-detail-modal.QUEUE_STATUS_QUEUED": "Queued",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_QUEUED": "Queued",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED": "في قائمة الانتظار",
 
   // "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "في قائمة الانتظار لإعادة المحاولة",
 
   // "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "في قائمة الانتظار لإعادة المحاولة",
 
   // "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Processing",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Processing",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "جارٍ المعالجة",
 
   // "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Processing",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Processing",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSING": "جارٍ المعالجة",
 
   // "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Processed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Processed",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "تمت معالجته",
 
   // "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Processed",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Processed",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSED": "تمت معالجته",
 
   // "search.filters.queue_status.QUEUE_STATUS_FAILED": "Failed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_FAILED": "Failed",
+  "search.filters.queue_status.QUEUE_STATUS_FAILED": "فشل",
 
   // "notify-detail-modal.QUEUE_STATUS_FAILED": "Failed",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_FAILED": "Failed",
+  "notify-detail-modal.QUEUE_STATUS_FAILED": "فشل",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Untrusted",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "غير موثوق",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "عنوان IP غير موثوق",
 
   // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Untrusted",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "غير موثوق",
 
   // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "عنوان IP غير موثوق",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "إجراء غير معين",
 
   // "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "إجراء غير معين",
 
   // "sorting.queue_last_start_time.DESC": "Last started queue Descending",
-  // TODO New key - Add a translation
-  "sorting.queue_last_start_time.DESC": "Last started queue Descending",
+  "sorting.queue_last_start_time.DESC": "آخر بدء لقائمة الانتظار - ترتيب تنازلي",
 
   // "sorting.queue_last_start_time.ASC": "Last started queue Ascending",
-  // TODO New key - Add a translation
-  "sorting.queue_last_start_time.ASC": "Last started queue Ascending",
+  "sorting.queue_last_start_time.ASC": "آخر بدء لقائمة الانتظار - ترتيب تصاعدي",
 
   // "sorting.queue_attempts.DESC": "Queue attempted Descending",
-  // TODO New key - Add a translation
-  "sorting.queue_attempts.DESC": "Queue attempted Descending",
+  "sorting.queue_attempts.DESC": "محاولات قائمة الانتظار - ترتيب تنازلي",
 
   // "sorting.queue_attempts.ASC": "Queue attempted Ascending",
-  // TODO New key - Add a translation
-  "sorting.queue_attempts.ASC": "Queue attempted Ascending",
+  "sorting.queue_attempts.ASC": "محاولات قائمة الانتظار - ترتيب تصاعدي",
 
   // "NOTIFY.incoming.involvedItems.search.results.head": "Items involved in incoming LDN",
-  // TODO New key - Add a translation
-  "NOTIFY.incoming.involvedItems.search.results.head": "Items involved in incoming LDN",
+  "NOTIFY.incoming.involvedItems.search.results.head": "العناصر المشاركة في LDN الوارد",
 
   // "NOTIFY.outgoing.involvedItems.search.results.head": "Items involved in outgoing LDN",
-  // TODO New key - Add a translation
-  "NOTIFY.outgoing.involvedItems.search.results.head": "Items involved in outgoing LDN",
+  "NOTIFY.outgoing.involvedItems.search.results.head": "العناصر المشاركة في LDN الصادر",
 
   // "type.notify-detail-modal": "Type",
-  // TODO New key - Add a translation
-  "type.notify-detail-modal": "Type",
+  "type.notify-detail-modal": "النوع",
 
   // "id.notify-detail-modal": "Id",
-  // TODO New key - Add a translation
-  "id.notify-detail-modal": "Id",
+  "id.notify-detail-modal": "المعرّف",
 
   // "coarNotifyType.notify-detail-modal": "COAR Notify type",
-  // TODO New key - Add a translation
-  "coarNotifyType.notify-detail-modal": "COAR Notify type",
+  "coarNotifyType.notify-detail-modal": "نوع COAR Notify",
 
   // "activityStreamType.notify-detail-modal": "Activity stream type",
-  // TODO New key - Add a translation
-  "activityStreamType.notify-detail-modal": "Activity stream type",
+  "activityStreamType.notify-detail-modal": "نوع تيار النشاط",
 
   // "inReplyTo.notify-detail-modal": "In reply to",
-  // TODO New key - Add a translation
-  "inReplyTo.notify-detail-modal": "In reply to",
+  "inReplyTo.notify-detail-modal": "ردًا على",
 
   // "object.notify-detail-modal": "Repository Item",
-  // TODO New key - Add a translation
-  "object.notify-detail-modal": "Repository Item",
+  "object.notify-detail-modal": "عنصر المستودع",
 
   // "context.notify-detail-modal": "Repository Item",
-  // TODO New key - Add a translation
-  "context.notify-detail-modal": "Repository Item",
+  "context.notify-detail-modal": "عنصر المستودع",
 
   // "queueAttempts.notify-detail-modal": "Queue attempts",
-  // TODO New key - Add a translation
-  "queueAttempts.notify-detail-modal": "Queue attempts",
+  "queueAttempts.notify-detail-modal": "محاولات قائمة الانتظار",
 
   // "queueLastStartTime.notify-detail-modal": "Queue last started",
-  // TODO New key - Add a translation
-  "queueLastStartTime.notify-detail-modal": "Queue last started",
+  "queueLastStartTime.notify-detail-modal": "آخر وقت بدء قائمة الانتظار",
 
   // "origin.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "origin.notify-detail-modal": "LDN Service",
+  "origin.notify-detail-modal": "خدمة LDN",
 
   // "target.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "target.notify-detail-modal": "LDN Service",
+  "target.notify-detail-modal": "خدمة LDN",
 
   // "queueStatusLabel.notify-detail-modal": "Queue status",
-  // TODO New key - Add a translation
-  "queueStatusLabel.notify-detail-modal": "Queue status",
+  "queueStatusLabel.notify-detail-modal": "حالة قائمة الانتظار",
 
   // "queueTimeout.notify-detail-modal": "Queue timeout",
-  // TODO New key - Add a translation
-  "queueTimeout.notify-detail-modal": "Queue timeout",
+  "queueTimeout.notify-detail-modal": "مهلة قائمة الانتظار",
 
   // "notify-message-modal.title": "Message Detail",
-  // TODO New key - Add a translation
-  "notify-message-modal.title": "Message Detail",
+  "notify-message-modal.title": "تفاصيل الرسالة",
 
   // "notify-message-modal.show-message": "Show message",
-  // TODO New key - Add a translation
-  "notify-message-modal.show-message": "Show message",
+  "notify-message-modal.show-message": "عرض الرسالة",
 
   // "notify-message-result.timestamp": "Timestamp",
-  // TODO New key - Add a translation
-  "notify-message-result.timestamp": "Timestamp",
+  "notify-message-result.timestamp": "الطابع الزمني",
 
   // "notify-message-result.repositoryItem": "Repository Item",
-  // TODO New key - Add a translation
-  "notify-message-result.repositoryItem": "Repository Item",
+  "notify-message-result.repositoryItem": "عنصر المستودع",
 
   // "notify-message-result.ldnService": "LDN Service",
-  // TODO New key - Add a translation
-  "notify-message-result.ldnService": "LDN Service",
+  "notify-message-result.ldnService": "خدمة LDN",
 
   // "notify-message-result.type": "Type",
-  // TODO New key - Add a translation
-  "notify-message-result.type": "Type",
+  "notify-message-result.type": "النوع",
 
   // "notify-message-result.status": "Status",
-  // TODO New key - Add a translation
-  "notify-message-result.status": "Status",
+  "notify-message-result.status": "الحالة",
 
   // "notify-message-result.action": "Action",
-  // TODO New key - Add a translation
-  "notify-message-result.action": "Action",
+  "notify-message-result.action": "الإجراء",
 
   // "notify-message-result.detail": "Detail",
-  // TODO New key - Add a translation
-  "notify-message-result.detail": "Detail",
+  "notify-message-result.detail": "التفاصيل",
 
   // "notify-message-result.reprocess": "Reprocess",
-  // TODO New key - Add a translation
-  "notify-message-result.reprocess": "Reprocess",
+  "notify-message-result.reprocess": "إعادة المعالجة",
 
   // "notify-queue-status.processed": "Processed",
-  // TODO New key - Add a translation
-  "notify-queue-status.processed": "Processed",
+  "notify-queue-status.processed": "تمت معالجته",
 
   // "notify-queue-status.failed": "Failed",
-  // TODO New key - Add a translation
-  "notify-queue-status.failed": "Failed",
+  "notify-queue-status.failed": "فشل",
 
   // "notify-queue-status.queue_retry": "Queued for retry",
-  // TODO New key - Add a translation
-  "notify-queue-status.queue_retry": "Queued for retry",
+  "notify-queue-status.queue_retry": "في قائمة الانتظار لإعادة المحاولة",
 
   // "notify-queue-status.unmapped_action": "Unmapped action",
-  // TODO New key - Add a translation
-  "notify-queue-status.unmapped_action": "Unmapped action",
+  "notify-queue-status.unmapped_action": "إجراء غير معين",
 
   // "notify-queue-status.processing": "Processing",
-  // TODO New key - Add a translation
-  "notify-queue-status.processing": "Processing",
+  "notify-queue-status.processing": "جارٍ المعالجة",
 
   // "notify-queue-status.queued": "Queued",
-  // TODO New key - Add a translation
-  "notify-queue-status.queued": "Queued",
+  "notify-queue-status.queued": "في قائمة الانتظار",
 
   // "notify-queue-status.untrusted": "Untrusted",
-  // TODO New key - Add a translation
-  "notify-queue-status.untrusted": "Untrusted",
+  "notify-queue-status.untrusted": "غير موثوق",
 
   // "ldnService.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "ldnService.notify-detail-modal": "LDN Service",
+  "ldnService.notify-detail-modal": "خدمة LDN",
 
   // "relatedItem.notify-detail-modal": "Related Item",
-  // TODO New key - Add a translation
-  "relatedItem.notify-detail-modal": "Related Item",
+  "relatedItem.notify-detail-modal": "عنصر ذو صلة",
 
   // "search.filters.filter.notifyEndorsement.head": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.head": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.head": "إشعار التأييد",
 
   // "search.filters.filter.notifyEndorsement.placeholder": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.placeholder": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.placeholder": "إشعار التأييد",
 
   // "search.filters.filter.notifyEndorsement.label": "Search Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.label": "Search Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.label": "بحث إشعار التأييد",
 
   // "form.date-picker.placeholder.year": "Year",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.year": "Year",
+  "form.date-picker.placeholder.year": "السنة",
 
   // "form.date-picker.placeholder.month": "Month",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.month": "Month",
+  "form.date-picker.placeholder.month": "الشهر",
 
   // "form.date-picker.placeholder.day": "Day",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.day": "Day",
+  "form.date-picker.placeholder.day": "اليوم",
 
   // "item.page.cc.license.title": "Creative Commons license",
-  // TODO New key - Add a translation
-  "item.page.cc.license.title": "Creative Commons license",
+  "item.page.cc.license.title": "ترخيص المشاع الإبداعي",
 
   // "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
-  // TODO New key - Add a translation
-  "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
+  "item.page.cc.license.disclaimer": "إلا إذا ذُكر خلاف ذلك، يتم وصف ترخيص هذه المادة على أنه",
 
   // "browse.search-form.placeholder": "Search the repository",
-  // TODO New key - Add a translation
-  "browse.search-form.placeholder": "Search the repository",
+  "browse.search-form.placeholder": "ابحث في المستودع",
 
   // "file-download-link.download": "Download ",
-  // TODO New key - Add a translation
-  "file-download-link.download": "Download ",
+  "file-download-link.download": "تنزيل ",
 
   // "register-page.registration.aria.label": "Enter your e-mail address",
-  // TODO New key - Add a translation
-  "register-page.registration.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "أدخل عنوان بريدك الإلكتروني",
 
   // "forgot-email.form.aria.label": "Enter your e-mail address",
-  // TODO New key - Add a translation
-  "forgot-email.form.aria.label": "Enter your e-mail address",
+  "forgot-email.form.aria.label": "أدخل عنوان بريدك الإلكتروني",
 
   // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
-  // TODO New key - Add a translation
-  "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
+  "search-facet-option.update.announcement": "سيتم إعادة تحميل الصفحة. تم تحديد عامل التصفية {{ filter }}.",
 
   // "live-region.ordering.instructions": "Press spacebar to reorder {{ itemName }}.",
-  // TODO New key - Add a translation
-  "live-region.ordering.instructions": "Press spacebar to reorder {{ itemName }}.",
+  "live-region.ordering.instructions": "اضغط على مفتاح المسافة لإعادة ترتيب {{ itemName }}.",
 
   // "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of  {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
-  // TODO New key - Add a translation
-  "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of  {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.status": "{{ itemName }}، تم سحبه. الموضع الحالي في القائمة: {{ index }} من {{ length }}. استخدم مفاتيح الأسهم للأعلى والأسفل لتغيير الموضع، المسافة للإفلات، وEsc للإلغاء.",
 
   // "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
-  // TODO New key - Add a translation
-  "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.moved": "{{ itemName }}، تم نقله إلى الموضع {{ index }} من {{ length }}. استخدم مفاتيح الأسهم للأعلى والأسفل لتغيير الموضع، المسافة للإفلات، وEsc للإلغاء.",
 
   // "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
-  // TODO New key - Add a translation
-  "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
+  "live-region.ordering.dropped": "{{ itemName }}، تم إفلاته عند الموضع {{ index }} من {{ length }}.",
 
   // "dynamic-form-array.sortable-list.label": "Sortable list",
-  // TODO New key - Add a translation
-  "dynamic-form-array.sortable-list.label": "Sortable list",
+  "dynamic-form-array.sortable-list.label": "قائمة قابلة للترتيب",
 
   // "external-login.component.or": "or",
-  // TODO New key - Add a translation
-  "external-login.component.or": "or",
+  "external-login.component.or": "أو",
 
   // "external-login.confirmation.header": "Information needed to complete the login process",
-  // TODO New key - Add a translation
-  "external-login.confirmation.header": "Information needed to complete the login process",
+  "external-login.confirmation.header": "معلومات مطلوبة لإتمام عملية تسجيل الدخول",
 
   // "external-login.noEmail.informationText": "The information received from {{authMethod}} are not sufficient to complete the login process. Please provide the missing information below, or login via a different method to associate your {{authMethod}} to an existing account.",
-  // TODO New key - Add a translation
-  "external-login.noEmail.informationText": "The information received from {{authMethod}} are not sufficient to complete the login process. Please provide the missing information below, or login via a different method to associate your {{authMethod}} to an existing account.",
+  "external-login.noEmail.informationText": "المعلومات المستلمة من {{authMethod}} غير كافية لإكمال عملية تسجيل الدخول. يرجى توفير المعلومات الناقصة أدناه، أو سجّل الدخول بطريقة أخرى لربط {{authMethod}} بحساب موجود.",
 
   // "external-login.haveEmail.informationText": "It seems that you have not yet an account in this system. If this is the case, please confirm the data received from {{authMethod}} and a new account will be created for you. Otherwise, if you already have an account in the system, please update the email address to match the one already in use in the system or login via a different method to associate your {{authMethod}} to your existing account.",
-  // TODO New key - Add a translation
-  "external-login.haveEmail.informationText": "It seems that you have not yet an account in this system. If this is the case, please confirm the data received from {{authMethod}} and a new account will be created for you. Otherwise, if you already have an account in the system, please update the email address to match the one already in use in the system or login via a different method to associate your {{authMethod}} to your existing account.",
+  "external-login.haveEmail.informationText": "يبدو أنه ليس لديك حساب بعد في هذا النظام. إذا كان الأمر كذلك، يرجى تأكيد البيانات المستلمة من {{authMethod}} وسيتم إنشاء حساب جديد لك. وإلا، إذا كان لديك حساب بالفعل، فحدّث عنوان البريد الإلكتروني ليتطابق مع المستخدم في النظام أو سجّل الدخول بطريقة مختلفة لربط {{authMethod}} بحسابك الحالي.",
 
   // "external-login.confirm-email.header": "Confirm or update email",
-  // TODO New key - Add a translation
-  "external-login.confirm-email.header": "Confirm or update email",
+  "external-login.confirm-email.header": "تأكيد البريد الإلكتروني أو تحديثه",
 
   // "external-login.confirmation.email-required": "Email is required.",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-required": "Email is required.",
+  "external-login.confirmation.email-required": "البريد الإلكتروني مطلوب.",
 
   // "external-login.confirmation.email-label": "User Email",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-label": "User Email",
+  "external-login.confirmation.email-label": "البريد الإلكتروني للمستخدم",
 
   // "external-login.confirmation.email-invalid": "Invalid email format.",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-invalid": "Invalid email format.",
+  "external-login.confirmation.email-invalid": "تنسيق البريد الإلكتروني غير صالح.",
 
   // "external-login.confirm.button.label": "Confirm this email",
-  // TODO New key - Add a translation
-  "external-login.confirm.button.label": "Confirm this email",
+  "external-login.confirm.button.label": "تأكيد هذا البريد الإلكتروني",
 
   // "external-login.confirm-email-sent.header": "Confirmation email sent",
-  // TODO New key - Add a translation
-  "external-login.confirm-email-sent.header": "Confirmation email sent",
+  "external-login.confirm-email-sent.header": "تم إرسال بريد التأكيد",
 
   // "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
-  // TODO New key - Add a translation
-  "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
+  "external-login.confirm-email-sent.info": "لقد أرسلنا بريدًا إلكترونيًا إلى العنوان المقدم للتحقق من إدخالك. <br> يرجى اتباع التعليمات في البريد الإلكتروني لإكمال عملية تسجيل الدخول.",
 
   // "external-login.provide-email.header": "Provide email",
-  // TODO New key - Add a translation
-  "external-login.provide-email.header": "Provide email",
+  "external-login.provide-email.header": "توفير بريد إلكتروني",
 
   // "external-login.provide-email.button.label": "Send Verification link",
-  // TODO New key - Add a translation
-  "external-login.provide-email.button.label": "Send Verification link",
+  "external-login.provide-email.button.label": "إرسال رابط التحقق",
 
   // "external-login-validation.review-account-info.header": "Review your account information",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.header": "Review your account information",
+  "external-login-validation.review-account-info.header": "راجع معلومات حسابك",
 
   // "external-login-validation.review-account-info.info": "The information received from ORCID differs from the one recorded in your profile. <br /> Please review them and decide if you want to update any of them.After saving you will be redirected to your profile page.",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.info": "The information received from ORCID differs from the one recorded in your profile. <br /> Please review them and decide if you want to update any of them.After saving you will be redirected to your profile page.",
+  "external-login-validation.review-account-info.info": "تختلف المعلومات المستلمة من ORCID عن تلك المسجلة في ملفك الشخصي. <br /> يرجى مراجعتها وتقرير ما إذا كنت تريد تحديث أيٍ منها. بعد الحفظ ستتم إعادة توجيهك إلى صفحة ملفك الشخصي.",
 
   // "external-login-validation.review-account-info.table.header.information": "Information",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.information": "Information",
+  "external-login-validation.review-account-info.table.header.information": "المعلومة",
 
   // "external-login-validation.review-account-info.table.header.received-value": "Received value",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.received-value": "Received value",
+  "external-login-validation.review-account-info.table.header.received-value": "القيمة المستلمة",
 
   // "external-login-validation.review-account-info.table.header.current-value": "Current value",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.current-value": "Current value",
+  "external-login-validation.review-account-info.table.header.current-value": "القيمة الحالية",
 
   // "external-login-validation.review-account-info.table.header.action": "Override",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.action": "Override",
+  "external-login-validation.review-account-info.table.header.action": "استبدال",
 
   // "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
+  "external-login-validation.review-account-info.table.row.not-applicable": "غير متاح",
 
   // "on-label": "ON",
-  // TODO New key - Add a translation
-  "on-label": "ON",
+  "on-label": "تشغيل",
 
   // "off-label": "OFF",
-  // TODO New key - Add a translation
-  "off-label": "OFF",
+  "off-label": "إيقاف",
 
   // "review-account-info.merge-data.notification.success": "Your account information has been updated successfully",
-  // TODO New key - Add a translation
-  "review-account-info.merge-data.notification.success": "Your account information has been updated successfully",
+  "review-account-info.merge-data.notification.success": "تم تحديث معلومات حسابك بنجاح",
 
   // "review-account-info.merge-data.notification.error": "Something went wrong while updating your account information",
-  // TODO New key - Add a translation
-  "review-account-info.merge-data.notification.error": "Something went wrong while updating your account information",
+  "review-account-info.merge-data.notification.error": "حدث خطأ أثناء تحديث معلومات حسابك",
 
   // "review-account-info.alert.error.content": "Something went wrong. Please try again later.",
-  // TODO New key - Add a translation
-  "review-account-info.alert.error.content": "Something went wrong. Please try again later.",
+  "review-account-info.alert.error.content": "حدث خطأ. يرجى المحاولة لاحقًا.",
 
   // "external-login-page.provide-email.notifications.error": "Something went wrong.Email address was omitted or the operation is not valid.",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.notifications.error": "Something went wrong.Email address was omitted or the operation is not valid.",
+  "external-login-page.provide-email.notifications.error": "حدث خطأ. تم إغفال عنوان البريد الإلكتروني أو أن العملية غير صالحة.",
 
   // "external-login.error.notification": "There was an error while processing your request. Please try again later.",
-  // TODO New key - Add a translation
-  "external-login.error.notification": "There was an error while processing your request. Please try again later.",
+  "external-login.error.notification": "حدث خطأ أثناء معالجة طلبك. يرجى المحاولة لاحقًا.",
 
   // "external-login.connect-to-existing-account.label": "Connect to an existing user",
-  // TODO New key - Add a translation
-  "external-login.connect-to-existing-account.label": "Connect to an existing user",
+  "external-login.connect-to-existing-account.label": "الاتصال بمستخدم موجود",
 
   // "external-login.modal.label.close": "Close",
-  // TODO New key - Add a translation
-  "external-login.modal.label.close": "Close",
+  "external-login.modal.label.close": "إغلاق",
 
   // "external-login-page.provide-email.create-account.notifications.error.header": "Something went wrong",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.create-account.notifications.error.header": "Something went wrong",
+  "external-login-page.provide-email.create-account.notifications.error.header": "حدث خطأ",
 
   // "external-login-page.provide-email.create-account.notifications.error.content": "Please check again your email address and try again.",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.create-account.notifications.error.content": "Please check again your email address and try again.",
+  "external-login-page.provide-email.create-account.notifications.error.content": "يرجى التحقق من عنوان بريدك الإلكتروني والمحاولة مرة أخرى.",
 
   // "external-login-page.confirm-email.create-account.notifications.error.no-netId": "Something went wrong with this email account. Try again or use a different method to login.",
-  // TODO New key - Add a translation
-  "external-login-page.confirm-email.create-account.notifications.error.no-netId": "Something went wrong with this email account. Try again or use a different method to login.",
+  "external-login-page.confirm-email.create-account.notifications.error.no-netId": "حدث خطأ في حساب البريد الإلكتروني هذا. حاول مرة أخرى أو استخدم طريقة مختلفة لتسجيل الدخول.",
 
   // "external-login-page.orcid-confirmation.firstname": "First name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.firstname": "First name",
+  "external-login-page.orcid-confirmation.firstname": "الاسم الأول",
 
   // "external-login-page.orcid-confirmation.firstname.label": "First name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.firstname.label": "First name",
+  "external-login-page.orcid-confirmation.firstname.label": "الاسم الأول",
 
   // "external-login-page.orcid-confirmation.lastname": "Last name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.lastname": "Last name",
+  "external-login-page.orcid-confirmation.lastname": "اسم العائلة",
 
   // "external-login-page.orcid-confirmation.lastname.label": "Last name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.lastname.label": "Last name",
+  "external-login-page.orcid-confirmation.lastname.label": "اسم العائلة",
 
   // "external-login-page.orcid-confirmation.netid": "Account Identifier",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.netid": "Account Identifier",
+  "external-login-page.orcid-confirmation.netid": "معرّف الحساب",
 
   // "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
-  // TODO New key - Add a translation
   "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
 
   // "external-login-page.orcid-confirmation.email": "Email",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.email": "Email",
+  "external-login-page.orcid-confirmation.email": "البريد الإلكتروني",
 
   // "external-login-page.orcid-confirmation.email.label": "Email",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.email.label": "Email",
+  "external-login-page.orcid-confirmation.email.label": "البريد الإلكتروني",
 
   // "search.filters.access_status.open.access": "Open access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.open.access": "Open access",
+  "search.filters.access_status.open.access": "وصول حر",
 
   // "search.filters.access_status.restricted": "Restricted access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.restricted": "Restricted access",
+  "search.filters.access_status.restricted": "وصول مقيد",
 
   // "search.filters.access_status.embargo": "Embargoed access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.embargo": "Embargoed access",
+  "search.filters.access_status.embargo": "وصول محجوب حتى موعد الرفع",
 
   // "search.filters.access_status.metadata.only": "Metadata only",
-  // TODO New key - Add a translation
-  "search.filters.access_status.metadata.only": "Metadata only",
+  "search.filters.access_status.metadata.only": "بيانات وصفية فقط",
 
   // "search.filters.access_status.unknown": "Unknown",
-  // TODO New key - Add a translation
-  "search.filters.access_status.unknown": "Unknown",
+  "search.filters.access_status.unknown": "غير معروف",
 
   // "metadata-export-filtered-items.tooltip": "Export report output as CSV",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.tooltip": "Export report output as CSV",
+  "metadata-export-filtered-items.tooltip": "تصدير ناتج التقرير بصيغة CSV",
 
   // "metadata-export-filtered-items.submit.success": "CSV export succeeded.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.submit.success": "CSV export succeeded.",
+  "metadata-export-filtered-items.submit.success": "تم تصدير CSV بنجاح.",
 
   // "metadata-export-filtered-items.submit.error": "CSV export failed.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.submit.error": "CSV export failed.",
+  "metadata-export-filtered-items.submit.error": "فشل تصدير CSV.",
 
   // "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
+  "metadata-export-filtered-items.columns.warning": "يتضمن تصدير CSV تلقائيًا جميع الحقول ذات الصلة، لذا لا تؤخذ الاختيارات في هذه القائمة بالحسبان.",
 
   // "embargo.listelement.badge": "Embargo until {{ date }}",
-  // TODO New key - Add a translation
-  "embargo.listelement.badge": "Embargo until {{ date }}",
+  "embargo.listelement.badge": "حظر حتى {{ date }}",
 
   // "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
-  // TODO New key - Add a translation
-  "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
+  "metadata-export-search.submit.error.limit-exceeded": "سيتم تصدير أول {{limit}} عنصرًا فقط",
 
   // "file-download-link.request-copy": "Request a copy of ",
-  // TODO New key - Add a translation
-  "file-download-link.request-copy": "Request a copy of ",
+  "file-download-link.request-copy": "طلب نسخة من ",
 
 
 }


### PR DESCRIPTION
## Description
This PR adds all missing Arabic translations

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
