### PR TITLE
Submission - Replace plaintext with relationship on lookup - 7.6

### DIFF
--- a/src/app/core/submission/submission-object-data.service.ts
+++ b/src/app/core/submission/submission-object-data.service.ts
@@ -12,6 +12,7 @@ import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { environment } from '../../../environments/environment';
 import { RequestEntryState } from '../data/request-entry-state.model';
 import { IdentifiableDataService } from '../data/base/identifiable-data.service';
+import { Operation } from 'fast-json-patch';
 
 /**
  * A service to retrieve submission objects (WorkspaceItem/WorkflowItem)
@@ -57,6 +58,26 @@ export class SubmissionObjectDataService {
         return this.workspaceitemDataService.findById(id, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
       case SubmissionScopeType.WorkflowItem:
         return this.workflowItemDataService.findById(id, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
+      default:
+        const now = new Date().getTime();
+        return observableOf(new RemoteData(
+          now,
+          environment.cache.msToLive.default,
+          now,
+          RequestEntryState.Error,
+          'The request couldn\'t be sent. Unable to determine the type of submission object',
+          undefined,
+          400
+        ));
+    }
+  }
+
+  patch(object: SubmissionObject, operations: Operation[]): Observable<RemoteData<SubmissionObject>> {
+    switch (this.submissionService.getSubmissionScope()) {
+      case SubmissionScopeType.WorkspaceItem:
+        return this.workspaceitemDataService.patch(object, operations);
+      case SubmissionScopeType.WorkflowItem:
+        return this.workflowItemDataService.patch(object, operations);
       default:
         const now = new Date().getTime();
         return observableOf(new RemoteData(

--- a/src/app/core/submission/workflowitem-data.service.spec.ts
+++ b/src/app/core/submission/workflowitem-data.service.spec.ts
@@ -19,6 +19,7 @@ import { WorkflowItemDataService } from './workflowitem-data.service';
 import { WorkflowItem } from './models/workflowitem.model';
 import { CoreState } from '../core-state.model';
 import { RequestEntry } from '../data/request-entry.model';
+import { DefaultChangeAnalyzer } from '../data/default-change-analyzer.service';
 
 describe('WorkflowItemDataService test', () => {
   let scheduler: TestScheduler;
@@ -87,6 +88,7 @@ describe('WorkflowItemDataService test', () => {
       objectCache,
       halService,
       notificationsService,
+      new DefaultChangeAnalyzer(),
     );
   }
 

--- a/src/app/core/submission/workflowitem-data.service.ts
+++ b/src/app/core/submission/workflowitem-data.service.ts
@@ -21,19 +21,34 @@ import { SearchData, SearchDataImpl } from '../data/base/search-data';
 import { DeleteData, DeleteDataImpl } from '../data/base/delete-data';
 import { PaginatedList } from '../data/paginated-list.model';
 import { dataService } from '../data/base/data-service.decorator';
+import { PatchData, PatchDataImpl } from '../data/base/patch-data';
+import { DefaultChangeAnalyzer } from '../data/default-change-analyzer.service';
+import { RestRequestMethod } from '../data/rest-request-method';
+import { Operation } from 'fast-json-patch';
+
+/**
+ * Constructs an endpoint taking into account that the WorkflowItem's "uuid" has a prefix by removing that prefix from the ID
+ * @param endpoint    Endpoint to append ID to
+ * @param resourceID  WorkflowItem's "uuid" including the prefix to remove
+ */
+const constructWorkflowItemIdEndpoint = (endpoint, resourceID) => {
+  const regex = new RegExp(`^${WorkflowItem.type.value}-`);
+  return `${endpoint}/${resourceID.replace(regex, '')}`;
+};
 
 /**
  * A service that provides methods to make REST requests with workflow items endpoint.
  */
 @Injectable()
 @dataService(WorkflowItem.type)
-export class WorkflowItemDataService extends IdentifiableDataService<WorkflowItem> implements SearchData<WorkflowItem>, DeleteData<WorkflowItem> {
+export class WorkflowItemDataService extends IdentifiableDataService<WorkflowItem> implements SearchData<WorkflowItem>, DeleteData<WorkflowItem>, PatchData<WorkflowItem> {
   protected linkPath = 'workflowitems';
   protected searchByItemLinkPath = 'item';
   protected responseMsToLive = 10 * 1000;
 
   private searchData: SearchDataImpl<WorkflowItem>;
   private deleteData: DeleteDataImpl<WorkflowItem>;
+  private patchData: PatchDataImpl<WorkflowItem>;
 
   constructor(
     protected requestService: RequestService,
@@ -41,11 +56,13 @@ export class WorkflowItemDataService extends IdentifiableDataService<WorkflowIte
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
     protected notificationsService: NotificationsService,
+    protected comparator: DefaultChangeAnalyzer<WorkflowItem>,
   ) {
     super('workspaceitems', requestService, rdbService, objectCache, halService);
 
     this.searchData = new SearchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
     this.deleteData = new DeleteDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, notificationsService, this.responseMsToLive, this.constructIdEndpoint);
+    this.patchData = new PatchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.comparator, this.responseMsToLive, constructWorkflowItemIdEndpoint);
   }
 
   /**
@@ -141,5 +158,21 @@ export class WorkflowItemDataService extends IdentifiableDataService<WorkflowIte
    */
   public deleteByHref(href: string, copyVirtualMetadata?: string[]): Observable<RemoteData<NoContent>> {
     return this.deleteData.deleteByHref(href, copyVirtualMetadata);
+  }
+
+  commitUpdates(method?: RestRequestMethod): void {
+    this.patchData.commitUpdates(method);
+  }
+
+  createPatchFromCache(object: WorkflowItem): Observable<Operation[]> {
+    return this.patchData.createPatchFromCache(object);
+  }
+
+  patch(object: WorkflowItem, operations: Operation[]): Observable<RemoteData<WorkflowItem>> {
+    return this.patchData.patch(object, operations);
+  }
+
+  update(object: WorkflowItem): Observable<RemoteData<WorkflowItem>> {
+    return this.patchData.update(object);
   }
 }

