### PR TITLE
DURACOM-416 Created fallback logic when user reaches an out of bound page number

### DIFF
--- a/src/app/core/pagination/pagination.service.ts
+++ b/src/app/core/pagination/pagination.service.ts
@@ -214,6 +214,25 @@ export class PaginationService {
     return `${paginationId}.page`;
   }
 
+  /**
+   * Centralized fallback logic for pagination. Returns the correct page to use and updates the route if needed.
+   * @param paginationId - The pagination id
+   * @param currentPage - The current page number
+   * @param totalPages - The total number of pages
+   * @returns {number} - The corrected page number to use for the next data fetch
+   */
+  public handlePaginationFallback(paginationId: string, currentPage: number, totalPages: number): number {
+    if (totalPages === 0 && currentPage !== 1) {
+      this.resetPage(paginationId);
+      return 1;
+    } else if (totalPages > 0 && currentPage > totalPages) {
+      this.updateRoute(paginationId, { page: totalPages });
+      return totalPages;
+    }
+    return currentPage;
+  }
+
+
   private getCurrentRouting(paginationId: string) {
     return this.getFindListOptions(paginationId, {}, true).pipe(
       take(1),


### PR DESCRIPTION


## Description
Added in the paginator a fallback logic to prevent the case where the user reaches an out of bound page and nothing is shown

## Instructions for Reviewers
Created methods that handles the fallback logic to prevent the user reaching an out of bound page

To test, in the processes page, visit the last page of section “Scheduled Processes”.

Then, delete the processes displayed on that page.

It previously remained stuck on an empty “Scheduled Processes” page, now we fallback to the page with the highest number

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
