### PR TITLE
fix: improve 'move' handling of controls in form array

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
@@ -35,7 +35,7 @@
               [formGroup]="group"
               [formModel]="formModel"
               [context]="groupModel"
-              [group]="getControlOfGroup(groupModel)"
+              [group]="control.get([groupModel.index])"
               [hidden]="_model.hidden"
               [class.d-none]="_model.hidden"
               [layout]="formLayout"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.spec.ts
@@ -159,4 +159,37 @@ describe('DsDynamicFormArrayComponent', () => {
     expect(component.elementBeingSorted).toBeNull();
     expect(component.elementBeingSortedStartingIndex).toBeNull();
   });
+
+  describe('moveFormControlToPosition', () => {
+    it('should move form control from one position to another', () => {
+      const formArray = component.control as any;
+      const initialControls = formArray.controls.map((ctrl: any) => ctrl);
+      const movedControl = initialControls[1];
+
+      // Move control from index 1 to index 3
+      (component as any).moveFormControlToPosition(1, 3);
+
+      expect(formArray.at(3)).toBe(movedControl);
+      expect(formArray.length).toBe(5);
+    });
+
+    it('should preserve form control values after move', () => {
+      const formArray = component.control as any;
+
+      // Set actual values to the form controls
+      formArray.at(0).patchValue({ testFormRowArrayGroupInput: 'Author 1' });
+      formArray.at(1).patchValue({ testFormRowArrayGroupInput: 'Author 2' });
+      formArray.at(2).patchValue({ testFormRowArrayGroupInput: 'Author 3' });
+      formArray.at(3).patchValue({ testFormRowArrayGroupInput: 'Author 4' });
+      formArray.at(4).patchValue({ testFormRowArrayGroupInput: 'Author 5' });
+
+      (component as any).moveFormControlToPosition(1, 3);
+
+      expect(formArray.at(0).value.testFormRowArrayGroupInput).toBe('Author 1');
+      expect(formArray.at(1).value.testFormRowArrayGroupInput).toBe('Author 3');
+      expect(formArray.at(2).value.testFormRowArrayGroupInput).toBe('Author 4');
+      expect(formArray.at(3).value.testFormRowArrayGroupInput).toBe('Author 2');
+      expect(formArray.at(4).value.testFormRowArrayGroupInput).toBe('Author 5');
+    });
+  });
 });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.ts
@@ -88,15 +88,16 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
   }
 
   moveSelection(event: CdkDragDrop<Relationship>) {
+    const prevIndex = event.previousIndex;
+    const index = event.currentIndex;
 
     // prevent propagating events generated releasing on the same position
-    if (event.previousIndex === event.currentIndex) {
+    if (prevIndex === index) {
       return;
     }
 
-    this.model.moveGroup(event.previousIndex, event.currentIndex - event.previousIndex);
-    const prevIndex = event.previousIndex;
-    const index = event.currentIndex;
+    this.model.moveGroup(prevIndex, index - prevIndex);
+    this.moveFormControlToPosition(prevIndex, index);
 
     if (hasValue(this.model.groups[index]) && hasValue((this.control as any).controls[index])) {
       this.onCustomEvent({
@@ -122,19 +123,6 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
    */
   get dragDisabled(): boolean {
     return this.model.groups.length === 1 || !this.model.isDraggable;
-  }
-
-  /**
-   * Gets the control of the specified group model. It adds the startingIndex property to the group model if it does not
-   * already have it. This ensures that the controls are always linked to the correct group model.
-   * @param groupModel The group model to get the control for.
-   * @returns The form control of the specified group model.
-   */
-  getControlOfGroup(groupModel: any) {
-    if (!groupModel.hasOwnProperty('startingIndex')) {
-      groupModel.startingIndex = groupModel.index;
-    }
-    return this.control.get([groupModel.startingIndex]);
   }
 
   /**
@@ -199,6 +187,7 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
 
     if (this.elementBeingSorted) {
       this.model.moveGroup(idx, newIndex - idx);
+      this.moveFormControlToPosition(idx, newIndex);
       if (hasValue(this.model.groups[newIndex]) && hasValue((this.control as any).controls[newIndex])) {
         this.onCustomEvent({
           previousIndex: idx,
@@ -227,6 +216,7 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
 
   cancelKeyboardDragAndDrop(sortableElement: HTMLDivElement, index: number, length: number) {
     this.model.moveGroup(index, this.elementBeingSortedStartingIndex - index);
+    this.moveFormControlToPosition(index, this.elementBeingSortedStartingIndex);
     if (hasValue(this.model.groups[this.elementBeingSortedStartingIndex]) && hasValue((this.control as any).controls[this.elementBeingSortedStartingIndex])) {
       this.onCustomEvent({
         previousIndex: index,
@@ -279,6 +269,21 @@ export class DsDynamicFormArrayComponent extends DynamicFormArrayComponent {
       this.liveRegionService.addMessage(this.translateService.instant('live-region.ordering.instructions', {
         itemName: sortableElement.querySelector('input')?.value,
       }));
+    }
+  }
+
+  private moveFormControlToPosition(fromIndex: number, toIndex: number) {
+    if (!hasValue(fromIndex) || !hasValue(toIndex)) {
+      return;
+    }
+
+    const formArray = this.control as any;
+    if (formArray && formArray.controls) {
+      const movedControl = formArray.at(fromIndex);
+      if (movedControl) {
+        formArray.removeAt(fromIndex,{ emitEvent: false });
+        formArray.insert(toIndex, movedControl, { emitEvent: false });
+      }
     }
   }
 }


### PR DESCRIPTION
## References
* Fixes [#4418](https://github.com/DSpace/dspace-angular/issues/4418)
* Might also fix the described behaviour in [#4736](https://github.com/DSpace/dspace-angular/issues/4736)

## Description
If a form element is repeatable, the values in the form array will no longer become disorganised when items are moved or deleted from the list in multiple operations. Each individual operation does not necessarily cause a problem, but if one operation is performed after another, the final values may not be correctly sent to the backend due to wrong values used in the form-array.

## Instructions for Reviewers / Steps to reproduce
Create a list of six items in a repeatable form control field, e.g. "Other titles". Enter values from 1 to 6. Now, move the last item (value: 6) to second place. Remove this moved item (from the second place). Move the new last item (value: 5) to the first place, then move the item with the "value: 4" to the first place, followed by pressing (the first time) the Save button. Check the corresponding PATCH request as also the form itself for the correct values and their sorting order. To double-check the correct data, hard-reload the submission to verify the values and their order are still right. The result should look like "4, 5, 1, 2, 3".

Before this patch, the result after pressing the Save button was: "5, 6, 1, 3 ,4" - in the PATCH request payload, as well in the form itself after the request was processed. This behaviour ist reproducable on the demo.dspace.org and sandbox.dspace.org pages using a workspace or workflow item.

To ensure that no new errors are introduced, I would be grateful if the reviewer(s) could carry out a few checks. For example, could you check that repeatable fields with controlled vocabularies are also still saved correctly alongside regular input fields, and that relationships between entities within a list are still saved the right way.

List of changes in this PR:
* Refactored control retrieval logic by replacing `getControlOfGroup` with direct use of `control.get` and using the regular index instead of startingIndex
* Added `moveFormControlToPosition` method to handle control positioning during drag-and-drop operations. Ensured controls remain correctly linked to their respective groups

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
