### PR TITLE
Support for dataset entities

### DIFF
--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
@@ -8,7 +8,7 @@
         <div class="col-6">
           <h4 [innerText]="'file.section.name' | translate"></h4>
         </div>
-        <div class="col-2">
+        <div class="col-3">
           <h4 [innerText]="'file.section.type' | translate"></h4>
         </div>
         <div class="col-2">

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
@@ -1,0 +1,53 @@
+<ng-container *ngVar="(bitstreamsRD$ | async) as bitstreamsRD">
+  <div class="file-section my-3 justify-content-center">
+    <div class="w-100 file-section-header mb-3">
+      <h3 [innerText]="label | translate"></h3>
+    </div>
+    <div class="file-section-table">
+      <div class="row heading mx-0">
+        <div class="col-6">
+          <h4 [innerText]="'file.section.name' | translate"></h4>
+        </div>
+        <div class="col-2">
+          <h4 [innerText]="'file.section.type' | translate"></h4>
+        </div>
+        <div class="col-2">
+          <h4 [innerText]="'file.section.size' | translate"></h4>
+        </div>
+        <div class="col-1">
+        </div>
+      </div>
+      <div class="mx-1">
+        @if (bitstreamsRD?.payload?.totalElements > 0) {
+          <ds-pagination
+            [paginationOptions]="pageConfig"
+            [collectionSize]="bitstreamsRD?.payload?.totalElements"
+            [hideGear]="true"
+            [hidePagerWhenSinglePage]="true"
+            [retainScrollPosition]="true">
+            <div class="entries">
+              @for (file of bitstreamsRD?.payload?.page; track file) {
+                <div class="row file-section-entry mx-0">
+                  <div class="col-6">
+                    <span [innerHTML]="dsoNameService.getName(file)"></span>
+                  </div>
+                  <div class="col-3">
+                    <span>{{ (bitstreamFormatDataService.findByBitstream(file) | async).payload?.shortDescription }}</span>
+                  </div>
+                   <div class="col-2">
+                    <span> {{ (file?.sizeBytes) | dsFileSize }}</span>
+                  </div>
+                  <div class="col-1 text-center">
+                    <ds-file-download-link [bitstream]="file" [item]="item">
+                      <i class="fa fa-download"></i>
+                    </ds-file-download-link>
+                  </div>
+                </div>
+              }
+            </div>
+          </ds-pagination>
+        }
+      </div>
+    </div>
+  </div>
+</ng-container>

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.scss
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.scss
@@ -1,0 +1,27 @@
+.file-section {
+  padding: 1rem;
+  background-color: var(--bs-gray-200);
+
+  .file-section-header {
+    border-bottom: 4px solid var(--bs-primary);
+  }
+
+  .file-section-table {
+    .row {
+      padding: 0.4em 0.75em;
+    }
+    .entries {
+      .file-section-entry {
+        background-color: var(--bs-300);
+        &:nth-child(2n + 1) {
+          background-color: var(--bs-gray-100);
+        }
+      }
+    }
+    .heading {
+      border-bottom: 1px solid var(--bs-gray-900);
+      background-color: var(--bs-gray-400);
+      font-size: 1.25em;
+    }
+  }
+}

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.scss
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../styles/variables.scss';
+
 .file-section {
   padding: 1rem;
   background-color: var(--bs-gray-200);

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExtendedFileSectionComponent } from './extended-file-section.component';
+
+describe('ExtendedFileSectionComponent', () => {
+  let component: ExtendedFileSectionComponent;
+  let fixture: ComponentFixture<ExtendedFileSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExtendedFileSectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ExtendedFileSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
@@ -1,23 +1,154 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { APP_CONFIG } from '@dspace/config/app-config.interface';
+import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
+import { BitstreamFormatDataService } from '@dspace/core/data/bitstream-format-data.service';
+import { LocaleService } from '@dspace/core/locale/locale.service';
+import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import { Bitstream } from '@dspace/core/shared/bitstream.model';
+import { BitstreamFormat } from '@dspace/core/shared/bitstream-format.model';
+import { Item } from '@dspace/core/shared/item.model';
+import { ActivatedRouteStub } from '@dspace/core/testing/active-router.stub';
+import { NotificationsServiceStub } from '@dspace/core/testing/notifications-service.stub';
+import { PaginationServiceStub } from '@dspace/core/testing/pagination-service.stub';
+import { TranslateLoaderMock } from '@dspace/core/testing/translate-loader.mock';
+import { createPaginatedList } from '@dspace/core/testing/utils.test';
+import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
+import { XSRFService } from '@dspace/core/xsrf/xsrf.service';
+import { provideMockStore } from '@ngrx/store/testing';
+import {
+  TranslateLoader,
+  TranslateModule,
+} from '@ngx-translate/core';
+import { of } from 'rxjs';
 
+import { environment } from '../../../../../environments/environment';
+import { ThemedFileDownloadLinkComponent } from '../../../../shared/file-download-link/themed-file-download-link.component';
+import { PaginationComponent } from '../../../../shared/pagination/pagination.component';
+import { SearchConfigurationService } from '../../../../shared/search/search-configuration.service';
+import { getMockThemeService } from '../../../../shared/theme-support/test/theme-service.mock';
+import { ThemeService } from '../../../../shared/theme-support/theme.service';
+import { FileSizePipe } from '../../../../shared/utils/file-size-pipe';
+import { VarDirective } from '../../../../shared/utils/var.directive';
 import { ExtendedFileSectionComponent } from './extended-file-section.component';
 
 describe('ExtendedFileSectionComponent', () => {
   let component: ExtendedFileSectionComponent;
   let fixture: ComponentFixture<ExtendedFileSectionComponent>;
+  let localeService: any;
+  const languageList = ['en;q=1', 'de;q=0.8'];
+  const mockLocaleService = jasmine.createSpyObj('LocaleService', {
+    getCurrentLanguageCode: jasmine.createSpy('getCurrentLanguageCode'),
+    getLanguageCodeList: of(languageList),
+  });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ExtendedFileSectionComponent]
-    })
-    .compileComponents();
+  const paginationServiceStub = new PaginationServiceStub();
 
+  const mockItem = Object.assign(new Item(), {
+    id: 'test-item-id',
+    uuid: 'test-item-id',
+    _links: {
+      self: { href: 'test-item-selflink' },
+    },
+  });
+
+  const mockBitstream = Object.assign(new Bitstream(), {
+    id: 'test-bitstream-id',
+    uuid: 'test-bitstream-id',
+    name: 'test-bitstream.pdf',
+    sizeBytes: 1024,
+    _links: {
+      self: { href: 'test-bitstream-selflink' },
+    },
+  });
+
+  const mockBitstreamFormat = Object.assign(new BitstreamFormat(), {
+    resourceType: 'testResourceType',
+    shortDescription: 'testShortDescription',
+    description: 'testDescription',
+    mimetype: 'test/mimeType',
+  });
+
+  const paginatedList = createPaginatedList([mockBitstream]);
+
+  paginatedList.pageInfo.elementsPerPage = environment.item.bitstream.pageSize;
+
+  const bitstreamDataService = jasmine.createSpyObj('bitstreamDataService', {
+    findAllByItemAndBundleName: createSuccessfulRemoteDataObject$(paginatedList),
+  });
+
+  const bitstreamFormatDataService = jasmine.createSpyObj('bitstreamFormatDataService', {
+    findByBitstream: createSuccessfulRemoteDataObject$(mockBitstreamFormat),
+  });
+
+  beforeEach(waitForAsync(() => {
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          },
+        }),
+        BrowserAnimationsModule,
+        ExtendedFileSectionComponent,
+        VarDirective,
+        FileSizePipe,
+      ],
+      providers: [
+        provideMockStore(),
+        { provide: XSRFService, useValue: {} },
+        { provide: BitstreamDataService, useValue: bitstreamDataService },
+        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: BitstreamFormatDataService, useValue: bitstreamFormatDataService },
+        { provide: ThemeService, useValue: getMockThemeService() },
+        { provide: SearchConfigurationService, useValue: jasmine.createSpyObj(['getCurrentConfiguration']) },
+        { provide: PaginationService, useValue: paginationServiceStub },
+        { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
+        { provide: LocaleService, useValue: mockLocaleService },
+        { provide: APP_CONFIG, useValue: environment },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).overrideComponent(ExtendedFileSectionComponent, {
+      remove: {
+        imports: [
+          PaginationComponent,
+          ThemedFileDownloadLinkComponent,
+        ],
+      },
+    }).compileComponents();
+  }));
+
+  beforeEach(waitForAsync(() => {
+    localeService = TestBed.inject(LocaleService);
+    localeService.getCurrentLanguageCode.and.returnValue(of('en'));
     fixture = TestBed.createComponent(ExtendedFileSectionComponent);
     component = fixture.componentInstance;
+    component.item = mockItem;
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set pageSize from appConfig', () => {
+    expect(component.pageSize).toEqual(environment.item.bitstream.pageSize);
+  });
+
+  describe('when the extended file section gets loaded with bitstreams available', () => {
+    it('should contain a list with bitstream', () => {
+      const fileSection = fixture.debugElement.queryAll(By.css('.file-section-entry'));
+      expect(fileSection.length).toEqual(1);
+    });
   });
 });

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
@@ -19,7 +19,7 @@ import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-c
 import { Bitstream } from '@dspace/core/shared/bitstream.model';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { Item } from '@dspace/core/shared/item.model';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
 import {
   from,
   Observable,
@@ -38,7 +38,7 @@ import { VarDirective } from '../../../../shared/utils/var.directive';
     FileSizePipe,
     PaginationComponent,
     ThemedFileDownloadLinkComponent,
-    TranslatePipe,
+    TranslateModule,
     VarDirective,
   ],
   templateUrl: './extended-file-section.component.html',
