### PR TITLE
Add showErrorStrategy config option for submission form

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -234,6 +234,8 @@ submission:
         - value: default
           style: text-muted
           icon: fa-circle-xmark
+  # Whether to show submission form errors 'onload' or 'onblur'
+  showErrorStrategy: onblur
 
 #  Fallback language in which the UI will be rendered if the user's browser language is not an active language
 fallbackLanguage: en

--- a/src/app/submission/form/submission-form.component.ts
+++ b/src/app/submission/form/submission-form.component.ts
@@ -7,6 +7,7 @@ import {
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
 import { AuthService } from '@dspace/core/auth/auth.service';
 import { SubmissionDefinitionsModel } from '@dspace/core/config/models/config-submission-definitions.model';
 import { SubmissionSectionModel } from '@dspace/core/config/models/config-submission-section.model';
@@ -24,6 +25,11 @@ import {
   isNotEmpty,
   isNotUndefined,
 } from '@dspace/shared/utils/empty.util';
+import {
+  DYNAMIC_ERROR_MESSAGES_MATCHER,
+  DynamicFormControlModel,
+  DynamicFormValidationService,
+} from '@ng-dynamic-forms/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import isEqual from 'lodash/isEqual';
 import {
@@ -38,6 +44,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import { environment } from '../../../environments/environment';
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { UploaderOptions } from '../../shared/upload/uploader/uploader-options.model';
 import { SubmissionObjectEntry } from '../objects/submission-objects.reducer';
@@ -67,6 +74,18 @@ import { ThemedSubmissionUploadFilesComponent } from './submission-upload-files/
     ThemedSubmissionUploadFilesComponent,
     TranslatePipe,
   ],
+  providers: environment.submission.showErrorStrategy === 'onload' ? [
+    // Always show validation errors, even if input hasn't been
+    // blurred yet
+    DynamicFormValidationService,
+    {
+      provide: DYNAMIC_ERROR_MESSAGES_MATCHER,
+      useValue: (
+        _control: AbstractControl,
+        _model: DynamicFormControlModel,
+        hasFocus: boolean) => !hasFocus,
+    },
+  ] : [],
 })
 export class SubmissionFormComponent implements OnChanges, OnDestroy {
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -253,6 +253,7 @@ export class DefaultAppConfig implements AppConfig {
         ],
       },
     },
+    showErrorStrategy: 'onblur',
   };
 
   // Fallback language in which the UI will be rendered if the user's browser language is not an active language

--- a/src/config/submission-config.interface.ts
+++ b/src/config/submission-config.interface.ts
@@ -31,9 +31,12 @@ export interface ConfidenceIconConfig extends Config {
   icon: string;
 }
 
+type ShowErrorStrategy = 'onload' | 'onblur';
+
 export interface SubmissionConfig extends Config {
   autosave: AutosaveConfig;
   duplicateDetection: DuplicateDetectionConfig;
   typeBind: TypeBindConfig;
   icons: IconsConfig;
+  showErrorStrategy: ShowErrorStrategy;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -194,6 +194,7 @@ export const environment: BuildConfig = {
         ],
       },
     },
+    showErrorStrategy: 'onblur',
   },
 
   // NOTE: will log all redux actions and transfers in console


### PR DESCRIPTION
Config option submission.showErrorStrategy is of type ShowErrorStrategy, which can be 'onblur' or 'onload'. The default is 'onblur', which will show errors only after clicking an input field.

This PR was provided by The Library Code with the support of FHNW.

## References

## Description

This PR adds a config option for submission forms to show validation errors on form load. The default strategy, 'onblur', is kept consistent with current behavior.

## Instructions for Reviewers

List of changes in this PR:
* Add new submission config option 'showErrorStrategy'
* Use submission config option in `src/app/submission/form/submission-form.component.ts`

Add the option to the `config/config.yml`, and test to see that form errors are displayed on form load, not on form input field blur.

```yml
rest:
  ssl: true
  host: sandbox.dspace.org
  port: 443
  nameSpace: /server
submission:
  showErrorStrategy: 'onload'
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
    (with existing errors)
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [na] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [na] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [na] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [na] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
