### PR TITLE
fix: hide admin sidebar when user has no admin permissions (#4770)

### DIFF
--- a/src/app/shared/menu/providers/access-control.menu.spec.ts
+++ b/src/app/shared/menu/providers/access-control.menu.spec.ts
@@ -94,4 +94,29 @@ describe('AccessControlMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: AccessControlMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          AccessControlMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+          { provide: ScriptDataService, useClass: ScriptServiceStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(AccessControlMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/access-control.menu.ts
+++ b/src/app/shared/menu/providers/access-control.menu.ts
@@ -15,7 +15,6 @@ import {
   combineLatest as observableCombineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { MenuItemType } from '../menu-item-type.model';
@@ -37,14 +36,19 @@ export class AccessControlMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of({
-      model: {
-        type: MenuItemType.TEXT,
-        text: 'menu.section.access_control',
-      },
-      icon: 'key',
-      visible: true,
-    });
+    return observableCombineLatest([
+      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
+      this.authorizationService.isAuthorized(FeatureID.CanManageGroups),
+    ]).pipe(
+      map(([isSiteAdmin, canManageGroups]) => ({
+        model: {
+          type: MenuItemType.TEXT,
+          text: 'menu.section.access_control',
+        },
+        icon: 'key',
+        visible: isSiteAdmin || canManageGroups,
+      })),
+    );
   }
 
   public getSubSections(): Observable<PartialMenuSection[]> {

--- a/src/app/shared/menu/providers/edit.menu.spec.ts
+++ b/src/app/shared/menu/providers/edit.menu.spec.ts
@@ -93,4 +93,28 @@ describe('EditMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: EditMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          EditMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(EditMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/edit.menu.ts
+++ b/src/app/shared/menu/providers/edit.menu.ts
@@ -14,7 +14,6 @@ import {
   combineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { ThemedEditCollectionSelectorComponent } from '../../dso-selector/modal-wrappers/edit-collection-selector/themed-edit-collection-selector.component';
@@ -37,16 +36,20 @@ export class EditMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of(
-      {
+    return combineLatest([
+      this.authorizationService.isAuthorized(FeatureID.IsCollectionAdmin),
+      this.authorizationService.isAuthorized(FeatureID.IsCommunityAdmin),
+      this.authorizationService.isAuthorized(FeatureID.CanEditItem),
+    ]).pipe(
+      map(([isCollectionAdmin, isCommunityAdmin, canEditItem]) => ({
         accessibilityHandle: 'edit',
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.edit',
         },
         icon: 'pencil',
-        visible: true,
-      },
+        visible: isCollectionAdmin || isCommunityAdmin || canEditItem,
+      })),
     );
   }
 

--- a/src/app/shared/menu/providers/export.menu.spec.ts
+++ b/src/app/shared/menu/providers/export.menu.spec.ts
@@ -82,4 +82,29 @@ describe('ExportMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: ExportMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ExportMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+          { provide: ScriptDataService, useClass: ScriptServiceStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(ExportMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/export.menu.ts
+++ b/src/app/shared/menu/providers/export.menu.ts
@@ -18,7 +18,6 @@ import {
   combineLatest as observableCombineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { ExportBatchSelectorComponent } from '../../dso-selector/modal-wrappers/export-batch-selector/export-batch-selector.component';
@@ -41,16 +40,16 @@ export class ExportMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of(
-      {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      map((isSiteAdmin) => ({
         accessibilityHandle: 'export',
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.export',
         },
         icon: 'file-export',
-        visible: true,
-      },
+        visible: isSiteAdmin,
+      })),
     );
   }
 

--- a/src/app/shared/menu/providers/import.menu.spec.ts
+++ b/src/app/shared/menu/providers/import.menu.spec.ts
@@ -81,4 +81,29 @@ describe('ImportMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: ImportMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          ImportMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+          { provide: ScriptDataService, useClass: ScriptServiceStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(ImportMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/import.menu.ts
+++ b/src/app/shared/menu/providers/import.menu.ts
@@ -18,7 +18,6 @@ import {
   combineLatest as observableCombineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { MenuItemType } from '../menu-item-type.model';
@@ -39,15 +38,15 @@ export class ImportMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of(
-      {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      map((isSiteAdmin) => ({
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.import',
         },
         icon: 'file-import',
-        visible: true,
-      },
+        visible: isSiteAdmin,
+      })),
     );
   }
 

--- a/src/app/shared/menu/providers/new.menu.spec.ts
+++ b/src/app/shared/menu/providers/new.menu.spec.ts
@@ -110,4 +110,28 @@ describe('NewMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: NewMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          NewMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(NewMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/new.menu.ts
+++ b/src/app/shared/menu/providers/new.menu.ts
@@ -14,7 +14,6 @@ import {
   combineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { ThemedCreateCollectionParentSelectorComponent } from '../../dso-selector/modal-wrappers/create-collection-parent-selector/themed-create-collection-parent-selector.component';
@@ -39,16 +38,22 @@ export class NewMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of(
-      {
+    return combineLatest([
+      this.authorizationService.isAuthorized(FeatureID.IsCollectionAdmin),
+      this.authorizationService.isAuthorized(FeatureID.IsCommunityAdmin),
+      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
+      this.authorizationService.isAuthorized(FeatureID.CanSubmit),
+      this.authorizationService.isAuthorized(FeatureID.CoarNotifyEnabled),
+    ]).pipe(
+      map(([isCollectionAdmin, isCommunityAdmin, isSiteAdmin, canSubmit, isCoarNotifyEnabled]) => ({
         accessibilityHandle: 'new',
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.new',
         } as TextMenuItemModel,
         icon: 'plus',
-        visible: true,
-      },
+        visible: isCollectionAdmin || isCommunityAdmin || isSiteAdmin || canSubmit || isCoarNotifyEnabled,
+      })),
     );
   }
 

--- a/src/app/shared/menu/providers/registries.menu.spec.ts
+++ b/src/app/shared/menu/providers/registries.menu.spec.ts
@@ -82,4 +82,29 @@ describe('RegistriesMenuProvider', () => {
       done();
     });
   });
+
+  describe('when user has no permissions', () => {
+    let noPermsProvider: RegistriesMenuProvider;
+    let noPermsAuthStub = new AuthorizationDataServiceStub();
+
+    beforeEach(() => {
+      spyOn(noPermsAuthStub, 'isAuthorized').and.returnValue(of(false));
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          RegistriesMenuProvider,
+          { provide: AuthorizationDataService, useValue: noPermsAuthStub },
+          { provide: ScriptDataService, useClass: ScriptServiceStub },
+        ],
+      });
+      noPermsProvider = TestBed.inject(RegistriesMenuProvider);
+    });
+
+    it('getTopSection should return visible false', (done) => {
+      noPermsProvider.getTopSection().subscribe((section) => {
+        expect(section.visible).toBeFalse();
+        done();
+      });
+    });
+  });
 });

