### PR TITLE
fix: use built-in Angular email validator for eperson form

### DIFF
--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -328,15 +328,28 @@ describe('EPersonFormComponent', () => {
       });
     });
 
+    describe('with uppercased email specified', () => {
+      beforeEach(() => {
+        component.formGroup.controls.firstName.setValue('test');
+        component.formGroup.controls.lastName.setValue('test');
+        component.formGroup.controls.email.setValue('TEST@test.com');
+        fixture.detectChanges();
+      });
+
+      it('passes validation check', () => {
+        expect(component.formGroup.controls.email.valid).toBeTrue();
+        expect(component.formGroup.controls.email.errors).toBeNull();
+      });
+    });
 
     describe('after inserting email wrong should show pattern validation error', () => {
       beforeEach(() => {
-        component.formGroup.controls.email.setValue('test@test');
+        component.formGroup.controls.email.setValue('test');
         fixture.detectChanges();
       });
       it('email should not be valid because the email pattern', () => {
         expect(component.formGroup.controls.email.valid).toBeFalse();
-        expect(component.formGroup.controls.email.errors.pattern).toBeTruthy();
+        expect(component.formGroup.controls.email.errors.email).toBeTruthy();
       });
     });
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -309,12 +309,12 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       name: 'email',
       validators: {
         required: null,
-        pattern: '^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$',
+        email: null,
       },
       required: true,
       errorMessages: {
         emailTaken: 'error.validation.emailTaken',
-        pattern: 'error.validation.NotValidEmail',
+        email: 'error.validation.NotValidEmail',
       },
       hint: this.translateService.instant(`${this.messagePrefix}.emailHint`),
     });


### PR DESCRIPTION
## References

Fixes [Not able to create an account with an email containing uppercase letters from eperson form #4338](https://github.com/DSpace/dspace-angular/issues/4338)

## Description

I have replaced regex pattern to use built-in one from Angular when we create e-person via form. 

I think we should refrain from using our own regex when Angular provides one similar. Unless there is a reason which I do not know about yet. 

e.g. issue shows to use pattern from `src/app/register-email-form/register-email-form.component.ts`

```regex
^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$
```

where Angular tries to adhere to WHATWG spec too https://github.com/angular/angular/blob/4755bbd94964f27921ec203fc1a9233a01c84792/packages/forms/src/validators.ts#L151

Angular adds 3 different constraints compared to WHATWG:

* Disallow `local-part` to begin or end with a period (`.`).
* Disallow `local-part` length to exceed 64 characters.
* Disallow total address length to exceed 254 characters.

## Instructions for Reviewers

List of changes in this PR:
* I have replaced pattern to use built-in email validator provided by Angular
* I have updated test to include uppercased case

Steps test this PR:
1. Visit http://localhost:4000/access-control/epeople/create
2. Fill a form with uppercased e-mail e.g. `TEST@example.com`
3. Create account and should success

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
