### PR TITLE
Bug: Improve back navigation logic in ItemComponent

### DIFF
--- a/src/app/core/services/route.service.ts
+++ b/src/app/core/services/route.service.ts
@@ -184,6 +184,34 @@ export class RouteService {
       });
   }
 
+  /**
+   * Store a URL in session storage for later retrieval
+   * Generic method that can be used by any component
+   * @param key The session storage key
+   * @param url The URL to store
+   */
+  public storeUrlInSession(key: string, url: string): void {
+    if (typeof window !== 'undefined' && hasValue(window.sessionStorage)) {
+      // Only write if the value is different to avoid unnecessary writes
+      const currentValue = window.sessionStorage.getItem(key);
+      if (currentValue !== url) {
+        window.sessionStorage.setItem(key, url);
+      }
+    }
+  }
+
+  /**
+   * Retrieve a URL from session storage
+   * Generic method that can be used by any component
+   * @param key The session storage key
+   */
+  public getUrlFromSession(key: string): string | null {
+    if (typeof window !== 'undefined' && hasValue(window.sessionStorage)) {
+      return window.sessionStorage.getItem(key);
+    }
+    return null;
+  }
+
   private getRouteParams(): Observable<Params> {
     let active = this.route;
     while (active.firstChild) {

--- a/src/app/core/testing/route-service.stub.ts
+++ b/src/app/core/testing/route-service.stub.ts
@@ -41,6 +41,16 @@ export const routeServiceStub: any = {
   getPreviousUrl: () => {
     return of('/home');
   },
+  // Added generic session helpers used by ItemComponent
+  storeUrlInSession: (key: string, url: string) => {
+    // no-op for tests
+  },
+  getUrlFromSession: (key: string): string | null => {
+    return null;
+  },
+  clearUrlFromSession: (key: string) => {
+    // no-op for tests
+  },
   setParameter: (key: any, value: any) => {
     return;
   },

--- a/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
+++ b/src/app/item-page/simple/item-types/dataset/dataset.component.spec.ts
@@ -213,6 +213,12 @@ describe('DatasetComponent', () => {
       getPreviousUrl(): Observable<string> {
         return of('/search?query=test%20query&fakeParam=true');
       },
+      storeUrlInSession(_key: string, _url: string): void {
+        // no-op
+      },
+      getUrlFromSession(_key: string): string | null {
+        return null;
+      },
     };
     beforeEach(waitForAsync(() => {
       const iiifEnabledMap: MetadataMap = {
@@ -242,6 +248,12 @@ describe('DatasetComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/item');
+      },
+      storeUrlInSession(_key: string, _url: string): void {
+        // no-op
+      },
+      getUrlFromSession(_key: string): string | null {
+        return null;
       },
     };
     beforeEach(waitForAsync(() => {

--- a/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
@@ -222,6 +222,12 @@ describe('PublicationComponent', () => {
       getPreviousUrl(): Observable<string> {
         return of('/search?query=test%20query&fakeParam=true');
       },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
+      },
     };
     beforeEach(waitForAsync(() => {
       const iiifEnabledMap: MetadataMap = {
@@ -251,6 +257,12 @@ describe('PublicationComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/item');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       },
     };
     beforeEach(waitForAsync(() => {

--- a/src/app/item-page/simple/item-types/shared/item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.spec.ts
@@ -104,6 +104,12 @@ export const mockRouteService = {
   getPreviousUrl(): Observable<string> {
     return of('');
   },
+  storeUrlInSession(key: string, url: string): void {
+    // no-op
+  },
+  getUrlFromSession(key: string): string | null {
+    return null;
+  },
   getQueryParameterValue(): Observable<string> {
     return of('');
   },
@@ -485,6 +491,7 @@ describe('ItemComponent', () => {
 
     const searchUrl = '/search?query=test&spc.page=2';
     const browseUrl = '/browse/title?scope=0cc&bbm.page=3';
+    const homeUrl = '/home';
     const recentSubmissionsUrl = '/collections/be7b8430-77a5-4016-91c9-90863e50583a?cp.page=3';
 
     beforeEach(waitForAsync(() => {
@@ -564,6 +571,32 @@ describe('ItemComponent', () => {
       comp.ngOnInit();
       comp.showBackButton$.subscribe((val) => {
         expect(val).toBeTrue();
+      });
+    });
+
+    it('should show back button for home', () => {
+      spyOn(mockRouteService, 'getPreviousUrl').and.returnValue(of(homeUrl));
+      comp.ngOnInit();
+      comp.showBackButton$.subscribe((val) => {
+        expect(val).toBeTrue();
+      });
+    });
+
+    it('should prioritize home previous url over session fallback', () => {
+      const staleSessionUrl = searchUrl;
+      const getPreviousUrlSpy = spyOn(mockRouteService, 'getPreviousUrl').and.returnValue(of(homeUrl));
+      const getUrlFromSessionSpy = spyOn(mockRouteService, 'getUrlFromSession').and.returnValue(staleSessionUrl);
+      const storeUrlInSessionSpy = spyOn(mockRouteService, 'storeUrlInSession');
+
+      comp.ngOnInit();
+      comp.showBackButton$.subscribe((val) => {
+        expect(val).toBeTrue();
+        expect(getPreviousUrlSpy).toHaveBeenCalled();
+        expect(getUrlFromSessionSpy).not.toHaveBeenCalled();
+        expect(storeUrlInSessionSpy).toHaveBeenCalledWith('item-previous-url', homeUrl);
+
+        comp.back();
+        expect(router.navigateByUrl).toHaveBeenCalledWith(homeUrl);
       });
     });
   });

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -42,10 +42,15 @@ export class ItemComponent implements OnInit {
   @Input() viewMode: ViewMode;
 
   /**
+   * Session storage key for storing the previous URL before entering item page
+   */
+  private readonly ITEM_PREVIOUS_URL_SESSION_KEY = 'item-previous-url';
+
+  /**
    * This regex matches previous routes. The button is shown
    * for matching paths and hidden in other cases.
    */
-  previousRoute = /^(\/search|\/browse|\/collections|\/admin\/search|\/mydspace)/;
+  previousRoute = /^(\/home|\/search|\/browse|\/collections|\/admin\/search|\/mydspace)/;
 
   /**
    * Used to show or hide the back to results button in the view.
@@ -80,6 +85,11 @@ export class ItemComponent implements OnInit {
   geospatialItemPageFieldsEnabled = false;
 
   /**
+   * Stores the previous URL retrieved either from RouteService or sessionStorage
+   */
+  private storedPreviousUrl: string;
+
+  /**
    * Flag to check whether to use the default relations or the authority based ones
    */
   areAuthorityRelationsEnabled: boolean;
@@ -96,24 +106,34 @@ export class ItemComponent implements OnInit {
 
   /**
    * The function used to return to list from the item.
+   * Uses stored previous URL if available, otherwise falls back to browser history.
    */
   back = () => {
-    this.routeService.getPreviousUrl().pipe(
-      take(1),
-    ).subscribe(
-      (url => {
-        this.router.navigateByUrl(url);
-      }),
-    );
+    this.router.navigateByUrl(this.storedPreviousUrl);
   };
 
   ngOnInit(): void {
-
     this.itemPageRoute = getItemPageRoute(this.object);
     // hide/show the back button
     this.showBackButton$ = this.routeService.getPreviousUrl().pipe(
-      map((url: string) => this.previousRoute.test(url)),
       take(1),
+      map(url => {
+        const fromRoute = this.pickAllowedPrevious(url);
+
+        if (fromRoute) {
+          this.routeService.storeUrlInSession(this.ITEM_PREVIOUS_URL_SESSION_KEY, fromRoute);
+          this.storedPreviousUrl = fromRoute;
+          return true;
+        }
+
+        const storedUrl = this.routeService.getUrlFromSession(this.ITEM_PREVIOUS_URL_SESSION_KEY);
+        if (this.pickAllowedPrevious(storedUrl)) {
+          this.storedPreviousUrl = storedUrl;
+          return true;
+        }
+
+        return false;
+      }),
     );
     // check to see if iiif viewer is required.
     this.iiifEnabled = isIiifEnabled(this.object);
@@ -121,5 +141,12 @@ export class ItemComponent implements OnInit {
     if (this.iiifSearchEnabled) {
       this.iiifQuery$ = getDSpaceQuery(this.object, this.routeService);
     }
+  }
+
+  /**
+   * Helper to check if a URL is from an allowed previous route and return it, otherwise null
+   */
+  private pickAllowedPrevious(url?: string | null): string | null {
+    return url && this.previousRoute.test(url) ? url : null;
   }
 }

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
@@ -242,6 +242,12 @@ describe('UntypedItemComponent', () => {
       getPreviousUrl(): Observable<string> {
         return of('/search?query=test%20query&fakeParam=true');
       },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
+      },
     };
     beforeEach(waitForAsync(() => {
       const iiifEnabledMap: MetadataMap = {
@@ -272,6 +278,12 @@ describe('UntypedItemComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/item');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       },
     };
     beforeEach(waitForAsync(() => {


### PR DESCRIPTION
## References
* Port of [ufal/dspace-angular#80](https://github.com/ufal/dspace-angular/pull/80)
* Related bug reports: 
  - [ufal/dspace-angular/issues/63](https://github.com/ufal/dspace-angular/issues/63)
  - [ufal/dspace-angular#106](https://github.com/ufal/dspace-angular/issues/106)

Original author: @amadulhaxxani 

## Description
Improves the "Back to results" button logic on item pages by adding session storage as a fallback for the previous URL. This ensures the back button works correctly across page refreshes and prevents stale navigation when users visit items from different contexts (e.g. homepage vs. collection browse).

## Instructions for Reviewers
List of changes in this PR:
* Added `storeUrlInSession()` and `getUrlFromSession()` generic helper methods to `RouteService` for persisting URLs in session storage
* Updated `ItemComponent` to store the previous URL in session storage and fall back to it when the route-based previous URL is not a valid navigation target
* Added `/home` to the list of allowed previous routes so the back button appears when navigating from the homepage
* Extracted URL validation into a `pickAllowedPrevious()` helper method for cleaner logic
* Simplified the `back()` method to use the stored URL directly instead of re-subscribing to the observable
* Updated test stubs and mocks in `route-service.stub.ts`, `publication.component.spec.ts`, `untyped-item.component.spec.ts`, and `item.component.spec.ts`
* Added new test cases for home URL back navigation and for prioritizing the current route URL over stale session storage

**How to test:**
1. Go to a collection page and click on an item — you should see "Back to results"; clicking it returns you to the collection
2. Refresh the item page — the "Back to results" button should still appear (session storage fallback)
3. Navigate to the homepage, click an item from "What's New" — you should see "Back to results" pointing to the homepage
4. **Regression check:** From a collection, open an item. Then go to the homepage and open a different item. The back button should now point to the homepage, **not** to the previous collection


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
