### PR TITLE
fix: silently fail when we cannot get visitorId from matomo for bitsream download

### DIFF
--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
@@ -116,6 +116,7 @@ describe('BitstreamDownloadPageComponent', () => {
     matomoService = jasmine.createSpyObj('MatomoService', {
       appendVisitorId: of(''),
       isMatomoEnabled$: of(true),
+      isMatomoScriptLoaded$: of(true),
     });
     matomoService.appendVisitorId.and.callFake((link) => of(link));
   }

--- a/src/app/statistics/matomo.factory.spec.ts
+++ b/src/app/statistics/matomo.factory.spec.ts
@@ -1,0 +1,49 @@
+import { Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { OrejimeService } from '@dspace/core/cookies/orejime.service';
+import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
+import { NativeWindowService } from '@dspace/core/services/window.service';
+import {
+  MatomoInitializerService,
+  MatomoTracker,
+} from 'ngx-matomo-client';
+import { firstValueFrom } from 'rxjs';
+
+import { customMatomoScriptFactory } from './matomo.factory';
+import { MatomoService } from './matomo.service';
+
+describe('customMatomoScriptFactory', () => {
+  let service: MatomoService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MatomoTracker, useValue: {} },
+        { provide: MatomoInitializerService, useValue: {} },
+        { provide: OrejimeService, useValue: {} },
+        { provide: NativeWindowService, useValue: {} },
+        { provide: ConfigurationDataService, useValue: {} },
+        { provide: Injector, useValue: TestBed },
+      ],
+    });
+
+    service = TestBed.inject(MatomoService);
+  });
+
+  it('should notify when the script loads', async () => {
+    const script = customMatomoScriptFactory(service)('', document);
+
+    script.dispatchEvent(new Event('load'));
+    const isMatomoScriptLoaded = await firstValueFrom(service.isMatomoScriptLoaded$());
+
+    expect(isMatomoScriptLoaded).toBeTruthy();
+  });
+
+  it('should notify when the script fails', async () => {
+    const script = customMatomoScriptFactory(service)('', document);
+
+    script.dispatchEvent(new Event('error'));
+    const isMatomoScriptLoaded = await firstValueFrom(service.isMatomoScriptLoaded$());
+
+    expect(isMatomoScriptLoaded).toBeFalsy();
+  });
+});

--- a/src/app/statistics/matomo.factory.ts
+++ b/src/app/statistics/matomo.factory.ts
@@ -2,6 +2,20 @@ import { createDefaultMatomoScriptElement } from 'ngx-matomo-client';
 
 import { MatomoService } from './matomo.service';
 
