### PR TITLE
Fix hierarchical & advanced search redirecting to global /search

### DIFF
--- a/src/app/shared/search/advanced-search/advanced-search.component.ts
+++ b/src/app/shared/search/advanced-search/advanced-search.component.ts
@@ -1,7 +1,4 @@
-import {
-  AsyncPipe,
-  KeyValuePipe,
-} from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import {
   Component,
   Inject,
@@ -37,6 +34,7 @@ import {
 } from '../../empty.util';
 import { FilterInputSuggestionsComponent } from '../../input-suggestions/filter-suggestions/filter-input-suggestions.component';
 import { InputSuggestion } from '../../input-suggestions/input-suggestions.model';
+import { currentPath } from '../../utils/route.utils';
 import { FilterType } from '../models/filter-type.model';
 import { SearchFilterConfig } from '../models/search-filter-config.model';
 
@@ -53,7 +51,6 @@ import { SearchFilterConfig } from '../models/search-filter-config.model';
     BtnDisabledDirective,
     FilterInputSuggestionsComponent,
     FormsModule,
-    KeyValuePipe,
     TranslateModule,
   ],
 })
@@ -68,6 +65,11 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
    * The facet configurations, used to determine if suggestions should be retrieved for the selected search filter
    */
   @Input() filtersConfig: SearchFilterConfig[];
+
+  /**
+   * True when the search component should show results on the current page
+   */
+  @Input() inPlaceSearch: boolean;
 
   /**
    * The current search scope
@@ -134,11 +136,21 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * @returns {string} The base path to the search page, or the current page when inPlaceSearch is true
+   */
+  getSearchLink(): string {
+    if (this.inPlaceSearch) {
+      return currentPath(this.router);
+    }
+    return this.searchService.getSearchLink();
+  }
+
   applyFilter(): void {
     if (isNotEmpty(this.currentValue)) {
       this.searchFilterService.minimizeAll();
       this.subs.push(this.searchConfigurationService.selectNewAppliedFilterParams(this.currentFilter, this.currentValue.trim(), this.currentOperator).pipe(take(1)).subscribe((params: Params) => {
-        void this.router.navigate([this.searchService.getSearchLink()], {
+        void this.router.navigate([this.getSearchLink()], {
           queryParams: params,
         });
         this.currentValue = '';

--- a/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-hierarchy-filter/search-hierarchy-filter.component.ts
@@ -138,7 +138,7 @@ export class SearchHierarchyFilterComponent extends SearchFacetFilterComponent i
       take(1),
     ).subscribe((params: Params) => {
       void this.router.navigate(
-        [this.searchService.getSearchLink()],
+        [this.getSearchLink()],
         {
           queryParams: params,
         },

--- a/src/app/shared/search/search-sidebar/search-sidebar.component.html
+++ b/src/app/shared/search/search-sidebar/search-sidebar.component.html
@@ -32,6 +32,7 @@
       <ds-advanced-search
         [configuration]="configuration"
         [filtersConfig]="(filters | async)?.payload"
+        [inPlaceSearch]="inPlaceSearch"
         [scope]="currentScope">
       </ds-advanced-search>
     }


### PR DESCRIPTION
## References
* Related #1789

## Description
Fixed bug where the hierarchical search & advanced search on community/collection pages redirected the user to the global `/search` route.

## Instructions for Reviewers
List of changes in this PR:
* Updated the `AdvancedSearchComponent` & `SearchHierarchyFilterComponent` to use the `currentPath` when `inPlaceSearch` is `true` (similar to the other search components)

**Guidance for how to test/review this PR:**
- Add the following config to your `config.yml` file
  ```yml
  vocabularies:
    - filter: 'subject'
      vocabulary: 'srsc'
      enabled: true
  search:
    advancedFilters:
      enabled: true
      filter: [title, author, subject, entityType]
  ```
- Navigate to a community/collection page
- Verify that adding a new filter using the Advanced Search section does not redirect you to `/search`
- Verify that selecting values in the subject facet by using the Browse subject tree does not redirect you to `/search`

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
