### PR TITLE
fix 5310 : show social links bar on non-scrollable item pages

### DIFF
--- a/src/app/social/social.component.html
+++ b/src/app/social/social.component.html
@@ -1,6 +1,6 @@
 <div id="dspace-a2a"
   [class.d-none]="(showOnCurrentRoute$ | async) !== true"
-  class="a2a_kit a2a_kit_size_32 a2a_floating_style a2a_default_style"
+  class="a2a_kit a2a_kit_size_32 a2a_floating_style a2a_vertical_style"
   [attr.data-a2a-title]="title"
   [attr.data-a2a-url]="url">
   @for (button of buttonList; track button) {

--- a/src/app/social/social.component.scss
+++ b/src/app/social/social.component.scss
@@ -1,12 +1,11 @@
 ::ng-deep {
   #dspace-a2a {
     z-index: 998;
-    display: flex !important;
-    justify-content: center !important;
-    width: 100% !important;
-    position: relative !important;
-    bottom: auto !important;
-    right: auto !important;
-    padding: 8px 0;
+    right: 0px !important;
+    top: 150px !important;
+
+    @media screen and (max-width: 980px) {
+      display: none !important;
+    }
   }
 }

--- a/src/app/social/social.component.spec.ts
+++ b/src/app/social/social.component.spec.ts
@@ -15,7 +15,6 @@ import { SocialService } from './social.service';
 describe('SocialComponent', () => {
   let component: SocialComponent;
   let fixture: ComponentFixture<SocialComponent>;
-  let document: Document;
 
   const socialServiceStub = {};
   const activatedRouteStub = {} as ActivatedRoute;
@@ -30,80 +29,12 @@ describe('SocialComponent', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(SocialComponent);
     component = fixture.componentInstance;
-    document = TestBed.inject(DOCUMENT) as any;
     fixture.detectChanges();
   });
 
   it('should create socialComponent', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should embed social bar inside footer when social is enabled', fakeAsync(() => {
-    const doc = TestBed.inject(DOCUMENT);
-    const footer = doc.createElement('footer');
-    doc.body.appendChild(footer);
-
-    (component as any).socialService = {
-      enabled: true,
-      configuration: { buttons: [], showPlusButton: false, showCounters: false, title: '' },
-      initializeAddToAnyScript: () => {},
-      showOnCurrentRoute$: null,
-    };
-
-    component.ngAfterViewInit();
-    tick(1100);
-
-    const bar = doc.getElementById('dspace-a2a');
-    expect(footer.contains(bar)).toBeTrue();
-    expect(bar.style.position).toBe('relative');
-    expect(bar.style.opacity).toBe('1');
-    expect(bar.style.pointerEvents).toBe('auto');
-
-    doc.body.removeChild(footer);
-  }));
-
-  it('should not move bar if social is disabled', fakeAsync(() => {
-    const doc = TestBed.inject(DOCUMENT);
-    const footer = doc.createElement('footer');
-    doc.body.appendChild(footer);
-
-    (component as any).socialService = { enabled: false };
-    component.ngAfterViewInit();
-    tick(1100);
-
-    const bar = doc.getElementById('dspace-a2a');
-    if (bar) {
-      expect(footer.contains(bar)).toBeFalse();
-      expect(bar.style.position).not.toBe('relative');
-      expect(bar.style.opacity).not.toBe('1');
-    } else {
-      expect(bar).toBeNull();
-    }
-
-    doc.body.removeChild(footer);
-  }));
-
-  it('should not move bar if platform is not browser', fakeAsync(() => {
-    const doc = TestBed.inject(DOCUMENT);
-    const footer = doc.createElement('footer');
-    doc.body.appendChild(footer);
-
-    (component as any).platformId = 'server';
-    (component as any).socialService = { enabled: true };
-    component.ngAfterViewInit();
-    tick(1100);
-
-    const bar = doc.getElementById('dspace-a2a');
-    if (bar) {
-      expect(footer.contains(bar)).toBeFalse();
-      expect(bar.style.position).not.toBe('relative');
-      expect(bar.style.opacity).not.toBe('1');
-    } else {
-      expect(bar).toBeNull();
-    }
-
-    doc.body.removeChild(footer);
-  }));
 
   it('should initialize properties from socialService configuration on ngOnInit', () => {
     const config = {
@@ -130,7 +61,6 @@ describe('SocialComponent', () => {
 
   describe('toggle d-none', () => {
     let toggleFixture: ComponentFixture<SocialComponent>;
-    let toggleComponent: SocialComponent;
     let showOnCurrentRoute$: BehaviorSubject<boolean>;
 
     beforeEach(async () => {
@@ -154,7 +84,6 @@ describe('SocialComponent', () => {
       }).compileComponents();
 
       toggleFixture = TestBed.createComponent(SocialComponent);
-      toggleComponent = toggleFixture.componentInstance;
       toggleFixture.detectChanges();
     });
 

--- a/src/app/social/social.component.ts
+++ b/src/app/social/social.component.ts
@@ -1,15 +1,8 @@
+import { AsyncPipe } from '@angular/common';
 import {
-  AsyncPipe,
-  DOCUMENT,
-  isPlatformBrowser,
-} from '@angular/common';
-import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  Inject,
   OnInit,
-  PLATFORM_ID,
 } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -27,7 +20,7 @@ import { SocialService } from './social.service';
 /**
  * Component to render dynamically the social2 buttons using addToAny plugin
  */
-export class SocialComponent implements OnInit, AfterViewInit {
+export class SocialComponent implements OnInit {
 
 
   /**
@@ -44,8 +37,6 @@ export class SocialComponent implements OnInit, AfterViewInit {
 
   constructor(
     private socialService: SocialService,
-    @Inject(PLATFORM_ID) private platformId: object,
-    @Inject(DOCUMENT) private _document: Document,
   ) {}
 
   ngOnInit() {
@@ -57,28 +48,6 @@ export class SocialComponent implements OnInit, AfterViewInit {
       this.socialService.initializeAddToAnyScript();
       this.showOnCurrentRoute$ = this.socialService.showOnCurrentRoute$;
     }
-  }
-
-  /**
-   * Embeds the social links bar inside the footer so it is always visible
-   * on all pages, including item pages that do not scroll.
-   */
-  ngAfterViewInit() {
-    if (!this.socialService.enabled || !isPlatformBrowser(this.platformId)) {return;}
-
-    setTimeout(() => {
-      const footer = this._document.querySelector('footer');
-      const bar = this._document.getElementById('dspace-a2a');
-      if (!footer || !bar) {return;}
-
-      bar.classList.remove('a2a_floating_style');
-      bar.style.setProperty('position', 'relative', 'important');
-      bar.style.setProperty('opacity', '1', 'important');
-      bar.style.setProperty('pointer-events', 'auto', 'important');
-      bar.style.bottom = 'auto';
-      bar.style.right = 'auto';
-      footer.prepend(bar);
-    }, 1000);
   }
 
 }


### PR DESCRIPTION
## References
Fixes #5310

## Description
The Social Links bar was only visible on pages that required scrolling. This fix detects whether the page is scrollable and adjusts the AddToAny plugin behavior accordingly, so the bar appears on all pages including short Item pages.

## Instructions for Reviewers
List of changes in this PR:

1. In social.component.ts: Added AfterViewInit lifecycle hook that detects whether the current page has a scrollbar by comparing document.body.scrollHeight vs window.innerHeight. Injected ChangeDetectorRef to force re-render after the check, since the component uses OnPush change detection.

2. In social.component.html: Made data-a2a-scroll-show attribute conditional. If the page is scrollable, the original 0,60 value is used. If the page has no scrollbar, the attribute is omitted so the AddToAny plugin displays the bar immediately without requiring a scroll event.


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

How to test:

1. Enable the Social Links feature in your config:
   addToAnyPlugin:
      socialNetworksEnabled: true
2. Browse to an Item page with minimal metadata (e.g. only title, author and date) that does not scroll.
3. Verify the Social Links bar appears at the bottom of the page without needing to scroll.
4. Browse to an Item page with enough metadata to require scrolling.
5. Verify the Social Links bar still appears correctly when scrolling, and does not block the footer.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
