### PR TITLE
Fix merge-i18n script

### DIFF
--- a/scripts/merge-i18n-files.ts
+++ b/scripts/merge-i18n-files.ts
@@ -19,9 +19,9 @@ parseCliInput();
  * This script uses the i18n files found in a source directory to override settings in files with the same
  * name in a destination directory. Only the i18n labels to be overridden need be in the source files.
  *
- * Execution (using custom theme):
+ * Example execution (using custom theme):
  * ```
- *   yarn merge-i18n -s src/themes/custom/assets/i18n
+ *   npm run merge-i18n -- -s src/themes/custom/assets/i18n
  * ```
  *
  * Input parameters:
@@ -42,21 +42,25 @@ function parseCliInput() {
     .usage('(-s <source-dir> [-d <output-dir>])')
     .parse(process.argv);
 
-  if (program.outputDir && program.sourceDir) {
-    if (!fs.existsSync(program.outputDir) && !fs.lstatSync(program.outputDir).isDirectory() ) {
+  const source = program.opts().sourceDir;
+  const destination = program.opts().outputDir;
+
+  if (destination && source) {
+    if (!fs.existsSync(destination) || !fs.lstatSync(destination).isDirectory() ) {
       console.error('Output does not exist or is not a directory.');
       console.log(program.outputHelp());
       process.exit(1);
     }
-    if (!fs.existsSync(program.sourceDir) && !fs.lstatSync(program.sourceDir).isDirectory() ) {
+    if (!fs.existsSync(source) || !fs.lstatSync(source).isDirectory() ) {
       console.error('Source does not exist or is not a directory.');
       console.log(program.outputHelp());
       process.exit(1);
     }
-    fs.readdirSync(projectRoot(program.sourceDir)).forEach(file => {
-      if (fs.existsSync(program.outputDir + '/' + file) ) {
-        console.log('Merging: ' + program.outputDir + '/' + file + ' with ' + program.sourceDir + '/' + file);
-        mergeFileWithSource(program.sourceDir + '/' + file, program.outputDir + '/' + file);
+
+    fs.readdirSync(projectRoot(source)).forEach(file => {
+      if (fs.existsSync(destination + '/' + file) ) {
+        console.log('Merging: ' + destination + '/' + file + ' with ' + source + '/' + file);
+        mergeFileWithSource(source + '/' + file, destination + '/' + file);
       }
     });
   } else {


### PR DESCRIPTION
## References

* Fixes #4930 

## Description

A recent change in DSpace 9.x explicitly added CommanderJS as a dependency because it has been used in various scripts for a long time, relying on it being present transitively. The specified version was 

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
- Update code documentation example to use NPM instead of Yarn
- Update options handling for specified version of [Commander.js](https://github.com/tj/commander.js/releases/tag/v14.0.2)
- Adjust script error detection

You can test this locally in `dspace-angular` on by running the `merge-i18n` script using the custom theme provided.

```
npm run merge-i18n -- -s src/themes/custom/assets/i18n
```

Without this change, the script will always exit with an error about missing arguments.

- If `-s`, or `-d` is invalid, you should be presented with an error message and the script's help text
- If `-d` is not provided, it should use the default location: `src/assets/i18n`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