@@ -52,18 +52,18 @@ export class ExtendedFileSectionComponent implements OnInit {
 
   @Input() label = 'item.page.extended-file-section';
 
-  pageSize = 10;
-
   bitstreamsRD$: Observable<RemoteData<PaginatedList<Bitstream>>>;
+
+  pageSize = this.appConfig.item.bitstream.pageSize;
 
 
   /**
    * The current pagination configuration for the page
    */
   pageConfig: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
-    id: 'afs',
-    pageSize: this.pageSize,
-    pageSizeOptions: [10, 20, 40, 60, 80, 100],
+    id: 'efs',
+    currentPage: 1,
+    pageSize: this.appConfig.item.bitstream.pageSize,
   });
 
 
@@ -74,7 +74,6 @@ export class ExtendedFileSectionComponent implements OnInit {
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
     private paginationService: PaginationService,
   ) {
-    this.pageSize = appConfig.item.bitstream.pageSize;
     this.bitstreamsRD$ = from([]);
   }
 

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
@@ -1,0 +1,98 @@
+import { AsyncPipe } from '@angular/common';
+import {
+  Component,
+  Inject,
+  Input,
+  OnInit,
+} from '@angular/core';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
+import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
+import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
+import { BitstreamFormatDataService } from '@dspace/core/data/bitstream-format-data.service';
+import { PaginatedList } from '@dspace/core/data/paginated-list.model';
+import { RemoteData } from '@dspace/core/data/remote-data';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
+import { Bitstream } from '@dspace/core/shared/bitstream.model';
+import { followLink } from '@dspace/core/shared/follow-link-config.model';
+import { Item } from '@dspace/core/shared/item.model';
+import { TranslatePipe } from '@ngx-translate/core';
+import {
+  from,
+  Observable,
+} from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+
+import { ThemedFileDownloadLinkComponent } from '../../../../shared/file-download-link/themed-file-download-link.component';
+import { PaginationComponent } from '../../../../shared/pagination/pagination.component';
+import { FileSizePipe } from '../../../../shared/utils/file-size-pipe';
+import { VarDirective } from '../../../../shared/utils/var.directive';
+
+@Component({
+  selector: 'ds-extended-file-section',
+  imports: [
+    AsyncPipe,
+    FileSizePipe,
+    PaginationComponent,
+    ThemedFileDownloadLinkComponent,
+    TranslatePipe,
+    VarDirective,
+  ],
+  templateUrl: './extended-file-section.component.html',
+  styleUrl: './extended-file-section.component.scss',
+})
+export class ExtendedFileSectionComponent implements OnInit {
+
+  @Input() item: Item;
+
+  @Input() bundleName = 'ORIGINAL';
+
+  @Input() label = 'item.page.extended-file-section';
+
+  pageSize = 10;
+
+  bitstreamsRD$: Observable<RemoteData<PaginatedList<Bitstream>>>;
+
+
+  /**
+   * The current pagination configuration for the page
+   */
+  pageConfig: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: 'afs',
+    pageSize: this.pageSize,
+    pageSizeOptions: [10, 20, 40, 60, 80, 100],
+  });
+
+
+  constructor(
+    protected bitstreamDataService: BitstreamDataService,
+    protected bitstreamFormatDataService: BitstreamFormatDataService,
+    public dsoNameService: DSONameService,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    private paginationService: PaginationService,
+  ) {
+    this.pageSize = appConfig.item.bitstream.pageSize;
+    this.bitstreamsRD$ = from([]);
+  }
+
+  ngOnInit(): void {
+    this.bitstreamsRD$ = this.paginationService.getCurrentPagination(this.pageConfig.id, this.pageConfig).pipe(
+      switchMap((options: PaginationComponentOptions) => {
+        return this.bitstreamDataService.findAllByItemAndBundleName(
+          this.item,
+          this.bundleName,
+          { elementsPerPage: options.pageSize, currentPage: options.currentPage },
+          true,
+          true,
+          followLink('format'),
+          followLink('accessStatus'),
+        );
+      }),
+    );
+  }
+
+
+}

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.html
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.html
@@ -1,0 +1,107 @@
+@if (showBackButton$ | async) {
+  <ds-results-back-button [back]="back"></ds-results-back-button>
+}
+@if (iiifEnabled) {
+  <div class="row">
+    <div class="col-12">
+      <ds-mirador-viewer  id="iiif-viewer"
+                          [object]="object"
+                          [searchable]="iiifSearchEnabled"
+                          [query]="iiifQuery$ | async">
+      </ds-mirador-viewer>
+    </div>
+  </div>
+}
+<div class="d-flex flex-row">
+  <ds-item-page-title-field [item]="object" class="me-auto">
+  </ds-item-page-title-field>
+  <ds-dso-edit-menu></ds-dso-edit-menu>
+</div>
+<div class="row">
+  <div class="col-12 col-md-4">
+    @if (!(mediaViewer.image || mediaViewer.video)) {
+      <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
+        <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
+      </ds-metadata-field-wrapper>
+    }
+    @if (mediaViewer.image || mediaViewer.video) {
+      <div class="mb-2">
+        <ds-media-viewer [item]="object"></ds-media-viewer>
+      </div>
+    }
+    <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
+    <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
+                                     [parentItem]="object"
+                                     [itemType]="'Person'"
+                                     [metadataFields]="['dc.contributor.author', 'dc.creator']"
+                                     [label]="'item.page.authors' | translate">
+    </ds-metadata-representation-list>
+  </div>
+  <div class="col-12 col-md-7">
+    <ds-related-items
+      [parentItem]="object"
+      [relationType]="'isProjectOfDataset'"
+      [label]="'item.page.projects' | translate">
+    </ds-related-items>
+    <ds-related-items
+      [parentItem]="object"
+      [relationType]="'isOrgUnitOfDataset'"
+      [label]="'item.page.org-units' | translate">
+    </ds-related-items>
+    <ds-related-items
+      [parentItem]="object"
+      [relationType]="'isPublicationOfDataset'"
+      [label]="'item.page.journal-issue' | translate">
+    </ds-related-items>
+    <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.description']"
+                                [label]="'dataset.page.description'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.subject']"
+                                [separator]="', '"
+                                [label]="'item.page.subject'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.identifier.citation']"
+                                [label]="'item.page.citation'">
+    </ds-generic-item-page-field>
+    <ds-item-page-uri-field [item]="object"
+                            [fields]="['dc.identifier.uri']"
+                            [label]="'item.page.uri'">
+    </ds-item-page-uri-field>
+    <ds-item-page-collections [item]="object"></ds-item-page-collections>
+    <ds-item-page-uri-field [item]="object"
+                            [fields]="['coar.notify.endorsedBy']"
+                            [label]="'item.page.endorsement'">
+    </ds-item-page-uri-field>
+    <ds-item-page-uri-field [item]="object"
+                            [fields]="['datacite.relation.isSupplementedBy']"
+                            [label]="'item.page.supplemented'">
+    </ds-item-page-uri-field>
+    <ds-item-page-uri-field [item]="object"
+                            [fields]="['datacite.relation.isReferencedBy']"
+                            [label]="'item.page.referenced'">
+    </ds-item-page-uri-field>
+    @if (geospatialItemPageFieldsEnabled) {
+      <ds-geospatial-item-page-field [item]="object"
+                                     [label]="'item.page.places'"
+                                     [pointFields]="['dcterms.spatial']"
+                                     [bboxFields]="['dcterms.spatial']"
+                                     [cluster]="true"
+      >
+      </ds-geospatial-item-page-field>
+    }
+    <div>
+      <a class="btn btn-outline-primary" role="button" [routerLink]="[itemPageRoute + '/full']" tabindex="0">
+        <i class="fas fa-info-circle"></i> {{"item.page.link.full" | translate}}
+      </a>
+    </div>
+  </div>
+  <div class="col-12">
+    <ds-extended-file-section [item]="object">
+    </ds-extended-file-section>
+  </div>
+</div>

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.html
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.html
@@ -51,7 +51,7 @@
     <ds-related-items
       [parentItem]="object"
       [relationType]="'isPublicationOfDataset'"
