### PR TITLE
[Docker] Update all Docker Compose scripts to allow for environment variable overrides

### DIFF
--- a/docker/cli.assetstore.yml
+++ b/docker/cli.assetstore.yml
@@ -16,7 +16,7 @@ services:
   dspace-cli:
     environment:
       # This assetstore zip is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADASSETS=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/assetstore.tar.gz
+      - LOADASSETS=${LOADASSETS:-https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/assetstore.tar.gz}
     entrypoint:
       - /bin/bash
       - '-c'

--- a/docker/cli.ingest.yml
+++ b/docker/cli.ingest.yml
@@ -15,9 +15,9 @@
 services:
   dspace-cli:
     environment:
-    - AIPZIP=https://github.com/DSpace-Labs/AIP-Files/raw/main/dogAndReport.zip
-    - ADMIN_EMAIL=test@test.edu
-    - AIPDIR=/tmp/aip-dir
+    - AIPZIP=${AIPZIP:-https://github.com/DSpace-Labs/AIP-Files/raw/main/dogAndReport.zip}
+    - ADMIN_EMAIL=${ADMIN_EMAIL:-test@test.edu}
+    - AIPDIR=${AIPDIR:-/tmp/aip-dir}
     entrypoint:
       - /bin/bash
       - '-c'

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -29,9 +29,9 @@ services:
       # __P__ => "." (e.g. dspace__P__dir => dspace.dir)
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/dspace}
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}
     networks:
     - dspacenet
     volumes:

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -18,7 +18,7 @@ services:
     environment:
       # This LOADSQL should be kept in sync with the URL in DSpace/DSpace
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql
+      - LOADSQL=${LOADSQL:-https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql}
   dspace:
     ### OVERRIDE default 'entrypoint' in 'docker-compose-rest.yml' ####
     # Ensure that the database is ready BEFORE starting tomcat

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -22,17 +22,17 @@ services:
       # __P__ => "." (e.g. dspace__P__dir => dspace.dir)
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # dspace.dir, dspace.server.url and dspace.ui.url
-      dspace__P__dir: /dspace
-      dspace__P__server__P__url: http://127.0.0.1:8080/server
-      dspace__P__ui__P__url: http://127.0.0.1:4000
+      dspace__P__dir: ${dspace__P__dir:-/dspace}
+      dspace__P__server__P__url: ${dspace__P__server__P__url:-http://127.0.0.1:8080/server}
+      dspace__P__ui__P__url: ${dspace__P__ui__P__url:-http://127.0.0.1:4000}
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/dspace}
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}
       # Tell Statistics to commit all views immediately instead of waiting on Solr's autocommit.
       # This allows us to generate statistics in e2e tests so that statistics pages can be tested thoroughly.
-      solr__D__statistics__P__autoCommit: 'false'
-      LOGGING_CONFIG: /dspace/config/log4j2-container.xml
+      solr__D__statistics__P__autoCommit: ${solr__D__statistics__P__autoCommit:-false}
+      LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     depends_on:
     - dspacedb

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -18,16 +18,16 @@ services:
   dspace-angular:
     container_name: dspace-angular
     environment:
-      DSPACE_UI_SSL: 'false'
-      DSPACE_UI_HOST: dspace-angular
-      DSPACE_UI_PORT: '4000'
-      DSPACE_UI_NAMESPACE: /
-      DSPACE_REST_SSL: 'false'
-      DSPACE_REST_HOST: localhost
-      DSPACE_REST_PORT: 8080
-      DSPACE_REST_NAMESPACE: /server
+      DSPACE_UI_SSL: ${DSPACE_UI_SSL:-false}
+      DSPACE_UI_HOST: ${DSPACE_UI_HOST:-dspace-angular}
+      DSPACE_UI_PORT: ${DSPACE_UI_PORT:-4000}
+      DSPACE_UI_NAMESPACE: ${DSPACE_UI_NAMESPACE:-/}
+      DSPACE_REST_SSL: ${DSPACE_REST_SSL:-false}
+      DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
+      DSPACE_REST_PORT: ${DSPACE_REST_PORT:-8080}
+      DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
       # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