--- a/src/app/shared/menu/providers/registries.menu.ts
+++ b/src/app/shared/menu/providers/registries.menu.ts
@@ -15,7 +15,6 @@ import {
   combineLatest,
   map,
   Observable,
-  of,
 } from 'rxjs';
 
 import { MenuItemType } from '../menu-item-type.model';
@@ -36,15 +35,15 @@ export class RegistriesMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getTopSection(): Observable<PartialMenuSection> {
-    return of(
-      {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      map((isSiteAdmin) => ({
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.registries',
         },
         icon: 'list',
-        visible: true,
-      },
+        visible: isSiteAdmin,
+      })),
     );
   }
 


### PR DESCRIPTION
  ## References
  * Fixes #4770

  ## Description
  Admin sidebar menu providers (New, Edit, Import, Export, Access Control, Registries) had their top-level sections set to `visible: true` unconditionally. This caused the
  sidebar to render for all authenticated users, even those with no admin permissions, showing an empty sidebar with only the pin/unpin toggle.

  Each provider's `getTopSection()` now gates visibility on the same authorization checks used by their subsections, matching the pattern already used by
  `NotificationsMenuProvider` and `CoarNotifyMenuProvider`.

  ## Instructions for Reviewers

  List of changes in this PR:
  * `NewMenuProvider` top section visibility gated on `IsCollectionAdmin || IsCommunityAdmin || AdministratorOf || CanSubmit || CoarNotifyEnabled`
  * `EditMenuProvider` top section visibility gated on `IsCollectionAdmin || IsCommunityAdmin || CanEditItem`
  * `ImportMenuProvider` top section visibility gated on `AdministratorOf`
  * `ExportMenuProvider` top section visibility gated on `AdministratorOf`
  * `AccessControlMenuProvider` top section visibility gated on `AdministratorOf || CanManageGroups`
  * `RegistriesMenuProvider` top section visibility gated on `AdministratorOf`
  * Added "when user has no permissions" unit tests for all 6 providers

  **How to test:**
  1. Log in as a site administrator — admin sidebar should appear with all menu sections
  2. Log in as a community administrator — sidebar should show New, Edit, Access Control
  3. Log in as a collection administrator — sidebar should show New, Edit, Access Control
  4. Log in as a submitter (with submit permissions only) — sidebar should show New only
  5. Log in as an authenticated user with no permissions — **sidebar should not appear at all** (this was the bug)

  ## Checklist
  - [x] My PR is **created against the `main` branch**
  - [x] My PR is **small in size** (12 files changed, ~100 lines net)
  - [x] My PR **passes ESLint** validation using `npm run lint`
  - [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
  - [x] My PR **includes TypeDoc comments** — no new public methods added, existing signatures unchanged
  - [x] My PR **passes all specs/tests and includes new/updated specs or tests** — 6 new test cases added
  - [x] My PR **aligns with Accessibility guidelines** — no UI changes, only visibility logic
  - [x] My PR **uses i18n keys** — no new user-facing text
  - [x] My PR **includes details on how to test it** — see above
  - [x] If my PR fixes an issue ticket, I've linked them together — Fixes #4770