--- a/src/app/core/submission/workspaceitem-data.service.spec.ts
+++ b/src/app/core/submission/workspaceitem-data.service.spec.ts
@@ -21,6 +21,7 @@ import { RequestEntry } from '../data/request-entry.model';
 import { CoreState } from '../core-state.model';
 import { testSearchDataImplementation } from '../data/base/search-data.spec';
 import { testDeleteDataImplementation } from '../data/base/delete-data.spec';
+import { DefaultChangeAnalyzer } from '../data/default-change-analyzer.service';
 
 describe('WorkspaceitemDataService test', () => {
   let scheduler: TestScheduler;
@@ -89,11 +90,12 @@ describe('WorkspaceitemDataService test', () => {
       objectCache,
       halService,
       notificationsService,
+      new DefaultChangeAnalyzer(),
     );
   }
 
   describe('composition', () => {
-    const initService = () => new WorkspaceitemDataService(null, null, null, null, null);
+    const initService = () => new WorkspaceitemDataService(null, null, null, null, null, null);
     testSearchDataImplementation(initService);
     testDeleteDataImplementation(initService);
   });

--- a/src/app/core/submission/workspaceitem-data.service.ts
+++ b/src/app/core/submission/workspaceitem-data.service.ts
@@ -16,17 +16,32 @@ import { PaginatedList } from '../data/paginated-list.model';
 import { DeleteData, DeleteDataImpl } from '../data/base/delete-data';
 import { NoContent } from '../shared/NoContent.model';
 import { dataService } from '../data/base/data-service.decorator';
+import { PatchData, PatchDataImpl } from '../data/base/patch-data';
+import { DefaultChangeAnalyzer } from '../data/default-change-analyzer.service';
+import { RestRequestMethod } from '../data/rest-request-method';
+import { Operation } from 'fast-json-patch';
+
+/**
+ * Constructs an endpoint taking into account that the WorkspaceItem's "uuid" has a prefix by removing that prefix from the ID
+ * @param endpoint    Endpoint to append ID to
+ * @param resourceID  WorkspaceItem's "uuid" including the prefix to remove
+ */
+const constructWorkspaceItemIdEndpoint = (endpoint, resourceID) => {
+  const regex = new RegExp(`^${WorkspaceItem.type.value}-`);
+  return `${endpoint}/${resourceID.replace(regex, '')}`;
+};
 
 /**
  * A service that provides methods to make REST requests with workspaceitems endpoint.
  */
 @Injectable()
 @dataService(WorkspaceItem.type)
-export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceItem> implements SearchData<WorkspaceItem>, DeleteData<WorkspaceItem> {
+export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceItem> implements SearchData<WorkspaceItem>, DeleteData<WorkspaceItem>, PatchData<WorkspaceItem> {
   protected searchByItemLinkPath = 'item';
 
   private searchData: SearchDataImpl<WorkspaceItem>;
   private deleteData: DeleteDataImpl<WorkspaceItem>;
+  private patchData: PatchDataImpl<WorkspaceItem>;
 
   constructor(
     protected requestService: RequestService,
@@ -34,11 +49,13 @@ export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceI
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
     protected notificationsService: NotificationsService,
+    protected comparator: DefaultChangeAnalyzer<WorkspaceItem>,
   ) {
     super('workspaceitems', requestService, rdbService, objectCache, halService);
 
     this.searchData = new SearchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
     this.deleteData = new DeleteDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, notificationsService, this.responseMsToLive, this.constructIdEndpoint);
+    this.patchData = new PatchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.comparator, this.responseMsToLive, constructWorkspaceItemIdEndpoint);
   }
 
   /**
@@ -113,6 +130,22 @@ export class WorkspaceitemDataService extends IdentifiableDataService<WorkspaceI
    */
   public deleteByHref(href: string, copyVirtualMetadata?: string[]): Observable<RemoteData<NoContent>> {
     return this.deleteData.deleteByHref(href, copyVirtualMetadata);
+  }
+
+  commitUpdates(method?: RestRequestMethod): void {
+    this.patchData.commitUpdates(method);
+  }
+
+  createPatchFromCache(object: WorkspaceItem): Observable<Operation[]> {
+    return this.patchData.createPatchFromCache(object);
+  }
+
+  patch(object: WorkspaceItem, operations: Operation[]): Observable<RemoteData<WorkspaceItem>> {
+    return this.patchData.patch(object, operations);
+  }
+
+  update(object: WorkspaceItem): Observable<RemoteData<WorkspaceItem>> {
+    return this.patchData.update(object);
   }
 
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.spec.ts
@@ -235,7 +235,8 @@ describe('DsDynamicFormControlContainerComponent test suite', () => {
           }
         },
         { provide: NgZone, useValue: new NgZone({}) },
-        { provide: APP_CONFIG, useValue: environment }
+        { provide: APP_CONFIG, useValue: environment },
+        { provide: 'sectionDataProvider', useValue: { id: 'mock-section-id' } },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents().then(() => {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -455,6 +455,11 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
         modalComp.query = this.model.value;
       } else if (typeof this.model.value.value === 'string') {
         modalComp.query = this.model.value.value;
+        // If the existing value is not virtual, store properties on the modal required to perform a replace operation
+        if (!this.model.value.isVirtual) {
+          modalComp.replaceValuePlace = this.model.value.place;
+          modalComp.replaceValueMetadataField = this.model.name;
+        }
       }
     }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -10,6 +10,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  Optional,
   Output,
   QueryList,
   SimpleChanges,
@@ -264,7 +265,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     public formBuilderService: FormBuilderService,
     private submissionService: SubmissionService,
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
-    @Inject('sectionDataProvider') public sectionData: SectionDataObject,
+    @Optional() @Inject('sectionDataProvider') public sectionData: SectionDataObject,
   ) {
     super(ref, componentFactoryResolver, layoutService, validationService, dynamicFormComponentService, relationService);
     this.fetchThumbnail = this.appConfig.browseBy.showThumbnails;
@@ -459,7 +460,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
       } else if (typeof this.model.value.value === 'string') {
         modalComp.query = this.model.value.value;
         // If the existing value is not virtual, store properties on the modal required to perform a replace operation
-        if (!this.model.value.isVirtual && hasValue(this.arrayIndex)) {
+        if (hasValue(this.sectionData) && !this.model.value.isVirtual && hasValue(this.arrayIndex)) {
           modalComp.replaceValuePlace = this.arrayIndex;
           modalComp.replaceValueMetadataField = this.model.name;
           modalComp.replaceValueSection = this.sectionData?.id;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -120,6 +120,7 @@ import { DYNAMIC_FORM_CONTROL_TYPE_RELATION_GROUP } from './ds-dynamic-form-cons
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { APP_CONFIG, AppConfig } from '../../../../../config/app-config.interface';
 import { itemLinksToFollow } from '../../../utils/relation-query.utils';
+import { SectionDataObject } from '../../../../submission/sections/models/section-data.model';
 
 export function dsDynamicFormControlMapFn(model: DynamicFormControlModel): Type<DynamicFormControl> | null {
   switch (model.type) {
@@ -209,6 +210,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
   @Input() hasErrorMessaging = false;
   @Input() layout = null as DynamicFormLayout;
   @Input() model: any;
+  @Input() arrayIndex: number;
   relationshipValue$: Observable<ReorderableRelationship>;
   isRelationship: boolean;
   modalRef: NgbModalRef;
@@ -262,6 +264,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     public formBuilderService: FormBuilderService,
     private submissionService: SubmissionService,
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject('sectionDataProvider') public sectionData: SectionDataObject,
   ) {
     super(ref, componentFactoryResolver, layoutService, validationService, dynamicFormComponentService, relationService);
     this.fetchThumbnail = this.appConfig.browseBy.showThumbnails;
@@ -456,9 +459,10 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
       } else if (typeof this.model.value.value === 'string') {
         modalComp.query = this.model.value.value;
         // If the existing value is not virtual, store properties on the modal required to perform a replace operation
-        if (!this.model.value.isVirtual) {
-          modalComp.replaceValuePlace = this.model.value.place;
+        if (!this.model.value.isVirtual && hasValue(this.arrayIndex)) {
+          modalComp.replaceValuePlace = this.arrayIndex;
           modalComp.replaceValueMetadataField = this.model.name;
+          modalComp.replaceValueSection = this.sectionData?.id;
         }
       }
     }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -459,12 +459,13 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
         modalComp.query = this.model.value;
       } else if (typeof this.model.value.value === 'string') {
         modalComp.query = this.model.value.value;
-        // If the existing value is not virtual, store properties on the modal required to perform a replace operation
-        if (hasValue(this.sectionData) && !this.model.value.isVirtual && hasValue(this.arrayIndex)) {
-          modalComp.replaceValuePlace = this.arrayIndex;
-          modalComp.replaceValueMetadataField = this.model.name;
-          modalComp.replaceValueSection = this.sectionData?.id;
-        }
+      }
+
+      // If the existing value is not virtual, store properties on the modal required to perform a replace operation
+      if (hasValue(this.sectionData) && !this.model.value.isVirtual) {
+        modalComp.replaceValuePlace = this.arrayIndex || 0;
+        modalComp.replaceValueMetadataField = this.model.name;
+        modalComp.replaceValueSection = this.sectionData?.id;
       }
     }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
@@ -30,6 +30,7 @@
                                              [class.d-none]="_model.hidden"
                                              [layout]="formLayout"
                                              [model]="_model"
+                                             [arrayIndex]="idx"
                                              [templates]="templates"
                                              [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
                                              (dfBlur)="onBlur($event)"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.html
@@ -6,8 +6,8 @@
     </button>
 </div>
 <div class="modal-body">
-    <ds-themed-loading *ngIf="!item || !collection"></ds-themed-loading>
-    <ng-container *ngIf="item && collection">
+    <ds-themed-loading *ngIf="!item || !collection || isSubmitting"></ds-themed-loading>
+    <ng-container *ngIf="item && collection && !isSubmitting">
         <ul ngbNav #nav="ngbNav" class="nav-tabs">
             <li ngbNavItem>
                 <a ngbNavLink>{{'submission.sections.describe.relationship-lookup.search-tab.tab-title.' + relationshipOptions.relationshipType | translate  : { count: (totalInternal$ | async)} }}</a>
@@ -71,18 +71,18 @@
   <small>{{ ('submission.sections.describe.relationship-lookup.selected' | translate: {size: (selection$ | async)?.length || 0}) }}</small>
   <div class="d-flex float-right space-children-mr">
     <div class="close-button">
-        <button type="button" [disabled]="isPending" class="btn btn-outline-secondary" (click)="close()">
+        <button type="button" [disabled]="isPending || isSubmitting" class="btn btn-outline-secondary" (click)="close()">
             {{ ('submission.sections.describe.relationship-lookup.close' | translate) }}</button>
     </div>
     <ng-container *ngIf="isEditRelationship">
       <button class="btn btn-danger discard"
-              [disabled]="(toAdd.length == 0 && toRemove.length == 0) || isPending"
+              [disabled]="(toAdd.length == 0 && toRemove.length == 0) || isPending || isSubmitting"
               (click)="discardEv()">
               <i class="fas fa-times"></i>
         <span class="d-none d-sm-inline">&nbsp;{{"item.edit.metadata.discard-button" | translate}}</span>
       </button>
       <button class="btn btn-primary submit"
-            [disabled]="(toAdd.length == 0 && toRemove.length == 0) || isPending"
+            [disabled]="(toAdd.length == 0 && toRemove.length == 0) || isPending || isSubmitting"
               (click)="submitEv()">
               <span *ngIf="isPending" class="spinner-border spinner-border-sm" role="status"
                               aria-hidden="true"></span>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -180,11 +180,12 @@ describe('DsDynamicLookupRelationModalComponent', () => {
       beforeEach(() => {
         component.replaceValuePlace = 3;
         component.replaceValueMetadataField = 'dc.subject';
+        component.replaceValueSection = 'traditionalpageone';
       });
 
       it('should dispatch a ReplaceRelationshipAction for the first selected object and a AddRelationshipAction for every other selected object', () => {
         component.select(searchResult1, searchResult2, searchResult3);
-        const action1 = new ReplaceRelationshipAction(component.item, searchResult1.indexableObject, true, 3, 'dc.subject', relationship.relationshipType, submissionId, nameVariant);
+        const action1 = new ReplaceRelationshipAction(component.item, searchResult1.indexableObject, true, 3, 'dc.subject', 'traditionalpageone', relationship.relationshipType, submissionId, nameVariant);
         const action2 = new AddRelationshipAction(component.item, searchResult2.indexableObject, relationship.relationshipType, submissionId, nameVariant);
         const action3 = new AddRelationshipAction(component.item, searchResult3.indexableObject, relationship.relationshipType, submissionId, nameVariant);
 
@@ -193,6 +194,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
         expect((component as any).store.dispatch).toHaveBeenCalledWith(action3);
         expect(component.replaceValuePlace).toBeUndefined();
         expect(component.replaceValueMetadataField).toBeUndefined();
+        expect(component.replaceValueSection).toBeUndefined();
       });
     });
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.spec.ts
@@ -24,6 +24,7 @@ import { RemoteDataBuildService } from '../../../../../core/cache/builders/remot
 import { WorkspaceItem } from '../../../../../core/submission/models/workspaceitem.model';
 import { Collection } from '../../../../../core/shared/collection.model';
 import { By } from '@angular/platform-browser';
+import { SubmissionService } from '../../../../../submission/submission.service';
 
 describe('DsDynamicLookupRelationModalComponent', () => {
   let component: DsDynamicLookupRelationModalComponent;
@@ -48,6 +49,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
   let lookupRelationService;
   let rdbService;
   let submissionId;
+  let submissionService;
 
   const externalSources = [
     Object.assign(new ExternalSource(), {
@@ -102,6 +104,9 @@ describe('DsDynamicLookupRelationModalComponent', () => {
       aggregate: createSuccessfulRemoteDataObject$(externalSources)
     });
     submissionId = '1234';
+    submissionService = jasmine.createSpyObj('submissionService', {
+      getSubmissionSaveProcessingStatus: observableOf(false),
+    });
   }
 
   beforeEach(waitForAsync(() => {
@@ -133,6 +138,7 @@ describe('DsDynamicLookupRelationModalComponent', () => {
           }
         },
         { provide: NgZone, useValue: new NgZone({}) },
+        { provide: SubmissionService, useValue: submissionService },
         NgbActiveModal
       ],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -107,6 +107,11 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   replaceValueMetadataField: string;
 
   /**
+   * The submission section of the plain-text value that should be replaced by adding a relationship
+   */
+  replaceValueSection: string;
+
+  /**
    * A map of subscriptions within this component
    */
   subMap: {
@@ -250,7 +255,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
               let action;
               if (i === 0 && hasValue(this.replaceValueMetadataField)) {
                 // This is the first action this modal performs and "replace" properties are present to replace an existing metadata value
-                action = new ReplaceRelationshipAction(this.item, object.item, true, this.replaceValuePlace, this.replaceValueMetadataField, this.relationshipOptions.relationshipType, this.submissionId, object.nameVariant);
+                action = new ReplaceRelationshipAction(this.item, object.item, true, this.replaceValuePlace, this.replaceValueMetadataField, this.replaceValueSection, this.relationshipOptions.relationshipType, this.submissionId, object.nameVariant);
                 // Only "replace" once, reset replace properties so future actions become "add"
                 this.resetReplaceProperties();
               } else {
@@ -320,6 +325,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   private resetReplaceProperties() {
     this.replaceValueMetadataField = undefined;
     this.replaceValuePlace = undefined;
+    this.replaceValueSection = undefined;
   }
 
   ngOnDestroy() {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/dynamic-lookup-relation-modal.component.ts
@@ -29,6 +29,7 @@ import { RemoteDataBuildService } from '../../../../../core/cache/builders/remot
 import { getAllSucceededRemoteDataPayload } from '../../../../../core/shared/operators';
 import { followLink } from '../../../../utils/follow-link-config.model';
 import { RelationshipType } from '../../../../../core/shared/item-relationships/relationship-type.model';
+import { SubmissionService } from '../../../../../submission/submission.service';
 
 @Component({
   selector: 'ds-dynamic-lookup-relation-modal',
@@ -169,6 +170,16 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
    */
   isPending = false;
 
+  /**
+   * Show a loading indicator if the form is currently submitting to avoid race conditions between requests
+   */
+  isSubmitting = false;
+
+  /**
+   * Open subscriptions
+   */
+  subs = [];
+
   constructor(
     public modal: NgbActiveModal,
     private selectableListService: SelectableListService,
@@ -181,6 +192,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
     private zone: NgZone,
     private store: Store<AppState>,
     private router: Router,
+    protected submissionService: SubmissionService,
   ) {
 
   }
@@ -216,6 +228,14 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
         })
       ).pipe(
         getAllSucceededRemoteDataPayload()
+      );
+    }
+
+    if (hasValue(this.submissionId)) {
+      this.subs.push(
+        this.submissionService.getSubmissionSaveProcessingStatus(this.submissionId).subscribe((isSubmitting) => {
+          this.isSubmitting = isSubmitting;
+        }),
       );
     }
 
@@ -331,6 +351,7 @@ export class DsDynamicLookupRelationModalComponent implements OnInit, OnDestroy 
   ngOnDestroy() {
     this.router.navigate([], {});
     Object.values(this.subMap).forEach((subscription) => subscription.unsubscribe());
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
   }
 
   /* eslint-disable no-empty,@typescript-eslint/no-empty-function */

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.actions.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.actions.ts
@@ -9,6 +9,7 @@ import { Relationship } from '../../../../../core/shared/item-relationships/rela
 
 export const RelationshipActionTypes = {
   ADD_RELATIONSHIP: type('dspace/relationship/ADD_RELATIONSHIP'),
+  REPLACE_RELATIONSHIP: type('dspace/relationship/REPLACE_RELATIONSHIP'),
   REMOVE_RELATIONSHIP: type('dspace/relationship/REMOVE_RELATIONSHIP'),
   UPDATE_NAME_VARIANT: type('dspace/relationship/UPDATE_NAME_VARIANT'),
   UPDATE_RELATIONSHIP: type('dspace/relationship/UPDATE_RELATIONSHIP'),
@@ -132,10 +133,53 @@ export class RemoveRelationshipAction implements Action {
   }
 }
 
+/**
+ * An ngrx action to replace a plain-text metadata value with a new relationship
+ */
+export class ReplaceRelationshipAction implements Action {
+  type = RelationshipActionTypes.REPLACE_RELATIONSHIP;
+
+  payload: {
+    item1: Item;
+    item2: Item;
+    replaceLeftSide: boolean;
+    place: number;
+    mdField: string;
+    relationshipType: string;
+    submissionId: string;
+    nameVariant: string;
+  };
+
+  /**
+   * Create a new AddRelationshipAction
+   *
+   * @param item1 The first item in the relationship
+   * @param item2 The second item in the relationship
+   * @param replaceLeftSide If true, the item on the left side (item1) will have its metadata value replaced
+   * @param place The index of the metadata value that should be replaced with the new relationship
+   * @param mdField The metadata field of the value to replace
+   * @param relationshipType The label of the relationshipType
+   * @param submissionId The current submissionId
+   * @param nameVariant The nameVariant of the relationshipType
+   */
+  constructor(
+    item1: Item,
+    item2: Item,
+    replaceLeftSide: boolean,
+    place: number,
+    mdField: string,
+    relationshipType: string,
+    submissionId: string,
+    nameVariant?: string,
+  ) {
+    this.payload = { item1, item2, replaceLeftSide, place, mdField, relationshipType, submissionId, nameVariant };
+  }
+}
 
 /**
  * A type to encompass all RelationshipActions
  */
 export type RelationshipAction
   = AddRelationshipAction
+  | ReplaceRelationshipAction
   | RemoveRelationshipAction;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.actions.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.actions.ts
@@ -145,6 +145,7 @@ export class ReplaceRelationshipAction implements Action {
     replaceLeftSide: boolean;
     place: number;
     mdField: string;
+    section: string;
     relationshipType: string;
     submissionId: string;
     nameVariant: string;
@@ -158,6 +159,7 @@ export class ReplaceRelationshipAction implements Action {
    * @param replaceLeftSide If true, the item on the left side (item1) will have its metadata value replaced
    * @param place The index of the metadata value that should be replaced with the new relationship
    * @param mdField The metadata field of the value to replace
+   * @param section The submission section of the value to replace
    * @param relationshipType The label of the relationshipType
    * @param submissionId The current submissionId
    * @param nameVariant The nameVariant of the relationshipType
@@ -168,11 +170,12 @@ export class ReplaceRelationshipAction implements Action {
     replaceLeftSide: boolean,
     place: number,
     mdField: string,
+    section: string,
     relationshipType: string,
     submissionId: string,
     nameVariant?: string,
   ) {
-    this.payload = { item1, item2, replaceLeftSide, place, mdField, relationshipType, submissionId, nameVariant };
+    this.payload = { item1, item2, replaceLeftSide, place, mdField, section, relationshipType, submissionId, nameVariant };
   }
 }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -3,7 +3,12 @@ import { BehaviorSubject, Observable, of as observableOf } from 'rxjs';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Store } from '@ngrx/store';
 import { RelationshipEffects } from './relationship.effects';
-import { AddRelationshipAction, RelationshipActionTypes, RemoveRelationshipAction } from './relationship.actions';
+import {
+  AddRelationshipAction,
+  RelationshipActionTypes,
+  RemoveRelationshipAction,
+  ReplaceRelationshipAction
+} from './relationship.actions';
 import { Item } from '../../../../../core/shared/item.model';
 import { MetadataValue } from '../../../../../core/shared/metadata.models';
 import { RelationshipTypeDataService } from '../../../../../core/data/relationship-type-data.service';
@@ -23,6 +28,7 @@ import { SelectableListService } from '../../../../object-list/selectable-list/s
 import { cold, hot } from 'jasmine-marbles';
 import { DEBOUNCE_TIME_OPERATOR } from '../../../../../core/shared/operators';
 import { last } from 'rxjs/operators';
+import { ItemDataService } from '../../../../../core/data/item-data.service';
 
 describe('RelationshipEffects', () => {
   let relationEffects: RelationshipEffects;
@@ -51,6 +57,7 @@ describe('RelationshipEffects', () => {
   let notificationsService;
   let translateService;
   let selectableListService;
+  let itemService;
 
   function init() {
     testUUID1 = '20e24c2f-a00a-467c-bdee-c929e79bf08d';
@@ -93,8 +100,8 @@ describe('RelationshipEffects', () => {
       getRelationshipByItemsAndLabel:
         () => observableOf(relationship),
       deleteRelationship: () => observableOf(new RestResponse(true, 200, 'OK')),
-      addRelationship: () => observableOf(new RestResponse(true, 200, 'OK'))
-
+      addRelationship: () => createSuccessfulRemoteDataObject$(new Relationship()),
+      update: () => createSuccessfulRemoteDataObject$(new Relationship()),
     };
     mockRelationshipTypeService = {
       getRelationshipTypeByLabelAndTypes:
@@ -108,6 +115,9 @@ describe('RelationshipEffects', () => {
       findSelectedByCondition: observableOf({}),
       deselectSingle: {}
     });
+    itemService = jasmine.createSpyObj('itemService', {
+      patch: createSuccessfulRemoteDataObject$(new Item()),
+    });
   }
 
   beforeEach(waitForAsync(() => {
@@ -118,6 +128,7 @@ describe('RelationshipEffects', () => {
         provideMockActions(() => actions),
         { provide: RelationshipTypeDataService, useValue: mockRelationshipTypeService },
         { provide: RelationshipDataService, useValue: mockRelationshipService },
+        { provide: ItemDataService, useValue: itemService },
         {
           provide: SubmissionObjectDataService, useValue: {
             findById: () => createSuccessfulRemoteDataObject$(new WorkspaceItem())
@@ -140,6 +151,7 @@ describe('RelationshipEffects', () => {
     identifier = (relationEffects as any).createIdentifier(leftItem, rightItem, relationshipType.leftwardType);
     spyOn((relationEffects as any), 'addRelationship').and.stub();
     spyOn((relationEffects as any), 'removeRelationship').and.stub();
+    spyOn((relationEffects as any), 'replaceRelationship').and.stub();
   });
 
   describe('mapLastActions$', () => {
@@ -202,6 +214,73 @@ describe('RelationshipEffects', () => {
             const expected = cold('--bb-|', { b: undefined });
             expect(relationEffects.mapLastActions$).toBeObservable(expected);
             expect((relationEffects as any).addRelationship).not.toHaveBeenCalled();
+            expect((relationEffects as any).removeRelationship).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+
+    describe('When a REPLACE_RELATIONSHIP action is triggered', () => {
+      describe('When it\'s the first time for this identifier', () => {
+        let action;
+
+        it('should set the current value debounceMap and the value of the initialActionMap to REPLACE_RELATIONSHIP', () => {
+          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+          actions = hot('--a-|', { a: action });
+          const expected = cold('--b-|', { b: undefined });
+          expect(relationEffects.mapLastActions$).toBeObservable(expected);
+
+          expect((relationEffects as any).initialActionMap[identifier]).toBe(action.type);
+          expect((relationEffects as any).debounceMap[identifier].value).toBe(action.type);
+        });
+      });
+
+      describe('When it\'s not the first time for this identifier', () => {
+        let action;
+        const testActionType = 'TEST_TYPE';
+        beforeEach(() => {
+          (relationEffects as any).initialActionMap[identifier] = testActionType;
+          (relationEffects as any).debounceMap[identifier] = new BehaviorSubject<string>(testActionType);
+        });
+
+        it('should set the current value debounceMap to REPLACE_RELATIONSHIP but not change the value of the initialActionMap', () => {
+          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+          actions = hot('--a-|', { a: action });
+
+          const expected = cold('--b-|', { b: undefined });
+          expect(relationEffects.mapLastActions$).toBeObservable(expected);
+
+          expect((relationEffects as any).initialActionMap[identifier]).toBe(testActionType);
+          expect((relationEffects as any).debounceMap[identifier].value).toBe(action.type);
+        });
+      });
+
+      describe('When the initialActionMap contains a REPLACE_RELATIONSHIP action', () => {
+        let action;
+        describe('When the last value in the debounceMap is also a REPLACE_RELATIONSHIP action', () => {
+          beforeEach(() => {
+            spyOn((relationEffects as any).relationshipService, 'update').and.callThrough();
+            ((relationEffects as any).debounceTime as jasmine.Spy).and.returnValue((v) => v);
+            (relationEffects as any).initialActionMap[identifier] = RelationshipActionTypes.REPLACE_RELATIONSHIP;
+          });
+
+          it('should call replaceRelationship on the effect', () => {
+            action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+            actions = hot('--a-|', { a: action });
+            const expected = cold('--b-|', { b: undefined });
+            expect(relationEffects.mapLastActions$).toBeObservable(expected);
+            expect((relationEffects as any).replaceRelationship).toHaveBeenCalledWith(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234', undefined);
+          });
+        });
+
+        describe('When the last value in the debounceMap is instead a REMOVE_RELATIONSHIP action', () => {
+          it('should <b>not</b> call removeRelationship or replaceRelationship on the effect', () => {
+            const actiona = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+            const actionb = new RemoveRelationshipAction(leftItem, rightItem, relationshipType.leftwardType, '1234');
+            actions = hot('--ab-|', { a: actiona, b: actionb });
+            const expected = cold('--bb-|', { b: undefined });
+            expect(relationEffects.mapLastActions$).toBeObservable(expected);
+            expect((relationEffects as any).replaceRelationship).not.toHaveBeenCalled();
             expect((relationEffects as any).removeRelationship).not.toHaveBeenCalled();
           });
         });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -261,6 +261,8 @@ describe('RelationshipEffects', () => {
         let action;
         describe('When the last value in the debounceMap is also a REPLACE_RELATIONSHIP action', () => {
           beforeEach(() => {
+            jasmine.getEnv().allowRespy(true);
+            spyOn((relationEffects as any), 'replaceRelationship').and.returnValue(createSuccessfulRemoteDataObject$(relationship));
             spyOn((relationEffects as any).relationshipService, 'update').and.callThrough();
             ((relationEffects as any).debounceTime as jasmine.Spy).and.returnValue((v) => v);
             (relationEffects as any).initialActionMap[identifier] = RelationshipActionTypes.REPLACE_RELATIONSHIP;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.spec.ts
@@ -227,7 +227,7 @@ describe('RelationshipEffects', () => {
         let action;
 
         it('should set the current value debounceMap and the value of the initialActionMap to REPLACE_RELATIONSHIP', () => {
-          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', 'traditionalpageone', relationshipType.leftwardType, '1234');
           actions = hot('--a-|', { a: action });
           const expected = cold('--b-|', { b: undefined });
           expect(relationEffects.mapLastActions$).toBeObservable(expected);
@@ -246,7 +246,7 @@ describe('RelationshipEffects', () => {
         });
 
         it('should set the current value debounceMap to REPLACE_RELATIONSHIP but not change the value of the initialActionMap', () => {
-          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+          action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', 'traditionalpageone', relationshipType.leftwardType, '1234');
           actions = hot('--a-|', { a: action });
 
           const expected = cold('--b-|', { b: undefined });
@@ -269,17 +269,17 @@ describe('RelationshipEffects', () => {
           });
 
           it('should call replaceRelationship on the effect', () => {
-            action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+            action = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', 'traditionalpageone', relationshipType.leftwardType, '1234');
             actions = hot('--a-|', { a: action });
             const expected = cold('--b-|', { b: undefined });
             expect(relationEffects.mapLastActions$).toBeObservable(expected);
-            expect((relationEffects as any).replaceRelationship).toHaveBeenCalledWith(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234', undefined);
+            expect((relationEffects as any).replaceRelationship).toHaveBeenCalledWith(leftItem, rightItem, true, 0, 'dc.subject', 'traditionalpageone', relationshipType.leftwardType, '1234', undefined);
           });
         });
 
         describe('When the last value in the debounceMap is instead a REMOVE_RELATIONSHIP action', () => {
           it('should <b>not</b> call removeRelationship or replaceRelationship on the effect', () => {
-            const actiona = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', relationshipType.leftwardType, '1234');
+            const actiona = new ReplaceRelationshipAction(leftItem, rightItem, true, 0, 'dc.subject', 'traditionalpageone', relationshipType.leftwardType, '1234');
             const actionb = new RemoveRelationshipAction(leftItem, rightItem, relationshipType.leftwardType, '1234');
             actions = hot('--ab-|', { a: actiona, b: actionb });
             const expected = cold('--bb-|', { b: undefined });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { filter, map, mergeMap, switchMap, take, tap, concatMap } from 'rxjs/operators';
+import { filter, map, mergeMap, switchMap, take, concatMap } from 'rxjs/operators';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { RelationshipDataService } from '../../../../../core/data/relationship-data.service';
 import {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/relationship.effects.ts
@@ -36,7 +36,6 @@ import { RemoteData } from '../../../../../core/data/remote-data';
 import { NotificationsService } from '../../../../notifications/notifications.service';
 import { SelectableListService } from '../../../../object-list/selectable-list/selectable-list.service';
 import { TranslateService } from '@ngx-translate/core';
-import { ItemDataService } from '../../../../../core/data/item-data.service';
 import { Operation } from 'fast-json-patch';
 
 const DEBOUNCE_TIME = 500;
@@ -57,6 +56,7 @@ interface RelationOperation {
   replaceLeftSide?: boolean
   place?: number
   mdField?: string
+  section?: string
 }
 
 /**
@@ -132,6 +132,7 @@ export class RelationshipEffects {
                         replaceLeftSide: replaceAction.payload.replaceLeftSide,
                         place: replaceAction.payload.place,
                         mdField: replaceAction.payload.mdField,
+                        section: replaceAction.payload.section,
                       });
                     }
                   } else {
@@ -209,7 +210,6 @@ export class RelationshipEffects {
   constructor(private actions$: Actions,
               private relationshipService: RelationshipDataService,
               private relationshipTypeService: RelationshipTypeDataService,
-              private itemService: ItemDataService,
               private submissionObjectService: SubmissionObjectDataService,
               private store: Store<SubmissionState>,
               private objectCache: ObjectCacheService,
@@ -237,7 +237,7 @@ export class RelationshipEffects {
               map(() => next)
             );
           case RelationOperationType.Replace:
-            return this.replaceRelationship(next.item1, next.item2, next.replaceLeftSide, next.place, next.mdField, next.relationshipType, next.submissionId, next.nameVariant).pipe(
+            return this.replaceRelationship(next.item1, next.item2, next.replaceLeftSide, next.place, next.mdField, next.section, next.relationshipType, next.submissionId, next.nameVariant).pipe(
               map(() => next)
             );
           case RelationOperationType.Remove:
@@ -318,34 +318,50 @@ export class RelationshipEffects {
    * @param replaceLeftSide   If true, item1 will have its metadata value replaced, otherwise item2
    * @param place             The index of the metadata value to replace
    * @param metadataField     The metadata field of the metadata value to replace
+   * @param section           The submission section of the metadata value to replace
    * @param relationshipType  The type of relationship
    * @param submissionId      The ID of the submission this action is taking place in
    * @param nameVariant       Optional name variant of the to-be-created relationship
    * @private
    */
-  private replaceRelationship(item1: Item, item2: Item, replaceLeftSide: boolean, place: number, metadataField: string, relationshipType: string, submissionId: string, nameVariant?: string) {
-    return this.itemService.patch(replaceLeftSide ? item1 : item2, [{ op: 'remove', path: `/metadata/${metadataField}/${place}` } as Operation]).pipe(
+  private replaceRelationship(item1: Item, item2: Item, replaceLeftSide: boolean, place: number, metadataField: string, section: string, relationshipType: string, submissionId: string, nameVariant?: string) {
+    return this.submissionObjectService.findById(submissionId).pipe(
       getFirstCompletedRemoteData(),
-      switchMap((rd: RemoteData<Item>) => {
+      switchMap((rd: RemoteData<SubmissionObject>) => {
         if (rd.hasSucceeded) {
-          return this.addRelationship(item1, item2, relationshipType, submissionId, nameVariant);
-        } else {
-          this.deselectAndShowError(item1, item2, relationshipType, submissionId);
-          return [undefined];
-        }
-      }),
-      switchMap((rel: Relationship) => {
-        if (hasValue(rel)) {
-          const updatedRelationship: Relationship = Object.assign(new Relationship(), rel);
-          if (replaceLeftSide) {
-            updatedRelationship.leftPlace = place;
-          } else {
-            updatedRelationship.rightPlace = place;
+          // If the place of the metadata value to replace is missing or -1, pick the last place with the section and field
+          let updatedPlace = place;
+          if (hasNoValue(place) || place < 0) {
+            updatedPlace = rd.payload.sections?.[section]?.[metadataField]?.length - 1;
           }
-          return this.relationshipService.update(updatedRelationship).pipe(
+          return this.submissionObjectService.patch(rd.payload, [{ op: 'remove', path: `/sections/${section}/${metadataField}/${updatedPlace}` } as Operation]).pipe(
             getFirstCompletedRemoteData(),
+            switchMap((patchedRd: RemoteData<SubmissionObject>) => {
+              if (patchedRd.hasSucceeded) {
+                return this.addRelationship(item1, item2, relationshipType, submissionId, nameVariant);
+              } else if (hasValue(patchedRd)) {
+                this.deselectAndShowError(item1, item2, relationshipType, submissionId);
+              }
+              return [undefined];
+            }),
+            switchMap((rel: Relationship) => {
+              if (hasValue(rel)) {
+                const updatedRelationship: Relationship = Object.assign(new Relationship(), rel);
+                if (replaceLeftSide) {
+                  updatedRelationship.leftPlace = updatedPlace;
+                } else {
+                  updatedRelationship.rightPlace = updatedPlace;
+                }
+                return this.relationshipService.update(updatedRelationship).pipe(
+                  getFirstCompletedRemoteData(),
+                );
+              } else {
+                return [undefined];
+              }
+            }),
           );
         } else {
+          this.deselectAndShowError(item1, item2, relationshipType, submissionId);
           return [undefined];
         }
       }),

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.spec.ts
@@ -133,24 +133,20 @@ describe('DsDynamicLookupRelationSearchTabComponent', () => {
 
   describe('selectPage', () => {
     beforeEach(() => {
-      spyOn(component.selectObject, 'emit');
       component.selectPage([searchResult1, searchResult2, searchResult4]);
     });
 
-    it('should emit the page filtered from already selected objects and call select on the service for all objects', () => {
-      expect(component.selectObject.emit).toHaveBeenCalledWith(searchResult4);
+    it('should call select on the service for all objects', () => {
       expect(selectableListService.select).toHaveBeenCalledWith(listID, [searchResult1, searchResult2, searchResult4]);
     });
   });
 
   describe('deselectPage', () => {
     beforeEach(() => {
-      spyOn(component.deselectObject, 'emit');
       component.deselectPage([searchResult1, searchResult2, searchResult3]);
     });
 
-    it('should emit the page filtered from not yet selected objects and call select on the service for all objects', () => {
-      expect((component.deselectObject as any).emit).toHaveBeenCalledWith(searchResult1, searchResult2);
+    it('should call deselect on the service for all objects', () => {
       expect(selectableListService.deselect).toHaveBeenCalledWith(listID, [searchResult1, searchResult2, searchResult3]);
     });
   });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
@@ -175,12 +175,6 @@ export class DsDynamicLookupRelationSearchTabComponent implements OnInit, OnDest
    * @param page The page to select
    */
   selectPage(page: SearchResult<DSpaceObject>[]) {
-    this.selection$
-      .pipe(take(1))
-      .subscribe((selection: SearchResult<Item>[]) => {
-        const filteredPage = page.filter((pageItem) => selection.findIndex((selected) => selected.equals(pageItem)) < 0);
-        this.selectObject.emit(...filteredPage);
-      });
     this.selectableListService.select(this.listId, page);
   }
 
@@ -190,12 +184,6 @@ export class DsDynamicLookupRelationSearchTabComponent implements OnInit, OnDest
    */
   deselectPage(page: SearchResult<DSpaceObject>[]) {
     this.allSelected = false;
-    this.selection$
-      .pipe(take(1))
-      .subscribe((selection: SearchResult<Item>[]) => {
-        const filteredPage = page.filter((pageItem) => selection.findIndex((selected) => selected.equals(pageItem)) >= 0);
-        this.deselectObject.emit(...filteredPage);
-      });
     this.selectableListService.deselect(this.listId, page);
   }
 

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -254,7 +254,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
       .forEach((key) => {
         diffObj[key].forEach((value) => {
           // the findIndex extra check excludes values already present in the form but in different positions
-          if (value.hasOwnProperty('value') && findIndex(this.formData[key], { value: value.value }) < 0) {
+          if (!value.hasOwnProperty('value') || findIndex(this.formData[key], { value: value.value }) < 0) {
             diffResult.push(value);
           }
         });


### PR DESCRIPTION
## References
* Fixes #4843
* main equivalent: #4911

## Description
This PR changes the submission relationship lookup to make the (first) selected relationship replace the plain text value the lookup started from, if it did.

## Instructions for Reviewers
Technical details:
* If the lookup is started from a plain-text metadata value, its "place" and "metadataField" is stored on the lookup modal
* When a relationship is selected for the first time in the modal and those "replace" properties are present, a `ReplaceRelationshipAction` will be created instead of the usual `AddRelationshipAction`. This only happens for the first selected relationship, the rest sends a `AddRelationshipAction` for each selection.
* Relationship-effects takes the following actions in order, when it recieves a `ReplaceRelationshipAction`:
  * Remove the plain-text metadata value from the item
  * Create the new relationship
  * Update the new relationship's place to be on the deleted value's spot

How to test:
* Start a submission and for a relationship-controlled field (e.g. author), create multiple plain-text values
* Start a lookup from one of the plain-text values
* Select a couple new relationships in the lookup modal (at least two)
* Close the lookup
* Verify the plain-text value you started the lookup from is not present anymore
* Verify the first selected relationship is placed where the removed plain-text value was
* Verify all other selected relationships are placed at the end of the list

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
