### PR TITLE
Feature (#4347) : Enable language specific DSpace links via lang quer…

### DIFF
--- a/src/app/core/locale/locale.service.ts
+++ b/src/app/core/locale/locale.service.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   OnDestroy,
 } from '@angular/core';
+import { Router } from '@angular/router';
 import {
   APP_CONFIG,
   AppConfig,
@@ -23,6 +24,7 @@ import {
   Subscription,
 } from 'rxjs';
 import {
+  filter,
   map,
   mergeMap,
   take,
@@ -66,8 +68,10 @@ export class LocaleService implements OnDestroy {
     protected translate: TranslateService,
     protected authService: AuthService,
     protected routeService: RouteService,
+    private router: Router,
     @Inject(DOCUMENT) protected document: any,
   ) {
+    this.checkQueryParamLanguage();
   }
 
   /**
@@ -92,6 +96,77 @@ export class LocaleService implements OnDestroy {
         );
     }
     return of(lang);
+  }
+
+  /**
+ * Checks if a "lang" query parameter exists in the current route.
+ *
+ * If present and non-empty, it will attempt to apply it as the current language.
+ * Uses take(1) to avoid multiple executions on route changes.
+ */
+  private checkQueryParamLanguage(): void {
+    this.subs.push(
+      this.routeService
+        .getQueryParameterValue('lang')
+        .pipe(
+          filter((lang: string | null) => typeof lang === 'string' && lang.trim().length > 0),
+          take(1),
+        )
+        .subscribe({
+          next: (lang: string) => {
+            this.applyLangIfValid(lang);
+          },
+          error: (error: unknown) => {
+            console.warn(
+              '[LocaleService] error reading query param value',
+              error,
+            );
+          },
+        }),
+    );
+  }
+
+  /**
+ * Applies the provided language if it is valid and active in appConfig.
+ *
+ * - Normalizes the language code to lowercase.
+ * - Verifies it exists and is active.
+ * - Sets it as current language.
+ * - Cleans the "lang" query param from the URL to avoid reapplying it.
+ */
+  private applyLangIfValid(lang: string): void {
+    if (!lang) {
+      return;
+    }
+
+    const normalizedLang = lang.toLowerCase();
+
+    const isValid = this.appConfig.languages.some(
+      (l) => l.code.toLowerCase() === normalizedLang && l.active,
+    );
+
+    if (!isValid) {
+      return;
+    }
+    this.setCurrentLanguageCode(normalizedLang);
+    try {
+      if (this.router) {
+        this.router.navigate([], {
+          queryParams: { lang: null },
+          queryParamsHandling: 'merge',
+          replaceUrl: true,
+        }).catch(() => {});
+      }
+      const currentUrl = this._window.nativeWindow.location.href;
+      if (currentUrl.includes('lang=')) {
+        const cleanUrl = currentUrl
+          .replace(/([?&])lang=[^&]+&?/, '$1')
+          .replace(/[?&]$/, '');
+        this._window.nativeWindow.history.replaceState({}, '', cleanUrl);
+      }
+    } catch (error: unknown) {
+      console.warn('[LocaleService] error cleaning URL', error);
+    }
   }
 
   /**

--- a/src/app/core/locale/locale.service.ts
+++ b/src/app/core/locale/locale.service.ts
@@ -68,8 +68,8 @@ export class LocaleService implements OnDestroy {
     protected translate: TranslateService,
     protected authService: AuthService,
     protected routeService: RouteService,
-    private router: Router,
-    @Inject(DOCUMENT) protected document: any,
+    private router?: Router,
+    @Inject(DOCUMENT) protected document?: any,
   ) {
     this.checkQueryParamLanguage();
   }


### PR DESCRIPTION
…y param

## References
Fixes #4347

## Description
Enable DSpace Angular frontend to respect a lang query parameter in the URL.
This allows linking directly to a specific language version (e.g., French, English, Spanish) and ensures the language selector works correctly afterward.

## Instructions for Reviewers
List of changes in this PR:

- Added checkQueryParamLanguage() in LocaleService to read lang from the URL and apply it on first load.
- Modified applyLangIfValid() to set the current language and remove the lang query param from the URL.
- Ensured that changing the language via the selector overrides any previously applied URL language.
- Added comments for clarity on private methods.

Testing instructions:

1. Open in a fresh browser or incognito mode.
2. Go to http://localhost:4000/home?lang=fr → page should display in French, URL should remove ?lang=fr.
3. Change the language using the selector → page should stay in the newly selected language.
4. Repeat with ?lang=en and ?lang=es to verify all supported languages.
5. Verify that ESLint passes: npm run lint.
6. Ensure no regression in other DSpace pages.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
