### PR TITLE
Translate locally Creative Commons answers not translated by CC API

### DIFF
--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
@@ -67,7 +67,7 @@
               <div
                 class="mb-4">
                 <h5>
-                  {{ value.label }}
+                  {{ 'submission.sections.ccLicense.option.answer.' + value.label | translate: {default:value.label} }}
                 </h5>
                 <div [innerHTML]="value.description" class="fw-light"></div>
               </div>
@@ -80,7 +80,7 @@
           <ng-container class="selection" *ngVar="getSelectedOption(getSelectedCcLicense(), field) as option">
             @if (option) {
               <span>
-                {{ option.label }}
+                {{ 'submission.sections.ccLicense.option.answer.' + option.label | translate: {default:option.label} }}
               </span>
             }
             @if (!option) {
@@ -95,7 +95,7 @@
                 <button
                   class="dropdown-item"
                   (click)="selectOption(getSelectedCcLicense(), field, option)">
-                  {{ option.label }}
+                  {{ 'submission.sections.ccLicense.option.answer.' + option.label | translate: {default:option.label} }}
                 </button>
               }
             </div>
@@ -111,7 +111,7 @@
                 title="{{ option.label }}"
                 class="me-1"
                 [checked]="isSelectedOption(getSelectedCcLicense(), field, option)">
-              <span>{{ option.label }}</span>
+              <span>{{ 'submission.sections.ccLicense.option.answer.' + option.label | translate: {default:option.label} }}</span>
             </div>
           </div>
         }

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -8404,6 +8404,15 @@
   // "submission.sections.ccLicense.confirmation": "I grant the license above",
   "submission.sections.ccLicense.confirmation": "Concedeixo la llicència",
 
+  // "submission.sections.ccLicense.option.answer.Yes": "Yes",
+  "submission.sections.ccLicense.option.answer.Yes": "Sí",
+
+  // "submission.sections.ccLicense.option.answer.ShareAlike": "ShareAlike",
+  "submission.sections.ccLicense.option.answer.ShareAlike": "CompartirIgual",
+
+  // "submission.sections.ccLicense.option.answer.No": "No",
+  "submission.sections.ccLicense.option.answer.No": "No",
+
   // "submission.sections.general.add-more": "Add more",
   "submission.sections.general.add-more": "Afegir més",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5550,6 +5550,12 @@
 
   "submission.sections.ccLicense.confirmation": "I grant the license above",
 
+  "submission.sections.ccLicense.option.answer.Yes": "Yes",
+
+  "submission.sections.ccLicense.option.answer.ShareAlike": "ShareAlike",
+
+  "submission.sections.ccLicense.option.answer.No": "No",
+
   "submission.sections.general.add-more": "Add more",
 
   "submission.sections.general.cannot_deposit": "Deposit cannot be completed due to errors in the form.<br>Please fill out all required fields to complete the deposit.",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -8348,6 +8348,15 @@
   // "submission.sections.ccLicense.confirmation": "I grant the license above",
   "submission.sections.ccLicense.confirmation": "Otorgo la licencia de arriba",
 
+  // "submission.sections.ccLicense.option.answer.Yes": "Yes",
+  "submission.sections.ccLicense.option.answer.Yes": "Si",
+
+  // "submission.sections.ccLicense.option.answer.ShareAlike": "ShareAlike",
+  "submission.sections.ccLicense.option.answer.ShareAlike": "CompartirIgual",
+
+  // "submission.sections.ccLicense.option.answer.No": "No",
+  "submission.sections.ccLicense.option.answer.No": "No",
+
   // "submission.sections.general.add-more": "Add more",
   "submission.sections.general.add-more": "Añadir más",
 


### PR DESCRIPTION
## References
* Fixes DSpace/DSpace#9393
* 8.x port: https://github.com/DSpace/dspace-angular/pull/5032

## Description
This PR introduces local translations for Creative Commons license answer labels that are returned untranslated by the CC API.

**Note:** This is a temporary workaround while the legacy CC API integration is still in use. See: DSpace/DSpace#9397

## Instructions for Reviewers

List of changes in this PR:
* Updated the CC License submission component to translate Creative Commons answer labels locally instead of displaying raw values from the CC API.
* Added new i18n translation keys for CC license answers (Yes, No, ShareAlike) in English, Spanish, and Catalan

To test it:
* Enable the cclicense step in item-submission.xml.
* Comment out or leave empty the `cc.license.locale` property in dspace.cfg.
* Configure supported locales in dspace.cfg, for example:

```
webui.supported.locales` = en, ca, es
```
* Start a new item submission and verify that CC license answers are properly translated according to the selected UI language.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.