### PR TITLE
Fix #2680 breadcrumbs collapse in mobile mode

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,24 +1,27 @@
 <ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
-  @if ((showBreadcrumbs$ | async)) {
+  <ng-container *ngIf="showBreadcrumbs$ | async">
     <nav aria-label="breadcrumb" class="nav-breadcrumb">
       <ng-container *ngTemplateOutlet="(isMobile$ | async) ? displayOnMobile : displayOnDesktop"></ng-container>
-      <ng-template #displayOnMobile>
-        <ol class="container breadcrumb my-0">
-          <ng-container *ngTemplateOutlet="listBreadcrumb"></ng-container>
-          <li class="breadcrumb-separator"><p>{{'/'}}</p></li>
-          <ng-container *ngTemplateOutlet="currentBreadcrumb"></ng-container>
-        </ol>
-      </ng-template>
-      <ng-template #displayOnDesktop>
-        <ol class="container breadcrumb my-0">
-          <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
-            @for (bc of breadcrumbs; track $index; let last = $last) {
-              <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
-            }
-        </ol>
-      </ng-template>
     </nav>
-  }
+  </ng-container>
+
+  <ng-template #displayOnMobile>
+    <ol class="container breadcrumb my-0">
+      <ng-container *ngTemplateOutlet="listBreadcrumb"></ng-container>
+      <li class="breadcrumb-separator"><p>{{'/'}}</p></li>
+      <ng-container *ngTemplateOutlet="currentBreadcrumb"></ng-container>
+    </ol>
+  </ng-template>
+
+  <ng-template #displayOnDesktop>
+    <ol class="container breadcrumb my-0">
+      <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
+      <ng-container *ngFor="let bc of breadcrumbs; let last = last">
+        <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
+      </ng-container>
+    </ol>
+  </ng-template>
+
   <ng-template #breadcrumb let-text="text" let-url="url">
     <li class="breadcrumb-item">
       <div class="breadcrumb-item-limiter">
@@ -33,6 +36,7 @@
       </div>
     </li>
   </ng-template>
+
   <ng-template #activeBreadcrumb let-text="text">
     <li class="breadcrumb-item active" aria-current="page">
       <div class="breadcrumb-item-limiter">
@@ -40,6 +44,7 @@
       </div>
     </li>
   </ng-template>
+
   <ng-template #listBreadcrumb>
     <li class="breadcrumb-item">
       <div class="dropdown">
@@ -52,13 +57,13 @@
               <li class="nav-item nav-link d-flex flex-row">
                 <div class="mr-2">
                   <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
-                    @for (bc of breadcrumbs; track $index; let last = $last) {
-                      @if (!last) {
-                        <div>
-                          <ng-container *ngTemplateOutlet="breadcrumb; context: bc"></ng-container>
-                        </div>
-                      }
-                    }
+                  <ng-container *ngFor="let bc of breadcrumbs; let last = last">
+                    <ng-container *ngIf="!last">
+                      <div>
+                        <ng-container *ngTemplateOutlet="breadcrumb; context: bc"></ng-container>
+                      </div>
+                    </ng-container>
+                  </ng-container>
                 </div>
               </li>
             </ul>
@@ -67,13 +72,14 @@
       </div>
     </li>
   </ng-template>
+
   <ng-template #currentBreadcrumb>
-    @for (bc of breadcrumbs; track $index; let last = $last) {
-      @if (last) {
+    <ng-container *ngFor="let bc of breadcrumbs; let last = last">
+      <ng-container *ngIf="last">
         <div>
           <ng-container *ngTemplateOutlet="activeBreadcrumb; context: bc"></ng-container>
         </div>
-      }
-    }
+      </ng-container>
+    </ng-container>
   </ng-template>
 </ng-container>

--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -1,22 +1,79 @@
 <ng-container *ngVar="(breadcrumbs$ | async) as breadcrumbs">
   @if ((showBreadcrumbs$ | async)) {
     <nav aria-label="breadcrumb" class="nav-breadcrumb">
-      <ol class="container breadcrumb my-0">
-        <ng-container
-        *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
-        @for (bc of breadcrumbs; track bc; let last = $last) {
-          <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
-        }
-      </ol>
+      <ng-container *ngTemplateOutlet="(isMobile$ | async) ? displayOnMobile : displayOnDesktop"></ng-container>
+      <ng-template #displayOnMobile>
+        <ol class="container breadcrumb my-0">
+          <ng-container *ngTemplateOutlet="listBreadcrumb"></ng-container>
+          <li class="breadcrumb-separator"><p>{{'/'}}</p></li>
+          <ng-container *ngTemplateOutlet="currentBreadcrumb"></ng-container>
+        </ol>
+      </ng-template>
+      <ng-template #displayOnDesktop>
+        <ol class="container breadcrumb my-0">
+          <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
+            @for (bc of breadcrumbs; track $index; let last = $last) {
+              <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
+            }
+        </ol>
+      </ng-template>
     </nav>
   }
