### PR TITLE
Cache-bust dynamic configuration files and theme CSS (main)

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -90,6 +90,9 @@ cache:
   # NOTE: When updates are made to compiled *.js files, it will automatically bypass this browser cache, because
   # all compiled *.js files include a unique hash in their name which updates when content is modified.
   control: max-age=604800 # revalidate browser
+  # These static files should not be cached (paths relative to dist/browser, including the leading slash)
+  noCacheFiles:
+    - '/index.html'
   autoSync:
     defaultTime: 0
     maxBufferSize: 100

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "ngx-pagination": "6.0.3",
         "ngx-skeleton-loader": "^11.3.0",
         "ngx-ui-switch": "^16.1.0",
+        "node-html-parser": "^7.0.1",
         "nouislider": "^15.7.1",
         "orejime": "^2.3.1",
         "pem": "1.14.8",
@@ -11275,7 +11276,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/bootstrap": {
@@ -13299,7 +13299,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -13314,7 +13313,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13327,7 +13325,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -13348,7 +13345,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -13447,27 +13443,6 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -13570,7 +13545,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -15531,6 +15505,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -19665,6 +19647,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -19969,7 +19986,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "ngx-pagination": "6.0.3",
     "ngx-skeleton-loader": "^11.3.0",
     "ngx-ui-switch": "^16.1.0",
+    "node-html-parser": "^7.0.1",
     "nouislider": "^15.7.1",
     "orejime": "^2.3.1",
     "pem": "1.14.8",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -46,6 +46,8 @@ import { ScrollToModule } from '@nicky-lenaers/ngx-scroll-to';
 import { provideEnvironmentNgxMask } from 'ngx-mask';
 
 import { environment } from '../environments/environment';
