### PR TITLE
Reduce bitstream authorization requests for item page

### DIFF
--- a/src/app/shared/file-download-link/file-download-link.component.spec.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.spec.ts
@@ -117,9 +117,11 @@ describe('FileDownloadLinkComponent', () => {
           component.item = item;
           fixture.detectChanges();
         });
+        it('should return canDownload truthy', () => {
+          expect(component.canDownload$).toBeObservable(cold('-a', { a: true }));
+        });
         it('should return the bitstreamPath based on the input bitstream', () => {
           expect(component.bitstreamPath$).toBeObservable(cold('-a', { a: { routerLink: new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString(), queryParams: {} } }));
-          expect(component.canDownload$).toBeObservable(cold('--a', { a: true }));
 
         });
         it('should init the component', () => {
@@ -151,9 +153,11 @@ describe('FileDownloadLinkComponent', () => {
           component.bitstream = bitstream;
           fixture.detectChanges();
         });
+        it('should return canDownload falsy', () => {
+          expect(component.canDownload$).toBeObservable(cold('-a', { a: false }));
+        });
         it('should return the bitstreamPath based on the input bitstream', () => {
-          expect(component.bitstreamPath$).toBeObservable(cold('-a', { a: { routerLink: new URLCombiner(getItemModuleRoute(), item.uuid, 'request-a-copy').toString(), queryParams: { bitstream: bitstream.uuid } } }));
-          expect(component.canDownload$).toBeObservable(cold('--a', { a: false }));
+          expect(component.bitstreamPath$).toBeObservable(cold('--a', { a: { routerLink: new URLCombiner(getItemModuleRoute(), item.uuid, 'request-a-copy').toString(), queryParams: { bitstream: bitstream.uuid } } }));
 
         });
         it('should init the component', () => {
@@ -180,9 +184,11 @@ describe('FileDownloadLinkComponent', () => {
           component.item = item;
           fixture.detectChanges();
         });
+        it('should return canDownload falsy', () => {
+          expect(component.canDownload$).toBeObservable(cold('-a', { a: false }));
+        });
         it('should return the bitstreamPath based on the input bitstream', () => {
-          expect(component.bitstreamPath$).toBeObservable(cold('-a', { a: { routerLink: new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString(), queryParams: {} } }));
-          expect(component.canDownload$).toBeObservable(cold('--a', { a: false }));
+          expect(component.bitstreamPath$).toBeObservable(cold('--a', { a: { routerLink: new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString(), queryParams: {} } }));
 
         });
         it('should init the component and show the locked icon', () => {
@@ -209,9 +215,11 @@ describe('FileDownloadLinkComponent', () => {
           component.item = item;
           fixture.detectChanges();
         });
+        it('should return canDownload falsy', () => {
+          expect(component.canDownload$).toBeObservable(cold('-a', { a: false }));
+        });
         it('should return the bitstreamPath based on the access token and request-a-copy path', () => {
-          expect(component.bitstreamPath$).toBeObservable(cold('-a', { a: { routerLink: new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString(), queryParams: { accessToken: 'abc123' } } }));
-          expect(component.canDownload$).toBeObservable(cold('--a', { a: false }));
+          expect(component.bitstreamPath$).toBeObservable(cold('--a', { a: { routerLink: new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString(), queryParams: { accessToken: 'abc123' } } }));
 
         });
         it('should init the component and show an open lock', () => {

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -36,7 +36,10 @@ import {
   Observable,
   of,
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
 
 import { ThemedAccessStatusBadgeComponent } from '../object-collection/shared/badges/access-status-badge/themed-access-status-badge.component';
 
@@ -112,13 +115,23 @@ export class FileDownloadLinkComponent implements OnInit {
     if (this.enableRequestACopy) {
       // Obtain item request data from the route snapshot
       this.itemRequest = this.route.snapshot.data.itemRequest;
-      // Set up observables to test access rights to a normal bitstream download, a valid token download, and the request-a-copy feature
+      // Set up observable to evaluate access rights for a normal download
       this.canDownload$ = this.authorizationService.isAuthorized(FeatureID.CanDownload, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
-      this.canDownloadWithToken$ = of((this.itemRequest && this.itemRequest.acceptRequest && !this.itemRequest.accessExpired) ? (this.itemRequest.allfiles !== false || this.itemRequest.bitstreamId === this.bitstream.uuid) : false);
-      this.canRequestACopy$ = this.authorizationService.isAuthorized(FeatureID.CanRequestACopy, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
-      // Set up observable to determine the path to the bitstream based on the user's access rights and features as above
-      this.bitstreamPath$ = observableCombineLatest([this.canDownload$, this.canDownloadWithToken$, this.canRequestACopy$]).pipe(
-        map(([canDownload, canDownloadWithToken, canRequestACopy]) => this.getBitstreamPath(canDownload, canDownloadWithToken, canRequestACopy)),
+      // Only set up and execute other observables if canDownload emits false
+      this.bitstreamPath$ = this.canDownload$.pipe(
+        switchMap(canDownload => {
+          if (canDownload) {
+            return of(this.getBitstreamDownloadPath());
+          }
+          // Set up and combine observables to evaluate access rights to a valid token download and the request-a-copy feature
+          this.canDownloadWithToken$ = of((this.itemRequest && this.itemRequest.acceptRequest && !this.itemRequest.accessExpired) ? (this.itemRequest.allfiles !== false || this.itemRequest.bitstreamId === this.bitstream.uuid) : false);
+          this.canRequestACopy$ = this.authorizationService.isAuthorized(FeatureID.CanRequestACopy, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
+          // Set up canDownload observable so the template can read the state
+          this.canDownload$ = of(false);
+          return observableCombineLatest([this.canDownloadWithToken$, this.canRequestACopy$]).pipe(
+            map(([canDownloadWithToken, canRequestACopy]) => this.getBitstreamPathForRequestACopy(canDownloadWithToken, canRequestACopy)),
+          );
+        }),
       );
     } else {
       this.bitstreamPath$ = of(this.getBitstreamDownloadPath());
@@ -130,21 +143,16 @@ export class FileDownloadLinkComponent implements OnInit {
    * Return a path to the bitstream based on what kind of access and authorization the user has, and whether
    * they may request a copy
    *
-   * @param canDownload user can download normally
    * @param canDownloadWithToken user can download using a token granted by a request approver
    * @param canRequestACopy user can request approval to access a copy
    */
-  getBitstreamPath(canDownload: boolean, canDownloadWithToken, canRequestACopy: boolean) {
-    // No matter what, if the user can download with their own authZ, allow it
-    if (canDownload) {
-      return this.getBitstreamDownloadPath();
-    }
-    // Otherwise, if they access token is valid, use this
+  getBitstreamPathForRequestACopy(canDownloadWithToken: boolean, canRequestACopy: boolean) {
+    //  if the access token is valid, use this
     if (canDownloadWithToken) {
       return this.getAccessByTokenBitstreamPath(this.itemRequest);
     }
     // If the user can't download, but can request a copy, show the request a copy link
-    if (!canDownload && canRequestACopy && hasValue(this.item)) {
+    if (canRequestACopy && hasValue(this.item)) {
       return getBitstreamRequestACopyRoute(this.item, this.bitstream);
     }
     // By default, return the plain path


### PR DESCRIPTION
## Description
This PR reduces the number of calls to the REST API by executing certain authorization requests only conditionally if the normal download is not possible for the user. Before, the authorization request "canRequestACopy" was always sent for every bitstream, now this only happens if the "canDownload" request returns false. This improves the response time performance for items with a large number of bitstreams and a large pagesize (>=50), as can be seen in a graph below.

## Instructions for Reviewers
Currently the response time is slow for items with a large number of bitstreams. The current workaround are small pageSizes for the item's bitstreams per default. However, from a UX standpoint it would be nice to be able to show a larger list of bitstreams to the users, especially in the case of uploaded research data.

How to test this PR:
- create an Item with >=50 bitstreams
- edit some bitstreams, so that they are embargoed, or the access is otherwise restricted to anonymous users
- set `item.bitstream.pageSize` to 50 (or more)
- check that the response time is slower without this PR on the item page, and faster with the PR changes
- check that the "Request a copy" functionality still works for embargoed and otherwise restricted items

Here is a comparison of the reponse time of an item page, varied in the page size:
<img width="721" height="363" alt="response-times-compared" src="https://github.com/user-attachments/assets/017129df-6313-4a4f-a653-c424e2f8df40" />

## Related Issues, former issues with item bitstream pagesize:
https://github.com/DSpace/DSpace/issues/8648
https://github.com/DSpace/dspace-angular/pull/2065

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

Co-funded by the European Union and Universitätsbibliothek TU Berlin (DSpaceQPO project)