### PR TITLE
Fix errors on edit template item DSO metadata table & removed authority column

### DIFF
--- a/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-metadata/collection-metadata.component.ts
@@ -29,12 +29,12 @@ import { ItemTemplateDataService } from '../../../core/data/item-template-data.s
 import { RemoteData } from '../../../core/data/remote-data';
 import { RequestService } from '../../../core/data/request.service';
 import { Collection } from '../../../core/shared/collection.model';
-import { Item } from '../../../core/shared/item.model';
 import { NoContent } from '../../../core/shared/NoContent.model';
 import {
   getFirstCompletedRemoteData,
   getFirstSucceededRemoteDataPayload,
 } from '../../../core/shared/operators';
+import { TemplateItem } from '../../../core/shared/template-item.model';
 import { ComcolMetadataComponent } from '../../../shared/comcol/comcol-forms/edit-comcol-page/comcol-metadata/comcol-metadata.component';
 import { hasValue } from '../../../shared/empty.util';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
@@ -64,7 +64,7 @@ export class CollectionMetadataComponent extends ComcolMetadataComponent<Collect
   /**
    * The collection's item template
    */
-  itemTemplateRD$: Observable<RemoteData<Item>>;
+  itemTemplateRD$: Observable<RemoteData<TemplateItem>>;
 
   public constructor(
     protected collectionDataService: CollectionDataService,
@@ -115,7 +115,7 @@ export class CollectionMetadataComponent extends ComcolMetadataComponent<Collect
       getFirstSucceededRemoteDataPayload(),
     );
     const template$ = collection$.pipe(
-      switchMap((collection: Collection) => this.itemTemplateService.createByCollectionID(new Item(), collection.uuid).pipe(
+      switchMap((collection: Collection) => this.itemTemplateService.createByCollectionID(new TemplateItem(), collection.uuid).pipe(
         getFirstSucceededRemoteDataPayload(),
       )),
     );

--- a/src/app/core/data/item-template-data.service.spec.ts
+++ b/src/app/core/data/item-template-data.service.spec.ts
@@ -11,7 +11,6 @@ import { RemoteDataBuildService } from '../cache/builders/remote-data-build.serv
 import { RestResponse } from '../cache/response.models';
 import { CoreState } from '../core-state.model';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
-import { Item } from '../shared/item.model';
 import { testCreateDataImplementation } from './base/create-data.spec';
 import { testDeleteDataImplementation } from './base/delete-data.spec';
 import { testPatchDataImplementation } from './base/patch-data.spec';
@@ -22,12 +21,13 @@ import { RequestEntry } from './request-entry.model';
 import { RestRequest } from './rest-request.model';
 import { RestRequestMethod } from './rest-request-method';
 import createSpyObj = jasmine.createSpyObj;
+import { TemplateItem } from '../shared/template-item.model';
 
 describe('ItemTemplateDataService', () => {
   let service: ItemTemplateDataService;
   let byCollection: any;
 
-  const item = new Item();
+  const item = new TemplateItem();
   const collectionEndpoint = 'https://rest.api/core/collections/4af28e99-6a9c-4036-a199-e1b587046d39';
   const itemEndpoint = `${collectionEndpoint}/itemtemplate`;
   const scopeID = '4af28e99-6a9c-4036-a199-e1b587046d39';

--- a/src/app/core/data/item-template-data.service.ts
+++ b/src/app/core/data/item-template-data.service.ts
@@ -9,7 +9,7 @@ import { BrowseService } from '../browse/browse.service';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { ObjectCacheService } from '../cache/object-cache.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
-import { Item } from '../shared/item.model';
+import { TemplateItem } from '../shared/template-item.model';
 import { CreateDataImpl } from './base/create-data';
 import { IdentifiableDataService } from './base/identifiable-data.service';
 import { BundleDataService } from './bundle-data.service';
@@ -22,8 +22,8 @@ import { RequestService } from './request.service';
 /**
  * Data service for interacting with Item templates via their Collection
  */
-class CollectionItemTemplateDataService extends IdentifiableDataService<Item> {
-  private createData: CreateDataImpl<Item>;
+class CollectionItemTemplateDataService extends IdentifiableDataService<TemplateItem> {
+  private createData: CreateDataImpl<TemplateItem>;
 
   constructor(
     protected requestService: RequestService,
@@ -36,7 +36,7 @@ class CollectionItemTemplateDataService extends IdentifiableDataService<Item> {
     super('itemtemplates', requestService, rdbService, objectCache, halService, undefined);
 
     // We only intend to use createOnEndpoint, so this inner data service feature doesn't need an endpoint at all
-    this.createData = new CreateDataImpl<Item>(undefined, requestService, rdbService, objectCache, halService, notificationsService, this.responseMsToLive);
+    this.createData = new CreateDataImpl<TemplateItem>(undefined, requestService, rdbService, objectCache, halService, notificationsService, this.responseMsToLive);
   }
 
   /**
@@ -56,7 +56,7 @@ class CollectionItemTemplateDataService extends IdentifiableDataService<Item> {
    * @param item
    * @param collectionID
    */
-  public createTemplate(item: Item, collectionID: string): Observable<RemoteData<Item>> {
+  public createTemplate(item: TemplateItem, collectionID: string): Observable<RemoteData<TemplateItem>> {
     return this.createData.createOnEndpoint(item, this.getIDHrefObs(collectionID));
   }
 }
@@ -74,7 +74,7 @@ export class ItemTemplateDataService extends BaseItemDataService {
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
     protected notificationsService: NotificationsService,
-    protected comparator: DSOChangeAnalyzer<Item>,
+    protected comparator: DSOChangeAnalyzer<TemplateItem>,
     protected browseService: BrowseService,
     protected bundleService: BundleDataService,
     protected collectionService: CollectionDataService,
@@ -94,7 +94,7 @@ export class ItemTemplateDataService extends BaseItemDataService {
    * @param linksToFollow               List of {@link FollowLinkConfig} that indicate which
    *                                    {@link HALLink}s should be automatically resolved
    */
-  findByCollectionID(collectionID: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<Item>[]): Observable<RemoteData<Item>> {
+  findByCollectionID(collectionID: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<TemplateItem>[]): Observable<RemoteData<TemplateItem>> {
     return this.byCollection.findById(collectionID, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
   }
 
@@ -103,7 +103,7 @@ export class ItemTemplateDataService extends BaseItemDataService {
    * @param item
    * @param collectionID
    */
-  createByCollectionID(item: Item, collectionID: string): Observable<RemoteData<Item>> {
+  createByCollectionID(item: TemplateItem, collectionID: string): Observable<RemoteData<TemplateItem>> {
     return this.byCollection.createTemplate(item, collectionID);
   }
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-headers/dso-edit-metadata-headers.component.html
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-headers/dso-edit-metadata-headers.component.html
@@ -4,7 +4,6 @@
     <div class="d-flex flex-row">
       <div class="flex-grow-1 ds-flex-cell ds-value-cell"><b class="dont-break-out preserve-line-breaks">{{ dsoType + '.edit.metadata.headers.value' | translate }}</b></div>
       <div class="ds-flex-cell ds-lang-cell"><b>{{ dsoType + '.edit.metadata.headers.language' | translate }}</b></div>
-      <div class="ds-flex-cell ds-authority-cell"><b>{{ dsoType + '.edit.metadata.headers.authority' | translate }}</b></div>
       <div class="ds-flex-cell ds-security-cell"><b>{{'item.edit.metadata.headers.security'| translate}}</b></div>
       <div class="text-center ds-flex-cell ds-edit-cell"><b>{{ dsoType + '.edit.metadata.headers.edit' | translate }}</b></div>
     </div>

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-headers/dso-edit-metadata-headers.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-headers/dso-edit-metadata-headers.component.spec.ts
@@ -29,7 +29,7 @@ describe('DsoEditMetadataHeadersComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should display five headers', () => {
-    expect(fixture.debugElement.queryAll(By.css('.ds-flex-cell')).length).toEqual(5);
+  it('should display four headers', () => {
+    expect(fixture.debugElement.queryAll(By.css('.ds-flex-cell')).length).toEqual(4);
   });
 });

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-shared/dso-edit-metadata-cells.scss
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-shared/dso-edit-metadata-cells.scss
@@ -12,11 +12,6 @@
   max-width: var(--ds-dso-edit-lang-width);
 }
 
-.ds-authority-cell {
-  min-width: var(--ds-dso-edit-authority-width);
-  max-width: var(--ds-dso-edit-authority-width);
-}
-
 .ds-security-cell {
   min-width: var(--ds-dso-edit-security-width);
   max-width: var(--ds-dso-edit-security-width);

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-authority-field/dso-edit-metadata-authority-field.component.html
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-authority-field/dso-edit-metadata-authority-field.component.html
@@ -28,14 +28,14 @@
     </button>
   }
   @if ((isAuthorityControlled$ | async) && (isSuggesterVocabulary$ | async)) {
-    <div class="mt-2">
-      <div class="btn-group w-75">
-        <i dsAuthorityConfidenceState
-           class="fas fa-fw p-0 me-1 mt-auto mb-auto"
-           aria-hidden="true"
-           [authorityValue]="mdValue.newValue.confidence"
-           [iconMode]="true"
-        ></i>
+    <div class="d-flex w-75 mt-2">
+      <i dsAuthorityConfidenceState
+         class="fas fa-fw p-0 me-1 mt-auto mb-auto"
+         aria-hidden="true"
+         [authorityValue]="mdValue.newValue.confidence"
+         [iconMode]="true"
+      ></i>
+      <div class="input-group">
         <input class="form-control form-outline" data-test="authority-input" [(ngModel)]="mdValue.newValue.authority"
                [disabled]="!editingAuthority"
                [attr.aria-label]="(dsoType + '.edit.metadata.edit.authority.key') | translate"

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-authority-field/dso-edit-metadata-authority-field.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-authority-field/dso-edit-metadata-authority-field.component.spec.ts
@@ -14,6 +14,7 @@ import { Collection } from '../../../../core/shared/collection.model';
 import { ConfidenceType } from '../../../../core/shared/confidence-type';
 import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { Item } from '../../../../core/shared/item.model';
+import { ITEM } from '../../../../core/shared/item.resource-type';
 import { MetadataValue } from '../../../../core/shared/metadata.models';
 import { Vocabulary } from '../../../../core/submission/vocabularies/models/vocabulary.model';
 import { VocabularyService } from '../../../../core/submission/vocabularies/vocabulary.service';
@@ -48,6 +49,7 @@ describe('DsoEditMetadataAuthorityFieldComponent', () => {
     },
     id: 'item',
     uuid: 'item',
+    type: ITEM.value,
     owningCollection: createSuccessfulRemoteDataObject$(collection),
   });
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-field.service.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-field.service.ts
@@ -9,7 +9,9 @@ import { ItemDataService } from '../../../core/data/item-data.service';
 import { Collection } from '../../../core/shared/collection.model';
 import { DSpaceObject } from '../../../core/shared/dspace-object.model';
 import { Item } from '../../../core/shared/item.model';
+import { ITEM } from '../../../core/shared/item.resource-type';
 import { getFirstSucceededRemoteDataPayload } from '../../../core/shared/operators';
+import { TemplateItem } from '../../../core/shared/template-item.model';
 import { Vocabulary } from '../../../core/submission/vocabularies/models/vocabulary.model';
 import { VocabularyService } from '../../../core/submission/vocabularies/vocabulary.service';
 import { isNotEmpty } from '../../../shared/empty.util';
@@ -38,9 +40,9 @@ export class DsoEditMetadataFieldService {
    */
   findDsoFieldVocabulary(dso: DSpaceObject, mdField: string): Observable<Vocabulary> {
     if (isNotEmpty(mdField)) {
-      const owningCollection$: Observable<Collection> = this.itemService.findByHref(dso._links.self.href, true, true, followLink('owningCollection')).pipe(
+      const owningCollection$: Observable<Collection> = this.itemService.findByHref(dso._links.self.href, true, true, followLink('owningCollection', { isOptional: true }), followLink('templateItemOf', { isOptional: true })).pipe(
         getFirstSucceededRemoteDataPayload(),
-        switchMap((item: Item) => item.owningCollection),
+        switchMap((item: Item | TemplateItem) => item.type as unknown === ITEM.value ? item.owningCollection : (item as TemplateItem).templateItemOf),
         getFirstSucceededRemoteDataPayload(),
       );
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.html
@@ -48,16 +48,6 @@
       <div class="dont-break-out preserve-line-breaks">{{ mdValue.newValue.language }}</div>
     }
   </div>
-  <div class="ds-flex-cell ds-authority-cell" role="cell">
-    @if (!mdValue.editing) {
-      <div class="dont-break-out preserve-line-breaks">{{ mdValue.newValue.authority }}</div>
-    }
-    @if(mdValue.editing) {
-      <textarea class="form-control" rows="5" [(ngModel)]="mdValue.newValue.authority"
-                [attr.aria-label]="(dsoType + '.edit.metadata.edit.authority') | translate"
-                [dsDebounce]="300" (onDebounce)="confirm.emit(false)"></textarea>
-    }
-  </div>
   <div class="flex-grow-1 ds-flex-cell ds-security-cell d-flex justify-content-center" role="cell">
     <div class="btn-group edit-field">
       @if (canShowMetadataSecurity$ | async) {
@@ -111,7 +101,7 @@
                   [class.disabled]="isOnlyValue || saving" [dsBtnDisabled]="isOnlyValue || saving"
                   [title]="dsoType + '.edit.metadata.edit.buttons.drag' | translate"
                   ngbTooltip="{{ dsoType + '.edit.metadata.edit.buttons.drag' | translate }}">
-            <i class="drag-icon"></i>
+            <i class="drag-icon d-flex m-auto"></i>
           </button>
         </div>
       </div>

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.scss
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.scss
@@ -7,6 +7,11 @@
   cursor: grab;
 }
 
+.drag-icon {
+  height: #{$font-size-base};
+  width: #{$font-size-base};
+}
+
 ::ng-deep .edit-field>ngb-tooltip-window .tooltip-inner {
   min-width: var(--ds-dso-edit-virtual-tooltip-min-width);
 }

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -1,6 +1,6 @@
 import {
+  CUSTOM_ELEMENTS_SCHEMA,
   DebugElement,
-  NO_ERRORS_SCHEMA,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -8,31 +8,22 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { RelationshipDataService } from '@dspace/core/data/relationship-data.service';
-import { MetadataField } from '@dspace/core/metadata/metadata-field.model';
-import { MetadataSchema } from '@dspace/core/metadata/metadata-schema.model';
-import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
-import { Collection } from '@dspace/core/shared/collection.model';
 import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
-import { Item } from '@dspace/core/shared/item.model';
 import {
   MetadataValue,
   VIRTUAL_METADATA_PREFIX,
 } from '@dspace/core/shared/metadata.models';
 import { ItemMetadataRepresentation } from '@dspace/core/shared/metadata-representation/item/item-metadata-representation.model';
 import { DsoEditMetadataFieldServiceStub } from '@dspace/core/testing/dso-edit-metadata-field.service.stub';
-import { createPaginatedList } from '@dspace/core/testing/utils.test';
-import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
-import { RegistryService } from 'src/app/admin/admin-registries/registry/registry.service';
 import { mockSecurityConfig } from 'src/app/submission/utils/submission.mock';
 
 import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
 import { ThemedTypeBadgeComponent } from '../../../shared/object-collection/shared/badges/type-badge/themed-type-badge.component';
-import { VarDirective } from '../../../shared/utils/var.directive';
 import {
   DsoEditMetadataChangeType,
   DsoEditMetadataValue,
@@ -54,27 +45,9 @@ describe('DsoEditMetadataValueComponent', () => {
   let relationshipService: RelationshipDataService;
   let dsoNameService: DSONameService;
   let dsoEditMetadataFieldService: DsoEditMetadataFieldServiceStub;
-  let registryService: RegistryService;
-  let notificationsService: NotificationsService;
   let editMetadataValue: DsoEditMetadataValue;
   let metadataValue: MetadataValue;
   let dso: DSpaceObject;
-
-  const collection =  Object.assign(new Collection(), {
-    uuid: 'fake-uuid',
-  });
-
-  const item = Object.assign(new Item(), {
-    _links: {
-      self: { href: 'fake-item-url/item' },
-    },
-    id: 'item',
-    uuid: 'item',
-    owningCollection: createSuccessfulRemoteDataObject$(collection),
-  });
-
-  let metadataSchema: MetadataSchema;
-  let metadataFields: MetadataField[];
 
   function initServices(): void {
     relationshipService = jasmine.createSpyObj('relationshipService', {
@@ -86,10 +59,6 @@ describe('DsoEditMetadataValueComponent', () => {
       getName: 'Related Name',
     });
     dsoEditMetadataFieldService = new DsoEditMetadataFieldServiceStub();
-    registryService = jasmine.createSpyObj('registryService', {
-      queryMetadataFields: createSuccessfulRemoteDataObject$(createPaginatedList(metadataFields)),
-    });
-    notificationsService = jasmine.createSpyObj('notificationsService', ['error', 'success']);
   }
 
   beforeEach(waitForAsync(async () => {
@@ -111,29 +80,26 @@ describe('DsoEditMetadataValueComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot(),
-        RouterTestingModule.withRoutes([]),
+        RouterModule.forRoot([]),
         DsoEditMetadataValueComponent,
-        VarDirective,
         BtnDisabledDirective,
       ],
       providers: [
         { provide: RelationshipDataService, useValue: relationshipService },
         { provide: DSONameService, useValue: dsoNameService },
         { provide: DsoEditMetadataFieldService, useValue: dsoEditMetadataFieldService },
-        { provide: RegistryService, useValue: registryService },
-        { provide: NotificationsService, useValue: notificationsService },
       ],
-      schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideComponent(DsoEditMetadataValueComponent, {
-        remove: {
-          imports: [
-            ThemedTypeBadgeComponent,
-            DsoEditMetadataValueFieldLoaderComponent,
-          ],
-        },
-      })
-      .compileComponents();
+    }).overrideComponent(DsoEditMetadataValueComponent, {
+      add: {
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      },
+      remove: {
+        imports: [
+          ThemedTypeBadgeComponent,
+          DsoEditMetadataValueFieldLoaderComponent,
+        ],
+      },
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
@@ -26,27 +26,18 @@ import { RouterLink } from '@angular/router';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { RelationshipDataService } from '@dspace/core/data/relationship-data.service';
 import { MetadataService } from '@dspace/core/metadata/metadata.service';
-import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { getItemPageRoute } from '@dspace/core/router/utils/dso-route.utils';
 import { ConfidenceType } from '@dspace/core/shared/confidence-type';
 import { Context } from '@dspace/core/shared/context.model';
 import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
-import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { ItemMetadataRepresentation } from '@dspace/core/shared/metadata-representation/item/item-metadata-representation.model';
 import {
   MetadataRepresentation,
   MetadataRepresentationType,
 } from '@dspace/core/shared/metadata-representation/metadata-representation.model';
-import {
-  getFirstCompletedRemoteData,
-  metadataFieldsToString,
-} from '@dspace/core/shared/operators';
 import { MetadataSecurityConfiguration } from '@dspace/core/submission/models/metadata-security-configuration';
 import { Vocabulary } from '@dspace/core/submission/vocabularies/models/vocabulary.model';
-import {
-  hasValue,
-  isNotEmpty,
-} from '@dspace/shared/utils/empty.util';
+import { hasValue } from '@dspace/shared/utils/empty.util';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import {
   TranslateModule,
@@ -57,7 +48,6 @@ import {
   combineLatest,
   EMPTY,
   Observable,
-  of,
   Subscription,
 } from 'rxjs';
 import {
@@ -65,11 +55,8 @@ import {
   filter,
   map,
   shareReplay,
-  switchMap,
-  take,
 } from 'rxjs/operators';
 
-import { RegistryService } from '../../../admin/admin-registries/registry/registry.service';
 import { EditMetadataSecurityComponent } from '../../../item-page/edit-item-page/edit-metadata-security/edit-metadata-security.component';
 import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
 import { AuthorityConfidenceStateDirective } from '../../../shared/form/directives/authority-confidence-state.directive';
@@ -235,17 +222,6 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
   private sub: Subscription;
 
   /**
-   * Whether or not the authority field is currently being edited
-   */
-  public editingAuthority = false;
-
-
-  /**
-   * Whether or not the free-text editing is enabled when scrollable dropdown or hierarchical vocabulary is used
-   */
-  public enabledFreeTextEditing = false;
-
-  /**
    * Field group used by authority field
    * @type {UntypedFormGroup}
    */
@@ -263,8 +239,6 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
     protected dsoNameService: DSONameService,
     protected metadataService: MetadataService,
     protected cdr: ChangeDetectorRef,
-    protected registryService: RegistryService,
-    protected notificationsService: NotificationsService,
     protected translate: TranslateService,
     protected dsoEditMetadataFieldService: DsoEditMetadataFieldService,
   ) {
@@ -366,49 +340,7 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
     if (changes.mdField) {
       this.fieldType$ = this.getFieldType();
     }
-
-    if (isNotEmpty(changes.mdField) && !changes.mdField.firstChange) {
-      if (isNotEmpty(changes.mdField.currentValue) ) {
-        if (isNotEmpty(changes.mdField.previousValue) &&
-          changes.mdField.previousValue !== changes.mdField.currentValue) {
-          // Clear authority value in case it has been assigned with the previous metadataField used
-          this.mdValue.newValue.authority = null;
-          this.mdValue.newValue.confidence = ConfidenceType.CF_UNSET;
-        }
-
-        // Only ask if the current mdField have a period character to reduce request
-        if (changes.mdField.currentValue.includes('.')) {
-          this.validateMetadataField().subscribe((isValid: boolean) => {
-            if (isValid) {
-              this.cdr.detectChanges();
-            }
-          });
-        }
-      }
-    }
   }
-
-  /**
-   * Validate the metadata field to check if it exists on the server and return an observable boolean for success/error
-   */
-  validateMetadataField(): Observable<boolean> {
-    return this.registryService.queryMetadataFields(this.mdField, null, true, false, followLink('schema')).pipe(
-      getFirstCompletedRemoteData(),
-      switchMap((rd) => {
-        if (rd.hasSucceeded) {
-          return of(rd).pipe(
-            metadataFieldsToString(),
-            take(1),
-            map((fields: string[]) => fields.indexOf(this.mdField) > -1),
-          );
-        } else {
-          this.notificationsService.error(this.translate.instant(`${this.dsoType}.edit.metadata.metadatafield.error`), rd.errorMessage);
-          return [false];
-        }
-      }),
-    );
-  }
-
 
   ngOnDestroy(): void {
     if (hasValue(this.sub)) {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2703,8 +2703,6 @@
 
   "item.edit.metadata.headers.security": "Security level",
 
-  "item.edit.metadata.headers.authority": "Authority",
-
   "item.edit.metadata.headers.value": "Value",
 
   "item.edit.metadata.metadatafield": "Edit field",
@@ -3421,8 +3419,6 @@
   "itemtemplate.edit.metadata.headers.language": "Lang",
 
   "itemtemplate.edit.metadata.headers.value": "Value",
-
-  "itemtemplate.edit.metadata.headers.authority": "Authority",
 
   "itemtemplate.edit.metadata.metadatafield": "Edit field",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3205,6 +3205,12 @@
 
   "itemtemplate.edit.metadata.edit.value": "Edit value",
 
+  "itemtemplate.edit.metadata.edit.authority.key": "Edit authority key",
+
+  "itemtemplate.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
+
+  "itemtemplate.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
+
   "itemtemplate.edit.metadata.edit.buttons.confirm": "Confirm",
 
   "itemtemplate.edit.metadata.edit.buttons.drag": "Drag to reorder",
@@ -3256,6 +3262,12 @@
   "itemtemplate.edit.metadata.reset-order-button": "Undo reorder",
 
   "itemtemplate.edit.metadata.save-button": "Save",
+
+  "itemtemplate.edit.metadata.authority.label": "Authority: ",
+
+  "itemtemplate.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
+
+  "itemtemplate.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
 
   "journal.listelement.badge": "Journal",
 

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -133,7 +133,6 @@
   --ds-dso-edit-field-width: 210px;
   --ds-dso-edit-lang-width: 90px;
   --ds-dso-edit-security-width: 136px;
-  --ds-dso-edit-authority-width: 150px;
   --ds-dso-edit-actions-width: 173px;
   --ds-dso-edit-virtual-tooltip-min-width: 300px;
 


### PR DESCRIPTION
## Description
Fixed bug on the collection's Edit template item page, that prevents the `DsoEditMetadataValueFieldLoaderComponent` from loading the correct edit value input field.

I also removed the authority column from the `DsoEditMetadataValueComponent` since this information is already customizable in the `DsoEditMetadataAuthorityFieldComponent` and doesn't add any new functionality

Before:
<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/fb7cd3c4-20ec-4f5a-a576-dcb4283e63dc" />
<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/73df705d-2df6-4f4e-889b-2182af5d1668" />

After:
<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/2c9cb4c3-18fa-4dca-ac9a-28aadd9e4fe9"/>
<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/e3a0b40b-b4d8-4036-8ef6-b7db6a818a8b"/>

## Instructions for Reviewers

List of changes in this PR:
* Changed the response of the `CollectionItemTemplateDataService` from `Item` to `TemplateItem`, this way we don't always have to cast the item when we want to access the embedded `templateItemOf`
* Removed the authority column
* Fixed size issues with the drag and drop icon
* Fixed bug on collection template item page that prevented the correct edit value input field from loading 

**Guidance for how to test/review this PR:**
- Enable authority:
  - Uncomment the following sections in `authority.cfg`:
     ```cfg
     choices.plugin.dc.contributor.author = SolrAuthorAuthority
     choices.presentation.dc.contributor.author = authorLookup
     authority.controlled.dc.contributor.author = true
     authority.author.indexer.field.1=dc.contributor.author
     ```
     ```cfg
     plugin.named.org.dspace.content.authority.ChoiceAuthority = org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
     ```
  - Add the authority consumer to the `event.dispatcher.default.consumers` in `dspace.cfg`
- Verify that the authority column is not necessary, since we can achieve the same thing for all authority controlled fields
- Create a new template item for a random collection
- Verify that changing the metadata field updates the metadata value input field:
  - `dspace.entity.type`: should render the `DsoEditMetadataEntityFieldComponent`
  - `dc.contributor.author`: should render the `DsoEditMetadataAuthorityFieldComponent`
  - `dc.title`: should render the `DsoEditMetadataTextFieldComponent`

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
