### PR TITLE
Fixed lint rule `themed-component-selectors` not working on Windows

### DIFF
--- a/lint/src/util/theme-support.ts
+++ b/lint/src/util/theme-support.ts
@@ -17,6 +17,7 @@ import {
   getComponentClassName,
   isPartOfViewChild,
 } from './angular';
+import { toUnixStylePath } from './misc';
 import {
   isPartOfClassDeclaration,
   isPartOfTypeExpression,
@@ -127,7 +128,7 @@ class ThemeableComponentRegistry {
                   continue;
                 }
 
-                const basePath = resolveLocalPath((importDeclaration.moduleSpecifier as ts.StringLiteral).text, path);
+                const basePath = resolveLocalPath((importDeclaration.moduleSpecifier as ts.StringLiteral).text, toUnixStylePath(path));
 
                 themeableComponents.add({
                   baseClass,


### PR DESCRIPTION
## References
* Fixes #4872

## Description
Resolved bug where the `themed-component-selectors` rule threw an error while linting the code (on Windows only).

## Instructions for Reviewers
List of changes in this PR:
* Fixed bug in `ThemeableComponentRegistry` where the components paths could not be correctly processed causing it to be incorrectly indexed

**Guidance for how to test/review this PR:**
1. Download latest code on Windows
2. Run `npm run clean`, `npm install` and `npm run lint`
3. Verify that no linting issues appear

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
