### PR TITLE
Fix type-bind submission form validation handling

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
@@ -23,6 +23,7 @@ import {
 import { FormBuilderService } from '../form-builder.service';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { DsDynamicTypeBindRelationService } from './ds-dynamic-type-bind-relation.service';
+import { getTypeBindRelations } from './type-bind.utils';
 
 describe('DSDynamicTypeBindRelationService test suite', () => {
   let service: DsDynamicTypeBindRelationService;
@@ -82,7 +83,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
     });
     it('Should get 1 related form models for mock relation model data', () => {
       const testModel = mockInputWithTypeBindModel;
-      testModel.typeBindRelations = DsDynamicTypeBindRelationService.getTypeBindRelations(['boundType'], 'dc.type');
+      testModel.typeBindRelations = getTypeBindRelations(['boundType'], 'dc.type');
       const relatedModels = service.getRelatedFormModel(testModel);
       expect(relatedModels).toHaveSize(1);
     });
@@ -91,7 +92,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
   describe('Test matchesCondition method', () => {
     it('Should receive one subscription to dc.type type binding"', () => {
       const testModel = mockInputWithTypeBindModel;
-      testModel.typeBindRelations = DsDynamicTypeBindRelationService.getTypeBindRelations(['boundType'], 'dc.type');
+      testModel.typeBindRelations = getTypeBindRelations(['boundType'], 'dc.type');
       const dcTypeControl = new UntypedFormControl();
       dcTypeControl.setValue('boundType');
       let subscriptions = service.subscribeRelations(testModel, dcTypeControl);
@@ -100,7 +101,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
 
     it('Expect hasMatch to be true (ie. this should be hidden)', () => {
       const testModel = mockInputWithTypeBindModel;
-      testModel.typeBindRelations = DsDynamicTypeBindRelationService.getTypeBindRelations(['boundType'], 'dc.type');
+      testModel.typeBindRelations = getTypeBindRelations(['boundType'], 'dc.type');
       const dcTypeControl = new UntypedFormControl();
       dcTypeControl.setValue('boundType');
       testModel.typeBindRelations[0].when[0].value = 'anotherType';
@@ -115,7 +116,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
 
     it('Expect hasMatch to be false (ie. this should NOT be hidden)', () => {
       const testModel = mockInputWithTypeBindModel;
-      testModel.typeBindRelations = DsDynamicTypeBindRelationService.getTypeBindRelations(['boundType'], 'dc.type');
+      testModel.typeBindRelations = getTypeBindRelations(['boundType'], 'dc.type');
       const dcTypeControl = new UntypedFormControl();
       dcTypeControl.setValue('boundType');
       testModel.typeBindRelations[0].when[0].value = 'boundType';

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
@@ -13,8 +13,6 @@ import {
   DynamicFormControlModel,
   DynamicFormControlRelation,
   DynamicFormRelationService,
-  MATCH_ENABLED,
-  MATCH_VISIBLE,
   OR_OPERATOR,
 } from '@ng-dynamic-forms/core';
 import { Subscription } from 'rxjs';
@@ -34,48 +32,6 @@ import { DYNAMIC_FORM_CONTROL_TYPE_RELATION_GROUP } from './ds-dynamic-form-cons
  */
 @Injectable({ providedIn: 'root' })
 export class DsDynamicTypeBindRelationService {
-
-  /**
-   * Get the type bind values from the REST data for a specific field
-   * The return value is any[] in the method signature but in reality it's
-   * returning the 'relation' that'll be used for a dynamic matcher when filtering
-   * fields in type bind, made up of a 'match' outcome (make this field visible), an 'operator'
-   * (OR) and a 'when' condition (the bindValues array).
-   * @param configuredTypeBindValues  array of types from the submission definition (CONFIG_DATA)
-   * @param typeField
-   * @private
-   * @return DynamicFormControlRelation[] array with one relation in it, for type bind matching to show a field
-   */
-  public static getTypeBindRelations(configuredTypeBindValues: string[], typeField: string): DynamicFormControlRelation[] {
-    const bindValues = [];
-    configuredTypeBindValues.forEach((value) => {
-      bindValues.push({
-        id: typeField,
-        value: value,
-      });
-    });
-    // match: MATCH_VISIBLE means that if true, the field / component will be visible
-    // operator: OR means that all the values in the 'when' condition will be compared with OR, not AND
-    // when: the list of values to match against, in this case the list of strings from <type-bind>...</type-bind>
-    // Example: Field [x] will be VISIBLE if item type = book OR item type = book_part
-    //
-    // The opposing match value will be the dc.type for the workspace item
-    //
-    // MATCH_ENABLED is now also returned, so that hidden type-bound fields that are 'required'
-    // do not trigger false validation errors
-    return [
-      {
-        match: MATCH_ENABLED,
-        operator: OR_OPERATOR,
-        when: bindValues,
-      },
-      {
-        match: MATCH_VISIBLE,
-        operator: OR_OPERATOR,
-        when: bindValues,
-      },
-    ];
-  }
 
   constructor(@Optional() @Inject(DYNAMIC_MATCHERS) private dynamicMatchers: DynamicFormControlMatcher[],
               protected dynamicFormRelationService: DynamicFormRelationService,

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/type-bind.utils.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/type-bind.utils.ts
@@ -1,0 +1,48 @@
+import {
+  DynamicFormControlRelation,
+  MATCH_ENABLED,
+  MATCH_VISIBLE,
+  OR_OPERATOR,
+} from '@ng-dynamic-forms/core';
+
+/**
+ * Get the type bind values from the REST data for a specific field
+ * The return value is any[] in the method signature but in reality it's
+ * returning the 'relation' that'll be used for a dynamic matcher when filtering
+ * fields in type bind, made up of a 'match' outcome (make this field visible), an 'operator'
+ * (OR) and a 'when' condition (the bindValues array).
+ * @param configuredTypeBindValues  array of types from the submission definition (CONFIG_DATA)
+ * @param typeField
+ * @private
+ * @return DynamicFormControlRelation[] array with one relation in it, for type bind matching to show a field
+ */
+export function getTypeBindRelations(configuredTypeBindValues: string[], typeField: string): DynamicFormControlRelation[] {
+  const bindValues = [];
+  configuredTypeBindValues.forEach((value) => {
+    bindValues.push({
+      id: typeField,
+      value: value,
+    });
+  });
+  // match: MATCH_VISIBLE means that if true, the field / component will be visible
+  // operator: OR means that all the values in the 'when' condition will be compared with OR, not AND
+  // when: the list of values to match against, in this case the list of strings from <type-bind>...</type-bind>
+  // Example: Field [x] will be VISIBLE if item type = book OR item type = book_part
+  //
+  // The opposing match value will be the dc.type for the workspace item
+  //
+  // MATCH_ENABLED is now also returned, so that hidden type-bound fields that are 'required'
+  // do not trigger false validation errors
+  return [
+    {
+      match: MATCH_ENABLED,
+      operator: OR_OPERATOR,
+      when: bindValues,
+    },
+    {
+      match: MATCH_VISIBLE,
+      operator: OR_OPERATOR,
+      when: bindValues,
+    },
+  ];
+}

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -15,7 +15,6 @@ import {
   isNotNull,
   isNotUndefined,
 } from '../../../empty.util';
-import { DsDynamicTypeBindRelationService } from '../ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service';
 import {
   DsDynamicInputModel,
   DsDynamicInputModelConfig,
@@ -24,6 +23,7 @@ import {
   DynamicRowArrayModel,
   DynamicRowArrayModelConfig,
 } from '../ds-dynamic-form-ui/models/ds-dynamic-row-array-model';
+import { getTypeBindRelations } from '../ds-dynamic-form-ui/type-bind.utils';
 import { FormFieldModel } from '../models/form-field.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { RelationshipOptions } from '../models/relationship-options.model';
@@ -94,7 +94,7 @@ export abstract class FieldParser {
         metadataFields: this.getAllFieldIds(),
         hasSelectableMetadata: isNotEmpty(this.configData.selectableMetadata),
         isDraggable,
-        typeBindRelations: isNotEmpty(this.configData.typeBind) ? DsDynamicTypeBindRelationService.getTypeBindRelations(this.configData.typeBind,
+        typeBindRelations: isNotEmpty(this.configData.typeBind) ? getTypeBindRelations(this.configData.typeBind,
           this.parserOptions.typeField) : null,
         groupFactory: () => {
           let model;
@@ -323,7 +323,7 @@ export abstract class FieldParser {
 
     // If typeBind is configured
     if (isNotEmpty(this.configData.typeBind)) {
-      (controlModel as DsDynamicInputModel).typeBindRelations = DsDynamicTypeBindRelationService.getTypeBindRelations(this.configData.typeBind,
+      (controlModel as DsDynamicInputModel).typeBindRelations = getTypeBindRelations(this.configData.typeBind,
         this.parserOptions.typeField);
     }
 


### PR DESCRIPTION
## References

Fixes #2742 and #2572 

## Description

Fixes an issue with submission section form validation, where fields that are both "required" but also hidden by type-bind (for the current submission based on dc.type) are still validated by the Angular `required` validator and causing the section to be marked as not valid / display the warning symbol, even though it is successfully validated by the server and can be deposited.

The fix for this is to disable the fields as well as simply hiding them, so they are skipped by the Angular validation process.

### To reproduce the problem:

1. Configure a form (describe) section with a field such as:
```
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>contributor</dc-element>
          <dc-qualifier>author</dc-qualifier>
          <label>Author</label>
          <input-type>onebox</input-type>
          <repeatable>false</repeatable>
          <required>You must enter at least the author.</required>
          <hint>Enter the names ...</hint>
          <type-bind>article</type-bind>
        </field>
```
(modify type-bind value to suit your own value pair or vocabulary for dc.type, or just set dc.type to onebox for testing)

Make sure you have some other fields in the same form, preferably one or more required fields that are NOT type-bound so you can test normal data entry.

3. Confirm that any submission without the type 'article' does NOT see that field
4. Note that even when all other required fields in the same section are completed, and there are no server-side errors to display, the section is still marked with an orange "Warning" icon.
5. Switch to the 'article' type, complete the remaining required fields, and note that the section should now finally be green/success.

### Changes

1. Return MATCHER_ENABLED (inclusive) relation in `getTypeBindRelations` in addition to MATCHER_VISIBLE, which means that fields *not* allowed by type bind will be both disabled and hidden
2. Consolidate duplicate code for `getTypeBindRelations` into a utility function (in a separate file to avoid circular dependencies) and update the inline documentation

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