+/**
+ * Creates a custom script factory function that integrates with the `MatomoService`.
+ *
+ * @param matomoService - The instance of `MatomoService` used to track the loading state.
+ * @returns A function to initialize script to listen onload/onerror events by MatomoService
+ *
+ * @example
+ * // In your app config or module providers:
+ * {
+ * provide: MATOMO_SCRIPT_FACTORY,
+ * useFactory: customMatomoScriptFactory,
+ * deps: [MatomoService]
+ * }
+ */
 export function customMatomoScriptFactory(matomoService: MatomoService) {
   return (scriptUrl: string, document: Document): HTMLScriptElement => {
     const script = createDefaultMatomoScriptElement(scriptUrl, document);

--- a/src/app/statistics/matomo.factory.ts
+++ b/src/app/statistics/matomo.factory.ts
@@ -1,0 +1,14 @@
+import { createDefaultMatomoScriptElement } from 'ngx-matomo-client';
+
+import { MatomoService } from './matomo.service';
+
+export function customMatomoScriptFactory(matomoService: MatomoService) {
+  return (scriptUrl: string, document: Document): HTMLScriptElement => {
+    const script = createDefaultMatomoScriptElement(scriptUrl, document);
+
+    script.onload = () => matomoService.markAsLoaded();
+    script.onerror = () => matomoService.markAsError();
+
+    return script;
+  };
+}

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -25,6 +25,7 @@ import {
   from as fromPromise,
   Observable,
   of,
+  ReplaySubject,
 } from 'rxjs';
 import {
   map,
@@ -45,7 +46,6 @@ import { environment } from '../../environments/environment';
  * Provides methods for initializing tracking, managing consent, and appending visitor identifiers.
  */
 export class MatomoService {
-
   /** Injects the MatomoInitializerService to initialize the Matomo tracker. */
   matomoInitializer: MatomoInitializerService;
 
@@ -61,8 +61,19 @@ export class MatomoService {
   /** Injects the ConfigurationService. */
   configService = inject(ConfigurationDataService);
 
-  constructor(private injector: EnvironmentInjector) {
+  private statusSubject = new ReplaySubject<'loading' | 'loaded' | 'error'>(1);
+  private status$ = this.statusSubject.asObservable();
 
+  constructor(private injector: EnvironmentInjector) {
+    this.statusSubject.next('loading');
+  }
+
+  markAsLoaded() {
+    this.statusSubject.next('loaded');
+  }
+
+  markAsError() {
+    this.statusSubject.next('error');
   }
 
   /**
@@ -163,6 +174,12 @@ export class MatomoService {
             res.payload.values[0]?.toLowerCase() === 'true';
         }),
       );
+  }
+
+  isMatomoScriptLoaded$(): Observable<boolean> {
+    return this.status$.pipe(
+      map(status => status === 'loaded'),
+    );
   }
 
   /**

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -176,6 +176,10 @@ export class MatomoService {
       );
   }
 
+  /**
+   * Checks if Matomo script loaded correctly
+   * @returns An Observable that emits a boolean indicating whether Matomo script loaded correctly.
+   */
   isMatomoScriptLoaded$(): Observable<boolean> {
     return this.status$.pipe(
       map(status => status === 'loaded'),

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -68,10 +68,16 @@ export class MatomoService {
     this.statusSubject.next('loading');
   }
 
+  /**
+   * This method indicates that the Matomo script loaded successfully thus we set state to loaded
+   */
   markAsLoaded() {
     this.statusSubject.next('loaded');
   }
 
+  /**
+   * This method indicates that the Matomo script failed to download or execute and sets state to error
+   */
   markAsError() {
     this.statusSubject.next('error');
   }

--- a/src/modules/app/browser-app.config.ts
+++ b/src/modules/app/browser-app.config.ts
@@ -56,10 +56,13 @@ import {
   Angulartics2RouterlessModule,
 } from 'angulartics2';
 import {
+  MATOMO_SCRIPT_FACTORY,
   provideMatomo,
   withRouteData,
   withRouter,
 } from 'ngx-matomo-client';
+import { customMatomoScriptFactory } from 'src/app/statistics/matomo.factory';
+import { MatomoService } from 'src/app/statistics/matomo.service';
 
 import { commonAppConfig } from '../../app/app.config';
 import { storeModuleConfig } from '../../app/app.reducer';
@@ -169,5 +172,10 @@ export const browserAppConfig: ApplicationConfig = mergeApplicationConfig({
       withRouter(),
       withRouteData(),
     ),
+    {
+      provide: MATOMO_SCRIPT_FACTORY,
+      useFactory: customMatomoScriptFactory,
+      deps: [MatomoService],
+    },
   ],
 }, commonAppConfig);


### PR DESCRIPTION
## References

Fixes [Bitstream downloads fail when script blockers are active on sites with Matomo integration #4991](https://github.com/DSpace/dspace-angular/issues/4991)

## Description

This fixes bitstream download when Matomo is enabled and user disabled Matomo script.

Matomo integration enqueues tasks to `window._paq` and then Matomo sdk itself pop tasks from queue and executes them. 

When user has any adblocker the task will never pop from the queue and process, thus promise will never get resolved or rejected. It will hang at this line of code exactly:

`src/app/statistics/matomo.service.ts`
```javascript
appendVisitorId(url: string): Observable<string> {
  return fromPromise(this.matomoTracker?.getVisitorId())
    .pipe(
      map(visitorId => this.appendTrackerId(url, visitorId)),
      take(1),
    );
}
```

This does not happen for built-in tracking of `ng-matomo-client` - perhaps we should be more defensive and timeout with catchError for appendVistorId method rather than only checking whenever script got loaded correctly.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* I have added `isMatomoScriptLoaded$` in Matomo service to check whenever script gets loaded, errors out or hangs with loading status
* I have integrated `ngx-matomo-client` with Matomo service to use [custom script factory](ngx-matomo-client) and use `markAsLoaded` and `markAsError` to set proper state respectively
* I have modified bitstream download page to ignore silently when we cannot load script

Steps to test this PR:

Environment: 
* Follow https://wiki.lyrasis.org/display/DSDOC9x/Matomo+Integration to run Matomo locally
* To test this on dev, in `init` method of MatomoService we need to comment out `environment.production` to allow to initialize tracker

Case 1. Firefox with Ublock Origin enabled

1. Attempt to download any bitstream resource and find out in network tab that `trackerId` will not be added to bitstream resource

Case 2. Firefox with Ublock Origin disabled

1. Attempt to download any bitstream resource and find out in network tab that `trackerId` will be added to bitstream resource


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