-      [label]="'item.page.journal-issue' | translate">
+      [label]="'item.page.publications' | translate">
     </ds-related-items>
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
     <ds-generic-item-page-field [item]="object"

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
@@ -1,0 +1,273 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_CONFIG } from '@dspace/config/app-config.interface';
+import { BrowseDefinitionDataService } from '@dspace/core/browse/browse-definition-data.service';
+import { RemoteDataBuildService } from '@dspace/core/cache/builders/remote-data-build.service';
+import { ObjectCacheService } from '@dspace/core/cache/object-cache.service';
+import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
+import { CommunityDataService } from '@dspace/core/data/community-data.service';
+import { DefaultChangeAnalyzer } from '@dspace/core/data/default-change-analyzer.service';
+import { DSOChangeAnalyzer } from '@dspace/core/data/dso-change-analyzer.service';
+import { ItemDataService } from '@dspace/core/data/item-data.service';
+import { RelationshipDataService } from '@dspace/core/data/relationship-data.service';
+import { RemoteData } from '@dspace/core/data/remote-data';
+import { VersionDataService } from '@dspace/core/data/version-data.service';
+import { VersionHistoryDataService } from '@dspace/core/data/version-history-data.service';
+import { APP_DATA_SERVICES_MAP } from '@dspace/core/data-services-map-type';
+import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
+import { RouteService } from '@dspace/core/services/route.service';
+import { Bitstream } from '@dspace/core/shared/bitstream.model';
+import { HALEndpointService } from '@dspace/core/shared/hal-endpoint.service';
+import { Item } from '@dspace/core/shared/item.model';
+import { MetadataMap } from '@dspace/core/shared/metadata.models';
+import { UUIDService } from '@dspace/core/shared/uuid.service';
+import { WorkspaceitemDataService } from '@dspace/core/submission/workspaceitem-data.service';
+import { BrowseDefinitionDataServiceStub } from '@dspace/core/testing/browse-definition-data-service.stub';
+import { mockTruncatableService } from '@dspace/core/testing/mock-trucatable.service';
+import { TranslateLoaderMock } from '@dspace/core/testing/translate-loader.mock';
+import { createPaginatedList } from '@dspace/core/testing/utils.test';
+import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
+import { Store } from '@ngrx/store';
+import {
+  TranslateLoader,
+  TranslateModule,
+} from '@ngx-translate/core';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+
+import { environment } from '../../../../../environments/environment.test';
+import { DsoEditMenuComponent } from '../../../../shared/dso-page/dso-edit-menu/dso-edit-menu.component';
+import { MetadataFieldWrapperComponent } from '../../../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
+import { ThemedResultsBackButtonComponent } from '../../../../shared/results-back-button/themed-results-back-button.component';
+import { SearchService } from '../../../../shared/search/search.service';
+import { TruncatableService } from '../../../../shared/truncatable/truncatable.service';
+import { TruncatePipe } from '../../../../shared/utils/truncate.pipe';
+import { ThemedThumbnailComponent } from '../../../../thumbnail/themed-thumbnail.component';
+import { CollectionsComponent } from '../../../field-components/collections/collections.component';
+import { ThemedMediaViewerComponent } from '../../../media-viewer/themed-media-viewer.component';
+import { MiradorViewerComponent } from '../../../mirador-viewer/mirador-viewer.component';
+import { ThemedFileSectionComponent } from '../../field-components/file-section/themed-file-section.component';
+import { ItemPageAbstractFieldComponent } from '../../field-components/specific-field/abstract/item-page-abstract-field.component';
+import { ItemPageDateFieldComponent } from '../../field-components/specific-field/date/item-page-date-field.component';
+import { GenericItemPageFieldComponent } from '../../field-components/specific-field/generic/generic-item-page-field.component';
+import { ThemedItemPageTitleFieldComponent } from '../../field-components/specific-field/title/themed-item-page-field.component';
+import { ItemPageUriFieldComponent } from '../../field-components/specific-field/uri/item-page-uri-field.component';
+import { ThemedMetadataRepresentationListComponent } from '../../metadata-representation-list/themed-metadata-representation-list.component';
+import { RelatedItemsComponent } from '../../related-items/related-items-component';
+import {
+  createRelationshipsObservable,
+  getIIIFEnabled,
+  getIIIFSearchEnabled,
+  mockRouteService,
+} from '../shared/item.component.spec';
+import { DatasetComponent } from './dataset.component';
+
+const noMetadata = new MetadataMap();
+
+function getItem(metadata: MetadataMap) {
+  return Object.assign(new Item(), {
+    bundles: createSuccessfulRemoteDataObject$(createPaginatedList([])),
+    metadata: metadata,
+    relationships: createRelationshipsObservable(),
+  });
+}
+
+describe('DatasetComponent', () => {
+  let comp: DatasetComponent;
+  let fixture: ComponentFixture<DatasetComponent>;
+
+  beforeEach(waitForAsync(() => {
+    const mockBitstreamDataService = {
+      getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
+        return createSuccessfulRemoteDataObject$(new Bitstream());
+      },
+    };
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          },
+        }),
+        RouterTestingModule,
+        GenericItemPageFieldComponent, TruncatePipe,
+        DatasetComponent,
+      ],
+      providers: [
+        { provide: ItemDataService, useValue: {} },
+        { provide: TruncatableService, useValue: mockTruncatableService },
+        { provide: RelationshipDataService, useValue: {} },
+        { provide: ObjectCacheService, useValue: {} },
+        { provide: UUIDService, useValue: {} },
+        { provide: Store, useValue: {} },
+        { provide: RemoteDataBuildService, useValue: {} },
+        { provide: CommunityDataService, useValue: {} },
+        { provide: HALEndpointService, useValue: {} },
+        { provide: NotificationsService, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: DSOChangeAnalyzer, useValue: {} },
+        { provide: DefaultChangeAnalyzer, useValue: {} },
+        { provide: VersionHistoryDataService, useValue: {} },
+        { provide: VersionDataService, useValue: {} },
+        { provide: BitstreamDataService, useValue: mockBitstreamDataService },
+        { provide: WorkspaceitemDataService, useValue: {} },
+        { provide: SearchService, useValue: {} },
+        { provide: RouteService, useValue: mockRouteService },
+        { provide: BrowseDefinitionDataService, useValue: BrowseDefinitionDataServiceStub },
+        { provide: APP_CONFIG, useValue: environment },
+        { provide: APP_DATA_SERVICES_MAP, useValue: {}  },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).overrideComponent(DatasetComponent, {
+      add: { changeDetection: ChangeDetectionStrategy.Default },
+      remove: {
+        imports: [ThemedResultsBackButtonComponent, MiradorViewerComponent, ThemedItemPageTitleFieldComponent, DsoEditMenuComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, ThemedMediaViewerComponent, ThemedFileSectionComponent, ItemPageDateFieldComponent, ThemedMetadataRepresentationListComponent, GenericItemPageFieldComponent, RelatedItemsComponent, ItemPageAbstractFieldComponent, ItemPageUriFieldComponent, CollectionsComponent,
+        ],
+      },
+    });
+  }));
+
+  describe('default view', () => {
+    beforeEach(waitForAsync(() => {
+      TestBed.compileComponents();
+      fixture = TestBed.createComponent(DatasetComponent);
+      comp = fixture.componentInstance;
+      comp.object = getItem(noMetadata);
+      fixture.detectChanges();
+    }));
+
+    it('should contain a component to display the date', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-item-page-date-field'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not contain a metadata only author field', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-item-page-author-field'));
+      expect(fields.length).toBe(0);
+    });
+
+    it('should contain a mixed metadata and relationship field for authors', () => {
+      const fields = fixture.debugElement.queryAll(By.css('.ds-item-page-mixed-author-field'));
+      expect(fields.length).toBe(1);
+    });
+
+    it('should contain a component to display the abstract', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-item-page-abstract-field'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should contain a component to display the uri', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-item-page-uri-field'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should contain a component to display the collections', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-item-page-collections'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('with IIIF viewer', () => {
+
+    beforeEach(waitForAsync(() => {
+      const iiifEnabledMap: MetadataMap = {
+        'dspace.iiif.enabled': [getIIIFEnabled(true)],
+        'iiif.search.enabled': [getIIIFSearchEnabled(false)],
+      };
+      TestBed.compileComponents();
+      fixture = TestBed.createComponent(DatasetComponent);
+      comp = fixture.componentInstance;
+      comp.object = getItem(iiifEnabledMap);
+      fixture.detectChanges();
+    }));
+
+    it('should contain an iiif viewer component', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-mirador-viewer'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+    it('should not retrieve the query term for previous route', fakeAsync((): void => {
+      //tick(10)
+      expect(comp.iiifQuery$).toBeFalsy();
+    }));
+
+  });
+
+  describe('with IIIF viewer and search', () => {
+
+    const localMockRouteService = {
+      getPreviousUrl(): Observable<string> {
+        return of('/search?query=test%20query&fakeParam=true');
+      },
+    };
+    beforeEach(waitForAsync(() => {
+      const iiifEnabledMap: MetadataMap = {
+        'dspace.iiif.enabled': [getIIIFEnabled(true)],
+        'iiif.search.enabled': [getIIIFSearchEnabled(true)],
+      };
+      TestBed.overrideProvider(RouteService, { useValue: localMockRouteService });
+      TestBed.compileComponents();
+      fixture = TestBed.createComponent(DatasetComponent);
+      comp = fixture.componentInstance;
+      comp.object = getItem(iiifEnabledMap);
+      fixture.detectChanges();
+    }));
+
+    it('should contain an iiif viewer component', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-mirador-viewer'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should retrieve the query term for previous route', fakeAsync((): void => {
+      expect(comp.iiifQuery$.subscribe(result => expect(result).toEqual('test query')));
+    }));
+
+  });
+
+  describe('with IIIF viewer and search but no previous search query', () => {
+    const localMockRouteService = {
+      getPreviousUrl(): Observable<string> {
+        return of('/item');
+      },
+    };
+    beforeEach(waitForAsync(() => {
+      const iiifEnabledMap: MetadataMap = {
+        'dspace.iiif.enabled': [getIIIFEnabled(true)],
+        'iiif.search.enabled': [getIIIFSearchEnabled(true)],
+      };
+      TestBed.overrideProvider(RouteService, { useValue: localMockRouteService });
+      TestBed.compileComponents();
+      fixture = TestBed.createComponent(DatasetComponent);
+      comp = fixture.componentInstance;
+      comp.object = getItem(iiifEnabledMap);
+      fixture.detectChanges();
+    }));
+
+    it('should contain an iiif viewer component', () => {
+      const fields = fixture.debugElement.queryAll(By.css('ds-mirador-viewer'));
+      expect(fields.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not retrieve the query term for previous route', fakeAsync( () => {
+      let emitted;
+      comp.iiifQuery$.subscribe(result => emitted = result);
+      tick(10);
+      expect(emitted).toBeUndefined();
+    }));
+
+  });
+});

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
@@ -60,10 +60,11 @@ import { ThemedThumbnailComponent } from '../../../../thumbnail/themed-thumbnail
 import { CollectionsComponent } from '../../../field-components/collections/collections.component';
 import { ThemedMediaViewerComponent } from '../../../media-viewer/themed-media-viewer.component';
 import { MiradorViewerComponent } from '../../../mirador-viewer/mirador-viewer.component';