-      DSPACE_REST_SSRBASEURL: http://dspace:8080/server
+      DSPACE_REST_SSRBASEURL: ${DSPACE_REST_SSRBASEURL:-http://dspace:8080/server}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}-dist"
     build:
       context: ..

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -36,18 +36,18 @@ services:
       # dspace__P__ui__P__url: http://localhost:4000
       # Set SSR URL to the Docker container name so that UI can contact container directly in Production mode.
       # (This is necessary for docker-compose-dist.yml)
-      dspace__P__server__P__ssr__P__url: http://dspace:8080/server
-      dspace__P__name: 'DSpace Started with Docker Compose'
+      dspace__P__server__P__ssr__P__url: ${dspace__P__server__P__ssr__P__url:-http://dspace:8080/server}
+      dspace__P__name: ${dspace__P__name:-DSpace Started with Docker Compose}
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/dspace}
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}
       # matomo.tracker.url: Ensure we are using the 'matomo' image for Matomo
-      matomo__P__tracker__P__url: http://matomo
+      matomo__P__tracker__P__url: ${matomo__P__tracker__P__url:-http://matomo}
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests 
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
-      proxies__P__trusted__P__ipranges: '172.23.0'
-      LOGGING_CONFIG: /dspace/config/log4j2-container.xml
+      proxies__P__trusted__P__ipranges: ${proxies__P__trusted__P__ipranges:-172.23.0}
+      LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     depends_on:
     - dspacedb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,14 +19,14 @@ services:
   dspace-angular:
     container_name: dspace-angular
     environment:
-      DSPACE_UI_SSL: 'false'
-      DSPACE_UI_HOST: dspace-angular
-      DSPACE_UI_PORT: '4000'
-      DSPACE_UI_NAMESPACE: /
-      DSPACE_REST_SSL: 'false'
-      DSPACE_REST_HOST: localhost
-      DSPACE_REST_PORT: 8080
-      DSPACE_REST_NAMESPACE: /server
+      DSPACE_UI_SSL: ${DSPACE_UI_SSL:-false}
+      DSPACE_UI_HOST: ${DSPACE_UI_HOST:-dspace-angular}
+      DSPACE_UI_PORT: ${DSPACE_UI_PORT:-4000}
+      DSPACE_UI_NAMESPACE: ${DSPACE_UI_NAMESPACE:-/}
+      DSPACE_REST_SSL: ${DSPACE_REST_SSL:-false}
+      DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
+      DSPACE_REST_PORT: ${DSPACE_REST_PORT:-8080}
+      DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}"
     build:
       context: ..


### PR DESCRIPTION
## References
* Discovered while developing #5276 

## Description
Our existing Docker Compose scripts are not allowing for overriding of environment variables in GitHub CI (or similar) because they **hardcode** a specific environment variable value.

So, for instance, in GitHub CI, we often want to override an environment variable like this:
```
env:
  # REST is running on 127.0.0.1 instead of localhost
  DSPACE_REST_HOST: 127.0.0.1
```

However, the `docker-compose-dist.yml` script hardcodes this environment variable like this:
```
environment:
  DSPACE_REST_HOST: localhost
```

So, in this situation, the variable ends up set to `localhost` (the hardcoded value) when we want it set to `127.0.0.1` (the overriding value).

The fix is to update the Docker Compose script to instead accept a different value but _default_ to `localhost` like this:
```
environment:
   # This syntax tells Docker to use the shell environment variable of the same name. If it doesn't exist, default to `localhost`
  DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
```

It appears we haven't encountered this flaw simply because our GitHub CI didn't need to override the default values. The first instance of this required override appears to be in #5276 (where I discovered this flaw).

This update to our Docker scripts should be backported to all active branches as other branches include this same flaw.

## Instructions for Reviewers
* Assuming GitHub CI passes, I plan to merge this immediately as it is blocking #5276. 
    * NOTE: there is a chance this modification will cause CI failures if we are improperly overriding an environment variable in some CI test (and that improper override was previously ignored).