### PR TITLE
fix(routes): set browser title for error pages using i18n translations

### DIFF
--- a/src/app/app-routes.ts
+++ b/src/app/app-routes.ts
@@ -48,7 +48,7 @@ import { provideSubmissionState } from './submission/provide-submission-state';
 import { SUGGESTION_MODULE_PATH } from './suggestions-page/suggestions-page-routing-paths';
 
 export const APP_ROUTES: Route[] = [
-  { path: INTERNAL_SERVER_ERROR, component: ThemedPageInternalServerErrorComponent },
+  { path: INTERNAL_SERVER_ERROR, component: ThemedPageInternalServerErrorComponent, data: { title: '500.page-internal-server-error' } },
   { path: ERROR_PAGE, component: ThemedPageErrorComponent },
   {
     path: '',
@@ -251,6 +251,7 @@ export const APP_ROUTES: Route[] = [
       {
         path: FORBIDDEN_PATH,
         component: ThemedForbiddenComponent,
+        data: { title: '403.forbidden' },
       },
       {
         path: 'statistics',
@@ -295,7 +296,7 @@ export const APP_ROUTES: Route[] = [
           .then((m) => m.ROUTES),
         canActivate: [notAuthenticatedGuard],
       },
-      { path: '**', pathMatch: 'full', component: ThemedPageNotFoundComponent },
+      { path: '**', pathMatch: 'full', component: ThemedPageNotFoundComponent, data: { title: '404.page-not-found' } },
     ],
   },
 ];


### PR DESCRIPTION
## References
Fixes #2672

## Description
The /404, /500, and /403 error pages did not update the browser tab title from the i18n translation files. The title remained as the default "DSpace" instead of reflecting the translated page name.

The fix adds data: { title: '...' } to the error page route definitions in app-routes.ts, which allows the existing HeadTagService to automatically pick up and set the translated title following the standard format (e.g., DSpace Repository :: Page not found).

## Instructions for Reviewers
List of changes in this PR:

- Added data: { title: '500.page-internal-server-error' } to the /500 route
- Added data: { title: '403.forbidden' } to the /403 route
- Added data: { title: '404.page-not-found' } to the ** wildcard (404) route

How to test:

1. Start the application locally
2. Navigate to the following error pages and check the browser tab title:
    -  /500 → Should display DSpace Repository :: Service unavailable
    -  /forbidden → Should display DSpace Repository :: Forbidden
    -  Any non-existing URL (e.g., /this-does-not-exist) → Should display DSpace Repository :: Page not found
8. Previously, all these pages showed just DSpace as the browser title

## Checklist

- [X]  My PR is created against the main branch
- [X]  My PR is small in size
- [X]  My PR passes ESLint validation using npm run lint
- [X]  My PR doesn't introduce circular dependencies
- [X]  My PR uses i18n keys instead of hardcoded English text
- [X]  My PR includes details on how to test it
- [X]  If my PR fixes an issue ticket, I've linked them together
