### PR TITLE
135574: Fix embargo status badge not showing up on refresh

### DIFF
--- a/src/app/shared/object-collection/shared/badges/access-status-badge/access-status-badge.component.ts
+++ b/src/app/shared/object-collection/shared/badges/access-status-badge/access-status-badge.component.ts
@@ -130,12 +130,8 @@ export class AccessStatusBadgeComponent implements OnDestroy, OnInit {
       map((accessStatus: AccessStatusObject) => hasValue(accessStatus.embargoDate) ? accessStatus.embargoDate : null),
       catchError(() => of(null)),
     );
-    this.subs.push(
-      this.embargoDate$.pipe().subscribe((embargoDate: string) => {
-        if (hasValue(embargoDate)) {
-          this.accessStatus$ = of('embargo.listelement.badge');
-        }
-      }),
+    this.accessStatus$ = this.embargoDate$.pipe(
+      map(date => hasValue(date) ? 'embargo.listelement.badge' : null),
     );
   }
 }


### PR DESCRIPTION
## References
Fixes #4811

## Description
Fixes `accessStatus$` getting reassigned inside `embargoDate$.subscribe`. This solved the issue that embargo status badges do not show up on refreshing the item page. 


## Instructions for Reviewers

To test:

1. Enable the config property `item.bitstream.showAccessStatuses`
2. Make an item with at least one embargoed item
3. Navigate to the item page and verify that the embargo badge shows up
4. Refresh the page and the badge should still render

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
