### PR TITLE
Add missing NgIf and NgFor imports to AuthorizedItemSelectorComponent (8x)

### DIFF
--- a/src/app/shared/dso-selector/dso-selector/authorized-item-selector/authorized-item-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-item-selector/authorized-item-selector.component.ts
@@ -1,6 +1,8 @@
 import {
   AsyncPipe,
   NgClass,
+  NgFor,
+  NgIf,
 } from '@angular/common';
 import {
   Component,
@@ -56,6 +58,8 @@ import { DSOSelectorComponent } from '../dso-selector.component';
     ReactiveFormsModule,
     ThemedLoadingComponent,
     TranslateModule,
+    NgIf,
+    NgFor,
   ],
 })
 /**


### PR DESCRIPTION
## References
* Related to #5118

## Description

During the backport of version x8 of #4918, two imports (`NgIf` and `NgFor`) were missing.
These were not needed in version 7x because it doesn’t use standalone components, and not required in `main` and `dspace-9_x` due to the use of the new Angular control flow syntax.
This PR simply adds the missing imports.

## Instructions for Reviewers

To verify, open the item edit selector and check that it correctly lists the items available for editing.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