-import { ThemedFileSectionComponent } from '../../field-components/file-section/themed-file-section.component';
+import { ExtendedFileSectionComponent } from '../../field-components/extended-file-section/extended-file-section.component';
 import { ItemPageAbstractFieldComponent } from '../../field-components/specific-field/abstract/item-page-abstract-field.component';
 import { ItemPageDateFieldComponent } from '../../field-components/specific-field/date/item-page-date-field.component';
 import { GenericItemPageFieldComponent } from '../../field-components/specific-field/generic/generic-item-page-field.component';
+import { GeospatialItemPageFieldComponent } from '../../field-components/specific-field/geospatial/geospatial-item-page-field.component';
 import { ThemedItemPageTitleFieldComponent } from '../../field-components/specific-field/title/themed-item-page-field.component';
 import { ItemPageUriFieldComponent } from '../../field-components/specific-field/uri/item-page-uri-field.component';
 import { ThemedMetadataRepresentationListComponent } from '../../metadata-representation-list/themed-metadata-representation-list.component';
@@ -136,8 +137,7 @@ describe('DatasetComponent', () => {
     }).overrideComponent(DatasetComponent, {
       add: { changeDetection: ChangeDetectionStrategy.Default },
       remove: {
-        imports: [ThemedResultsBackButtonComponent, MiradorViewerComponent, ThemedItemPageTitleFieldComponent, DsoEditMenuComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, ThemedMediaViewerComponent, ThemedFileSectionComponent, ItemPageDateFieldComponent, ThemedMetadataRepresentationListComponent, GenericItemPageFieldComponent, RelatedItemsComponent, ItemPageAbstractFieldComponent, ItemPageUriFieldComponent, CollectionsComponent,
-        ],
+        imports: [ThemedResultsBackButtonComponent, MiradorViewerComponent, ThemedItemPageTitleFieldComponent, DsoEditMenuComponent, MetadataFieldWrapperComponent, ThemedThumbnailComponent, ThemedMediaViewerComponent, ExtendedFileSectionComponent, ItemPageDateFieldComponent, ThemedMetadataRepresentationListComponent, GenericItemPageFieldComponent, RelatedItemsComponent, ItemPageAbstractFieldComponent, ItemPageUriFieldComponent, CollectionsComponent, GeospatialItemPageFieldComponent],
       },
     });
   }));

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.ts
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.ts
@@ -1,0 +1,59 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ViewMode } from '@dspace/core/shared/view-mode.model';
+import { TranslatePipe } from '@ngx-translate/core';
+
+import { DsoEditMenuComponent } from '../../../../shared/dso-page/dso-edit-menu/dso-edit-menu.component';
+import { MetadataFieldWrapperComponent } from '../../../../shared/metadata-field-wrapper/metadata-field-wrapper.component';
+import { listableObjectComponent } from '../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { ThemedResultsBackButtonComponent } from '../../../../shared/results-back-button/themed-results-back-button.component';
+import { ThemedThumbnailComponent } from '../../../../thumbnail/themed-thumbnail.component';
+import { CollectionsComponent } from '../../../field-components/collections/collections.component';
+import { ThemedMediaViewerComponent } from '../../../media-viewer/themed-media-viewer.component';
+import { MiradorViewerComponent } from '../../../mirador-viewer/mirador-viewer.component';
+import { ExtendedFileSectionComponent } from '../../field-components/extended-file-section/extended-file-section.component';
+import { ItemPageAbstractFieldComponent } from '../../field-components/specific-field/abstract/item-page-abstract-field.component';
+import { ItemPageDateFieldComponent } from '../../field-components/specific-field/date/item-page-date-field.component';
+import { GenericItemPageFieldComponent } from '../../field-components/specific-field/generic/generic-item-page-field.component';
+import { GeospatialItemPageFieldComponent } from '../../field-components/specific-field/geospatial/geospatial-item-page-field.component';
+import { ThemedItemPageTitleFieldComponent } from '../../field-components/specific-field/title/themed-item-page-field.component';
+import { ItemPageUriFieldComponent } from '../../field-components/specific-field/uri/item-page-uri-field.component';
+import { ThemedMetadataRepresentationListComponent } from '../../metadata-representation-list/themed-metadata-representation-list.component';
+import { RelatedItemsComponent } from '../../related-items/related-items-component';
+import { ItemComponent } from '../shared/item.component';
+
+/**
+ * Component that represents a Dataset Item page
+ */
+
+@listableObjectComponent('Dataset', ViewMode.StandalonePage)
+@Component({
+  selector: 'ds-dataset',
+  imports: [
+    AsyncPipe,
+    CollectionsComponent,
+    DsoEditMenuComponent,
+    ExtendedFileSectionComponent,
+    GenericItemPageFieldComponent,
+    GeospatialItemPageFieldComponent,
+    ItemPageAbstractFieldComponent,
+    ItemPageDateFieldComponent,
+    ItemPageUriFieldComponent,
+    MetadataFieldWrapperComponent,
+    MiradorViewerComponent,
+    RelatedItemsComponent,
+    RouterLink,
+    ThemedItemPageTitleFieldComponent,
+    ThemedMediaViewerComponent,
+    ThemedMetadataRepresentationListComponent,
+    ThemedResultsBackButtonComponent,
+    ThemedThumbnailComponent,
+    TranslatePipe,
+  ],
+  templateUrl: './dataset.component.html',
+  styleUrl: './dataset.component.scss',
+})
+export class DatasetComponent extends ItemComponent {
+
+}

