### PR TITLE
Fix: Full community path in sidebar search results

### DIFF
--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
@@ -3,6 +3,7 @@ import {
   NgClass,
 } from '@angular/common';
 import { Component } from '@angular/core';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { LinkService } from '@dspace/core/cache/builders/link.service';
 import { Context } from '@dspace/core/shared/context.model';
@@ -19,7 +20,6 @@ import { listableObjectComponent } from '../../../../../shared/object-collection
 import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
 import { TruncatableService } from '../../../../../shared/truncatable/truncatable.service';
 import { TruncatablePartComponent } from '../../../../../shared/truncatable/truncatable-part/truncatable-part.component';
-import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
 
 @listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)

--- a/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
+++ b/src/app/entity-groups/research-entities/item-list-elements/sidebar-search-list-elements/person/person-sidebar-search-list-element.component.ts
@@ -19,6 +19,7 @@ import { listableObjectComponent } from '../../../../../shared/object-collection
 import { SidebarSearchListElementComponent } from '../../../../../shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component';
 import { TruncatableService } from '../../../../../shared/truncatable/truncatable.service';
 import { TruncatablePartComponent } from '../../../../../shared/truncatable/truncatable-part/truncatable-part.component';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
 
 @listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent('PersonSearchResult', ViewMode.ListElement, Context.SideBarSearchModalCurrent)
@@ -43,8 +44,9 @@ export class PersonSidebarSearchListElementComponent extends SidebarSearchListEl
               protected linkService: LinkService,
               protected translateService: TranslateService,
               public dsoNameService: DSONameService,
