### PR TITLE
Fix for issue #4960 PM2 cluster mode ECONNREFUSED errors

### DIFF
--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -1,9 +1,3 @@
-/**
- * Fix for Node.js 17+ where DNS resolution prefers IPv6 over IPv4.
- * This causes "ECONNREFUSED ::1:8080" errors in PM2 cluster mode when
- * the backend only listens on IPv4.
- * See: https://github.com/nodejs/node/issues/40537
- */
 import 'core-js/es/reflect';
 import 'zone.js';
 import 'reflect-metadata';
@@ -23,7 +17,10 @@ import {
 import { AppComponent } from './app/app.component';
 import { serverAppConfig } from './modules/app/server-app.config';
 
-// Apply DNS resolution order fix for Node.js 17+
+// Apply DNS resolution order fix for Node.js 17+ by preferring IPv4 over IPv6.
+// This fixes "ECONNREFUSED ::1:8080" errors in PM2 cluster mode when
+// the backend only listens on IPv4
+// See https://github.com/DSpace/dspace-angular/issues/4960
 setDefaultResultOrder('ipv4first');
 
 const bootstrap = (context: BootstrapContext) => bootstrapApplication(AppComponent, serverAppConfig, context);


### PR DESCRIPTION
## References
  * Fixes #4960

  ## Description
  Node.js 17+ changed DNS resolution to prefer IPv6 over IPv4. When running in PM2 cluster mode, this causes "ECONNREFUSED ::1:8080" errors if the backend only listens on IPv4 (127.0.0.1).

  This fix sets dns.setDefaultResultOrder('ipv4first') at the very start of the SSR bootstrap to ensure localhost resolves to IPv4.

  See: https://github.com/nodejs/node/issues/40537

  ## Instructions for Reviewers

  List of changes in this PR:
  * Added `dns.setDefaultResultOrder('ipv4first')` at the top of `src/main.server.ts` before any other imports
  * This ensures Node.js resolves "localhost" to IPv4 (127.0.0.1) instead of IPv6 (::1)

  **How to test:**
  1. Build the production app: `npm run build:prod`
  2. Start with PM2 in cluster mode: `pm2 start dspace-ui.json` (ensure `exec_mode: "cluster"` in config)
  3. Access http://localhost:4000/ - should return HTTP 200
  4. Without this fix, you would see "ECONNREFUSED ::1:8080" errors in the PM2 logs and HTTP 500 responses

  **Note:** This issue only occurs when:
  - Running Node.js 17+ (which prefers IPv6 for DNS resolution)
  - Using PM2 cluster mode (fork mode is unaffected)
  - The backend (Tomcat) only listens on IPv4

  ## Checklist

  - [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
  - [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
  - [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
  - [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
  - [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
  - [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
  - [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface. *(N/A - no UI changes)*
  - [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations. *(N/A - no user-facing text)*
  - [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
  - [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. *(N/A - uses built-in Node.js `dns` module)*
  - [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
  - [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).