### PR TITLE
Fix #3248: Ensure form controls reset when type-bind visibility condi…

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
@@ -15,6 +15,7 @@ import {
   HIDDEN_MATCHER_PROVIDER,
   REQUIRED_MATCHER_PROVIDER,
 } from '@ng-dynamic-forms/core';
+import { Subject } from 'rxjs';
 
 import { getMockFormBuilderService } from '../../testing/form-builder-service.mock';
 import {
@@ -97,6 +98,29 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
       dcTypeControl.setValue('boundType');
       let subscriptions = service.subscribeRelations(testModel, dcTypeControl);
       expect(subscriptions).toHaveSize(1);
+    });
+
+    describe('Test control reset on MATCH_VISIBLE', () => {
+      it('should reset control when MATCH_VISIBLE becomes false', () => {
+        const testModel = mockInputWithTypeBindModel;
+        testModel.typeBindRelations = getTypeBindRelations(['boundType'], 'dc.type');
+
+        const control = new UntypedFormControl();
+        control.setValue('test value');
+
+        const typeModel: any = (service as any).formBuilderService.getTypeBindModel();
+
+        typeModel.valueChanges = new Subject();
+
+        typeModel.value = 'boundType';
+
+        service.subscribeRelations(testModel, control);
+
+        typeModel.value = 'anotherType';
+        typeModel.valueChanges.next('anotherType');
+
+        expect(control.value).toBeNull();
+      });
     });
 
     it('Expect hasMatch to be true (ie. this should be hidden)', () => {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
@@ -19,6 +19,7 @@ import {
   DynamicFormControlModel,
   DynamicFormControlRelation,
   DynamicFormRelationService,
+  MATCH_VISIBLE,
   OR_OPERATOR,
 } from '@ng-dynamic-forms/core';
 import { Subscription } from 'rxjs';
@@ -205,6 +206,10 @@ export class DsDynamicTypeBindRelationService {
               if (relation !== undefined) {
                 const hasMatch = this.matchesCondition(relation, matcher);
                 matcher.onChange(hasMatch, model, control, this.injector);
+                // When field becomes hidden, reset its FormControl to clear stale values
+                if (relation.match === MATCH_VISIBLE && !hasMatch && hasValue(control)) {
+                  control.reset();
+                }
               }
             });
           }


### PR DESCRIPTION
## References
Fixes #3248 

## Description
Reset type-bound form controls when the MATCH_VISIBLE condition is false. Ensures form inputs are cleared when their visibility conditions are no longer met.

## Instructions for Reviewers
List of changes in this PR:

- Updated DsDynamicTypeBindRelationService to reset form controls when type-bind visibility rules fail.
- Added/updated specs in ds-dynamic-type-bind-relation.service.spec.ts to verify control reset behavior.
- Minor adjustments to type-bind handling in getTypeBindValue and matchesCondition for multi-value support.

How to test/review this PR:

1. Open the submission form in DSpace frontend.
2. Fill a type-bind field (e.g., publication type).
3. Trigger a change that should hide dependent fields (MATCH_VISIBLE becomes false).
4. Verify that hidden fields are reset to null/empty.
5. Confirm all existing type-bind behaviors remain functional.
6. Run npm run lint and npm test to ensure no errors or failed tests.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
