### PR TITLE
Use nofollow for Discovery search facet links

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.html
@@ -3,7 +3,8 @@
     [tabIndex]="-1"
     [routerLink]="[searchLink]"
     [queryParams]="addQueryParams$ | async"
-    (click)="announceFilter(); filterService.minimizeAll()">
+    (click)="announceFilter(); filterService.minimizeAll()"
+    rel="nofollow">
     <label class="mb-0 d-flex w-100">
       <input type="checkbox" [checked]="false" class="my-1 align-self-stretch filter-checkbox" role="checkbox" tabindex="0"/>
       <span class="w-100 ps-1 break-facet">


### PR DESCRIPTION
# References
* Related to https://github.com/DSpace/dspace-angular/issues/4565

# Description
Use `rel="nofollow"` on Discovery search facet links to signal to well-behaved bots that they should not crawl facets. Faceted search results are derivative content of primary DSpace objects and cause excessive load on the server and even exhaust your crawl budget on crawlers like Google.

Should this be configurable? How? Is there a case where a site would want bots to crawl the exponential combinations of search facets?

See: https://developers.google.com/search/blog/2024/12/crawling-december-faceted-nav
See: https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation

# Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, add `rel="nofollow"` to facet links on Discovery search pages

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

Inspect facet links on Discovery search, entity, community, and collection pages to see if they have the `rel="nofollow"` tag.

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).