### PR TITLE
[GitHub Actions] Enable updating GitHub action dependencies via dependabot (for dspace-angular)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,17 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the main branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   #####################
   ## dspace-9_x branch
   #####################
@@ -187,6 +198,18 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the dspace-9_x branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dspace-9_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   #####################
   ## dspace-8_x branch
   #####################
@@ -277,6 +300,18 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the dspace-8_x branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dspace-8_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   #####################
   ## dspace-7_x branch
   #####################
@@ -362,3 +397,15 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the dspace-7_x branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dspace-7_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## References
* Port of https://github.com/DSpace/DSpace/pull/12007 to `dspace-angular`

## Description
This PR ports https://github.com/DSpace/DSpace/pull/12007 to the `dspace-angular` project.

This PR enables dependabot updates to our GitHub action files on all active branches. This way we can better keep them up-to-date in order to avoid deprecation warnings, like in #5153.

Once this is merged, I expect we'll have an autogenerated PR which fixes #5153. We also may have additional auto-generated PRs to update other out-of-date actions.


## Instructions for Reviewers
* This can only be tested via merger as `@dependabot` will only run once it's merged.