### PR TITLE
backport DSpace 7: Improve community list e2e tests

### DIFF
--- a/cypress/e2e/community-list.cy.ts
+++ b/cypress/e2e/community-list.cy.ts
@@ -2,6 +2,86 @@ import { testA11y } from 'cypress/support/utils';
 
 describe('Community List Page', () => {
 
+    function validateHierarchyLevel(currentLevel = 1): void {
+        // Find all <cdk-tree-node> elements with the current aria-level
+        cy.get(`ds-community-list cdk-tree-node.expandable-node[aria-level="${currentLevel}"]`).should('exist').then(($nodes) => {
+            let sublevelExists = false;
+            cy.wrap($nodes).each(($node) => {
+                // Check if the current node has an expand button and click it
+                if ($node.find('[data-test="expand-button"]').length) {
+                    sublevelExists = true;
+                    cy.wrap($node).find('[data-test="expand-button"]').click();
+                }
+            }).then(() => {
+                // After expanding all buttons, validate if a sublevel exists
+                if (sublevelExists) {
+                    const nextLevelSelector = `ds-community-list cdk-tree-node.expandable-node[aria-level="${currentLevel + 1}"]`;
+                    cy.get(nextLevelSelector).then(($nextLevel) => {
+                        if ($nextLevel.length) {
+                        // Recursively validate the next level
+                        validateHierarchyLevel(currentLevel + 1);
+                        }
+                    });
+                }
+            });
+        });
+    }
+
+    beforeEach(() => {
+        cy.visit('/community-list');
+
+        // <ds-community-list-page> tag must be loaded
+        cy.get('ds-community-list-page').should('be.visible');
+
+        // <ds-community-list-list> tag must be loaded
+        cy.get('ds-community-list').should('be.visible');
+    });
+
+    it('should expand community/collection hierarchy', () => {
+        // Execute Hierarchy levels validation recursively
+        validateHierarchyLevel(1);
+    });
+
+    it('should display community/collections name with item count', () => {
+        // Open every <cdk-tree-node>
+        cy.get('[data-test="expand-button"]').click({ multiple: true });
+        cy.wait(300);
+
+        // A first <cdk-tree-node> must be found and validate that <a> tag (community name) and <span> tag (item count) exists in it
+        cy.get('ds-community-list').find('cdk-tree-node.expandable-node').then(($nodes) => {
+            cy.wrap($nodes).each(($node) => {
+                cy.wrap($node).find('a').should('exist');
+                cy.wrap($node).find('span').should('exist');
+            });
+        });
+    });
+
+    it('should enable "show more" button when 20 top-communities or more are presents', () => {
+        cy.get('ds-community-list').find('cdk-tree-node.expandable-node[aria-level="1"]').then(($nodes) => {
+            //Validate that there are 20 or more top-community elements
+            if ($nodes.length >= 20) {
+                //Validate that "show more" button is visible and then click on it
+                cy.get('[data-test="show-more-button"]').should('be.visible');
+            } else {
+                cy.get('[data-test="show-more-button"]').should('not.exist');
+            }
+        });
+    });
+
+    it('should show 21 or more top-communities if click "show more" button', () => {
+        cy.get('ds-community-list').find('cdk-tree-node.expandable-node[aria-level="1"]').then(($nodes) => {
+            //Validate that there are 20 or more top-community elements
+            if ($nodes.length >= 20) {
+                //Validate that "show more" button is visible and then click on it
+                cy.get('[data-test="show-more-button"]').click();
+                cy.wait(300);
+                cy.get('ds-community-list').find('cdk-tree-node.expandable-node[aria-level="1"]').should('have.length.at.least', 21);
+            } else {
+                cy.get('[data-test="show-more-button"]').should('not.exist');
+            }
+        });
+    });
+
     it('should pass accessibility tests', () => {
         cy.visit('/community-list');
 

--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -9,7 +9,7 @@
       </span>
       <div class="align-middle pt-2">
         <button *ngIf="!(dataSource.loading$ | async)" (click)="getNextPage(node)"
-           class="btn btn-outline-primary btn-sm" role="button" tabindex="0">
+           class="btn btn-outline-primary btn-sm" role="button" tabindex="0" data-test="show-more-button">
            <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
         </button>
         <ds-themed-loading *ngIf="node===loadingNode && dataSource.loading$ | async" class="ds-themed-loading"></ds-themed-loading>


### PR DESCRIPTION
## References

* related to #3989
* manual backport of  DSpace/dspace-angular#4291

## Description

This PR enable 4 new tests to testing community list page functions and elements.

## Instructions for Reviewers

1. Start dspace in development mode
2. Open cypress testing tool
3. Click on community-list tests
4. There will be 4 new tests additional to existing accessibility tests

List of changes in this PR:
* Enabled a data-test property in "show more" button of community list page
* Added the fallowing e2e tests to community-list tests.
   * Validate the expansion of community/collection hierarchy 
   * Validate correct display of community/collection name and counter
   * If 20 top-communities are present, the button "show more" must be present, otherwise, not will be rendered
   * If 20 top-communities are present and the button "show more" is clicked, after it there will be at least 21 top-communities

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).