### PR TITLE
fix: prevent drop files overlay from appearing when dragging text

### DIFF
--- a/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.ts
+++ b/src/app/shared/upload/file-dropzone-no-uploader/file-dropzone-no-uploader.component.ts
@@ -87,6 +87,11 @@ export class FileDropzoneNoUploaderComponent implements OnInit {
 
   @HostListener('window:dragover', ['$event'])
   onDragOver(event: DragEvent) {
+    // Only show drop area when dragging files or event is manually triggered
+    const hasFiles = event.dataTransfer?.types ? Array.from(event.dataTransfer.types).includes('Files') : true;
+    if (!hasFiles) {
+      return;
+    }
     // Show drop area on the page
     event.preventDefault();
     event.stopPropagation();

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -128,6 +128,11 @@ export class UploaderComponent implements OnInit, AfterViewInit {
   onDragOver(event: any) {
 
     if (this.enableDragOverDocument && this.dragService.isAllowedDragOverPage()) {
+      // Only show drop area when dragging files or event is manually triggered
+      const hasFiles = event.dataTransfer?.types ? Array.from(event.dataTransfer.types).includes('Files') : true;
+      if (!hasFiles) {
+        return;
+      }
       // Show drop area on the page
       event.preventDefault();
       if ((event.target as any).tagName !== 'HTML') {


### PR DESCRIPTION
## References
* Fixes #1268 
* Port of #5164 

## Description
Prevent the "drop files" overlay from appearing when dragging text selections in Firefox on submission pages.

List of changes in this PR:
- Added `dataTransfer.types.includes('Files')` guard in `UploaderComponent.onDragOver() (uploader.component.ts`)
- Added the same guard in `FileDropzoneNoUploaderComponent.onDragOver() (file-dropzone-no-uploader.component.ts)
`

## Instructions for Reviewers
1. Open the application in Firefox
2. Navigate to a new submission or edit a workspace item
3. Select some text on the page
4. Drag the text selection around the page
5. Expected: The "Drop files" overlay should NOT appear
6. Now drag an actual file from your file explorer onto the page
7. Expected: The "Drop files" overlay should appear as normal

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).