### PR TITLE
Fix 'sync-i18n' script source file access

### DIFF
--- a/scripts/sync-i18n-files.ts
+++ b/scripts/sync-i18n-files.ts
@@ -38,11 +38,13 @@ function parseCliInput() {
     .usage('([-d <output-dir>] [-s <source-file>]) || (-t <target-file> (-i | -o <output>) [-s <source-file>])')
     .parse(process.argv);
 
-  if (!program.targetFile) {
+  const sourceFile = program.opts().sourceFile;
+
+    if (!program.targetFile) {
     fs.readdirSync(projectRoot(LANGUAGE_FILES_LOCATION)).forEach(file => {
-      if (!program.sourceFile.toString().endsWith(file)) {
+      if (!sourceFile.toString().endsWith(file)) {
         const targetFileLocation = projectRoot(LANGUAGE_FILES_LOCATION + "/" + file);
-        console.log('Syncing file at: ' + targetFileLocation + ' with source file at: ' + program.sourceFile);
+        console.log('Syncing file at: ' + targetFileLocation + ' with source file at: ' + sourceFile);
         if (program.outputDir) {
           if (!fs.existsSync(program.outputDir)) {
             fs.mkdirSync(program.outputDir);
@@ -67,7 +69,7 @@ function parseCliInput() {
       console.log(program.outputHelp());
       process.exit(1);
     }
-    if (!checkIfFileExists(program.sourceFile)) {
+    if (!checkIfFileExists(sourceFile)) {
       console.error('Path of source file is not valid.');
       console.log(program.outputHelp());
       process.exit(1);
@@ -101,7 +103,7 @@ function syncFileWithSource(pathToTargetFile, pathToOutputFile) {
     targetLines.push(line.trim());
   }));
   progressBar.update(10);
-  const sourceFile = readFileIfExists(program.sourceFile);
+  const sourceFile = readFileIfExists(program.opts().sourceFile);
   sourceFile.toString().split("\n").forEach((function (line) {
     sourceLines.push(line.trim());
   }));


### PR DESCRIPTION
## References

Fixes #4842

## Description

Fixed access to source file in sync-i18n script
 
## Instructions for Reviewers

adapt a label on en.json5 and run command:

npm run sync-i18n

List of changes in this PR:
Fixed sync-i18n script


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