+              protected dsoBreadcrumbsService: DSOBreadcrumbsService,
   ) {
-    super(truncatableService, linkService, dsoNameService);
+    super(truncatableService, linkService, dsoNameService, dsoBreadcrumbsService);
   }
 
   /**

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
@@ -2,7 +2,10 @@ import { Collection } from '@dspace/core/shared/collection.model';
 import { Community } from '@dspace/core/shared/community.model';
 import { CollectionSearchResult } from '@dspace/core/shared/object-collection/collection-search-result.model';
 
-import { createHierarchicalParentTitleTests, createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+import {
+  createHierarchicalParentTitleTests,
+  createSidebarSearchListElementTests,
+} from '../sidebar-search-list-element.component.spec';
 import { CollectionSidebarSearchListElementComponent } from './collection-sidebar-search-list-element.component';
 
 const object = Object.assign(new CollectionSearchResult(), {
@@ -38,5 +41,5 @@ describe('CollectionSidebarSearchListElementComponent',
 );
 
 describe('CollectionSidebarSearchListElementComponent - hierarchical path',
-  createHierarchicalParentTitleTests(CollectionSidebarSearchListElementComponent, object, 'title')
+  createHierarchicalParentTitleTests(CollectionSidebarSearchListElementComponent, object, 'title'),
 );

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.spec.ts
@@ -2,7 +2,7 @@ import { Collection } from '@dspace/core/shared/collection.model';
 import { Community } from '@dspace/core/shared/community.model';
 import { CollectionSearchResult } from '@dspace/core/shared/object-collection/collection-search-result.model';
 
-import { createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+import { createHierarchicalParentTitleTests, createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
 import { CollectionSidebarSearchListElementComponent } from './collection-sidebar-search-list-element.component';
 
 const object = Object.assign(new CollectionSearchResult(), {
@@ -34,5 +34,9 @@ const parent = Object.assign(new Community(), {
 });
 
 describe('CollectionSidebarSearchListElementComponent',
-  createSidebarSearchListElementTests(CollectionSidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description'),
+  createSidebarSearchListElementTests(CollectionSidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description', [], true),
+);
+
+describe('CollectionSidebarSearchListElementComponent - hierarchical path',
+  createHierarchicalParentTitleTests(CollectionSidebarSearchListElementComponent, object, 'title')
 );

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
@@ -12,6 +12,10 @@ import { TranslateModule } from '@ngx-translate/core';
 import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
 import { TruncatablePartComponent } from '../../../truncatable/truncatable-part/truncatable-part.component';
 import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
+import { TruncatableService } from '../../../truncatable/truncatable.service';
+import { LinkService } from '../../../../core/cache/builders/link.service';
+import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
+import { DSOBreadcrumbsService } from '../../../../core/breadcrumbs/dso-breadcrumbs.service';
 
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
@@ -31,6 +35,16 @@ import { SidebarSearchListElementComponent } from '../sidebar-search-list-elemen
  * Component displaying a list element for a {@link CollectionSearchResult} within the context of a sidebar search modal
  */
 export class CollectionSidebarSearchListElementComponent extends SidebarSearchListElementComponent<CollectionSearchResult, Collection> {
+
+  constructor(
+    protected truncatableService: TruncatableService,
+    protected linkService: LinkService,
+    public dsoNameService: DSONameService,
+    protected dsoBreadcrumbsService: DSOBreadcrumbsService,
+  ) {
+    super(truncatableService, linkService, dsoNameService, dsoBreadcrumbsService);
+  }
+
   /**
    * Get the description of the Collection by returning its abstract
    */

--- a/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/collection/collection-sidebar-search-list-element.component.ts
@@ -3,19 +3,19 @@ import {
   NgClass,
 } from '@angular/common';
 import { Component } from '@angular/core';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
+import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
+import { LinkService } from '@dspace/core/cache/builders/link.service';
 import { Collection } from '@dspace/core/shared/collection.model';
 import { Context } from '@dspace/core/shared/context.model';
 import { CollectionSearchResult } from '@dspace/core/shared/object-collection/collection-search-result.model';
 import { ViewMode } from '@dspace/core/shared/view-mode.model';
 import { TranslateModule } from '@ngx-translate/core';
+import { listableObjectComponent } from 'src/app/shared/object-collection/shared/listable-object/listable-object.decorator';
+import { TruncatableService } from 'src/app/shared/truncatable/truncatable.service';
+import { TruncatablePartComponent } from 'src/app/shared/truncatable/truncatable-part/truncatable-part.component';
 
-import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
-import { TruncatablePartComponent } from '../../../truncatable/truncatable-part/truncatable-part.component';
 import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
-import { TruncatableService } from '../../../truncatable/truncatable.service';
-import { LinkService } from '../../../../core/cache/builders/link.service';
-import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
-import { DSOBreadcrumbsService } from '../../../../core/breadcrumbs/dso-breadcrumbs.service';
 
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent(CollectionSearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
@@ -1,7 +1,7 @@
 import { Community } from '@dspace/core/shared/community.model';
 import { CommunitySearchResult } from '@dspace/core/shared/object-collection/community-search-result.model';
 
-import { createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+import { createHierarchicalParentTitleTests, createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
 import { CommunitySidebarSearchListElementComponent } from './community-sidebar-search-list-element.component';
 
 const object = Object.assign(new CommunitySearchResult(), {
@@ -33,5 +33,9 @@ const parent = Object.assign(new Community(), {
 });
 
 describe('CommunitySidebarSearchListElementComponent',
-  createSidebarSearchListElementTests(CommunitySidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description'),
+  createSidebarSearchListElementTests(CommunitySidebarSearchListElementComponent, object, parent, 'parent title', 'title', 'description', [], true),
+);
+
+describe('CommunitySidebarSearchListElementComponent - hierarchical path',
+  createHierarchicalParentTitleTests(CommunitySidebarSearchListElementComponent, object, 'title')
 );

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.spec.ts
@@ -1,7 +1,10 @@
 import { Community } from '@dspace/core/shared/community.model';
 import { CommunitySearchResult } from '@dspace/core/shared/object-collection/community-search-result.model';
 
-import { createHierarchicalParentTitleTests, createSidebarSearchListElementTests } from '../sidebar-search-list-element.component.spec';
+import {
+  createHierarchicalParentTitleTests,
+  createSidebarSearchListElementTests,
+} from '../sidebar-search-list-element.component.spec';
 import { CommunitySidebarSearchListElementComponent } from './community-sidebar-search-list-element.component';
 
 const object = Object.assign(new CommunitySearchResult(), {
@@ -37,5 +40,5 @@ describe('CommunitySidebarSearchListElementComponent',
 );
 
 describe('CommunitySidebarSearchListElementComponent - hierarchical path',
-  createHierarchicalParentTitleTests(CommunitySidebarSearchListElementComponent, object, 'title')
+  createHierarchicalParentTitleTests(CommunitySidebarSearchListElementComponent, object, 'title'),
 );

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
@@ -11,7 +11,11 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
 import { TruncatablePartComponent } from '../../../truncatable/truncatable-part/truncatable-part.component';
+import { TruncatableService } from '../../../truncatable/truncatable.service';
 import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
+import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
+import { LinkService } from '@dspace/core/cache/builders/link.service';
 
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)
@@ -31,6 +35,16 @@ import { SidebarSearchListElementComponent } from '../sidebar-search-list-elemen
  * Component displaying a list element for a {@link CommunitySearchResult} within the context of a sidebar search modal
  */
 export class CommunitySidebarSearchListElementComponent extends SidebarSearchListElementComponent<CommunitySearchResult, Community> {
+
+  constructor(
+    protected truncatableService: TruncatableService,
+    protected linkService: LinkService,
+    public dsoNameService: DSONameService,
+    protected dsoBreadcrumbsService: DSOBreadcrumbsService,
+  ) {
+    super(truncatableService, linkService, dsoNameService, dsoBreadcrumbsService);
+  }
+
   /**
    * Get the description of the Community by returning its abstract
    */

--- a/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/community/community-sidebar-search-list-element.component.ts
@@ -3,19 +3,20 @@ import {
   NgClass,
 } from '@angular/common';
 import { Component } from '@angular/core';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
+import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
+import { LinkService } from '@dspace/core/cache/builders/link.service';
 import { Community } from '@dspace/core/shared/community.model';
 import { Context } from '@dspace/core/shared/context.model';
 import { CommunitySearchResult } from '@dspace/core/shared/object-collection/community-search-result.model';
 import { ViewMode } from '@dspace/core/shared/view-mode.model';
 import { TranslateModule } from '@ngx-translate/core';
+import { listableObjectComponent } from 'src/app/shared/object-collection/shared/listable-object/listable-object.decorator';
+import { TruncatableService } from 'src/app/shared/truncatable/truncatable.service';
+import { TruncatablePartComponent } from 'src/app/shared/truncatable/truncatable-part/truncatable-part.component';
 
-import { listableObjectComponent } from '../../../object-collection/shared/listable-object/listable-object.decorator';
-import { TruncatablePartComponent } from '../../../truncatable/truncatable-part/truncatable-part.component';
-import { TruncatableService } from '../../../truncatable/truncatable.service';
 import { SidebarSearchListElementComponent } from '../sidebar-search-list-element.component';
-import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
-import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
-import { LinkService } from '@dspace/core/cache/builders/link.service';
+
 
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModal)
 @listableObjectComponent(CommunitySearchResult, ViewMode.ListElement, Context.SideBarSearchModalCurrent)

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.html
@@ -1,6 +1,8 @@
 <ds-truncatable-part [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'" [showToggle]="false">
+  @let parentTitle = parentTitle$ | async;
   <div [ngClass]="isCurrent() ? 'text-light' : 'text-body'"
-  [innerHTML]="(parentTitle$ && parentTitle$ | async) ? (parentTitle$ | async) : ('home.breadcrumbs' | translate)"></div>
+       [title]="parentTitle || ('home.breadcrumbs' | translate)"
+       [innerHTML]="parentTitle || ('home.breadcrumbs' | translate)"></div>
 </ds-truncatable-part>
 <ds-truncatable-part [maxLines]="1" [background]="isCurrent() ? 'primary' : 'default'" [showToggle]="false">
   <div class="fw-bold"

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
@@ -6,25 +6,28 @@ import {
 } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
+import { Breadcrumb } from '@dspace/core/breadcrumbs/models/breadcrumb.model';
 import { LinkService } from '@dspace/core/cache/builders/link.service';
 import { ChildHALResource } from '@dspace/core/shared/child-hal-resource.model';
 import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
 import { HALResource } from '@dspace/core/shared/hal-resource.model';
+import { ResourceType } from '@dspace/core/shared/resource-type';
 import { SearchResult } from '@dspace/core/shared/search/models/search-result.model';
 import { mockTruncatableService } from '@dspace/core/testing/mock-trucatable.service';
-import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
+import {
+  createNoContentRemoteDataObject$,
+  createSuccessfulRemoteDataObject$,
+} from '@dspace/core/utilities/remote-data.utils';
 import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
 import { TruncatableService } from '../../truncatable/truncatable.service';
 import { TruncatablePartComponent } from '../../truncatable/truncatable-part/truncatable-part.component';
 import { VarDirective } from '../../utils/var.directive';
-import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
-import { Breadcrumb } from '@dspace/core/breadcrumbs/models/breadcrumb.model';
-import { ResourceType } from '@dspace/core/shared/resource-type';
-import { createNoContentRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
-import { of as observableOf } from 'rxjs';
 import { BREADCRUMB_SEPARATOR } from './sidebar-search-list-element.component';
+
 
 export function createSidebarSearchListElementTests(
   componentClass: any,
@@ -34,7 +37,7 @@ export function createSidebarSearchListElementTests(
   expectedTitle: string,
   expectedDescription: string,
   extraProviders: any[] = [],
-  assertBreadcrumbsUsed = false
+  assertBreadcrumbsUsed = false,
 ) {
   return () => {
     let component;
@@ -68,7 +71,7 @@ export function createSidebarSearchListElementTests(
       }
       breadcrumbs.push(new Breadcrumb(expectedTitle, ''));
       dsoBreadcrumbsService = jasmine.createSpyObj('dsoBreadcrumbsService', {
-        getBreadcrumbs: observableOf(breadcrumbs)
+        getBreadcrumbs: of(breadcrumbs),
       });
       TestBed.configureTestingModule({
         imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), VarDirective],
@@ -104,7 +107,7 @@ export function createSidebarSearchListElementTests(
         component.parentTitle$.subscribe(() => {
           expect(dsoBreadcrumbsService.getBreadcrumbs).toHaveBeenCalledWith(
             object.indexableObject,
-            ''
+            '',
           );
           done();
         });
@@ -136,7 +139,7 @@ export function createHierarchicalParentTitleTests(
   componentClass: any,
   object: SearchResult<DSpaceObject & ChildHALResource>,
   expectedTitle: string,
-  extraProviders: any[] = []
+  extraProviders: any[] = [],
 ) {
   return () => {
     let component;
@@ -163,11 +166,11 @@ export function createHierarchicalParentTitleTests(
       const parentLinkKey = (object.indexableObject as ChildHALResource).getParentLinkKey() as string;
       const linkService = jasmine.createSpyObj('linkService', {
         resolveLink: Object.assign(new HALResource(), {
-          [parentLinkKey]: createNoContentRemoteDataObject$()
-        })
+          [parentLinkKey]: createNoContentRemoteDataObject$(),
+        }),
       });
       dsoBreadcrumbsService = jasmine.createSpyObj('dsoBreadcrumbsService', {
-        getBreadcrumbs: observableOf(breadcrumbs)
+        getBreadcrumbs: of(breadcrumbs),
       });
 
       TestBed.configureTestingModule({
@@ -202,7 +205,7 @@ export function createHierarchicalParentTitleTests(
       component.parentTitle$.subscribe(() => {
         expect(dsoBreadcrumbsService.getBreadcrumbs).toHaveBeenCalledWith(
           object.indexableObject,
-          ''
+          '',
         );
         done();
       });

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
@@ -19,6 +19,12 @@ import { TranslateModule } from '@ngx-translate/core';
 import { TruncatableService } from '../../truncatable/truncatable.service';
 import { TruncatablePartComponent } from '../../truncatable/truncatable-part/truncatable-part.component';
 import { VarDirective } from '../../utils/var.directive';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
+import { Breadcrumb } from '@dspace/core/breadcrumbs/models/breadcrumb.model';
+import { ResourceType } from '@dspace/core/shared/resource-type';
+import { createNoContentRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
+import { of as observableOf } from 'rxjs';
+import { BREADCRUMB_SEPARATOR } from './sidebar-search-list-element.component';
 
 export function createSidebarSearchListElementTests(
   componentClass: any,
@@ -28,12 +34,14 @@ export function createSidebarSearchListElementTests(
   expectedTitle: string,
   expectedDescription: string,
   extraProviders: any[] = [],
+  assertBreadcrumbsUsed = false
 ) {
   return () => {
     let component;
     let fixture: ComponentFixture<any>;
 
     let linkService;
+    let dsoBreadcrumbsService;
 
     const environment = {
       browseBy: {
@@ -42,10 +50,25 @@ export function createSidebarSearchListElementTests(
     };
 
     beforeEach(waitForAsync(() => {
+      // Propagate the class-level static ResourceType onto the instance so that
+      // the community/collection branch in getParentTitle() is reached correctly.
+      const staticType: ResourceType | undefined = (object.indexableObject.constructor as any).type;
+      if (staticType) {
+        (object.indexableObject as any).type = staticType;
+      }
+
       linkService = jasmine.createSpyObj('linkService', {
         resolveLink: Object.assign(new HALResource(), {
           [object.indexableObject.getParentLinkKey()]: createSuccessfulRemoteDataObject$(parent),
         }),
+      });
+      const breadcrumbs: Breadcrumb[] = [];
+      if (expectedParentTitle) {
+        breadcrumbs.push(new Breadcrumb(expectedParentTitle, ''));
+      }
+      breadcrumbs.push(new Breadcrumb(expectedTitle, ''));
+      dsoBreadcrumbsService = jasmine.createSpyObj('dsoBreadcrumbsService', {
+        getBreadcrumbs: observableOf(breadcrumbs)
       });
       TestBed.configureTestingModule({
         imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), VarDirective],
@@ -53,6 +76,7 @@ export function createSidebarSearchListElementTests(
           { provide: TruncatableService, useValue: mockTruncatableService },
           { provide: LinkService, useValue: linkService },
           { provide: APP_CONFIG, useValue: environment },
+          { provide: DSOBreadcrumbsService, useValue: dsoBreadcrumbsService },
           DSONameService,
           ...extraProviders,
         ],
@@ -75,12 +99,113 @@ export function createSidebarSearchListElementTests(
       });
     });
 
+    if (assertBreadcrumbsUsed) {
+      it('should delegate to DSOBreadcrumbsService.getBreadcrumbs to resolve the parent title', (done) => {
+        component.parentTitle$.subscribe(() => {
+          expect(dsoBreadcrumbsService.getBreadcrumbs).toHaveBeenCalledWith(
+            object.indexableObject,
+            ''
+          );
+          done();
+        });
+      });
+    }
+
     it('should contain the correct title', () => {
       expect(component.dsoTitle).toEqual(expectedTitle);
     });
 
     it('should contain the correct description', () => {
       expect(component.description).toEqual(expectedDescription);
+    });
+  };
+}
+
+/**
+ * Shared test suite that verifies the hierarchical parent-path behaviour for community/collection
+ * list elements: when the DSO has multiple ancestor breadcrumbs the component must join them with
+ * {@link BREADCRUMB_SEPARATOR} and must delegate to {@link DSOBreadcrumbsService#getBreadcrumbs} rather than the simple
+ * parent link.
+ *
+ * @param componentClass  The component under test (community or collection sidebar element)
+ * @param object          A {@link SearchResult} whose `indexableObject` is a Community/Collection
+ * @param expectedTitle   The dc.title of the current item (last breadcrumb)
+ * @param extraProviders  Any additional providers required by the component
+ */
+export function createHierarchicalParentTitleTests(
+  componentClass: any,
+  object: SearchResult<DSpaceObject & ChildHALResource>,
+  expectedTitle: string,
+  extraProviders: any[] = []
+) {
+  return () => {
+    let component;
+    let fixture: ComponentFixture<any>;
+    let dsoBreadcrumbsService;
+
+    // Three-level hierarchy:  Root → Parent → Current
+    const rootBreadcrumb   = new Breadcrumb('Root',    '');
+    const parentBreadcrumb = new Breadcrumb('Parent',  '');
+    const currentBreadcrumb = new Breadcrumb(expectedTitle, '');
+    const breadcrumbs = [rootBreadcrumb, parentBreadcrumb, currentBreadcrumb];
+
+    beforeEach(waitForAsync(() => {
+      // Propagate the class-level static ResourceType onto the instance so that
+      // the community/collection branch in getParentTitle() is reached correctly.
+      const staticType: ResourceType | undefined = (object.indexableObject.constructor as any).type;
+      if (staticType) {
+        (object.indexableObject as any).type = staticType;
+      }
+
+      // Set up the linkService with a safe RemoteData observable for the parent link so that
+      // even if the type-check guard ever regresses, the fallback getParent() path resolves
+      // cleanly via the find() predicate (statusCode === 204) without a TypeError.
+      const parentLinkKey = (object.indexableObject as ChildHALResource).getParentLinkKey() as string;
+      const linkService = jasmine.createSpyObj('linkService', {
+        resolveLink: Object.assign(new HALResource(), {
+          [parentLinkKey]: createNoContentRemoteDataObject$()
+        })
+      });
+      dsoBreadcrumbsService = jasmine.createSpyObj('dsoBreadcrumbsService', {
+        getBreadcrumbs: observableOf(breadcrumbs)
+      });
+
+      TestBed.configureTestingModule({
+        imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), VarDirective],
+        providers: [
+          { provide: TruncatableService, useValue: {} },
+          { provide: LinkService, useValue: linkService },
+          { provide: DSOBreadcrumbsService, useValue: dsoBreadcrumbsService },
+          DSONameService,
+          ...extraProviders,
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+      }).overrideComponent(componentClass, { remove: { imports: [TruncatablePartComponent] } }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(componentClass);
+      component = fixture.componentInstance;
+      component.object = object;
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should join multiple ancestor breadcrumbs with BREADCRUMB_SEPARATOR as the parent title', (done) => {
+      component.parentTitle$.subscribe((title) => {
+        expect(title).toEqual(['Root', 'Parent'].join(BREADCRUMB_SEPARATOR));
+        done();
+      });
+    });
+
+    it('should call DSOBreadcrumbsService.getBreadcrumbs to build the hierarchy path', (done) => {
+      component.parentTitle$.subscribe(() => {
+        expect(dsoBreadcrumbsService.getBreadcrumbs).toHaveBeenCalledWith(
+          object.indexableObject,
+          ''
+        );
+        done();
+      });
     });
   };
 }

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.ts
@@ -6,12 +6,14 @@ import {
   Component,
   OnInit,
 } from '@angular/core';
+import { DSOBreadcrumbsService } from '@dspace/core/breadcrumbs/dso-breadcrumbs.service';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { LinkService } from '@dspace/core/cache/builders/link.service';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { ChildHALResource } from '@dspace/core/shared/child-hal-resource.model';
 import { Context } from '@dspace/core/shared/context.model';
 import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
+import { DSpaceObjectType } from '@dspace/core/shared/dspace-object-type.model';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { SearchResult } from '@dspace/core/shared/search/models/search-result.model';
 import {
@@ -26,11 +28,15 @@ import {
 import {
   find,
   map,
+  shareReplay,
 } from 'rxjs/operators';
 
 import { TruncatableService } from '../../truncatable/truncatable.service';
 import { TruncatablePartComponent } from '../../truncatable/truncatable-part/truncatable-part.component';
 import { SearchResultListElementComponent } from '../search-result-list-element/search-result-list-element.component';
+
+/** Separator used when joining hierarchical breadcrumb labels into a single parent-title string. */
+export const BREADCRUMB_SEPARATOR = ' / ';
 
 @Component({
   selector: 'ds-sidebar-search-list-element',
@@ -61,6 +67,7 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
   public constructor(protected truncatableService: TruncatableService,
                      protected linkService: LinkService,
                      public dsoNameService: DSONameService,
+                     protected dsoBreadcrumbsService: DSOBreadcrumbsService,
   ) {
     super(truncatableService, dsoNameService, null);
   }
@@ -84,14 +91,42 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
   }
 
   /**
-   * Get the title of the object's parent
-   * Retrieve the parent by using the object's parent link and retrieving its 'dc.title' metadata
+   * Type guard that narrows a {@link DSpaceObject} to {@link ChildHALResource} & {@link DSpaceObject},
+   * which is the signature expected by {@link DSOBreadcrumbsService#getBreadcrumbs}.
+   */
+  private isChildHALResource(dso: DSpaceObject): dso is ChildHALResource & DSpaceObject {
+    return typeof (dso as unknown as ChildHALResource).getParentLinkKey === 'function';
+  }
+
+  /**
+   * Get the title of the object's parent(s)
+   * For communities and collections, show the full hierarchical path excluding the current item
+   * For other objects, show just the immediate parent
    */
   getParentTitle(): Observable<string> {
+    // Fallback handles cases where type is a raw string rather than a ResourceType instance
+    const typeValue = this.dso.type?.value ?? (this.dso as any).type;
+    const dso: DSpaceObject = this.dso;
+    if (dso && this.isChildHALResource(dso) && (typeValue === DSpaceObjectType.COMMUNITY.toLowerCase() || typeValue === DSpaceObjectType.COLLECTION.toLowerCase())) {
+      // For communities and collections, build hierarchical path via breadcrumbs
+      return this.dsoBreadcrumbsService.getBreadcrumbs(dso, '').pipe(
+        map(breadcrumbs => {
+          // Remove the last breadcrumb (current item) and join the rest with ' / '
+          const parentBreadcrumbs = breadcrumbs.slice(0, -1);
+          return parentBreadcrumbs.length > 0
+            ? parentBreadcrumbs.map(crumb => crumb.text).join(BREADCRUMB_SEPARATOR)
+            : undefined;
+        }),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      );
+    }
+
+    // For other DSO types, use the simple parent
     return this.getParent().pipe(
       map((parentRD: RemoteData<DSpaceObject>) => {
-        return hasValue(parentRD) && hasValue(parentRD.payload) ? this.dsoNameService.getName(parentRD.payload, true) : undefined;
+        return hasValue(parentRD) && hasValue(parentRD.payload) ? this.dsoNameService.getName(parentRD.payload) : undefined;
       }),
+      shareReplay({ bufferSize: 1, refCount: true }),
     );
   }
 
@@ -99,8 +134,8 @@ export class SidebarSearchListElementComponent<T extends SearchResult<K>, K exte
    * Get the parent of the object
    */
   getParent(): Observable<RemoteData<DSpaceObject>> {
-    if (typeof (this.dso as any).getParentLinkKey === 'function') {
-      const propertyName = (this.dso as any).getParentLinkKey();
+    if (this.isChildHALResource(this.dso)) {
+      const propertyName = this.dso.getParentLinkKey() as string;
       return this.linkService.resolveLink(this.dso, followLink(propertyName))[propertyName].pipe(
         find((parentRD: RemoteData<ChildHALResource & DSpaceObject>) => parentRD.hasSucceeded || parentRD.statusCode === 204),
       );


### PR DESCRIPTION
## Problem description
Fixes https://github.com/DSpace/dspace-angular/issues/1602

Display the complete hierarchical path from the root to the parent for communities and collections in the sidebar search modal, instead of showing only the immediate parent.

Currently, when multiple communities contain community or collections with the same name, the UI does not provide enough context to distinguish between them.

**For example:**
Community1 / DSpace/ Collection
Community2 / DSpace/ Collection

When creating an item, the search modal shows:
<img width="523" height="568" alt="image" src="https://github.com/user-attachments/assets/d5b3ac7e-291c-4fb6-a274-507c72baf86b" />

Since both entries appear identical, users cannot determine which collection they are selecting.

When the community or collection name is too long, it is truncated with “...”, and the full name is not visible even when hovering over it.
<img width="547" height="287" alt="image" src="https://github.com/user-attachments/assets/abac06bd-07d1-44b6-99c9-6c9866b62ded" />

## Solution
Show the full hierarchical path for each result, allowing users to clearly identify the correct location. Additionally, when a community or collection name is truncated, hovering over it now displays the full name, ensuring it remains fully visible.

<img width="1061" height="406" alt="image" src="https://github.com/user-attachments/assets/07e00dac-2b93-408e-be44-0fab843e4c7c" />

<img width="1263" height="418" alt="image" src="https://github.com/user-attachments/assets/e239ff26-11e0-48ad-acc1-a34262723d72" />

## Instructions for Reviewers

Run the application and verify that the sidebar search modal (when creating a new community, collection, or item) displays the full hierarchical path instead of only the immediate parent.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
