### PR TITLE
[Port dspace-7_x] Fix: Full item view - bitstreams continuous text overflow in full file section

### DIFF
--- a/src/app/item-page/full/field-components/file-section/full-file-section.component.html
+++ b/src/app/item-page/full/field-components/file-section/full-file-section.component.html
@@ -15,7 +15,7 @@
                         <ds-themed-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-themed-thumbnail>
                     </div>
                     <div class="col-7">
-                        <dl class="row">
+                        <dl class="row dont-break-out">
                             <dt class="col-md-4">{{"item.page.filesection.name" | translate}}</dt>
                             <dd class="col-md-8">{{ dsoNameService.getName(file) }}</dd>
 


### PR DESCRIPTION
Port of https://github.com/DSpace/dspace-angular/pull/4990 to dspace-7_x.