### PR TITLE
Add configurable option to show/hide metadatafield names in external import preview

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -256,6 +256,16 @@ submission:
         # The configured icon will be displayed next to the authority value in submission and on item page or search results.
         - source: orcid
         - path: assets/images/orcid.logo.icon.svg
+  # Settings for import item from an external source
+  importExternal:
+    # Toggle visibility of metadata field names in the external import preview modal.
+    # Possible values:
+    # - 'disable': show only the translated label
+    # - 'tooltip': (default) also show an info icon with the field name as tooltip
+    # - 'labeled': also show the field name in parentheses
+    # - 'full': show both the 'labeled' and 'tooltip' modes
+    viewMode: tooltip
+
 #  Fallback language in which the UI will be rendered if the user's browser language is not an active language
 fallbackLanguage: en
 

--- a/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.html
+++ b/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.html
@@ -18,8 +18,15 @@
       </div>
       @for (metadata of metadataList; track metadata) {
         <div class="row">
-          <p class="col-md-12">
-            <strong class="">{{'item.preview.' + metadata.key | translate}}</strong><br>
+          <p id="{{metadata.key}}" class="col-md-12">
+            <strong class="">{{'item.preview.' + metadata.key | translate}}</strong>
+            @if ([MetadataFieldViewMode.Labeled, MetadataFieldViewMode.Full].includes(viewMode)) {
+              <span class="text-muted ps-2">({{metadata.key}})</span>
+            }
+            @if ([MetadataFieldViewMode.Tooltip, MetadataFieldViewMode.Full].includes(viewMode)) {
+              <i class="fas fa-info-circle text-primary ps-2" [ngbTooltip]="metadata.key"></i>
+            }
+            <br>
             @for (metadatum of metadata.values; track metadatum) {
               <span>{{metadatum.value}}</span><br>
             }

--- a/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.spec.ts
+++ b/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.spec.ts
@@ -8,7 +8,10 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
+import { APP_CONFIG } from '@dspace/config/app-config.interface';
+import { ImportExternalMetadataViewMode } from '@dspace/config/import-external-metadata-view.mode';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { ExternalSourceEntry } from '@dspace/core/shared/external-source-entry.model';
 import { Metadata } from '@dspace/core/shared/metadata.utils';
@@ -25,6 +28,7 @@ import { getTestScheduler } from 'jasmine-marbles';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
+import { environment } from '../../../../environments/environment.test';
 import { CollectionListEntry } from '../../../shared/collection-dropdown/collection-dropdown.component';
 import { SubmissionService } from '../../submission.service';
 import { SubmissionImportExternalCollectionComponent } from '../import-external-collection/submission-import-external-collection.component';
@@ -68,6 +72,7 @@ describe('SubmissionImportExternalPreviewComponent test suite', () => {
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: NgbModal, useValue: ngbModal },
         { provide: NgbActiveModal, useValue: ngbActiveModal },
+        { provide: APP_CONFIG, useValue: environment },
         SubmissionImportExternalPreviewComponent,
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -118,6 +123,7 @@ describe('SubmissionImportExternalPreviewComponent test suite', () => {
       fixture.detectChanges();
 
       expect(comp.metadataList).toEqual(expected);
+      expect(comp.viewMode).toEqual(environment.submission.importExternal.viewMode);
     });
 
     it('Should close the modal calling \'activeModal.dismiss\'', () => {
@@ -163,6 +169,61 @@ describe('SubmissionImportExternalPreviewComponent test suite', () => {
       expect(compAsAny.submissionService.createSubmissionFromExternalSource).toHaveBeenCalledWith(externalEntry._links.self.href, emittedEvent.collection.id);
       expect(compAsAny.router.navigateByUrl).toHaveBeenCalledWith('/workspaceitems/' + submissionObjects[0].id + '/edit');
       done();
+    });
+  });
+
+  describe('Metadatafield View Modes UI rendering', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SubmissionImportExternalPreviewComponent);
+      comp = fixture.componentInstance;
+      comp.externalSourceEntry = externalEntry;
+      fixture.detectChanges();
+    });
+
+    it('should display tooltip only in Tooltip mode', () => {
+      comp.viewMode = ImportExternalMetadataViewMode.Tooltip;
+      fixture.detectChanges();
+
+      const tooltipIcon = fixture.debugElement.query(By.css('.fa-info-circle'));
+      const labelText = fixture.debugElement.query(By.css('span.text-muted'));
+
+      expect(tooltipIcon).toBeTruthy();
+      expect(labelText).toBeNull();
+    });
+
+    it('should display label only in Labeled mode', () => {
+      comp.viewMode = ImportExternalMetadataViewMode.Labeled;
+      fixture.detectChanges();
+
+      const tooltipIcon = fixture.debugElement.query(By.css('.fa-info-circle'));
+      const labelText = fixture.debugElement.query(By.css('span.text-muted'));
+
+      expect(tooltipIcon).toBeNull();
+      expect(labelText).toBeTruthy();
+      expect(labelText.nativeElement.textContent).toContain('(dc.identifier.uri)');
+    });
+
+    it('should display both in Full mode', () => {
+      comp.viewMode = ImportExternalMetadataViewMode.Full;
+      fixture.detectChanges();
+
+      const tooltipIcon = fixture.debugElement.query(By.css('.fa-info-circle'));
+      const labelText = fixture.debugElement.query(By.css('span.text-muted'));
+
+      expect(tooltipIcon).toBeTruthy();
+      expect(labelText).toBeTruthy();
+      expect(labelText.nativeElement.textContent).toContain('(dc.identifier.uri)');
+    });
+
+    it('should display neither in Disable mode', () => {
+      comp.viewMode = ImportExternalMetadataViewMode.Disable;
+      fixture.detectChanges();
+
+      const tooltipIcon = fixture.debugElement.query(By.css('.fa-info-circle'));
+      const labelText = fixture.debugElement.query(By.css('span.text-muted'));
+
+      expect(tooltipIcon).toBeNull();
+      expect(labelText).toBeNull();
     });
   });
 });

