### PR TITLE
Fix: make alert for new sections fully translatable (#4740)

### DIFF
--- a/src/app/submission/submission.service.ts
+++ b/src/app/submission/submission.service.ts
@@ -541,9 +541,20 @@ export class SubmissionService {
    *    The section type
    */
   notifyNewSection(submissionId: string, sectionId: string, sectionType?: SectionsType) {
-    const m = this.translate.instant('submission.sections.general.metadata-extracted-new-section', { sectionId });
-    this.notificationsService.info(null, m, null, true);
+    const specificKey =
+      `submission.sections.general.metadata-extracted-new-section.${sectionId}`;
+
+    let message = this.translate.instant(specificKey);
+    if (message === specificKey) {
+      message = this.translate.instant(
+        'submission.sections.general.metadata-extracted-new-section',
+        { sectionId },
+      );
+    }
+
+    this.notificationsService.info(null, message, null, true);
   }
+
 
   /**
    * Redirect to MyDspace page


### PR DESCRIPTION
## References
* Fixes #4740 

## Description
This PR improves internationalization support for submission alerts when new sections are dynamically added.
Instead of using a partially translatable message, the alert now supports fully translatable i18n keys per section, with a fallback to the generic message when a specific translation is not available.

### Summary of changes
- Updated `submission.service.ts` to generate section-specific i18n keys for the “new section added” alert.
- Allows translations to be defined per section (e.g. `duplicates`) while maintaining backward compatibility via a fallback key.

## Instructions for Reviewers
1. Start the Angular UI and create a new submission.
2. Add metadata that triggers a new section to appear (for example, trigger the **duplicates** section by submitting metadata that already exists in the database).
3. Observe the notification alert shown in the upper-right corner.
4. Verify that:
   - The alert message is fully translatable.
   - A section-specific i18n key is used when available.
   - The generic fallback message is used if no section-specific translation exists.
  
## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
