### PR TITLE
Show GeoIP warning on homepage when GeoLite database is missing

### DIFF
--- a/src/app/home-page/geoip-warning/geoip-warning.component.html
+++ b/src/app/home-page/geoip-warning/geoip-warning.component.html
@@ -1,0 +1,6 @@
+@if (showWarning$ | async) {
+  <ds-alert [type]="AlertType.Warning" [dismissible]="true"
+            [content]="'home.geoip-warning'"
+            (close)="onDismiss()">
+  </ds-alert>
+}

--- a/src/app/home-page/geoip-warning/geoip-warning.component.ts
+++ b/src/app/home-page/geoip-warning/geoip-warning.component.ts
@@ -1,0 +1,96 @@
+import {
+  AsyncPipe,
+  isPlatformBrowser,
+} from '@angular/common';
+import {
+  Component,
+  Inject,
+  OnInit,
+  PLATFORM_ID,
+} from '@angular/core';
+import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '@dspace/core/data/feature-authorization/feature-id';
+import {
+  HealthResponse,
+  HealthStatus,
+} from '@dspace/core/shared/health-component.model';
+import { TranslateModule } from '@ngx-translate/core';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+import {
+  catchError,
+  map,
+  switchMap,
+  take,
+} from 'rxjs/operators';
+
+import { HealthService } from '../../health-page/health.service';
+import { AlertComponent } from '../../shared/alert/alert.component';
+import { AlertType } from '../../shared/alert/alert-type';
+
+const DISMISSED_KEY = 'geoip-warning-dismissed';
+
+/**
+ * Component that displays a warning when the GeoLite database is not installed.
+ * Only visible to administrators. Once dismissed, stays hidden for the browser session.
+ */
+@Component({
+  selector: 'ds-geoip-warning',
+  templateUrl: './geoip-warning.component.html',
+  imports: [
+    AlertComponent,
+    AsyncPipe,
+    TranslateModule,
+  ],
+})
+export class GeoIpWarningComponent implements OnInit {
+
+  /**
+   * Whether to show the GeoIP warning.
+   */
+  showWarning$: Observable<boolean>;
+
+  readonly AlertType = AlertType;
+
+  constructor(
+    private authorizationService: AuthorizationDataService,
+    private healthService: HealthService,
+    @Inject(PLATFORM_ID) private platformId: object,
+  ) {
+  }
+
+  ngOnInit(): void {
+    if (isPlatformBrowser(this.platformId) && sessionStorage.getItem(DISMISSED_KEY)) {
+      this.showWarning$ = of(false);
+      return;
+    }
+
+    this.showWarning$ = this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      switchMap((isAdmin: boolean) => {
+        if (!isAdmin) {
+          return of(false);
+        }
+        return this.healthService.getHealth().pipe(
+          take(1),
+          map((data: any) => {
+            const response: HealthResponse = data.payload;
+            return response?.components?.geoIp?.status === HealthStatus.UP_WITH_ISSUES;
+          }),
+          catchError(() => of(false)),
+        );
+      }),
+    );
+  }
+
+  /**
+   * Dismiss the warning and remember it for the session.
+   */
+  onDismiss(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      sessionStorage.setItem(DISMISSED_KEY, 'true');
+    }
+  }
+
+}

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -1,3 +1,4 @@
+<ds-geoip-warning></ds-geoip-warning>
 <ds-home-coar></ds-home-coar>
 <ds-home-news></ds-home-news>
 @if (showDiscoverFilters) {

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -17,6 +17,7 @@ import { map } from 'rxjs/operators';
 import { SuggestionsPopupComponent } from '../notifications/suggestions/popup/suggestions-popup.component';
 import { ThemedConfigurationSearchPageComponent } from '../search-page/themed-configuration-search-page.component';
 import { ThemedSearchFormComponent } from '../shared/search-form/themed-search-form.component';
+import { GeoIpWarningComponent } from './geoip-warning/geoip-warning.component';
 import { HomeCoarComponent } from './home-coar/home-coar.component';
 import { ThemedHomeNewsComponent } from './home-news/themed-home-news.component';
 import { RecentItemListComponent } from './recent-item-list/recent-item-list.component';
@@ -27,6 +28,7 @@ import { ThemedTopLevelCommunityListComponent } from './top-level-community-list
   styleUrls: ['./home-page.component.scss'],
   templateUrl: './home-page.component.html',
   imports: [
+    GeoIpWarningComponent,
     HomeCoarComponent,
     NgTemplateOutlet,
     RecentItemListComponent,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2273,6 +2273,8 @@
 
   "home.breadcrumbs": "Home",
 
+  "home.geoip-warning": "The GeoLite database is not installed. Location-based statistics (countries, cities) are unavailable. See the DSpace installation instructions for details.",
+
   "home.search-form.placeholder": "Search the repository ...",
 
   "home.title": "Home",

--- a/src/themes/custom/app/home-page/home-page.component.ts
+++ b/src/themes/custom/app/home-page/home-page.component.ts
@@ -2,6 +2,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { Component } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
+import { GeoIpWarningComponent } from '../../../../app/home-page/geoip-warning/geoip-warning.component';
 import { HomeCoarComponent } from '../../../../app/home-page/home-coar/home-coar.component';
 import { ThemedHomeNewsComponent } from '../../../../app/home-page/home-news/themed-home-news.component';
 import { HomePageComponent as BaseComponent } from '../../../../app/home-page/home-page.component';
@@ -18,6 +19,7 @@ import { ThemedSearchFormComponent } from '../../../../app/shared/search-form/th
   // templateUrl: './home-page.component.html'
   templateUrl: '../../../../app/home-page/home-page.component.html',
   imports: [
+    GeoIpWarningComponent,
     HomeCoarComponent,
     NgTemplateOutlet,
     RecentItemListComponent,


### PR DESCRIPTION
## References

Fixes https://github.com/DSpace/dspace-angular/issues/5219
Related to https://github.com/DSpace/DSpace/pull/12043

## Description

Display a dismissible warning banner on the homepage for administrators when the GeoLite database is not installed.

## Instructions for Reviewers

List of changes in this PR:
* New `GeoIpWarningComponent` in `src/app/home-page/geoip-warning/` — standalone component that checks admin status via `AuthorizationDataService` and GeoIP health via `HealthService`
* Warning is shown only when the user is an administrator AND the `geoIp` health component reports `UP_WITH_ISSUES`
* Uses the existing `AlertComponent` with `AlertType.Warning` and `dismissible=true`
* Once dismissed, the warning stays hidden for the browser session using `sessionStorage` (does not affect other alerts)
* Uses `isPlatformBrowser` to guard `sessionStorage` access for SSR compatibility
* Added `GeoIpWarningComponent` to imports of both the base and custom theme `HomePageComponent`
* Added `home.geoip-warning` i18n key to `en.json5`

**How to test:**
1. Ensure the GeoLite database is **not** configured (comment out `usage-statistics.dbfile` in `usage-statistics.cfg`)
2. Start the backend and frontend
3. Log in as an administrator
4. Verify the warning banner appears at the top of the homepage
5. Click the X button to dismiss — the warning disappears
6. Navigate away and return to the homepage — the warning remains hidden
7. Open a new browser session (close tab, open new one) — the warning reappears
8. Log in as a non-admin user — verify no warning is shown

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).