### PR TITLE
LocaleInterceptor leads to hanging page if user is logged in and previous requests became stale

### DIFF
--- a/src/app/core/locale/locale.interceptor.spec.ts
+++ b/src/app/core/locale/locale.interceptor.spec.ts
@@ -8,13 +8,21 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { APP_CONFIG } from '@dspace/config/app-config.interface';
 import { RestRequestMethod } from '@dspace/config/rest-request-method';
 import { of } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { DspaceRestService } from '../dspace-rest/dspace-rest.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { LocaleInterceptor } from './locale.interceptor';
 import { LocaleService } from './locale.service';
+
+const envConfig = {
+  rest: {
+    baseUrl: 'server',
+  },
+};
 
 describe(`LocaleInterceptor`, () => {
   let service: DspaceRestService;
@@ -24,10 +32,11 @@ describe(`LocaleInterceptor`, () => {
   const languageList = ['en;q=1', 'it;q=0.9', 'de;q=0.8', 'fr;q=0.7'];
   const rootHref = 'https://sandbox.dspace.org/server/api';
 
-  const mockLocaleService = jasmine.createSpyObj('LocaleService', [
-    'getCurrentLanguageCode',
-    'getLanguageCodeList',
-  ]);
+  const mockLocaleService = jasmine.createSpyObj('LocaleService', {
+    getCurrentLanguageCode: jasmine.createSpy('getCurrentLanguageCode'),
+    getLanguageCodeList: of(languageList),
+    ignoreEPersonSettings: false,
+  });
 
   const mockHalEndpointService = {
     getRootHref: jasmine.createSpy('getRootHref'),
@@ -45,6 +54,7 @@ describe(`LocaleInterceptor`, () => {
         },
         { provide: HALEndpointService, useValue: mockHalEndpointService },
         { provide: LocaleService, useValue: mockLocaleService },
+        { provide: APP_CONFIG, useValue: envConfig  },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],
@@ -108,6 +118,30 @@ describe(`LocaleInterceptor`, () => {
       httpMock.expectOne(epersonHref);
 
       expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(true);
+    });
+
+  });
+
+  describe('', () => {
+
+    it('should call the getLanguageCodeList method with ignoreEPersonSettings as true', () => {
+      localeService.getLanguageCodeList.calls.reset();
+      service.request(RestRequestMethod.GET, 'server/api/eperson/epersons/123').pipe(take(1)).subscribe();
+
+      const httpRequest = httpMock.expectOne(`server/api/eperson/epersons/123`);
+      httpRequest.flush({});
+
+      expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(true);
+    });
+
+    it('should call the getLanguageCodeList method with ignoreEPersonSettings as false', () => {
+      localeService.getLanguageCodeList.calls.reset();
+      service.request(RestRequestMethod.GET, 'server/api/submission/workspaceitems/123').pipe(take(1)).subscribe();
+
+      const httpRequest = httpMock.expectOne(`server/api/submission/workspaceitems/123`);
+      httpRequest.flush({});
+
+      expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(false);
     });
 
   });

--- a/src/app/core/locale/locale.interceptor.ts
+++ b/src/app/core/locale/locale.interceptor.ts
@@ -4,7 +4,15 @@ import {
   HttpInterceptor,
   HttpRequest,
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import {
+  inject,
+  Injectable,
+} from '@angular/core';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
+import { RESTURLCombiner } from '@dspace/core/url-combiner/rest-url-combiner';
 import { Observable } from 'rxjs';
 import {
   mergeMap,
@@ -17,6 +25,7 @@ import { LocaleService } from './locale.service';
 
 @Injectable()
 export class LocaleInterceptor implements HttpInterceptor {
+  protected readonly appConfig: AppConfig = inject(APP_CONFIG);
 
   constructor(
     protected halEndpointService: HALEndpointService,
@@ -31,7 +40,12 @@ export class LocaleInterceptor implements HttpInterceptor {
    */
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     let newReq: HttpRequest<any>;
-    const ignoreEPersonSettings: boolean = this.shouldIgnoreEPersonSettings(req.url);
+    let ignoreEPersonSettings = false;
+    const ePersonEndpointUrl = new RESTURLCombiner(this.appConfig.rest.baseUrl, 'eperson/epersons').toString();
+
+    if (req.url === this.halEndpointService.getRootHref() || req.url.startsWith(ePersonEndpointUrl)) {
+      ignoreEPersonSettings = true;
+    }
 
     return this.localeService.getLanguageCodeList(ignoreEPersonSettings)
       .pipe(


### PR DESCRIPTION
The current implementation of the "LocaleInterceptor" leads Dspace to hang if the current user is logged in and the (previous) "eperson/epersons"-request has become stale.

## References
* (not reported yet)

## Description
Requirements:
- User is logged in
- the (previous) request to /server/api/eperson/epersons/UUID has become stale in the meantime

The LocaleInterceptor adds a http header ("Accept-Language") to almost each request. While this works in most cases, the interceptor should set "ignoreEPersonSettings" to "true", if the request url itself leads to the endpoint of "server/api/eperson/epersons" and the state of the previous request got stale. Otherwise, the following chain is called again and again:
"LocaleService.getLanguageCodeList()" -> "AuthService.getAuthenticatedUserFromStore()" -> epersonService.findById() -> ...which leads to process the LocaleInterceptor again.

## Instructions for Reviewers
List of changes in this PR:
* The LocaleInterceptor got a new condition when to set `ignoreEPersonSettings` to `true`

**Test the behaviour before the fix following these steps**
- Make sure you decrease the default cache time to lets say 30 seconds in the "default-app-config.ts" 
  - ```  cache: CacheConfig = {
    // NOTE: how long should objects be cached for by default
    msToLive: {
      // default: 15 * 60 * 1000, // 15 minutes
      default: 30000, // 30 seconds
    },
    ```
- _Restart dspace to make sure the settings becomes active_
- Login as an administrator
- Open the "MyDSpace" page; make a hard-reload in the browser - wait for at least 30 seconds
- Click on "Workflows tasks" in the dropdown ui element in the left sidebar
- ...see the loading spinner never end and the data are never shown. To go on, you need to hard-refresh your browser for example.

_Even though the circumstances sound unusual, our colleagues have experienced the “MyDSpace” page remaining open in the browser for a longer time. As soon as they start working again with DSpace, the effect described above occurs. Especially since the auto-logout in the default configuration occurs regulary after 20 minutes._

This video should show the problem:
https://github.com/user-attachments/assets/b862bfb4-fb2a-499a-84e1-9ef784ca9077



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
