### PR TITLE
Handle all supported date value types in date picker

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.spec.ts
@@ -206,6 +206,44 @@ describe('DsDatePickerComponent test suite', () => {
       });
     });
 
+    describe('when init model value is a Date object', () => {
+      beforeEach(() => {
+        dateFixture = TestBed.createComponent(DsDatePickerComponent);
+        dateComp = dateFixture.componentInstance;
+        dateComp.group = DATE_TEST_GROUP;
+        dateComp.model = new DynamicDsDatePickerModel(DATE_TEST_MODEL_CONFIG);
+        dateComp.model.value = new Date(Date.UTC(1983, 10, 18));
+        dateFixture.detectChanges();
+      });
+
+      it('should init component properly from a Date object', () => {
+        expect(dateComp.year).toBe(1983);
+        expect(dateComp.month).toBe(11);
+        expect(dateComp.day).toBe(18);
+        expect(dateComp.disabledMonth).toBeFalsy();
+        expect(dateComp.disabledDay).toBeFalsy();
+      });
+    });
+
+    describe('when init model value is a NgbDateStruct-like object', () => {
+      beforeEach(() => {
+        dateFixture = TestBed.createComponent(DsDatePickerComponent);
+        dateComp = dateFixture.componentInstance;
+        dateComp.group = DATE_TEST_GROUP;
+        dateComp.model = new DynamicDsDatePickerModel(DATE_TEST_MODEL_CONFIG);
+        dateComp.model.value = { year: 1983, month: 11, day: 18 };
+        dateFixture.detectChanges();
+      });
+
+      it('should init component properly from a NgbDateStruct-like object', () => {
+        expect(dateComp.year).toBe(1983);
+        expect(dateComp.month).toBe(11);
+        expect(dateComp.day).toBe(18);
+        expect(dateComp.disabledMonth).toBeFalsy();
+        expect(dateComp.disabledDay).toBeFalsy();
+      });
+    });
+
     describe('when init model value is not empty', () => {
       beforeEach(() => {
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.ts
@@ -14,6 +14,7 @@ import {
   FormsModule,
   UntypedFormGroup,
 } from '@angular/forms';
+import { dateValueToString } from '@dspace/shared/utils/date.util';
 import { hasValue } from '@dspace/shared/utils/empty.util';
 import {
   DynamicFormControlComponent,
@@ -91,7 +92,7 @@ export class DsDatePickerComponent extends DynamicFormControlComponent implement
     if (this.model && this.model.value !== null) {
       // todo: model value could object or Date according to its type annotation
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      const values = this.model.value.toString().split(DS_DATE_PICKER_SEPARATOR);
+      const values = dateValueToString(this.model.value).split(DS_DATE_PICKER_SEPARATOR);
       if (values.length > 0) {
         this.initialYear = parseInt(values[0], 10);
         this.year = this.initialYear;

--- a/src/app/shared/form/builder/parsers/date-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/date-field-parser.ts
@@ -1,4 +1,5 @@
 import { FormFieldMetadataValueObject } from '@dspace/core/shared/form/models/form-field-metadata-value.model';
+import { dateValueToString } from '@dspace/shared/utils/date.util';
 import { isNotEmpty } from '@dspace/shared/utils/empty.util';
 
 import { DS_DATE_PICKER_SEPARATOR } from '../ds-dynamic-form-ui/models/date-picker/date-picker.component';
@@ -21,7 +22,7 @@ export class DateFieldParser extends FieldParser {
     if (isNotEmpty(inputDateModelConfig.value)) {
       // todo: model value could be object or Date according to its type annotation
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      const value = inputDateModelConfig.value.toString();
+      const value = dateValueToString(inputDateModelConfig.value);
       if (value.length >= 4) {
         const valuesArray = value.split(DS_DATE_PICKER_SEPARATOR);
         if (valuesArray.length < 4) {

--- a/src/app/utils/date.util.spec.ts
+++ b/src/app/utils/date.util.spec.ts
@@ -2,6 +2,7 @@ import {
   dateToISOFormat,
   dateToNgbDateStruct,
   dateToString,
+  dateValueToString,
   isValidDate,
   yearFromString,
 } from './date.util';
@@ -90,6 +91,24 @@ describe('Date Utils', () => {
     });
     it('should return false for a time that does not exist', () => {
       expect(isValidDate('2022-02-60T10:60:20')).toBe(false);
+    });
+  });
+
+  describe('dateValueToString', () => {
+    it('should return the same string when given a string', () => {
+      expect(dateValueToString('1983-11-18')).toEqual('1983-11-18');
+    });
+    it('should return YYYY-MM-DD when given a Date object', () => {
+      expect(dateValueToString(new Date(Date.UTC(1983, 10, 18)))).toEqual('1983-11-18');
+    });
+    it('should return YYYY-MM-DD when given a NgbDateStruct-like object', () => {
+      expect(dateValueToString({ year: 1983, month: 11, day: 18 })).toEqual('1983-11-18');
+    });
+    it('should throw an error for an arbitrary object', () => {
+      expect(() => dateValueToString({ foo: 'bar' })).toThrowError(/Unsupported date value type/);
+    });
+    it('should throw an error for an empty object', () => {
+      expect(() => dateValueToString({})).toThrowError(/Unsupported date value type/);
     });
   });
 

--- a/src/app/utils/date.util.ts
+++ b/src/app/utils/date.util.ts
@@ -108,3 +108,28 @@ export function yearFromString(date: string) {
   return isValidDate(date) ? new Date(date).getUTCFullYear() : null;
 }
 
+/**
+ * Converts a date model value (string | Date | object) to a YYYY-MM-DD formatted string.
+ *
+ * The dynamic form library defines date values as string | object | Date.
+ * This function safely handles all supported types and throws an informative
+ * error if an unsupported object type is encountered.
+ *
+ * @param value The date value to convert
+ * @returns The date as a string (e.g. "1983-11-18")
+ * @throws Error if value is an object without year/month/day properties
+ */
+export function dateValueToString(value: string | Date | object): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return dateToString(value);
+  }
+  if (isNgbDateStruct(value)) {
+    return dateToString(value as NgbDateStruct);
+  }
+  throw new Error(
+    `Unsupported date value type: expected a string, Date, or object with {year, month, day} properties, but received: ${JSON.stringify(value)}`,
+  );
+}


### PR DESCRIPTION
## References
* Fixes #2956
* Malware-Free PR of #5163 

## Description
Replace unsafe .toString() calls on date model values with a new dateValueToString() utility that properly handles all supported types (string, Date, NgbDateStruct) and throws an informative error for unsupported object types.

## Instructions for Reviewers
1. Run `npm test -- --include="src/app/utils/date.util.spec.ts"` — all 32 tests should pass
2. Run `npm test -- --include="src/app/shared/form/builder/ds-dynamic-form-ui/models/date-picker/date-picker.component.spec.ts"` — all 17 tests should pass
3. Run `npm test -- --include="src/app/shared/form/builder/parsers/date-field-parser.spec.ts"` — all 3 tests should pass
4. Verify date picker fields work correctly in submission forms (e.g. Date of Issue)

List of changes in this PR:
* Added `dateValueToString()` utility function in `src/app/utils/date.util.ts` that safely converts `string | Date | object` values to `YYYY-MM-DD` formatted strings
* Updated `date-picker.component.ts` to use `dateValueToString()` instead of `.toString()`, removing the `eslint-disable` comment and `todo`
* Updated `date-field-parser.ts` to use `dateValueToString()` instead of `.toString()`, removing the `eslint-disable` comment and `todo`
* Added 5 unit tests for `dateValueToString()` in `date.util.spec.ts` (string, Date, NgbDateStruct, arbitrary object, empty object)
* Added 2 test suites in `date-picker.component.spec.ts` to verify initialization from `Date` and `NgbDateStruct`-like objects

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