--- a/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.ts
+++ b/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.ts
@@ -1,10 +1,15 @@
-
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
 import { Router } from '@angular/router';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
+import { ImportExternalMetadataViewMode } from '@dspace/config/import-external-metadata-view.mode';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { ExternalSourceEntry } from '@dspace/core/shared/external-source-entry.model';
 import { MetadataValue } from '@dspace/core/shared/metadata.models';
@@ -14,6 +19,7 @@ import {
   NgbActiveModal,
   NgbModal,
   NgbModalRef,
+  NgbTooltipModule,
 } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { mergeMap } from 'rxjs/operators';
@@ -30,6 +36,7 @@ import { SubmissionImportExternalCollectionComponent } from '../import-external-
   styleUrls: ['./submission-import-external-preview.component.scss'],
   templateUrl: './submission-import-external-preview.component.html',
   imports: [
+    NgbTooltipModule,
     TranslateModule,
   ],
 })
@@ -52,12 +59,23 @@ export class SubmissionImportExternalPreviewComponent implements OnInit {
   modalRef: NgbModalRef;
 
   /**
+   * The view mode for the metadatafield names
+   */
+  public viewMode: ImportExternalMetadataViewMode;
+
+  /**
+   * The available view modes
+   */
+  public MetadataFieldViewMode = ImportExternalMetadataViewMode;
+
+  /**
    * Initialize the component variables.
    * @param {NgbActiveModal} activeModal
    * @param {SubmissionService} submissionService
    * @param {NgbModal} modalService
    * @param {Router} router
    * @param {NotificationsService} notificationService
+   * @param {AppConfig} appConfig
    */
   constructor(
     private activeModal: NgbActiveModal,
@@ -65,12 +83,15 @@ export class SubmissionImportExternalPreviewComponent implements OnInit {
     private modalService: NgbModal,
     private router: Router,
     private notificationService: NotificationsService,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) { }
 
   /**
    * Metadata initialization for HTML display.
    */
   ngOnInit(): void {
+    this.viewMode = this.appConfig.submission.importExternal.viewMode
+                    ?? this.MetadataFieldViewMode.Default;
     this.metadataList = [];
     const metadataKeys = Object.keys(this.externalSourceEntry.metadata);
     metadataKeys.forEach((key) => {

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -1,3 +1,4 @@
+import { ImportExternalMetadataViewMode } from '@dspace/config/import-external-metadata-view.mode';
 import { LayoutConfig } from '@dspace/config/layout-config.interfaces';
 import { SearchResultConfig } from '@dspace/config/search-result-config.interface';
 
@@ -297,6 +298,10 @@ export class DefaultAppConfig implements AppConfig {
       },
       // Icons that should remain visible even when no authority value is present for the metadata field
       iconsVisibleWithNoAuthority: ['fas fa-user'],
+    },
+    importExternal: {
+      // Visibility of metadatafield names in preview item from an external source
+      viewMode: ImportExternalMetadataViewMode.Default,
     },
   };
 

--- a/src/config/import-external-metadata-view.mode.ts
+++ b/src/config/import-external-metadata-view.mode.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents the view modes for metadatafield names in the external import preview modal.
+ */
+export enum ImportExternalMetadataViewMode {
+  /**
+   * Hide metadatafield names (show only labels).
+   */
+  Disable = 'disable',
+  /**
+   * Show tooltip with field name.
+   */
+  Tooltip = 'tooltip',
+  /**
+   * Show field name in parentheses.
+   */
+  Labeled = 'labeled',
+  /**
+   * Show both labeled and tooltip modes.
+   */
+  Full = 'full',
+
+  Default = Tooltip,
+}

--- a/src/config/submission-config.interface.ts
+++ b/src/config/submission-config.interface.ts
@@ -1,3 +1,5 @@
+import { ImportExternalMetadataViewMode } from '@dspace/config/import-external-metadata-view.mode';
+
 import { Config } from './config.interface';
 
 interface AutosaveConfig extends Config {
@@ -43,4 +45,7 @@ export interface SubmissionConfig extends Config {
   duplicateDetection: DuplicateDetectionConfig;
   typeBind: TypeBindConfig;
   icons: IconsConfig;
+  importExternal: {
+    viewMode: ImportExternalMetadataViewMode;
+  };
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,5 +1,6 @@
 // This configuration is only used for unit tests, end-to-end tests use environment.production.ts
 import { AdvancedAttachmentElementType } from '@dspace/config/advanced-attachment-rendering.config';
+import { ImportExternalMetadataViewMode } from '@dspace/config/import-external-metadata-view.mode';
 import { NotificationAnimationsType } from '@dspace/config/notifications-config.interfaces';
 import { RestRequestMethod } from '@dspace/config/rest-request-method';
 import { BuildConfig } from 'src/config/build-config.interface';
@@ -200,6 +201,10 @@ export const environment: BuildConfig = {
           },
         ],
       },
+    },
+    importExternal: {
+      // Visibility of metadatafield names in preview item from an external source
+      viewMode: ImportExternalMetadataViewMode.Default,
     },
   },
 


### PR DESCRIPTION
## References
* Fixes #5151

## Description
This PR adds configurable metadata field name visibility to the **external import** preview modal. It allows users to see which metadata field corresponds to each label.

Previously, users could only see the display labels (e.g., 'Container end page') without knowing the underlying metadata field name, making it difficult to understand source mappings or debug import configurations (without access to `*-integration.xml` backend files).

## Instructions for Reviewers

### Key Changes

This PR introduces four new view modes that can be configured via `config.yml` under `submission.importExtenral.viewMode`:
- `disable`: (current behavior) Shows only display labels
- `tooltip`: (new default) Show an info icon with the field name as a tooltip
- `labeled`: show the field name in parentheses next to the label
- `full`: combines `tooltip` and `labeled`, showing both the parenthetical label and an info icon with tooltip

### Examples

#### Mode = Disable (original behavior)

Only display labels shown. No metadata field information.

![screenshot_20260224001823](https://github.com/user-attachments/assets/4a06e1cd-82d6-4f9e-93ed-ced93e41da67)

#### Mode = Tooltip (new default)

Info icon appears next to labels. Hovering reveals the metadata field name.

:thought_balloon: **Needs Discussion**: Maybe tooltip could, instead of `{{metadata.key}}`, show `{{ 'item.preview.' + metadata.key + '.hint' | translate}}`? This could potentially extend this feature

![screenshot_20260224002939](https://github.com/user-attachments/assets/2861cdd6-eafa-4027-958d-e51dab3bfc2c)

#### Mode = Labeled

Metadata field name shown in parentheses directly after the display label.

:thought_balloon: **Needs Discussion**: Is the mode's name clear?

![screenshot_20260224003749](https://github.com/user-attachments/assets/945eff5c-5787-4215-bc19-854df4baf4a2)

#### Mode = Full

Both parenthetical label and info icon with tooltip are shown.

:thought_balloon: **Needs Discussion**: I have mixed feelings about this mode's usability, as it seems redundant. Opening this up for discussion. (Perhaps, changing the tooltip to show i18n key with a `.hint` suffix could provide more descriptive help text for each metadata field?) Happy to hear thoughts on this approach or alternative suggestions!

![screenshot_20260224004630](https://github.com/user-attachments/assets/5c0ea412-7fa7-40b2-b2d1-c4a401aeae34)

## How to Test

1. **Configuration**:
- `config.yml`: Test each mode (`disable`, `tooltip`, `labeled`, `full`) by changing the `submission.importExternal.viewMode` value. Observe no regression

2. **Functional**:
- Navigate to any external import source in MyDSpace (e.g., PubMed, arXiv, ORCID, DOI)
- Search for and select an item to import. Click to open the preview modal
- Verify that metadata field names appear according to the selected mode
- Also, confirm that tooltips work correctly in `tooltip` and `full` modes (should already be covered in unit tests)
- Also, ensure all metadata fields in the preview respect the configured mode
- Confirm no regressions when importing item from external source

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
