### PR TITLE
Restore "Fix current parent order when creating subcommunity" (#4568)

### DIFF
--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.ts
@@ -63,6 +63,7 @@ export class CreateCommunityParentSelectorComponent extends DSOSelectorModalWrap
   }
 
   ngOnInit() {
+    super.ngOnInit();
     this.isAdmin$ = this.authorizationService.isAuthorized(FeatureID.AdministratorOf);
   }
 


### PR DESCRIPTION
## References
* Restores changes from #4568
* Related to #4639 (which appears to have unintentionally reverted this behavior)

## Description
This PR restores the behavior originally introduced in #4568, which appears to have been unintentionally reverted in #4639.

The change allows retrieving the ID of the current community and using it in the initial search when opening the community selector popup when creating a community.

## Instructions for Reviewers

How to test:
1. Go to the page of an existing community.
2. From the administration menu, open the community selector (e.g. when creating a new community).
3. Verify using the browser's developer tools that the initial request to `FindAddAuthorized` includes the **ID of the current community**.

Ideally, the first result shown should be the current community.
However, the current behavior is not fully perfect. In my tests, when the current community has subcommunities, the subcommunities are often listed first. This happens because the parent community ID is indexed in several fields of the child communities and tends to have higher relevance.

This issue would likely be better addressed in the backend in future PRs. Nevertheless, restoring this change improves the current behavior.