--- a/src/app/shared/listable.module.ts
+++ b/src/app/shared/listable.module.ts
@@ -123,6 +123,7 @@ import { PublicationSidebarSearchListElementComponent } from './object-list/side
 import { ThemedResultsBackButtonComponent } from './results-back-button/themed-results-back-button.component';
 import { TruncatableComponent } from './truncatable/truncatable.component';
 import { TruncatablePartComponent } from './truncatable/truncatable-part/truncatable-part.component';
+import {DatasetComponent} from "../item-page/simple/item-types/dataset/dataset.component";
 
 const ENTRY_COMPONENTS = [
   ...THEME_LISTABLE_COMPONENTS,
@@ -208,6 +209,7 @@ const ENTRY_COMPONENTS = [
   PoolSearchResultDetailElementComponent,
   ItemSearchResultListElementSubmissionComponent,
   PublicationComponent,
+  DatasetComponent,
   UntypedItemComponent,
 ];
 

--- a/src/app/shared/listable.module.ts
+++ b/src/app/shared/listable.module.ts
@@ -68,6 +68,7 @@ import { ItemPageDateFieldComponent } from '../item-page/simple/field-components
 import { GenericItemPageFieldComponent } from '../item-page/simple/field-components/specific-field/generic/generic-item-page-field.component';
 import { ThemedItemPageTitleFieldComponent } from '../item-page/simple/field-components/specific-field/title/themed-item-page-field.component';
 import { ItemPageUriFieldComponent } from '../item-page/simple/field-components/specific-field/uri/item-page-uri-field.component';
+import { DatasetComponent } from '../item-page/simple/item-types/dataset/dataset.component';
 import { PublicationComponent } from '../item-page/simple/item-types/publication/publication.component';
 import { UntypedItemComponent } from '../item-page/simple/item-types/untyped-item/untyped-item.component';
 import { ThemedMetadataRepresentationListComponent } from '../item-page/simple/metadata-representation-list/themed-metadata-representation-list.component';
@@ -123,7 +124,6 @@ import { PublicationSidebarSearchListElementComponent } from './object-list/side
 import { ThemedResultsBackButtonComponent } from './results-back-button/themed-results-back-button.component';
 import { TruncatableComponent } from './truncatable/truncatable.component';
 import { TruncatablePartComponent } from './truncatable/truncatable-part/truncatable-part.component';
-import {DatasetComponent} from "../item-page/simple/item-types/dataset/dataset.component";
 
 const ENTRY_COMPONENTS = [
   ...THEME_LISTABLE_COMPONENTS,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7363,4 +7363,16 @@
   "metadata-link-view.popover.label.other.dc.description.abstract": "Description",
 
   "metadata-link-view.popover.label.more-info": "More info",
+
+  "item.page.extended-file-section": "Bitstreams",
+
+  "file.section.name": "Document",
+
+  "file.section.type": "Type",
+
+  "file.section.size": "Size",
+
+  "dataset.page.titleprefix": "Dataset",
+
+  "dataset.listelement.badge": "Dataset"
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7374,5 +7374,29 @@
 
   "dataset.page.titleprefix": "Dataset",
 
-  "dataset.listelement.badge": "Dataset"
+  "dataset.listelement.badge": "Dataset",
+
+  "dataset.page.options": "Options",
+
+  "dataset.page.edit": "Edit this Dataset",
+
+  "relationships.Dataset.isAuthorOfDataset.Person": "Authors (Persons)",
+
+  "relationships.Dataset.isProjectOfDataset.Project": "Research Projects",
+
+  "relationships.Dataset.isAuthorOfDataset.OrgUnit": "Organizational Units",
+
+  "relationships.Dataset.isOrgUnitOfDataset.OrgUnit": "Authors (Organizational Units)",
+
+  "relationships.Dataset.isPublicationOfDataset.Publication": "Publications",
+
+  "relationships.Publication.isDatasetOfPublication.Dataset": "Datasets",
+
+  "relationships.Person.isDatasetOfAuthor.Dataset": "Datasets",
+
+  "relationships.Project.isDatasetOfProject.Dataset": "Datasets",
+
+  "relationships.OrgUnit.isDatasetOfAuthor.Dataset": "Authored Datasets",
+
+  "relationships.OrgUnit.isDatasetOfOrgUnit.Dataset": "Organisation Datasets",
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7399,4 +7399,10 @@
   "relationships.OrgUnit.isDatasetOfAuthor.Dataset": "Authored Datasets",
 
   "relationships.OrgUnit.isDatasetOfOrgUnit.Dataset": "Organisation Datasets",
+
+  "submission.sections.describe.relationship-lookup.title.Dataset": "Datasets",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Dataset": "Local Datasets",
+
+  "dataset.search.results.head": "Dataset Search Results"
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7404,5 +7404,55 @@
 
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.Dataset": "Local Datasets",
 
-  "dataset.search.results.head": "Dataset Search Results"
+  "dataset.search.results.head": "Dataset Search Results",
+
+  "submission.sections.describe.relationship-lookup.title.isAuthorOfDataset": "Authors",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfDataset": "Local Authors ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.title.isPublicationOfDataset": "Publications",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfDataset": "Local Publications ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.cinii": "CiNii ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.cinii": "Importing from CiNii",
+
+  "submission.sections.describe.relationship-lookup.selection-tab.title.cinii": "Search Results",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.datacite": "DataCite ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.datacite": "Importing from DataCite",
+
+  "submission.sections.describe.relationship-lookup.selection-tab.title.datacite": "Search Results",
+
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.doi": "DOI ({{ count }})",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.doi": "Importing from DOI",
+
+  "submission.sections.describe.relationship-lookup.selection-tab.title.doi": "Search Results",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.title": "Import Remote Publication",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.local-entity": "Successfully added local publication to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.new-entity": "Successfully imported and added external publication to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.title": "Import Remote Author",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.local-entity": "Successfully added local author to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.new-entity": "Successfully imported and added external author to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.title": "Import Remote Project",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.local-entity": "Successfully added local project to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.new-entity": "Successfully imported and added external project to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.title": "Import Remote Organization",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.local-entity": "Successfully added local organization to the selection",
+
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.new-entity": "Successfully imported and added external organization to the selection",
 }


### PR DESCRIPTION
## References

* Requires DSpace/DSpace#11969

## Description

This PR adds an item-page and extended-file-section for Dataset entities. The extended-file-section aims to provide a better overview about existing bitstreams and their metadata.


## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Created new extended-file-section component
* Added dataset item page including the newly created extended-file-section-component
* Provided spec.test files
* i18n labels

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

In order to test this PR, it is necessary to work on a rest backend that support Dataset entites (see related backend PR DSpace/DSpace#11969)

1. Create a Dataset item with at least one bitstream
2. Open the item page and make sure the bitstreams are displayed correctly in the bitstream section at the end of the page.
3. Add more than 5 (or your configured page size for bitstreams on item pages) bitstreams and make sure the pagination works correctly.
 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
