### PR TITLE
Add canonical link tags for item pages and bitstream downloads

### DIFF
--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
@@ -12,6 +12,10 @@ import {
   ActivatedRoute,
   Router,
 } from '@angular/router';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
 import { AuthService } from '@dspace/core/auth/auth.service';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
@@ -19,6 +23,7 @@ import { AuthorizationDataService } from '@dspace/core/data/feature-authorizatio
 import { SignpostingDataService } from '@dspace/core/data/signposting-data.service';
 import { getForbiddenRoute } from '@dspace/core/router/core-routing-paths';
 import { HardRedirectService } from '@dspace/core/services/hard-redirect.service';
+import { LinkHeadService } from '@dspace/core/services/link-head.service';
 import { ServerResponseService } from '@dspace/core/services/server-response.service';
 import { Bitstream } from '@dspace/core/shared/bitstream.model';
 import { FileService } from '@dspace/core/shared/file.service';
@@ -46,6 +51,8 @@ describe('BitstreamDownloadPageComponent', () => {
   let serverResponseService: jasmine.SpyObj<ServerResponseService>;
   let signpostingDataService: jasmine.SpyObj<SignpostingDataService>;
   let matomoService: jasmine.SpyObj<MatomoService>;
+  let linkHeadService: jasmine.SpyObj<LinkHeadService>;
+  let appConfig: AppConfig;
 
   const mocklink = {
     href: 'http://test.org',
@@ -119,6 +126,20 @@ describe('BitstreamDownloadPageComponent', () => {
       isMatomoScriptLoaded$: of(true),
     });
     matomoService.appendVisitorId.and.callFake((link) => of(link));
+    linkHeadService = jasmine.createSpyObj('LinkHeadService', {
+      addTag: {},
+      removeTag: {},
+    });
+    appConfig = {
+      seo: {
+        canonical: {
+          items: true,
+          bitstreams: true,
+        },
+      },
+    } as any;
+
+    (hardRedirectService as any).getBaseUrl = jasmine.createSpy('getBaseUrl').and.returnValue('https://example.org');
   }
 
   function initTestbed() {
@@ -138,6 +159,8 @@ describe('BitstreamDownloadPageComponent', () => {
         { provide: Location, useValue: location },
         { provide: DSONameService, useValue: dsoNameService },
         { provide: ConfigurationDataService, useValue: {} },
+        { provide: APP_CONFIG, useValue: appConfig },
+        { provide: LinkHeadService, useValue: linkHeadService },
       ],
     })
       .compileComponents();
@@ -270,5 +293,52 @@ describe('BitstreamDownloadPageComponent', () => {
         expect(hardRedirectService.redirect).toHaveBeenCalledWith('content-url-with-headers');
       });
     }));
