### PR TITLE
Add noindex robots meta tag for non-discoverable items (main)

### DIFF
--- a/src/app/core/metadata/head-tag.service.spec.ts
+++ b/src/app/core/metadata/head-tag.service.spec.ts
@@ -33,6 +33,7 @@ import {
   MockBitstream1,
   MockBitstream2,
   MockBitstream3,
+  NonDiscoverableItemMock,
 } from '../testing/item.mock';
 import { getMockTranslateService } from '../testing/translate.service.mock';
 import { createPaginatedList } from '../testing/utils.test';
@@ -125,6 +126,37 @@ describe('HeadTagService', () => {
       appConfig,
       authorizationService,
     );
+  });
+
+  describe(`robots tag`, () => {
+    it(`should be set to noindex for non-discoverable items`, fakeAsync(() => {
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(NonDiscoverableItemMock),
+          },
+        },
+      });
+      tick();
+      expect(meta.addTag).toHaveBeenCalledWith({
+        name: 'robots',
+        content: 'noindex',
+      });
+    }));
+    it(`should not be set for discoverable items`, fakeAsync(() => {
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(ItemMock),
+          },
+        },
+      });
+      tick();
+      expect(meta.addTag).not.toHaveBeenCalledWith({
+        name: 'robots',
+        content: 'noindex',
+      });
+    }));
   });
 
   it('items page should set meta tags', fakeAsync(() => {

--- a/src/app/core/metadata/head-tag.service.ts
+++ b/src/app/core/metadata/head-tag.service.ts
@@ -173,6 +173,8 @@ export class HeadTagService {
 
   protected setDSOMetaTags(): void {
 
+    this.setNoIndexTag();
+
     this.setTitleTag();
     this.setDescriptionTag();
 
@@ -208,6 +210,15 @@ export class HeadTagService {
     // this.setCitationPatentCountryTag();
     // this.setCitationPatentNumberTag();
 
+  }
+
+  /**
+   * Add <meta name="robots" content="noindex">  to the <head> if non-discoverable item
+   */
+  protected setNoIndexTag(): void {
+    if (this.currentObject.value instanceof Item && this.currentObject.value.isDiscoverable === false) {
+      this.addMetaTag('robots', 'noindex');
+    }
   }
 
   /**

--- a/src/app/core/testing/item.mock.ts
+++ b/src/app/core/testing/item.mock.ts
@@ -293,4 +293,55 @@ export const ItemMock: Item = Object.assign(new Item(), {
   },
   ),
 });
+
+export const NonDiscoverableItemMock: Item = Object.assign(new Item(), {
+  handle: '10673/7',
+  lastModified: '2017-04-24T19:44:08.178+0000',
+  isArchived: true,
+  isDiscoverable: false,
+  isWithdrawn: false,
+  bundles: createSuccessfulRemoteDataObject$(createPaginatedList([
+    MockOriginalBundle,
+  ])),
+  _links:{
+    self: {
+      href: 'https://dspace7.4science.it/dspace-spring-rest/api/core/items/0ec7ff22-f211-40ab-a69e-c819b0b1f358',
+    },
+  },
+  id: '0ec7ff22-f211-40ab-a69e-c819b0b1f358',
+  uuid: '0ec7ff22-f211-40ab-a69e-c819b0b1f358',
+  type: 'item',
+  metadata: {
+    'dc.date.accessioned': [
+      {
+        language: null,
+        value: '1650-06-26T19:58:25Z',
+      },
+    ],
+    'dc.date.available': [
+      {
+        language: null,
+        value: '1650-06-26T19:58:25Z',
+      },
+    ],
+    'dc.date.issued': [
+      {
+        language: null,
+        value: '1650-06-26',
+      },
+    ],
+    'dc.identifier.uri': [
+      {
+        language: null,
+        value: 'http://dspace7.4science.it/xmlui/handle/10673/7',
+      },
+    ],
+    'dc.title': [
+      {
+        language: 'en_US',
+        value: 'Test Non-Discoverable',
+      },
+    ],
+  },
+});
 /* eslint-enable @typescript-eslint/no-shadow */


### PR DESCRIPTION
## References
* Fixes #4835
* `9_x`: #4839
* `8_x`: #4838
* `7_x`: #4837

## Description
Add a `robots=noindex` meta tag to Item pages when `discoverable=false`, restoring the expected behavior for Private items. Implemented in `head-tag.service.ts` via a new `setNoIndexTag()` method invoked during meta tag generation.

## Instructions for Reviewers
List of changes in this PR:
* First, added a new `setNoIndexTag()` method in `head-tag.service.ts` to insert `<meta name="robots" content="noindex">` for non-discoverable Items.
* Second, invoked `setNoIndexTag()` from `setDSOMetaTags()` so the meta tag is added whenever an Item with `discoverable=false` is displayed.
* Third, updated unit tests to verify the meta tag is added or not added based on the Item’s discoverability.

How to test or review this PR:
* Open a non-discoverable Item and inspect the page’s `<head>` section.
    * Confirm that a meta tag exists: `<meta name="robots" content="noindex">`.
* Open an Item that is discoverable.
    * Confirm that no `robots=noindex` meta tag is present.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