-
   <ng-template #breadcrumb let-text="text" let-url="url">
-    <li class="breadcrumb-item"><div class="breadcrumb-item-limiter"><a [routerLink]="url" class="text-truncate" [ngbTooltip]="text | translate" placement="bottom" role="link" tabindex="0">{{text | translate}}</a></div></li>
+    <li class="breadcrumb-item">
+      <div class="breadcrumb-item-limiter">
+        <a [routerLink]="url"
+           class="text-truncate"
+           [ngbTooltip]="text | translate"
+           placement="bottom"
+           role="link"
+           tabindex="0">
+          {{text | translate}}
+        </a>
+      </div>
+    </li>
   </ng-template>
-
   <ng-template #activeBreadcrumb let-text="text">
-    <li class="breadcrumb-item active" aria-current="page"><div class="breadcrumb-item-limiter"><div class="text-truncate">{{text | translate}}</div></div></li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <div class="breadcrumb-item-limiter">
+        <div class="text-truncate">{{text | translate}}</div>
+      </div>
+    </li>
+  </ng-template>
+  <ng-template #listBreadcrumb>
+    <li class="breadcrumb-item">
+      <div class="dropdown">
+        <div class="dso-button-menu mb-1" ngbDropdown container="body" placement="bottom-left">
+          <div class="d-flex flex-row flex-nowrap">
+            <a type="button" class="breadcrumb-action" aria-expanded="false" ngbDropdownToggle>
+              {{ ('...') }}
+            </a>
+            <ul ngbDropdownMenu class="menu-dropdown">
+              <li class="nav-item nav-link d-flex flex-row">
+                <div class="mr-2">
+                  <ng-container *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
+                    @for (bc of breadcrumbs; track $index; let last = $last) {
+                      @if (!last) {
+                        <div>
+                          <ng-container *ngTemplateOutlet="breadcrumb; context: bc"></ng-container>
+                        </div>
+                      }
+                    }
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ng-template>
+  <ng-template #currentBreadcrumb>
+    @for (bc of breadcrumbs; track $index; let last = $last) {
+      @if (last) {
+        <div>
+          <ng-container *ngTemplateOutlet="activeBreadcrumb; context: bc"></ng-container>
+        </div>
+      }
+    }
   </ng-template>
 </ng-container>
-

--- a/src/app/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/breadcrumbs/breadcrumbs.component.scss
@@ -38,3 +38,18 @@ li.breadcrumb-item.active {
   display: block;
   content: quote("•") !important;
 }
+
+.breadcrumb-action {
+  font-size: 17px;
+  padding-right: 5px;
+  padding-bottom: 5px;
+}
+
+.breadcrumb-separator {
+  padding-right: 5px;
+  padding-left: 5px;
+}
+
+.dropdown-toggle::after {
+  display: none !important;
+}

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -47,6 +47,10 @@ describe('BreadcrumbsComponent', () => {
       showBreadcrumbs$: of(true),
     } as BreadcrumbsService;
 
+    const hostWindowServiceMock = {
+      isUpTo: (width: number) => true,
+    };
+
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes([]),
@@ -61,15 +65,8 @@ describe('BreadcrumbsComponent', () => {
       ],
       providers: [
         { provide: BreadcrumbsService, useValue: breadcrumbsServiceMock },
+        { provide: HostWindowService, useValue: hostWindowServiceMock },
       ],
-    });
-
-    TestBed.overrideComponent(BreadcrumbsComponent, {
-      set: {
-        providers: [
-          { provide: HostWindowService, useValue: {} },
-        ],
-      },
     });
 
     TestBed.compileComponents();

--- a/src/app/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
+import { HostWindowService } from '../shared/host-window.service';
 import { VarDirective } from '../shared/utils/var.directive';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 import { BreadcrumbsService } from './breadcrumbs.service';
