### PR TITLE
[Docker] Fix bug in `docker-deploy` test by always pulling backend image from docker.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,10 +74,6 @@ jobs:
       DSPACE_REST_HOST: 127.0.0.1
       # Override default dspace.ui.url to also use 127.0.0.1.
       dspace__P__ui__P__url: http://127.0.0.1:4000
-      # Docker Registry to use for Docker compose scripts below.
-      # If this is a PR, then we need to use docker.io (as the registry must be public),
-      # Otherwise we default to ghcr.io to avoid aggressive rate limits at DockerHub.
-      DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && 'docker.io' || 'ghcr.io' }}
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase
@@ -98,6 +94,11 @@ jobs:
           docker image ls -a
       # Start backend using our compose script in the codebase.
       - name: Start backend in Docker
+        # MUST use docker.io as we don't have a copy of this backend image in our GitHub Action,
+        # and docker.io is the only public image. If we ever hit aggressive rate limits at DockerHub,
+        # we may need to consider making the 'ghcr.io' images public & switch this to 'ghcr.io'
+        env:
+          DOCKER_REGISTRY: docker.io
         run: |
           docker compose -f docker/docker-compose-rest.yml up -d
           sleep 10


### PR DESCRIPTION
## Description
Currently, our `docker-deploy` step is *failing* (on all active branches) whenever it runs *post-merger* of a PR.

Examples:
* https://github.com/DSpace/dspace-angular/actions/runs/21182082205/job/60933641993
* https://github.com/DSpace/dspace-angular/actions/runs/21184451358/job/60936020654

The reason for this failure is that we're attempting to pull the *backend* image from ghcr.io (in order to start a backend to test against).  But, we run into a permissions error every time as our ghcr.io images are private (and only used for build verifications).

This small PR just updates our GitHub actions `docker.yml` to ensure the backend image is always pulled from `docker.io` (our public images).   This fixes a minor flaw in the new `docker-deploy` tests added in #4987

(NOTE: The frontend images continue to be taken from `ghcr.io` in order to test the latest built frontend image.  This remains unchanged because the `dspace-angular` repo can easily pull frontend images from `ghcr.io`.  It just doesn't have permissions to pull the **backend images**)

## Instructions for Reviewers
* Unfortunately, this cannot be manually tested as it is only updating our GitHub actions `docker.yml` script.   Therefore, assuming our automated tests all pass, I'll merge this immediately and port to all active branches (as this same flaw appears on all branches)