### PR TITLE
fix OIDC login redirect flow

### DIFF
--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -316,6 +316,7 @@ describe('AuthService test', () => {
       mockStore = TestBed.inject(MockStore);
       authService = TestBed.inject(AuthService);
       mockStore.overrideSelector(isAuthenticated, true);
+      mockStore.overrideSelector(getAuthenticationToken, token);
       mockStore.refreshState();
       storage = (authService as any).storage;
       storage.get = jasmine.createSpy().and.returnValue(null);

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -447,6 +447,45 @@ describe('AuthService test', () => {
       expect(hardRedirectService.redirect).toHaveBeenCalledWith(jasmine.stringMatching(new RegExp('reload/[0-9]*\\?redirect=' + encodeURIComponent('/home'))));
     });
 
+    it('should replace a top-level external redirectUrl', () => {
+      const externalServerUrl = authService.getExternalServerRedirectUrl(
+        'https://dspace.test',
+        '/itemtemplate',
+        '/api/authn/shibboleth?redirectUrl=https://dspace.test/home',
+      );
+
+      expect(externalServerUrl).toBe('/api/authn/shibboleth?redirectUrl=https%3A%2F%2Fdspace.test%2Fitemtemplate');
+    });
+
+    it('should inject redirectUrl into a nested redirect_uri for OIDC providers', () => {
+      const externalServerUrl = authService.getExternalServerRedirectUrl(
+        'https://dspace.test',
+        '/itemtemplate',
+        'https://provider.example/authorize?client_id=test-client&response_type=code&scope=openid%20email&redirect_uri=' +
+        encodeURIComponent('https://rest.test/api/authn/oidc'),
+      );
+
+      const providerUrl = new URL(externalServerUrl);
+      const redirectUri = new URL(providerUrl.searchParams.get('redirect_uri'));
+
+      expect(redirectUri.toString()).toBe('https://rest.test/api/authn/oidc?redirectUrl=https%3A%2F%2Fdspace.test%2Fitemtemplate');
+    });
+
+    it('should preserve existing redirect_uri query params when injecting redirectUrl', () => {
+      const externalServerUrl = authService.getExternalServerRedirectUrl(
+        'https://dspace.test',
+        '/itemtemplate',
+        'https://provider.example/authorize?client_id=test-client&response_type=code&scope=openid%20email&redirect_uri=' +
+        encodeURIComponent('https://rest.test/api/authn/orcid?foo=bar'),
+      );
+
+      const providerUrl = new URL(externalServerUrl);
+      const redirectUri = new URL(providerUrl.searchParams.get('redirect_uri'));
+
+      expect(redirectUri.searchParams.get('foo')).toBe('bar');
+      expect(redirectUri.searchParams.get('redirectUrl')).toBe('https://dspace.test/itemtemplate');
+    });
+
     it('should redirect to regular reload and not to /login', () => {
       authService.navigateToRedirectUrl('/login');
       // Reload without a redirect URL

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -23,7 +23,6 @@ import {
   Store,
 } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import Cookies from 'js-cookie';
 import {
   Observable,
   of,
@@ -613,20 +612,23 @@ export class AuthService {
    */
   getExternalServerRedirectUrl(origin: string, redirectRoute: string, location: string): string {
     const correctRedirectUrl = new URLCombiner(origin, redirectRoute).toString();
+    const externalServerUrl = new URL(location, origin);
 
-    let externalServerUrl = location;
-    const myRegexp = /\?redirectUrl=(.*)/g;
-    const match = myRegexp.exec(location);
-    const redirectUrlFromServer = (match && match[1]) ? match[1] : null;
-
-    // Check whether the current page is different from the redirect url received from rest
-    if (isNotNull(redirectUrlFromServer) && redirectUrlFromServer !== correctRedirectUrl) {
-      // change the redirect url with the current page url
-      const newRedirectUrl = `?redirectUrl=${correctRedirectUrl}`;
-      externalServerUrl = location.replace(/\?redirectUrl=(.*)/g, newRedirectUrl);
+    if (externalServerUrl.searchParams.has('redirectUrl')) {
+      externalServerUrl.searchParams.set('redirectUrl', correctRedirectUrl);
+    } else if (externalServerUrl.searchParams.has('redirect_uri')) {
+      const redirectUri = new URL(externalServerUrl.searchParams.get('redirect_uri'), origin);
+      redirectUri.searchParams.set('redirectUrl', correctRedirectUrl);
+      externalServerUrl.searchParams.set('redirect_uri', redirectUri.toString());
+    } else {
+      externalServerUrl.searchParams.set('redirectUrl', correctRedirectUrl);
     }
 
-    return externalServerUrl;
+    if (isNotNull(location.match(/^https?:\/\//))) {
+      return externalServerUrl.toString();
+    }
+
+    return `${externalServerUrl.pathname}${externalServerUrl.search}${externalServerUrl.hash}`;
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/12133

## Description
This change fixes the post-login redirect behavior for external authentication providers that rely on a nested callback URL, such as OIDC and ORCID.

## Instructions for Reviewers
**Root Cause**
The logic in AuthService.getExternalServerRedirectUrl() only handled this case: `.../login?redirectUrl=<ui-route>`
It did not handle this case: `https://provider.example/authorize?...&redirect_uri=https://rest.example/api/authn/oidc`
As a result, OIDC/ORCID callbacks reached the backend without the intended redirectUrl.

**Implementation**
The redirect URL handling was updated in [src/app/core/auth/auth.service.ts](https://github.com/LA-Referencia-Lyrasis-Project/dspace-docs/blob/main/src/app/core/auth/auth.service.ts) to support three scenarios:
1. If the external URL already has a top-level redirectUrl, replace it.
2. If the external URL has a redirect_uri, append the requested page as redirectUrl to that nested callback URL.
3. If neither parameter exists, add a top-level redirectUrl.

The implementation also preserves existing query parameters already present on the nested redirect_uri.

**List of changes in this PR:** 

1. Redirect URL handling: [src/app/core/auth/auth.service.ts](https://github.com/LA-Referencia-Lyrasis-Project/dspace-docs/blob/main/src/app/core/auth/auth.service.ts)
Updated getExternalServerRedirectUrl() so that it:
- parses the external login URL with URL
- rewrites a top-level redirectUrl when present
- injects redirectUrl into nested redirect_uri values for OIDC/ORCID
- preserves hashes and existing query parameters
- returns either an absolute URL or a path-relative URL, depending on the original input

2. Unit tests: [src/app/core/auth/auth.service.spec.ts](https://github.com/LA-Referencia-Lyrasis-Project/dspace-docs/blob/main/src/app/core/auth/auth.service.spec.ts)
Added coverage for:
- replacing a top-level redirectUrl
- injecting redirectUrl into a nested redirect_uri
- preserving existing nested query parameters when injecting redirectUrl


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
