### PR TITLE
fix(locale): prevent recursive EPerson language lookup for specific endpoint requests

### DIFF
--- a/src/app/core/locale/locale.interceptor.spec.ts
+++ b/src/app/core/locale/locale.interceptor.spec.ts
@@ -22,11 +22,12 @@ describe(`LocaleInterceptor`, () => {
   let localeService: any;
 
   const languageList = ['en;q=1', 'it;q=0.9', 'de;q=0.8', 'fr;q=0.7'];
+  const rootHref = 'https://sandbox.dspace.org/server/api';
 
-  const mockLocaleService = jasmine.createSpyObj('LocaleService', {
-    getCurrentLanguageCode: jasmine.createSpy('getCurrentLanguageCode'),
-    getLanguageCodeList: of(languageList),
-  });
+  const mockLocaleService = jasmine.createSpyObj('LocaleService', [
+    'getCurrentLanguageCode',
+    'getLanguageCodeList',
+  ]);
 
   const mockHalEndpointService = {
     getRootHref: jasmine.createSpy('getRootHref'),
@@ -54,6 +55,8 @@ describe(`LocaleInterceptor`, () => {
     localeService = TestBed.inject(LocaleService);
 
     localeService.getCurrentLanguageCode.and.returnValue(of('en'));
+    localeService.getLanguageCodeList.and.returnValue(of(languageList));
+    mockHalEndpointService.getRootHref.and.returnValue(rootHref);
   });
 
   describe('', () => {
@@ -82,6 +85,29 @@ describe(`LocaleInterceptor`, () => {
       const lang = httpRequest.request.headers.get('Accept-Language');
       expect(lang).toBeDefined();
       expect(lang).toBe(languageList.toString());
+      expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(false);
+    });
+
+    it('should ignore EPerson settings for root endpoint requests', () => {
+      service.request(RestRequestMethod.GET, rootHref).subscribe((response) => {
+        expect(response).toBeTruthy();
+      });
+
+      httpMock.expectOne(rootHref);
+
+      expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(true);
+    });
+
+    it('should ignore EPerson settings for eperson endpoint requests', () => {
+      const epersonHref = `${rootHref}/eperson/epersons/1234`;
+
+      service.request(RestRequestMethod.GET, epersonHref).subscribe((response) => {
+        expect(response).toBeTruthy();
+      });
+
+      httpMock.expectOne(epersonHref);
+
+      expect(localeService.getLanguageCodeList).toHaveBeenCalledWith(true);
     });
 
   });

--- a/src/app/core/locale/locale.interceptor.ts
+++ b/src/app/core/locale/locale.interceptor.ts
@@ -31,7 +31,9 @@ export class LocaleInterceptor implements HttpInterceptor {
    */
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     let newReq: HttpRequest<any>;
-    return this.localeService.getLanguageCodeList(req.url === this.halEndpointService.getRootHref())
+    const ignoreEPersonSettings: boolean = this.shouldIgnoreEPersonSettings(req.url);
+
+    return this.localeService.getLanguageCodeList(ignoreEPersonSettings)
       .pipe(
         take(1),
         scan((acc: any, value: any) => [...acc, value], []),
@@ -44,5 +46,13 @@ export class LocaleInterceptor implements HttpInterceptor {
           // Pass on the new request instead of the original request.
           return next.handle(newReq);
         }));
+  }
+
+  /**
+   * Avoid recursive EPerson language lookup for requests that are needed to resolve EPerson itself.
+   */
+  private shouldIgnoreEPersonSettings(url: string): boolean {
+    const rootHref = this.halEndpointService.getRootHref();
+    return url === rootHref || url.startsWith(`${rootHref}/eperson/epersons`);
   }
 }


### PR DESCRIPTION

• ## References

  - Fixes #5085

  ## Description

  This PR fixes a locale-related request loop that could cause the End User Agreement submit flow to stall.
  LocaleInterceptor now skips EPerson language lookup for root API and /eperson/epersons/* requests to avoid recursive dependency chains.

  ## Instructions for Reviewers

  List of changes in this PR:

  - Added shouldIgnoreEPersonSettings(url) in locale.interceptor.ts to detect requests that must not trigger EPerson language metadata lookup.
  - Updated interceptor flow to call localeService.getLanguageCodeList(ignoreEPersonSettings) instead of only checking equality with root href.
  - Added unit tests in locale.interceptor.spec.ts to verify:
      - standard requests still use getLanguageCodeList(false),
      - root endpoint requests use getLanguageCodeList(true),
      - /eperson/epersons/{id} requests use getLanguageCodeList(true).

  How to test/review:

  1. Review unit tests in src/app/core/locale/locale.interceptor.spec.ts for the new branch logic.
  2. Reproduce the original flow (EUA submit) and confirm submission no longer stalls.
  3. Verify Accept-Language header is still set on outgoing requests.
  4. Run tests focused on locale interceptor and confirm they pass.

  ## Checklist

  - [x] My PR is created against the main branch of code (unless it is a backport or is fixing an issue specific to an older branch).
  - [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
  - [x] My PR passes ESLint (https://eslint.org/) validation using npm run lint
  - [x] My PR doesn't introduce circular dependencies (verified via npm run check-circ-deps)
  - [x] My PR includes TypeDoc (https://typedoc.org/) comments for all new (or modified) public methods and classes. It also includes TypeDoc for large or complex private methods.
  - [x] My PR passes all specs/tests and includes new/updated specs or tests based on the Code Testing Guide (https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
  - [x] My PR aligns with Accessibility guidelines (https://wiki.lyrasis.org/display/DSDOC9x/Accessibility) if it makes changes to the user interface.
  - [x] My PR uses i18n (internationalization) keys instead of hardcoded English text, to allow for translations.
  - [x] My PR includes details on how to test it. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
  - [x] If my PR includes new libraries/dependencies (in package.json), I've made sure their licenses align with the DSpace BSD License (https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the Licensing of Contributions
    (https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
  - [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
  - [x] If my PR fixes an issue ticket, I've linked them together (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).