### PR TITLE
Fix improve UX for back button on workflow bitstream downloads (#4146)

### DIFF
--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.html
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.html
@@ -1,8 +1,5 @@
 <div class="container">
-  <h1 class="h2">{{'bitstream.download.page' | translate:{ bitstream: dsoNameService.getName((bitstream$ | async)) } }}</h1>
-  <div class="pt-3">
-    <button (click)="back()" class="btn btn-outline-secondary">
-      <i class="fas fa-arrow-left"></i> {{'bitstream.download.page.back' | translate}}
-    </button>
-  </div>
+  <h1 class="h2">
+    {{ 'bitstream.download.page' | translate:{ bitstream: dsoNameService.getName((bitstream$ | async)) } }}
+  </h1>
 </div>

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -85,10 +85,6 @@ export class BitstreamDownloadPageComponent implements OnInit {
     this.initPageLinks();
   }
 
-  back(): void {
-    this.location.back();
-  }
-
   ngOnInit(): void {
     const accessToken$: Observable<string> = this.route.queryParams.pipe(
       map((queryParams: Params) => queryParams?.accessToken || null),


### PR DESCRIPTION
## References
* Fixes #4146

## Description
This PR improves navigation reliability during workflow bitstream downloads by removing the Back button from the bitstream download page.
The button could lead to a Whitelabel error in certain workflow navigation scenarios due to missing or invalid navigation history.

## Instructions for Reviewers
This PR removes the Back button from the bitstream download page, as suggested in issue #4146, to ensure consistent and predictable behavior across the UI.

List of changes in this PR:

- Removed the Back button from bitstream-download-page.component.html.
- Removed the unused back() method and related Location dependency from BitstreamDownloadPageComponent.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

1. Go to a workflow item page (e.g. /workflowitems/{id}/view).

2. Download a bitstream.

3. Verify that:

    -  The download still works as expected.
    - No Back button is displayed on the bitstream download page.
    - Navigation relies on the browser back button, avoiding Whitelabel errors.

4. Confirm that bitstream downloads from the Full Item Page and Admin UI remain unaffected.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
