### PR TITLE
Fix #2789: prevent linkify from converting words with dots into links

### DIFF
--- a/src/app/shared/utils/markdown.directive.spec.ts
+++ b/src/app/shared/utils/markdown.directive.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import {
   Component,
   DebugElement,
@@ -20,6 +21,14 @@ import { MarkdownDirective } from './markdown.directive';
   ],
 })
 class TestComponent {}
+
+@Component({
+  template: `<div [dsMarkdown]="'Les informations demandés.es ne sont pas disponibles.'"></div>`,
+  imports: [
+    MarkdownDirective,
+  ],
+})
+class LinkifyTestComponent {}
 
 describe('MarkdownDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
@@ -55,10 +64,9 @@ describe('MarkdownDirective sanitization with markdown disabled', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     divEl = fixture.debugElement.query(By.css('div'));
-
   });
 
-  it('should sanitize the script element out of innerHTML (markdown disabled)',() => {
+  it('should sanitize the script element out of innerHTML (markdown disabled)', () => {
     fixture.detectChanges();
     divEl = fixture.debugElement.query(By.css('div'));
     expect(divEl.nativeElement.innerHTML).toEqual('test');
@@ -80,13 +88,37 @@ describe('MarkdownDirective sanitization with markdown enabled', () => {
     }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
     divEl = fixture.debugElement.query(By.css('div'));
-
   });
 
-  it('should sanitize the script element out of innerHTML (markdown enabled)',() => {
+  it('should sanitize the script element out of innerHTML (markdown enabled)', () => {
     fixture.detectChanges();
     divEl = fixture.debugElement.query(By.css('div'));
     expect(divEl.nativeElement.innerHTML).toEqual('test');
+  });
+
+});
+
+describe('MarkdownDirective linkify with markdown enabled', () => {
+  let fixture: ComponentFixture<LinkifyTestComponent>;
+  let divEl: DebugElement;
+  // Enable markdown
+  environment.markdown.enabled = true;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: MathService, useClass: MockMathService },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(LinkifyTestComponent);
+    divEl = fixture.debugElement.query(By.css('div'));
+  });
+
+  it('should not convert words with dots (e.g. demandés.es) to links (#2789)', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    divEl = fixture.debugElement.query(By.css('div'));
+    expect(divEl.nativeElement.innerHTML).not.toContain('<a href');
   });
 
 });

--- a/src/app/shared/utils/markdown.directive.ts
+++ b/src/app/shared/utils/markdown.directive.ts
@@ -85,6 +85,9 @@ export class MarkdownDirective implements OnInit, OnDestroy {
       html: true,
       linkify: true,
     });
+    md.linkify.set({
+      fuzzyLink: false,
+    });
 
     const html = alreadySanitized ? md.render(value) : this.sanitizer.sanitize(SecurityContext.HTML, md.render(value));
     this.el.innerHTML = html;


### PR DESCRIPTION
## References
Fixes #2789

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
* Disabled `fuzzyLink` in markdown-it configuration to prevent incorrect linkification of dotted words
* Added a unit test to verify that words containing dots (e.g. "demandés.es") are not converted into links
* Ensured existing sanitization behavior remains unchanged

### How to test:
1. Go to any page where markdown content is rendered (e.g. item description or abstract)
2. Add or locate text containing words with dots, such as:
   - `demandés.es`
3. Verify that:
   - The text is displayed normally
   - It is NOT converted into a clickable link
4. Run unit tests:
     npm run test

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
