### PR TITLE
[Port dspace-9_x] Add route guard to prevent access to register page for authenticated users

### DIFF
--- a/src/app/app-routes.ts
+++ b/src/app/app-routes.ts
@@ -25,6 +25,7 @@ import { COLLECTION_MODULE_PATH } from './collection-page/collection-page-routin
 import { COMMUNITY_MODULE_PATH } from './community-page/community-page-routing-paths';
 import { authBlockingGuard } from './core/auth/auth-blocking.guard';
 import { authenticatedGuard } from './core/auth/authenticated.guard';
+import { notAuthenticatedGuard } from './core/auth/not-authenticated.guard';
 import { groupAdministratorGuard } from './core/data/feature-authorization/feature-authorization-guard/group-administrator.guard';
 import { siteAdministratorGuard } from './core/data/feature-authorization/feature-authorization-guard/site-administrator.guard';
 import { siteRegisterGuard } from './core/data/feature-authorization/feature-authorization-guard/site-register.guard';
@@ -97,13 +98,13 @@ export const APP_ROUTES: Route[] = [
         path: REGISTER_PATH,
         loadChildren: () => import('./register-page/register-page-routes')
           .then((m) => m.ROUTES),
-        canActivate: [siteRegisterGuard],
+        canActivate: [notAuthenticatedGuard, siteRegisterGuard],
       },
       {
         path: FORGOT_PASSWORD_PATH,
         loadChildren: () => import('./forgot-password/forgot-password-routes')
           .then((m) => m.ROUTES),
-        canActivate: [endUserAgreementCurrentUserGuard, forgotPasswordCheckGuard],
+        canActivate: [notAuthenticatedGuard, endUserAgreementCurrentUserGuard, forgotPasswordCheckGuard],
       },
       {
         path: COMMUNITY_MODULE_PATH,
@@ -180,11 +181,13 @@ export const APP_ROUTES: Route[] = [
         path: 'login',
         loadChildren: () => import('./login-page/login-page-routes')
           .then((m) => m.ROUTES),
+        canActivate: [notAuthenticatedGuard],
       },
       {
         path: 'logout',
         loadChildren: () => import('./logout-page/logout-page-routes')
           .then((m) => m.ROUTES),
+        canActivate: [authenticatedGuard],
       },
       {
         path: 'submit',
@@ -272,6 +275,7 @@ export const APP_ROUTES: Route[] = [
       {
         path: 'external-login/:token',
         loadChildren: () => import('./external-login-page/external-login-routes').then((m) => m.ROUTES),
+        canActivate: [notAuthenticatedGuard],
       },
       {
         path: 'review-account/:token',
@@ -282,6 +286,7 @@ export const APP_ROUTES: Route[] = [
         path: 'email-confirmation',
         loadChildren: () => import('./external-login-email-confirmation-page/external-login-email-confirmation-page-routes')
           .then((m) => m.ROUTES),
+        canActivate: [notAuthenticatedGuard],
       },
       { path: '**', pathMatch: 'full', component: ThemedPageNotFoundComponent },
     ],

--- a/src/app/core/auth/not-authenticated.guard.spec.ts
+++ b/src/app/core/auth/not-authenticated.guard.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
+import {
+  firstValueFrom,
+  of,
+} from 'rxjs';
+import { PAGE_NOT_FOUND_PATH } from 'src/app/app-routing-paths';
+
+import { HardRedirectService } from '../services/hard-redirect.service';
+import { AuthService } from './auth.service';
+import { notAuthenticatedGuard } from './not-authenticated.guard';
+
+describe('notAuthenticatedGuard', () => {
+  let authService: jasmine.SpyObj<AuthService>;
+  let hardRedirectService: jasmine.SpyObj<HardRedirectService>;
+  const mockRoute = {} as ActivatedRouteSnapshot;
+  const mockState = {} as RouterStateSnapshot;
+
+  beforeEach(() => {
+    const authSpy = jasmine.createSpyObj('AuthService', ['isAuthenticated']);
+    const redirectSpy = jasmine.createSpyObj('HardRedirectService', ['redirect']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: HardRedirectService, useValue: redirectSpy },
+      ],
+    });
+
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    hardRedirectService = TestBed.inject(HardRedirectService) as jasmine.SpyObj<HardRedirectService>;
+  });
+
+  it('should block access and redirect if user is logged in', async () => {
+    authService.isAuthenticated.and.returnValue(of(true));
+
+    const result$ = TestBed.runInInjectionContext(() =>
+      notAuthenticatedGuard(mockRoute, mockState),
+    );
+
+    const result = await firstValueFrom(result$ as any);
+    expect(result).toBe(false);
+    expect(hardRedirectService.redirect).toHaveBeenCalledWith(PAGE_NOT_FOUND_PATH);
+  });
+
+  it('should allow access if user is not logged in', async () => {
+    authService.isAuthenticated.and.returnValue(of(false));
+
+    const result$ = TestBed.runInInjectionContext(() =>
+      notAuthenticatedGuard(mockRoute, mockState),
+    );
+
+    const result = await firstValueFrom(result$ as any);
+    expect(result).toBe(true);
+    expect(hardRedirectService.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/auth/not-authenticated.guard.ts
+++ b/src/app/core/auth/not-authenticated.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { map } from 'rxjs/operators';
+import { PAGE_NOT_FOUND_PATH } from 'src/app/app-routing-paths';
+
+import { HardRedirectService } from '../services/hard-redirect.service';
+import { AuthService } from './auth.service';
+
+export const notAuthenticatedGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const redirectService = inject(HardRedirectService);
+
+  return authService.isAuthenticated().pipe(
+    map((isLoggedIn) => {
+      if (isLoggedIn) {
+        redirectService.redirect(PAGE_NOT_FOUND_PATH);
+        return false;
+      }
+
+      return true;
+    }),
+  );
+};


### PR DESCRIPTION
## References

Backporting of https://github.com/DSpace/dspace-angular/pull/4764 to `dspace-9_x`

## Description

Implemented route guard to prevent logged user from accessing register page.
The user will be redirected on page 404 if already logged in.


## Instructions for Reviewers

To test this feature you can try and log in while navigating the register page.
The logged user will be redirected to the "Not found" page.

List of changes in this PR:

Implemented new route guard to check if the user is authenticated.
Adapted route config.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
