### PR TITLE
[GitHub Actions] Add `stale` bot settings based on those in DSpace/DSpace

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,72 @@
+# DSpace rules for flagging untouched issues and PRs as stale using 'stale':
+# https://github.com/actions/stale
+name: 'Mark issues and PRs as stale'
+on:
+  # Schedule to run weekly on Sunday at 3:03am UTC
+  # NOTE: This time is purposefully different from the "stale" bot settings in "DSpace/DSpace" to help
+  # ensure we don't hit GitHub's rate limits.
+  schedule:
+    - cron: '3 3 * * 0'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Number of GitHub API calls to allow in a single run (to avoid hitting GitHub's rate limit)
+          # Default is 30. But, we've found that only results in processing ~7 issues or PRs. So, we've increased it.
+          operations-per-run: 60
+          # Issues will be marked stale after 3 years of no activity
+          days-before-issue-stale: 1095
+          # Issues marked stale will be closed after one additional week of no activity
+          days-before-issue-close: 7
+          # High priority issues are never marked stale
+          exempt-issue-labels: 'high priority'
+          # When an issue is marked stale, this label and comment will be added to the issue.
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            activity in 3 years. It will be closed in 7 days if no further activity occurs.
+
+            Allowing issues to close as stale helps us filter out issues which can wait
+            for future development time. All issues closed by this bot will continue to act 
+            like normal issues; they can be searched for, commented on or reopened at any point.
+
+            To extend the lifetime of an issue please comment below. This will help us to see
+            that this issue is still affecting you with current versions of DSpace, and encourage
+            us to re-prioritize this issue.
+          # When an issue is closed, this comment will be added to the issue.
+          close-issue-message: |
+            This issue has been closed automatically as "stale". If this still affects you please 
+            request to re-open this issue via a comment, providing us with details on how this still
+            impacts your usage of DSpace.
+          # PRs will be marked stale after 1 year of no activity
+          days-before-pr-stale: 365
+          # PRs marked stale will be closed after two additional weeks of no activity
+          days-before-pr-close: 14
+          # High priority PRs are never marked stale
+          exempt-pr-labels: 'high priority'
+          # When a PR is marked stale, this label and comment will be added to the issue.
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            activity in one year. It will be closed in 14 days if no further activity occurs.
+
+            Allowing pull requests to close as stale helps us filter out old work that is no longer
+            relevant and helps developers focus on reviewing current work.
+
+            All pull requests closed by this bot act like normal pull requests;
+            they can be searched for, commented on or reopened at any point.
+
+            If these changes are still relevant then please comment and/or rebase your PR based on the
+            latest DSpace code. This will remove the stale status and notify us to assign a reviewer
+            for your PR.
+          close-pr-message: |
+            This pull request has been closed automatically. If these changes are still relevant
+            then please re-open this pull request with a comment and rebase your PR based on the latest
+            DSpace code. This will notify us to assign a reviewer to your PR.


### PR DESCRIPTION
## Description

This PR copies `stale` bot settings from `DSpace/DSpace` in order to enable them also on this `dspace-angular` repository.  

This PR is a copy of these two backend PRs:
* https://github.com/DSpace/DSpace/pull/11550  (initial settings)
* https://github.com/DSpace/DSpace/pull/11772  (minor updates based on yesterday's Developers Meeting)

Only one minor change has been made.  For `DSpace/dspace-angular`, I've changed the cron schedule for the `stale` bot to have it run **one hour later** than the `stale` bot for `DSpace/DSpace`.  This just ensures we (hopefully) don't encounter GitHub rate limits.

## Instructions for Reviewers
These settings have already been verified in the `DSpace/DSpace` repository.  I'll merge this immediately once all automated tests succeed.