+  });
+
+  describe('canonical link', () => {
+    describe('when seo.canonical.bitstreams is true', () => {
+      beforeEach(waitForAsync(() => {
+        init();
+        initTestbed();
+      }));
+      beforeEach(() => {
+        fixture = TestBed.createComponent(BitstreamDownloadPageComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+      it('should add canonical link tag to the head', () => {
+        expect(linkHeadService.addTag).toHaveBeenCalledWith({
+          rel: 'canonical',
+          href: 'https://example.org/bitstreams/testid/download',
+        });
+      });
+      it('should include canonical in the Link header', () => {
+        expect(serverResponseService.setHeader).toHaveBeenCalled();
+        const linkHeaderValue = (serverResponseService.setHeader as jasmine.Spy).calls.mostRecent().args[1];
+        expect(linkHeaderValue).toContain('rel="canonical"');
+        expect(linkHeaderValue).toContain('https://example.org/bitstreams/testid/download');
+      });
+      it('should remove canonical link tag on destroy', () => {
+        component.ngOnDestroy();
+        expect(linkHeadService.removeTag).toHaveBeenCalledWith('rel="canonical"');
+      });
+    });
+
+    describe('when seo.canonical.bitstreams is false', () => {
+      beforeEach(waitForAsync(() => {
+        init();
+        appConfig = { seo: { canonical: { items: true, bitstreams: false } } } as any;
+        (hardRedirectService as any).getBaseUrl = jasmine.createSpy('getBaseUrl').and.returnValue('https://example.org');
+        initTestbed();
+      }));
+      beforeEach(() => {
+        fixture = TestBed.createComponent(BitstreamDownloadPageComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+      it('should not add canonical link tag', () => {
+        expect(linkHeadService.addTag).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.ts
@@ -7,6 +7,7 @@ import {
   Component,
   Inject,
   inject,
+  OnDestroy,
   OnInit,
   PLATFORM_ID,
 } from '@angular/core';
@@ -15,6 +16,10 @@ import {
   Params,
   Router,
 } from '@angular/router';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
 import { AuthService } from '@dspace/core/auth/auth.service';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
@@ -25,6 +30,7 @@ import { SignpostingDataService } from '@dspace/core/data/signposting-data.servi
 import { SignpostingLink } from '@dspace/core/data/signposting-links.model';
 import { getForbiddenRoute } from '@dspace/core/router/core-routing-paths';
 import { HardRedirectService } from '@dspace/core/services/hard-redirect.service';
+import { LinkHeadService } from '@dspace/core/services/link-head.service';
 import { ServerResponseService } from '@dspace/core/services/server-response.service';
 import { redirectOn4xx } from '@dspace/core/shared/authorized.operators';
 import { Bitstream } from '@dspace/core/shared/bitstream.model';
@@ -60,7 +66,7 @@ import { MatomoService } from '../../statistics/matomo.service';
 /**
  * Page component for downloading a bitstream
  */
-export class BitstreamDownloadPageComponent implements OnInit {
+export class BitstreamDownloadPageComponent implements OnInit, OnDestroy {
 
   bitstream$: Observable<Bitstream>;
   bitstreamRD$: Observable<RemoteData<Bitstream>>;
@@ -80,6 +86,8 @@ export class BitstreamDownloadPageComponent implements OnInit {
     private responseService: ServerResponseService,
     private matomoService: MatomoService,
     @Inject(PLATFORM_ID) protected platformId: string,
+    @Inject(APP_CONFIG) private appConfig: AppConfig,
+    private linkHeadService: LinkHeadService,
   ) {
     this.initPageLinks();
   }
@@ -160,8 +168,14 @@ export class BitstreamDownloadPageComponent implements OnInit {
    * @private
    */
   private initPageLinks(): void {
-    if (isPlatformServer(this.platformId)) {
-      this.route.params.subscribe(params => {
+    this.route.params.subscribe(params => {
+      if (this.appConfig.seo?.canonical?.bitstreams !== false) {
+        const origin = this.hardRedirectService.getBaseUrl();
+        const canonicalUrl = `${origin}/bitstreams/${params.id}/download`;
+        this.linkHeadService.addTag({ rel: 'canonical', href: canonicalUrl });
+      }
+
+      if (isPlatformServer(this.platformId)) {
         this.signpostingDataService.getLinks(params.id).pipe(take(1)).subscribe((signpostingLinks: SignpostingLink[]) => {
           let links = '';
 
@@ -169,9 +183,19 @@ export class BitstreamDownloadPageComponent implements OnInit {
             links = links + (isNotEmpty(links) ? ', ' : '') + `<${link.href}> ; rel="${link.rel}"` + (isNotEmpty(link.type) ? ` ; type="${link.type}" ` : ' ');
           });
 
+          if (this.appConfig.seo?.canonical?.bitstreams !== false) {
+            const origin = this.hardRedirectService.getBaseUrl();
+            const canonicalUrl = `${origin}/bitstreams/${params.id}/download`;
+            links = links + (isNotEmpty(links) ? ', ' : '') + `<${canonicalUrl}> ; rel="canonical"`;
+          }
+
           this.responseService.setHeader('Link', links);
         });
-      });
-    }
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.linkHeadService.removeTag('rel="canonical"');
   }
 }

--- a/src/app/core/metadata/head-tag.service.spec.ts
+++ b/src/app/core/metadata/head-tag.service.spec.ts
@@ -24,8 +24,10 @@ import { PaginatedList } from '../data/paginated-list.model';
 import { RemoteData } from '../data/remote-data';
 import { RootDataService } from '../data/root-data.service';
 import { HardRedirectService } from '../services/hard-redirect.service';
+import { LinkHeadService } from '../services/link-head.service';
 import { Bitstream } from '../shared/bitstream.model';
 import { Bundle } from '../shared/bundle.model';
+import { DSpaceObject } from '../shared/dspace-object.model';
 import { Item } from '../shared/item.model';
 import { MetadataValue } from '../shared/metadata.models';
 import {
@@ -64,6 +66,7 @@ describe('HeadTagService', () => {
 
   let router: Router;
   let store;
+  let linkHeadService: LinkHeadService;
 
   let appConfig: AppConfig;
 
@@ -101,6 +104,10 @@ describe('HeadTagService', () => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: of(true),
     });
+    linkHeadService = jasmine.createSpyObj('linkHeadService', {
+      addTag: {},
+      removeTag: {},
+    });
 
     store = createMockStore({ initialState });
     spyOn(store, 'dispatch');
@@ -125,6 +132,7 @@ describe('HeadTagService', () => {
       hardRedirectService,
       appConfig,
       authorizationService,
+      linkHeadService,
     );
   });
 
@@ -491,6 +499,99 @@ describe('HeadTagService', () => {
       expect(store.dispatch.calls.argsFor(1)).toEqual([new AddMetaTagAction('title')]);
       expect(store.dispatch.calls.argsFor(2)).toEqual([new AddMetaTagAction('description')]);
     });
+  });
+
+  describe('canonical link tag', () => {
+    it('should add canonical link tag for Item DSO', fakeAsync(() => {
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(ItemMock),
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.addTag).toHaveBeenCalledWith({
+        rel: 'canonical',
+        href: 'https://request.org/items/0ec7ff22-f211-40ab-a69e-c819b0b1f357',
+      });
+    }));
+
+    it('should ignore a custom URL and use the UUID-based canonical', fakeAsync(() => {
+      const itemWithCustomUrl = Object.assign(new Item(), ItemMock, {
+        metadata: {
+          ...ItemMock.metadata,
+          'dspace.customurl': [{ value: 'my-custom-slug' }] as MetadataValue[],
+        },
+      });
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(itemWithCustomUrl),
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.addTag).toHaveBeenCalledWith({
+        rel: 'canonical',
+        href: 'https://request.org/items/0ec7ff22-f211-40ab-a69e-c819b0b1f357',
+      });
+    }));
+
+    it('should remove canonical link tag on route change', fakeAsync(() => {
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(ItemMock),
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.removeTag).toHaveBeenCalledWith('rel="canonical"');
+    }));
+
+    it('should not add canonical link tag when navigating to a non-DSO page', fakeAsync(() => {
+      (translateService.get as jasmine.Spy).and.returnValues(of('DSpace :: '), of('Dummy Title'));
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            title: 'Dummy Title',
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.addTag).not.toHaveBeenCalled();
+    }));
+
+    it('should not add canonical link tag when seo.canonical.items is false', fakeAsync(() => {
+      (appConfig as any).seo = { canonical: { items: false, bitstreams: true } };
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(ItemMock),
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.addTag).not.toHaveBeenCalled();
+    }));
+
+    it('should not add canonical link tag for non-Item DSO', fakeAsync(() => {
+      const nonItemDso = Object.assign(new DSpaceObject(), {
+        uuid: 'some-uuid',
+        metadata: {},
+      });
+      (dsoNameService.getName as jasmine.Spy).and.returnValue('Non-Item');
+      (headTagService as any).processRouteChange({
+        data: {
+          value: {
+            dso: createSuccessfulRemoteDataObject(nonItemDso),
+          },
+        },
+      });
+      tick();
+      expect(linkHeadService.addTag).not.toHaveBeenCalled();
+    }));
   });
 
   const mockType = (mockItem: Item, type: string): Item => {

--- a/src/app/core/metadata/head-tag.service.ts
+++ b/src/app/core/metadata/head-tag.service.ts
@@ -52,8 +52,12 @@ import { FindListOptions } from '../data/find-list-options.model';
 import { PaginatedList } from '../data/paginated-list.model';
 import { RemoteData } from '../data/remote-data';
 import { RootDataService } from '../data/root-data.service';
-import { getBitstreamDownloadRoute } from '../router/utils/dso-route.utils';
+import {
+  getBitstreamDownloadRoute,
+  getItemPageRoute,
+} from '../router/utils/dso-route.utils';
 import { HardRedirectService } from '../services/hard-redirect.service';
+import { LinkHeadService } from '../services/link-head.service';
 import { Bitstream } from '../shared/bitstream.model';
 import { getDownloadableBitstream } from '../shared/bitstream.operators';
 import { BitstreamFormat } from '../shared/bitstream-format.model';
@@ -123,6 +127,7 @@ export class HeadTagService {
     protected hardRedirectService: HardRedirectService,
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
     protected authorizationService: AuthorizationDataService,
+    protected linkHeadService: LinkHeadService,
   ) {
   }
 
@@ -143,6 +148,7 @@ export class HeadTagService {
 
   protected processRouteChange(routeInfo: any): void {
     this.clearMetaTags();
+    this.linkHeadService.removeTag('rel="canonical"');
 
     if (hasValue(routeInfo.data.value.dso) && hasValue(routeInfo.data.value.dso.payload)) {
       this.currentObject.next(routeInfo.data.value.dso.payload);
@@ -210,6 +216,7 @@ export class HeadTagService {
     // this.setCitationPatentCountryTag();
     // this.setCitationPatentNumberTag();
 
+    this.setCanonicalLinkTag();
   }
 
   /**
@@ -218,6 +225,23 @@ export class HeadTagService {
   protected setNoIndexTag(): void {
     if (this.currentObject.value instanceof Item && this.currentObject.value.isDiscoverable === false) {
       this.addMetaTag('robots', 'noindex');
+    }
+  }
+
+  /**
+   * Add <link rel="canonical"> to the <head> for Item pages.
+   * The canonical URL always points to the UUID-based item/entity route
+   * (e.g. /items/{uuid} or /entities/{type}/{uuid}), ignoring any custom URL,
+   * because a custom URL can change with the item's metadata and is therefore
+   * not a stable canonical reference.
+   */
+  protected setCanonicalLinkTag(): void {
+    if (this.appConfig.seo?.canonical?.items !== false
+      && this.currentObject.value instanceof Item) {
+      const origin = this.hardRedirectService.getBaseUrl();
+      const route = getItemPageRoute(this.currentObject.value as Item, true);
+      const canonicalUrl = new URLCombiner(origin, route).toString();
+      this.linkHeadService.addTag({ rel: 'canonical', href: canonicalUrl });
     }
   }
 

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -33,6 +33,7 @@ import { INotificationBoardOptions } from './notifications-config.interfaces';
 import { QualityAssuranceConfig } from './quality-assurance.config';
 import { SearchConfig } from './search-page-config.interface';
 import { SearchResultConfig } from './search-result-config.interface';
+import { SeoConfig } from './seo-config.interface';
 import { ServerConfig } from './server-config.interface';
 import { SubmissionConfig } from './submission-config.interface';
 import { SuggestionConfig } from './suggestion-config.interfaces';
@@ -77,6 +78,7 @@ interface AppConfig extends Config {
   searchResult: SearchResultConfig;
   addToAnyPlugin: AddToAnyPluginConfig;
   cms: CmsMetadata;
+  seo?: SeoConfig;
 }
 
 /**

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -35,6 +35,7 @@ import {
 import { QualityAssuranceConfig } from './quality-assurance.config';
 import { RestRequestMethod } from './rest-request-method';
 import { SearchConfig } from './search-page-config.interface';
+import { SeoConfig } from './seo-config.interface';
 import { ServerConfig } from './server-config.interface';
 import { SubmissionConfig } from './submission-config.interface';
 import { SuggestionConfig } from './suggestion-config.interfaces';
@@ -869,5 +870,13 @@ export class DefaultAppConfig implements AppConfig {
       'dspace.cms.home-news',
       'dspace.cms.footer',
     ],
+  };
+
+  // SEO settings
+  seo: SeoConfig = {
+    canonical: {
+      items: true,
+      bitstreams: true,
+    },
   };
 }

--- a/src/config/seo-config.interface.ts
+++ b/src/config/seo-config.interface.ts
@@ -1,0 +1,25 @@
+import { Config } from './config.interface';
+
+/**
+ * Config related to search engine optimization (SEO).
+ */
+export interface SeoConfig extends Config {
+
+  /**
+   * Configuration for canonical link tags.
+   */
+  canonical: {
+
+    /**
+     * Whether to add {@code <link rel="canonical">} to item pages.
+     * The canonical URL points to the simple item view (e.g. {@code /items/{uuid}} or {@code /entities/{type}/{uuid}}).
+     */
+    items: boolean;
+
+    /**
+     * Whether to add a canonical {@code Link} HTTP header and {@code <link rel="canonical">} to bitstream download responses.
+     * The canonical URL points to {@code /bitstreams/{uuid}/download}.
+     */
+    bitstreams: boolean;
+  };
+}


### PR DESCRIPTION
## References

* Fixes https://github.com/DSpace/dspace-angular/issues/4509

## Description

Adds `<link rel="canonical">` to item page HTML heads and a `Link` HTTP header with `rel="canonical"` to bitstream download responses, improving SEO by declaring preferred URLs.

## Instructions for Reviewers

List of changes in this PR:
* **New `SeoConfig` interface** (`src/config/seo-config.interface.ts`) with `canonical.items` and `canonical.bitstreams` boolean settings (both default to `true`)
* **`HeadTagService`**: injects `LinkHeadService`, adds `<link rel="canonical">` pointing to the UUID-based item view URL (via `getItemPageRoute(item, true)`), and removes it on every route change. This covers both simple (`/items/{uuid}`) and full (`/items/{uuid}/full`) views; the canonical always points to the simple view. Entity pages (`/entities/{type}/{uuid}`) get their own canonical. Any custom URL (`dspace.customurl`) is deliberately ignored, because a custom URL can change with the item's metadata and is therefore not a stable canonical reference; the canonical always uses the UUID-based route. Handle URLs (`/handle/{p}/{s}`) already 301-redirect, so no canonical is needed there.
* **`BitstreamDownloadPageComponent`**: adds `<link rel="canonical">` to the HTML `<head>` (works for both SSR and client-side rendering) and appends `rel="canonical"` to the `Link` HTTP header (SSR only). Implements `OnDestroy` to clean up the tag.
* **Tests** added for both `HeadTagService` and `BitstreamDownloadPageComponent` covering: tag added for Items, not added for non-Item DSOs, not added for non-DSO pages, removed on route change, respects config `false`, a custom URL still yielding the UUID-based canonical, and cleanup on destroy.
* **Note for reviewers:** rebased onto current `main`. Canonical URLs are built from the configured `ui.baseUrl` via `HardRedirectService.getBaseUrl()` (main recently replaced `getCurrentOrigin()` with `getBaseUrl()` so the `Host` header is no longer trusted).

**How to test:**
1. Build with SSR: `npm run build:ssr && npm run serve:ssr`
2. Visit an item page, view page source — confirm `<link rel="canonical" href="https://your-host/items/{uuid}">` is present in the `<head>`
3. Visit the full item page (`/items/{uuid}/full`), view source — canonical should still point to `/items/{uuid}` (without `/full`)
4. Visit an entity page (`/entities/{type}/{uuid}`) — canonical should point to `/entities/{type}/{uuid}`
5. `curl -i https://localhost:4000/bitstreams/{uuid}/download` — confirm the `Link` header contains `rel="canonical"` (use `-i` for a GET; `-I` issues a HEAD request, which does not render the SSR response and so does not emit the header)
6. To test the config toggle, set `seo.canonical.items: false` or `seo.canonical.bitstreams: false` in your config and verify the canonical tags are no longer added

**New configuration (in `config.yml` or environment config):**
```yaml
seo:
  canonical:
    items: true        # default: true
    bitstreams: true   # default: true
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