+import { HashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping';
+import { BrowserHashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping.browser';
 import { appEffects } from './app.effects';
 import { MENUS } from './app.menus';
 import {
@@ -152,6 +154,10 @@ export const commonAppConfig: ApplicationConfig = {
       provide: HTTP_INTERCEPTORS,
       useClass: DspaceRestInterceptor,
       multi: true,
+    },
+    {
+      provide: HashedFileMapping,
+      useClass: BrowserHashedFileMapping,
     },
     // register the dynamic matcher used by form. MUST be provided by the app module
     ...DYNAMIC_MATCHER_PROVIDERS,

--- a/src/app/shared/theme-support/theme.service.ts
+++ b/src/app/shared/theme-support/theme.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
   Injectable,
   Injector,
+  Optional,
 } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
@@ -62,6 +63,7 @@ import {
 } from 'rxjs/operators';
 
 import { environment } from '../../../environments/environment';
+import { HashedFileMapping } from '../../../modules/dynamic-hash/hashed-file-mapping';
 import { GET_THEME_CONFIG_FOR_FACTORY } from '../object-collection/shared/listable-object/listable-object.decorator';
 import {
   SetThemeAction,
@@ -106,6 +108,7 @@ export class ThemeService {
     private router: Router,
     @Inject(DOCUMENT) private document: any,
     @Inject(APP_CONFIG) private appConfig: BuildConfig,
+    @Optional() private hashedFileMapping: HashedFileMapping,
   ) {
     // Create objects from the theme configs in the environment file
     this.themes = environment.themes.map((themeConfig: ThemeConfig) => themeFactory(themeConfig, injector));
@@ -228,10 +231,14 @@ export class ThemeService {
     // automatically updated if we add nodes later
     const currentThemeLinks = Array.from(head.getElementsByClassName('theme-css'));
     const link = this.document.createElement('link');
+    const themeCSS = `${encodeURIComponent(themeName)}-theme.css`;
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('type', 'text/css');
     link.setAttribute('class', 'theme-css');
-    link.setAttribute('href', `${encodeURIComponent(themeName)}-theme.css`);
+    link.setAttribute(
+      'href',
+      this.hashedFileMapping?.resolve(themeCSS) ?? themeCSS,
+    );
     // wait for the new css to download before removing the old one to prevent a
     // flash of unstyled content
     link.onload = () => {

--- a/src/config/cache-config.interface.ts
+++ b/src/config/cache-config.interface.ts
@@ -7,6 +7,8 @@ export interface CacheConfig extends Config {
   };
   // Cache-Control HTTP Header
   control: string;
+  // These static files should not be cached (paths relative to dist/browser, including the leading slash)
+  noCacheFiles: string[]
   autoSync: AutoSyncConfig;
   // In-memory caches of server-side rendered (SSR) content. These caches can be used to limit the frequency
   // of re-generating SSR pages to improve performance.

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -14,7 +14,9 @@ import {
 } from 'colors';
 import { load } from 'js-yaml';
 
+import { ServerHashedFileMapping } from '../modules/dynamic-hash/hashed-file-mapping.server';
 import { AppConfig } from './app-config.interface';
+import { BuildConfig } from './build-config.interface';
 import { Config } from './config.interface';
 import { mergeConfig } from './config.util';
 import { DefaultAppConfig } from './default-app-config';
@@ -169,6 +171,7 @@ const buildBaseUrl = (config: ServerConfig): void => {
   ].join('');
 };
 
+
 /**
  * Build app config with the following chain of override.
  *
@@ -179,7 +182,7 @@ const buildBaseUrl = (config: ServerConfig): void => {
  * @param destConfigPath optional path to save config file
  * @returns app config
  */
-export const buildAppConfig = (destConfigPath?: string): AppConfig => {
+export const buildAppConfig = (destConfigPath?: string, mapping?: ServerHashedFileMapping): AppConfig => {
   // start with default app config
   const appConfig: AppConfig = new DefaultAppConfig();
 
@@ -247,7 +250,21 @@ export const buildAppConfig = (destConfigPath?: string): AppConfig => {
   buildBaseUrl(appConfig.rest);
 
   if (isNotEmpty(destConfigPath)) {
-    writeFileSync(destConfigPath, JSON.stringify(appConfig, null, 2));
+    const content = JSON.stringify(appConfig, null, 2);
+
+    writeFileSync(destConfigPath, content);
+    if (mapping !== undefined) {
+      mapping.add(destConfigPath, content);
+      if (!(appConfig as BuildConfig).ssr?.enabled) {
+        // If we're serving for CSR we can retrieve the configuration before JS is loaded/executed
+        mapping.addHeadLink({
+          path: destConfigPath,
+          rel: 'preload',
+          as: 'fetch',
+          crossorigin: 'anonymous',
+        });
+      }
+    }
 
     console.log(`Angular ${bold('config.json')} file generated correctly at ${bold(destConfigPath)} \n`);
   }

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -82,6 +82,10 @@ export class DefaultAppConfig implements AppConfig {
     },
     // Cache-Control HTTP Header
     control: 'max-age=604800', // revalidate browser
+    // These static files should not be cached (paths relative to dist/browser, including the leading slash)
+    noCacheFiles: [
+      '/index.html',  // see https://web.dev/articles/http-cache#unversioned-urls
+    ],
     autoSync: {
       defaultTime: 0,
       maxBufferSize: 100,

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -75,6 +75,10 @@ export const environment: BuildConfig = {
     },
     // msToLive: 1000, // 15 minutes
     control: 'max-age=60',
+    // These static files should not be cached (paths relative to dist/browser, including the leading slash)
+    noCacheFiles: [
+      '/index.html',  // see https://web.dev/articles/http-cache#unversioned-urls
+    ],
     autoSync: {
       defaultTime: 0,
       maxBufferSize: 100,

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -10,7 +10,9 @@ import { extendEnvironmentWithAppConfig } from '@dspace/config/config.util';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { browserAppConfig } from './modules/app/browser-app.config';
+import { BrowserHashedFileMapping } from './modules/dynamic-hash/hashed-file-mapping.browser';
 
+const hashedFileMapping = new BrowserHashedFileMapping(document);
 /*const bootstrap = () => platformBrowserDynamic()
   .bootstrapModule(BrowserAppModule, {});*/
 const bootstrap = () => bootstrapApplication(AppComponent, browserAppConfig);
@@ -33,7 +35,7 @@ const main = () => {
     return bootstrap();
   } else {
     // Configuration must be fetched explicitly
-    return fetch('assets/config.json')
+    return fetch(hashedFileMapping.resolve('assets/config.json'))
       .then((response) => response.json())
       .then((config: AppConfig) => {
         // extend environment with app config for browser when not prerendered

--- a/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.browser.ts
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import { DOCUMENT } from '@angular/common';
+import {
+  Inject,
+  Injectable,
+  Optional,
+} from '@angular/core';
+import { hasValue } from '@dspace/shared/utils/empty.util';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
+
+import {
+  HashedFileMapping,
+  ID,
+} from './hashed-file-mapping';
+
+/**
+ * Client-side implementation of {@link HashedFileMapping}.
+ * Reads out the mapping from index.html before the app is bootstrapped.
+ * Afterwards, {@link resolve} can be used to grab the latest file.
+ */
+@Injectable()
+export class BrowserHashedFileMapping extends HashedFileMapping {
+  constructor(
+    @Optional() @Inject(DOCUMENT) protected document: any,
+  ) {
+    super();
+    const element = document?.querySelector(`script#${ID}`);
+
+    if (hasValue(element?.textContent)) {
+      const mapping = JSON.parse(element.textContent);
+
+      if (isObject(mapping)) {
+        Object.entries(mapping)
+          .filter(([key, value]: [unknown, unknown]) => isString(key) && isString(value))
+          .forEach(([plainPath, hashPath]: [string, string]) => this.map.set(plainPath, hashPath));
+      }
+    }
+  }
+}

--- a/src/modules/dynamic-hash/hashed-file-mapping.server.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.server.ts
@@ -1,0 +1,186 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import crypto from 'node:crypto';
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {
+  extname,
+  join,
+  relative,
+} from 'node:path';
+import zlib from 'node:zlib';
+
+import { hasValue } from '@dspace/shared/utils/empty.util';
+import { globSync } from 'glob';
+import { parse } from 'node-html-parser';
+
+import { ThemeConfig } from '../../config/theme.config';
+import {
+  HashedFileMapping,
+  ID,
+} from './hashed-file-mapping';
+
+const HEAD_LINK_CLASS = 'hfm';
+
+interface HeadLink {
+  path: string;
+  rel: string;
+  as: string;
+  crossorigin?: string;
+}
+
+/**
+ * Server-side implementation of {@link HashedFileMapping}.
+ * Registers dynamically hashed files and stores them in index.html for the browser to use.
+ */
+export class ServerHashedFileMapping extends HashedFileMapping {
+  public readonly indexPath: string;
+  private readonly indexContent: string;
+
+  protected readonly headLinks: Set<HeadLink> = new Set();
+
+  constructor(
+    private readonly root: string,
+    file: string,
+  ) {
+    super();
+    this.root = join(root, '');
+    this.indexPath = join(root, file);
+    this.indexContent = readFileSync(this.indexPath).toString();
+  }
+
+  /**
+   * Add a new file to the mapping by an absolute path (within the root directory).
+   * If {@link content} is provided, the {@link path} itself does not have to exist.
+   * Otherwise, it is read out from the original path.
+   * The original path is never overwritten.
+   */
+  add(path: string, content?: string, compress = false): string {
+    if (content === undefined) {
+      content = readFileSync(path).toString();
+    }
+
+    // remove previous files
+    const ext = extname(path);
+    globSync(path.replace(`${ext}`, `.*${ext}*`))
+      .forEach(p => rmSync(p));
+
+    // hash the content
+    const hash = crypto.createHash('md5')
+      .update(content)
+      .digest('hex');
+
+    // add the hash to the path
+    const hashPath = path.replace(`${ext}`, `.${hash}${ext}`);
+
+    // store it in the mapping
+    this.map.set(path, hashPath);
+
+    // write the file
+    writeFileSync(hashPath, content);
+
+    if (compress) {
+      // write the file as .br
+      zlib.brotliCompress(content, (err, compressed) => {
+        if (err) {
+          throw new Error('Brotli compress failed');
+        } else {
+          writeFileSync(hashPath + '.br', compressed);
+        }
+      });
+
+      // write the file as .gz
+      zlib.gzip(content, (err, compressed) => {
+        if (err) {
+          throw new Error('Gzip compress failed');
+        } else {
+          writeFileSync(hashPath + '.gz', compressed);
+        }
+      });
+    }
+
+    return hashPath;
+  }
+
+  /**
+   * Add CSS for all configured themes to the mapping
+   * @param themeConfigurations
+   */
+  addThemeStyles(themeConfigurations: ThemeConfig[]) {
+    for (const themeConfiguration of themeConfigurations) {
+      const p = `${this.root}/${encodeURIComponent(themeConfiguration.name)}-theme.css`;
+      const hp = this.add(p);
+
+      // We know this CSS is likely needed, so wecan avoid a FOUC by retrieving it in advance
+      // Angular does the same for global styles, but doesn't "know" about out themes
+      this.addHeadLink({
+        path: p,
+        rel: 'prefetch',
+        as: 'style',
+      });
+
+      this.ensureCompressedFilesAssumingUnchangedContent(p, hp, '.br');
+      this.ensureCompressedFilesAssumingUnchangedContent(p, hp, '.gz');
+    }
+  }
+
+  /**
+   * Include a head link for a given resource to the index HTML.
+   */
+  addHeadLink(headLink: HeadLink) {
+    this.headLinks.add(headLink);
+  }
+
+  private renderHeadLink(link: HeadLink): string {
+    const href = relative(this.root, this.resolve(link.path));
+
+    if (hasValue(link.crossorigin)) {
+      return `<link rel="${link.rel}" as="${link.as}" href="${href}" crossorigin="${link.crossorigin}" class="${HEAD_LINK_CLASS}">`;
+    } else {
+      return `<link rel="${link.rel}" as="${link.as}" href="${href}" class="${HEAD_LINK_CLASS}">`;
+    }
+  }
+
+  private ensureCompressedFilesAssumingUnchangedContent(path: string, hashedPath: string, compression: string) {
+    const compressedPath = `${path}${compression}`;
+    const compressedHashedPath = `${hashedPath}${compression}`;
+
+    if (existsSync(compressedPath) && !existsSync(compressedHashedPath)) {
+      copyFileSync(compressedPath, compressedHashedPath);
+    }
+  }
+
+  /**
+   * Save the mapping as JSON in the index file.
+   * The updated index file itself is hashed as well, and must be sent {@link resolve}.
+   */
+  save(): void {
+    const out = Array.from(this.map.entries())
+      .reduce((object, [plain, hashed]) => {
+        object[relative(this.root, plain)] = relative(this.root, hashed);
+        return object;
+      }, {});
+
+    const root = parse(this.indexContent);
+    root.querySelectorAll(`script#${ID}, link.${HEAD_LINK_CLASS}`)?.forEach(e => e.remove());
+    root.querySelector('head')
+      .appendChild(`<script id="${ID}" type="application/json">${JSON.stringify(out)}</script>` as any);
+
+    for (const headLink of this.headLinks) {
+      root.querySelector('head')
+        .appendChild(this.renderHeadLink(headLink) as any);
+    }
+
+    writeFileSync(this.indexPath, root.toString());
+  }
+}

--- a/src/modules/dynamic-hash/hashed-file-mapping.ts
+++ b/src/modules/dynamic-hash/hashed-file-mapping.ts
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+export const ID = 'hashed-file-mapping';
+
+/**
+ * A mapping of plain path to hashed path, used for cache-busting files that are created dynamically after DSpace has been built.
+ * The production server can register hashed files here and attach the map to index.html.
+ * The browser can then use it to resolve hashed files and circumvent the browser cache.
+ *
+ * This can ensure that e.g. configuration changes are consistently served to all CSR clients.
+ */
+export abstract class HashedFileMapping {
+  protected readonly map: Map<string, string> = new Map();
+
+  /**
+   * Resolve a hashed path based on a plain path.
+   */
+  resolve(plainPath: string): string {
+    if (this.map.has(plainPath)) {
+      const hashPath = this.map.get(plainPath);
+      return hashPath;
+    }
+    return plainPath;
+  }
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/3992
* Fixes https://github.com/DSpace/dspace-angular/issues/1961
* Main PR for https://github.com/DSpace/dspace-angular/pull/3993

## Description
DSpace Angular's production server can modify the configuration it serves to CSR-only clients through YAML or environment variables. However, these files can remain cached in the browser and leave users with out-of-date configuration until the TTL runs out or the user does a "hard refresh". On build time this sort of problem is solved by saving the content hash as part of the path of each file (JS, CSS, ...)

We introduce HashedFileMapping to bridge the same gap for dynamic content generated _after_ the server is built:
- Files added to this mapping on the server are copied to a hashed path
- A copy is injected into index.html, where clients can read it out and resolve the hashed paths
- If a given path is not found in the mapping, the client will fall back to the original version (to prevent errors in development mode)

With this mechanism we can ensure updates to config.json and similar files take immediate effect without losing the performance benefit of client-side caching.

Compression support is included in anticipation of a pending PR for https://github.com/DSpace/dspace-angular/issues/3961, where the initial size of `config.json` can become large enough where compressing it would be a plus.

## Discussion
- It's not clear how/if we can unit test this at the time of writing
- Should we inlude a configuration flag to toggle this feature on/off? We may want to roll it out as opt-in so downstream users can wait it out until it has been battle-tested a bit.


## Instructions for Reviewers

To test:
1. Run DSpace Angular locally, in production mode
2. Confirm that you see the following files:
    - `[dist]/assets/config.<hash>.json` → hashed configuration file
    - `[dist]/dspace-theme.<hash>.css` → hashed theme CSS file
    - `[dist]/index.html` → index file with an extra `script#hashed-file-mapping` element containing the mapping of plain paths to hashed paths
3. Confirm that `config.<hash>.json` and `dspace-theme.<hash>.css` are correctly served to the browser, and that the app runs/looks as before the PR
5. Confirm that https://github.com/DSpace/dspace-angular/issues/3992 is resolved

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC8x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
