### PR TITLE
[Docker] Remove more unnecessary tty/stdin_open settings from Docker scripts

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -41,8 +41,6 @@ services:
     ports:
     - published: 8080
       target: 8080
-    stdin_open: true
-    tty: true
     volumes:
     - assetstore:/dspace/assetstore
     # Ensure that the database is ready BEFORE starting tomcat

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -85,8 +85,6 @@ services:
     ports:
     - published: 5432
       target: 5432
-    stdin_open: true
-    tty: true
     volumes:
     # Keep Postgres data directory between reboots
     - pgdata:/pgdata


### PR DESCRIPTION
## References
* Found while backporting #4987. 
* This is a small follow-up to #4987

## Description
During the manual backport of #4987, I realized we still had a few Docker Compose files with unnecessary `tty` and `stdin_open` configurations. I've removed these few remaining from all the backport PRs (#4994, #4995, #4996).  

So, this PR is essentially a "forward port" of that tiny change back to `main`, as it's already been applied in #4994, #4995, #4996. 

## Instructions for Reviewers
* We now have automated tests which cover these small changes.