@@ -61,7 +62,17 @@ describe('BreadcrumbsComponent', () => {
       providers: [
         { provide: BreadcrumbsService, useValue: breadcrumbsServiceMock },
       ],
-    }).compileComponents();
+    });
+
+    TestBed.overrideComponent(BreadcrumbsComponent, {
+      set: {
+        providers: [
+          { provide: HostWindowService, useValue: {} },
+        ],
+      },
+    });
+
+    TestBed.compileComponents();
 
     fixture = TestBed.createComponent(BreadcrumbsComponent);
     component = fixture.componentInstance;

--- a/src/app/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/breadcrumbs/breadcrumbs.component.ts
@@ -2,13 +2,20 @@ import {
   AsyncPipe,
   NgTemplateOutlet,
 } from '@angular/common';
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { Breadcrumb } from '@dspace/core/breadcrumbs/models/breadcrumb.model';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
+import {
+  HostWindowService,
+  WidthCategory,
+} from '../shared/host-window.service';
 import { VarDirective } from '../shared/utils/var.directive';
 import { BreadcrumbsService } from './breadcrumbs.service';
 
@@ -28,7 +35,14 @@ import { BreadcrumbsService } from './breadcrumbs.service';
     VarDirective,
   ],
 })
-export class BreadcrumbsComponent {
+export class BreadcrumbsComponent implements OnInit {
+
+  public isMobile$: Observable<boolean>;
+
+  /**
+   * Observable of max mobile width
+  */
+  maxMobileWidth = WidthCategory.SM;
 
   /**
    * Observable of the list of breadcrumbs for this page
@@ -42,9 +56,14 @@ export class BreadcrumbsComponent {
 
   constructor(
     private breadcrumbsService: BreadcrumbsService,
+    public windowService: HostWindowService,
   ) {
     this.breadcrumbs$ = breadcrumbsService.breadcrumbs$;
     this.showBreadcrumbs$ = breadcrumbsService.showBreadcrumbs$;
+  }
+
+  ngOnInit(): void {
+    this.isMobile$ = this.windowService.isUpTo(this.maxMobileWidth);
   }
 
 }

--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -1,6 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import {
+  NgbDropdownModule,
+  NgbModule,
+  NgbTooltipModule,
+} from '@ng-bootstrap/ng-bootstrap';
 
 import { EAGER_THEME_COMPONENTS } from '../themes/eager-themes-components';
 import { AdminSidebarComponent } from './admin/admin-sidebar/admin-sidebar.component';
@@ -33,6 +37,8 @@ import { IdleModalComponent } from './shared/idle-modal/idle-modal.component';
 const IMPORTS = [
   CommonModule,
   NgbModule,
+  NgbDropdownModule,
+  NgbTooltipModule,
 ];
 
 const PROVIDERS = [

--- a/src/app/shared/host-window.service.ts
+++ b/src/app/shared/host-window.service.ts
@@ -150,3 +150,5 @@ export class HostWindowService {
     );
   }
 }
+export { WidthCategory };
+

--- a/src/app/shared/test-module.ts
+++ b/src/app/shared/test-module.ts
@@ -29,6 +29,7 @@ import { MySimpleItemActionComponent } from '../item-page/edit-item-page/simple-
     QueryParamsDirectiveStub,
     RouterLinkDirectiveStub,
     BrowserOnlyMockPipe,
+    NgComponentOutletDirectiveStub,
   ],
   schemas: [
     CUSTOM_ELEMENTS_SCHEMA,


### PR DESCRIPTION
## References
* Fixes #2680

## Description
This PR updates the breadcrumb template to comply with Angular control flow syntax and resolves the linting error requiring a track expression in @for loops.

## Instructions for Reviewers


List of changes in this PR:
* Updated breadcrumb templates to use Angular's modern control flow syntax.
* Replaced deprecated *ngFor with @for.
* Replaced deprecated *ngIf with @if.
* Added the required `track` expression in all @for loops to satisfy ESLint validation.
* Ensured the breadcrumb component compiles and passes lint validation.

**How to test**
1. Run `npm install`
2. Run `npm run lint` and verify there are no lint errors related to the breadcrumb component.
3. Run the Angular UI (`npm start`).
4. Navigate to pages where breadcrumbs are displayed.
5. Verify that breadcrumbs render correctly on both desktop and mobile views.
6. Verify the mobile breadcrumb collapse behavior still works as expected.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).