### PR TITLE
Fix #5331: update system-wide alert preview countdown dynamically

### DIFF
--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  NgZone,
   OnDestroy,
   OnInit,
 } from '@angular/core';
@@ -134,6 +135,7 @@ export class SystemWideAlertFormComponent implements OnInit, OnDestroy {
     protected router: Router,
     protected requestService: RequestService,
     protected translateService: TranslateService,
+    protected ngZone: NgZone,
   ) {
   }
 
@@ -162,10 +164,12 @@ export class SystemWideAlertFormComponent implements OnInit, OnDestroy {
       this.initFormValues(alert);
     });
 
-    this.previewSubscription = interval(1000).subscribe(() => {
-      if (this.counterEnabled$.getValue() && this.date && this.time) {
-        this.updatePreviewTime();
-      }
+    this.ngZone.runOutsideAngular(() => {
+      this.previewSubscription = interval(1000).subscribe(() => {
+        if (this.counterEnabled$.getValue() && this.date && this.time) {
+          this.ngZone.run(() => this.updatePreviewTime());
+        }
+      });
     });
   }
 

--- a/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
+++ b/src/app/system-wide-alert/alert-form/system-wide-alert-form.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
 import {
@@ -39,7 +40,9 @@ import {
 import { UiSwitchModule } from 'ngx-ui-switch';
 import {
   BehaviorSubject,
+  interval,
   Observable,
+  Subscription,
 } from 'rxjs';
 import {
   filter,
@@ -67,7 +70,7 @@ import { BtnDisabledDirective } from '../../shared/btn-disabled.directive';
     UiSwitchModule,
   ],
 })
-export class SystemWideAlertFormComponent implements OnInit {
+export class SystemWideAlertFormComponent implements OnInit, OnDestroy {
 
   /**
    * Observable to track an existing system-wide alert
@@ -119,6 +122,11 @@ export class SystemWideAlertFormComponent implements OnInit {
    */
   previewDays: number;
 
+  /**
+   * Subscription used to periodically update the preview countdown timer
+   */
+  previewSubscription: Subscription;
+
 
   constructor(
     protected systemWideAlertDataService: SystemWideAlertDataService,
@@ -152,6 +160,12 @@ export class SystemWideAlertFormComponent implements OnInit {
     this.systemWideAlert$.subscribe((alert) => {
       this.currentAlert = alert;
       this.initFormValues(alert);
+    });
+
+    this.previewSubscription = interval(1000).subscribe(() => {
+      if (this.counterEnabled$.getValue() && this.date && this.time) {
+        this.updatePreviewTime();
+      }
     });
   }
 
@@ -231,6 +245,12 @@ export class SystemWideAlertFormComponent implements OnInit {
    * @param timeDifference  - The time difference to calculate and push the time units for
    */
   private allocateTimeUnits(timeDifference) {
+    if (timeDifference <= 0) {
+      this.previewMinutes = 0;
+      this.previewHours = 0;
+      this.previewDays = 0;
+      return;
+    }
     this.previewMinutes = Math.floor((timeDifference) / (1000 * 60) % 60);
     this.previewHours = Math.floor((timeDifference) / (1000 * 60 * 60) % 24);
     this.previewDays = Math.floor((timeDifference) / (1000 * 60 * 60 * 24));
@@ -293,6 +313,12 @@ export class SystemWideAlertFormComponent implements OnInit {
    */
   back() {
     this.router.navigate(['/home']);
+  }
+
+  ngOnDestroy(): void {
+    if (this.previewSubscription) {
+      this.previewSubscription.unsubscribe();
+    }
   }
 
 


### PR DESCRIPTION
## References
Fixes #5331

## Description
Fixes the system-wide alert countdown timer in the preview. The countdown now updates dynamically every second and disappears when it reaches zero.

## Instructions for Reviewers

Changes included in this PR:

- Added checks for date and time before updating the preview to prevent errors.
- Modified the allocateTimeUnits function so that when the countdown reaches zero, days, hours, and minutes are set to 0 and the visible countdown stops.
- Adjusted the previewSubscription using interval(1000) to refresh the countdown every second.
- Added a comment to the previewSubscription variable for consistency with other variables (counterEnabled$, previewMinutes, previewHours, previewDays).

How to test:

1. Go to System Alerts → System-Wide Alert.
2. Activate an alert and enable the countdown timer.
3. Set the timer to one minute in the future.
4. Observe the alert preview: the countdown should update dynamically every second showing the correct remaining time.
5. When it reaches zero, the counter disappears from the banner.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
