### PR TITLE
Add audio transcript and video description features for a11y

### DIFF
--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
@@ -192,6 +192,21 @@ describe('EditBitstreamPageComponent', () => {
               value: 'Bitstream title',
             },
           ],
+          'dc.description.audiovideo': [
+            {
+              value: 'audio',
+            },
+          ],
+          'dc.description.audiotranscript': [
+            {
+              value: 'Audio transcript content',
+            },
+          ],
+          'dc.description.videodescription': [
+            {
+              value: 'Video description content',
+            },
+          ],
         },
         format: createSuccessfulRemoteDataObject$(selectedFormat),
         _links: {
@@ -258,6 +273,18 @@ describe('EditBitstreamPageComponent', () => {
 
       it('should fill in the bitstream\'s description', () => {
         expect(rawForm.descriptionContainer.description).toEqual(bitstream.firstMetadataValue('dc.description'));
+      });
+
+      it('should fill in the media type', () => {
+        expect(rawForm.mediaInfoContainer.mediaType).toEqual('audio');
+      });
+
+      it('should fill in the audio transcript', () => {
+        expect(rawForm.mediaInfoContainer.audioTranscript).toEqual('Audio transcript content');
+      });
+
+      it('should fill in the video description', () => {
+        expect(rawForm.mediaInfoContainer.videoDescription).toEqual('Video description content');
       });
 
       it('should select the correct format', () => {

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
@@ -192,19 +192,19 @@ describe('EditBitstreamPageComponent', () => {
               value: 'Bitstream title',
             },
           ],
-          'dc.description.audiovideo': [
+          'dc.type': [
             {
               value: 'audio',
             },
           ],
-          'dc.description.audiotranscript': [
+          'dspace.bitstream.transcript': [
             {
               value: 'Audio transcript content',
             },
           ],
-          'dc.description.videodescription': [
+          'dspace.bitstream.textalternative': [
             {
-              value: 'Video description content',
+              value: 'Text alternative content',
             },
           ],
         },
@@ -283,8 +283,8 @@ describe('EditBitstreamPageComponent', () => {
         expect(rawForm.mediaInfoContainer.audioTranscript).toEqual('Audio transcript content');
       });
 
-      it('should fill in the video description', () => {
-        expect(rawForm.mediaInfoContainer.videoDescription).toEqual('Video description content');
+      it('should fill in the text alternative', () => {
+        expect(rawForm.mediaInfoContainer.videoDescription).toEqual('Text alternative content');
       });
 
       it('should select the correct format', () => {

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -44,6 +44,9 @@ import {
   DynamicFormLayout,
   DynamicFormService,
   DynamicInputModel,
+  DynamicSelectModel,
+  MATCH_VISIBLE,
+  OR_OPERATOR,
 } from '@ng-dynamic-forms/core';
 import {
   TranslateModule,
@@ -308,11 +311,92 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
     },
   });
 
+
+  /**
+   * The Dynamic Select Model for the media type
+   */
+  mediaTypeModel = new DynamicSelectModel({
+    id: 'mediaType',
+    name: 'mediaType',
+    options: [
+      {
+        label: this.translate.instant('bitstream.edit.form.mediaType.option.neither'),
+        value: 'neither',
+      },
+      {
+        label: this.translate.instant('bitstream.edit.form.mediaType.option.audio'),
+        value: 'audio',
+      },
+      {
+        label: this.translate.instant('bitstream.edit.form.mediaType.option.video'),
+        value: 'video',
+      },
+      {
+        label: this.translate.instant('bitstream.edit.form.mediaType.option.audio-video'),
+        value: 'audiovideo',
+      },
+    ],
+    value: 'neither',
+  });
+
+  /**
+   * The Dynamic TextArea Model for the audio transcript
+   */
+  audioTranscriptModel = new DsDynamicTextAreaModel({
+    hasSelectableMetadata: false, metadataFields: [], repeatable: false, submissionId: '',
+    id: 'audioTranscript',
+    name: 'audioTranscript',
+    rows: 10,
+    relations: [
+      {
+        match: MATCH_VISIBLE,
+        operator: OR_OPERATOR,
+        when: [
+          {
+            id: 'mediaType',
+            value: 'audio',
+          },
+          {
+            id: 'mediaType',
+            value: 'audiovideo',
+          },
+        ],
+      },
+    ],
+  });
+
+  /**
+   * The Dynamic TextArea Model for the video description
+   */
+  videoDescriptionModel = new DsDynamicTextAreaModel({
+    hasSelectableMetadata: false, metadataFields: [], repeatable: false, submissionId: '',
+    id: 'videoDescription',
+    name: 'videoDescription',
+    rows: 10,
+    relations: [
+      {
+        match: MATCH_VISIBLE,
+        operator: OR_OPERATOR,
+        when: [
+          {
+            id: 'mediaType',
+            value: 'video',
+          },
+          {
+            id: 'mediaType',
+            value: 'audiovideo',
+          },
+        ],
+      },
+    ],
+  });
+
+
   /**
    * All input models in a simple array for easier iterations
    */
-  inputModels = [this.primaryBitstreamModel, this.fileNameModel, this.descriptionModel, this.selectedFormatModel,
-    this.newFormatModel];
+  inputModels = [this.primaryBitstreamModel, this.fileNameModel, this.descriptionModel, this.mediaTypeModel,
+    this.audioTranscriptModel, this.videoDescriptionModel, this.selectedFormatModel, this.newFormatModel];
 
   /**
    * The dynamic form fields used for editing the information of a bitstream
@@ -335,6 +419,18 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       group: [
         this.descriptionModel,
       ],
+    }),
+    new DynamicFormGroupModel({
+      id: 'mediaInfoContainer',
+      group: [
+        this.mediaTypeModel,
+        this.audioTranscriptModel,
+        this.videoDescriptionModel,
+      ],
+    }, {
+      grid: {
+        host: 'row',
+      },
     }),
     new DynamicFormGroupModel({
       id: 'formatContainer',
@@ -387,12 +483,32 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
         host: this.newFormatBaseLayout + ' invisible',
       },
     },
+    mediaType: {
+      grid: {
+        host: 'col-12 d-inline-block',
+      },
+    },
+    audioTranscript: {
+      grid: {
+        host: 'col-12 d-inline-block',
+      },
+    },
+    videoDescription: {
+      grid: {
+        host: 'col-12 d-inline-block',
+      },
+    },
     fileNamePrimaryContainer: {
       grid: {
         host: 'row position-relative',
       },
     },
     descriptionContainer: {
+      grid: {
+        host: 'row',
+      },
+    },
+    mediaInfoContainer: {
       grid: {
         host: 'row',
       },
@@ -546,6 +662,11 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       },
       descriptionContainer: {
         description: bitstream.firstMetadataValue('dc.description'),
+      },
+      mediaInfoContainer: {
+        mediaType: bitstream.firstMetadataValue('dc.description.audiovideo') ?? 'neither',
+        audioTranscript: bitstream.firstMetadataValue('dc.description.audiotranscript'),
+        videoDescription: bitstream.firstMetadataValue('dc.description.videodescription'),
       },
       formatContainer: {
         selectedFormat: this.selectedFormat.shortDescription,
@@ -732,6 +853,22 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       delete newMetadata['dc.description'];
     } else {
       Metadata.setFirstValue(newMetadata, 'dc.description', rawForm.descriptionContainer.description);
+    }
+    const mediaType = rawForm.mediaInfoContainer?.mediaType;
+    if (isEmpty(mediaType) || mediaType === 'neither') {
+      delete newMetadata['dc.description.audiovideo'];
+    } else {
+      Metadata.setFirstValue(newMetadata, 'dc.description.audiovideo', mediaType);
+    }
+    if (isEmpty(rawForm.mediaInfoContainer?.audioTranscript)) {
+      delete newMetadata['dc.description.audiotranscript'];
+    } else {
+      Metadata.setFirstValue(newMetadata, 'dc.description.audiotranscript', rawForm.mediaInfoContainer.audioTranscript);
+    }
+    if (isEmpty(rawForm.mediaInfoContainer?.videoDescription)) {
+      delete newMetadata['dc.description.videodescription'];
+    } else {
+      Metadata.setFirstValue(newMetadata, 'dc.description.videodescription', rawForm.mediaInfoContainer.videoDescription);
     }
     if (this.isIIIF) {
       // It's helpful to remove these metadata elements entirely when the form value is empty.

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -333,7 +333,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
       },
       {
         label: this.translate.instant('bitstream.edit.form.mediaType.option.audio-video'),
-        value: 'audiovideo',
+        value: 'audio+video',
       },
     ],
     value: 'neither',
@@ -358,7 +358,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
           },
           {
             id: 'mediaType',
-            value: 'audiovideo',
+            value: 'audio+video',
           },
         ],
       },
@@ -384,7 +384,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
           },
           {
             id: 'mediaType',
-            value: 'audiovideo',
+            value: 'audio+video',
           },
         ],
       },
@@ -664,9 +664,9 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
         description: bitstream.firstMetadataValue('dc.description'),
       },
       mediaInfoContainer: {
-        mediaType: bitstream.firstMetadataValue('dc.description.audiovideo') ?? 'neither',
-        audioTranscript: bitstream.firstMetadataValue('dc.description.audiotranscript'),
-        videoDescription: bitstream.firstMetadataValue('dc.description.videodescription'),
+        mediaType: bitstream.firstMetadataValue('dc.type') ?? 'neither',
+        audioTranscript: bitstream.firstMetadataValue('dspace.bitstream.transcript'),
+        videoDescription: bitstream.firstMetadataValue('dspace.bitstream.textalternative'),
       },
       formatContainer: {
         selectedFormat: this.selectedFormat.shortDescription,
@@ -856,19 +856,19 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
     }
     const mediaType = rawForm.mediaInfoContainer?.mediaType;
     if (isEmpty(mediaType) || mediaType === 'neither') {
-      delete newMetadata['dc.description.audiovideo'];
+      delete newMetadata['dc.type'];
     } else {
-      Metadata.setFirstValue(newMetadata, 'dc.description.audiovideo', mediaType);
+      Metadata.setFirstValue(newMetadata, 'dc.type', mediaType);
     }
     if (isEmpty(rawForm.mediaInfoContainer?.audioTranscript)) {
-      delete newMetadata['dc.description.audiotranscript'];
+      delete newMetadata['dspace.bitstream.transcript'];
     } else {
-      Metadata.setFirstValue(newMetadata, 'dc.description.audiotranscript', rawForm.mediaInfoContainer.audioTranscript);
+      Metadata.setFirstValue(newMetadata, 'dspace.bitstream.transcript', rawForm.mediaInfoContainer.audioTranscript);
     }
     if (isEmpty(rawForm.mediaInfoContainer?.videoDescription)) {
-      delete newMetadata['dc.description.videodescription'];
+      delete newMetadata['dspace.bitstream.textalternative'];
     } else {
-      Metadata.setFirstValue(newMetadata, 'dc.description.videodescription', rawForm.mediaInfoContainer.videoDescription);
+      Metadata.setFirstValue(newMetadata, 'dspace.bitstream.textalternative', rawForm.mediaInfoContainer.videoDescription);
     }
     if (this.isIIIF) {
       // It's helpful to remove these metadata elements entirely when the form value is empty.

--- a/src/app/shared/file-download-link/file-download-link.component.html
+++ b/src/app/shared/file-download-link/file-download-link.component.html
@@ -7,26 +7,26 @@
 
 <a [routerLink]="bitstreamPath?.routerLink" class="d-block dont-break-out mb-1"
   [queryParams]="bitstreamPath?.queryParams"
-  [target]="isBlank ? '_blank': '_self'"
-  [ngClass]="cssClasses"
+   [target]="isBlank ? '_blank': '_self'"
+   [ngClass]="cssClasses"
   [attr.aria-label]="getDownloadLinkTitle(canDownload, canDownloadWithToken, dsoNameService.getName(bitstream))"
   [title]="getDownloadLinkTitle(canDownload, canDownloadWithToken, dsoNameService.getName(bitstream))"
-  role="link"
-  tabindex="0">
+   role="link"
+   tabindex="0">
   @if ((canDownload) === false && (canDownloadWithToken) === false) {
     <!-- If the user cannot download the file by auth or token, show a lock icon -->
     <span role="img"
-    [attr.aria-label]="'file-download-link.restricted' | translate"
-    [title]="'file-download-link.restricted' | translate"
-    class="pe-1">
+          [attr.aria-label]="'file-download-link.restricted' | translate"
+          [title]="'file-download-link.restricted' | translate"
+          class="pe-1">
       <i class="fas fa-lock"></i>
     </span>
   } @else if (canDownloadWithToken && (canDownload === false)) {
     <!-- If the user can download the file by token, and NOT normally show a lock open icon -->
     <span role="img"
-    [attr.aria-label]="'file-download-link.secure-access' | translate"
-    [title]="'file-download-link.secure-access' | translate"
-    class="pe-1 request-a-copy-access-icon">
+          [attr.aria-label]="'file-download-link.secure-access' | translate"
+          [title]="'file-download-link.secure-access' | translate"
+          class="pe-1 request-a-copy-access-icon">
       <i class="fa-solid fa-lock-open"></i>
     </span>
   } @else if (showIcon) {
@@ -35,6 +35,41 @@
   <ng-container *ngTemplateOutlet="content"></ng-container>
 </a>
 
+@let showAudioTranscript = audioTranscript && isAudioMediaType;
+@let showVideoDescription = videoDescription && isVideoMediaType;
+@if (audioTranscript || videoDescription) {
+  <span class="file-download-link">
+    @if (showAudioTranscript) {
+      <button
+        class="btn btn-link p-0 file-download-link-button"
+        type="button"
+        (click)="openTextModal(textModal, 'file-download-link.audio-transcript.title', audioTranscript)"
+        [attr.aria-label]="'file-download-link.audio-transcript.aria' | translate">
+        {{ 'file-download-link.audio-transcript.label' | translate }}
+      </button>
+    }
+    @if (showVideoDescription) {
+      <button
+        class="btn btn-link p-0 file-download-link-button"
+        type="button"
+        (click)="openTextModal(textModal, 'file-download-link.video-description.title', videoDescription)"
+        [attr.aria-label]="'file-download-link.video-description.aria' | translate">
+        {{ 'file-download-link.video-description.label' | translate }}
+      </button>
+    }
+  </span>
+}
+
 <ng-template #content>
   <ng-content></ng-content>
+</ng-template>
+
+<ng-template #textModal let-modal>
+  <div class="modal-header">
+    <h2 class="modal-title" id="file-download-link-text-modal-title">{{ modalTitle }}</h2>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    <div>{{ modalContent }}</div>
+  </div>
 </ng-template>

--- a/src/app/shared/file-download-link/file-download-link.component.scss
+++ b/src/app/shared/file-download-link/file-download-link.component.scss
@@ -5,3 +5,12 @@
 .btn-download{
   width: fit-content;
 }
+
+.file-download-link {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.file-download-link-button:hover {
+  text-decoration: underline;
+}

--- a/src/app/shared/file-download-link/file-download-link.component.spec.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.spec.ts
@@ -22,6 +22,7 @@ import { ItemRequest } from '@dspace/core/shared/item-request.model';
 import { ActivatedRouteStub } from '@dspace/core/testing/active-router.stub';
 import { RouterLinkDirectiveStub } from '@dspace/core/testing/router-link-directive.stub';
 import { URLCombiner } from '@dspace/core/url-combiner/url-combiner';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -38,6 +39,7 @@ describe('FileDownloadLinkComponent', () => {
 
   let scheduler;
   let authorizationService: AuthorizationDataService;
+  let modalService: jasmine.SpyObj<NgbModal>;
 
   let bitstream: Bitstream;
   let item: Item;
@@ -56,6 +58,7 @@ describe('FileDownloadLinkComponent', () => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: cold('-a', { a: true }),
     });
+    modalService = jasmine.createSpyObj('modalService', ['open']);
     bitstream = Object.assign(new Bitstream(), {
       uuid: 'bitstreamUuid',
       _links: {
@@ -89,6 +92,7 @@ describe('FileDownloadLinkComponent', () => {
         { provide: Store, useValue: storeMock },
         { provide: APP_DATA_SERVICES_MAP, useValue: {} },
         { provide: APP_CONFIG, useValue: { cache: { msToLive: { default: 15 * 60 * 1000 } } } },
+        { provide: NgbModal, useValue: modalService },
       ],
     })
       .overrideComponent(FileDownloadLinkComponent, {
@@ -231,6 +235,71 @@ describe('FileDownloadLinkComponent', () => {
           expect(lock).toBeTruthy();
         });
       });
+    });
+  });
+
+  describe('text links for accessibility metadata', () => {
+    beforeEach(waitForAsync(() => {
+      scheduler = getTestScheduler();
+      init();
+      initTestbed();
+    }));
+
+    beforeEach(() => {
+      bitstream.firstMetadataValue = jasmine.createSpy('firstMetadataValue').and.callFake((key: string) => {
+        if (key === 'dc.description.audiotranscript') {
+          return 'Audio transcript text';
+        }
+        if (key === 'dc.description.videodescription') {
+          return 'Video description text';
+        }
+        if (key === 'dc.description.audiovideo') {
+          return 'audiovideo';
+        }
+        return undefined;
+      });
+      fixture = TestBed.createComponent(FileDownloadLinkComponent);
+      component = fixture.componentInstance;
+      component.bitstream = bitstream;
+      component.item = item;
+      fixture.detectChanges();
+    });
+
+    it('should show buttons for audio transcript and video description when metadata is present', () => {
+      const buttons = fixture.debugElement.queryAll(By.css('.file-download-link-button'));
+      expect(buttons.length).toBe(2);
+    });
+
+    it('should open a modal with the audio transcript content', () => {
+      scheduler.flush();
+      fixture.detectChanges();
+      const audioButton = fixture.debugElement.queryAll(By.css('.file-download-link-button'))[0];
+      audioButton.triggerEventHandler('click');
+      expect(modalService.open).toHaveBeenCalled();
+      expect(component.modalTitle).toContain('file-download-link.audio-transcript.title');
+      expect(component.modalContent).toBe('Audio transcript text');
+    });
+  });
+
+  describe('text links visibility with no metadata', () => {
+    beforeEach(waitForAsync(() => {
+      scheduler = getTestScheduler();
+      init();
+      initTestbed();
+    }));
+
+    beforeEach(() => {
+      bitstream.firstMetadataValue = jasmine.createSpy('firstMetadataValue').and.returnValue(undefined);
+      fixture = TestBed.createComponent(FileDownloadLinkComponent);
+      component = fixture.componentInstance;
+      component.bitstream = bitstream;
+      component.item = item;
+      fixture.detectChanges();
+    });
+
+    it('should not render text link buttons when no metadata is present', () => {
+      const buttons = fixture.debugElement.queryAll(By.css('.file-download-link-button'));
+      expect(buttons.length).toBe(0);
     });
   });
 });

--- a/src/app/shared/file-download-link/file-download-link.component.spec.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.spec.ts
@@ -247,14 +247,14 @@ describe('FileDownloadLinkComponent', () => {
 
     beforeEach(() => {
       bitstream.firstMetadataValue = jasmine.createSpy('firstMetadataValue').and.callFake((key: string) => {
-        if (key === 'dc.description.audiotranscript') {
+        if (key === 'dspace.bitstream.transcript') {
           return 'Audio transcript text';
         }
-        if (key === 'dc.description.videodescription') {
+        if (key === 'dspace.bitstream.textalternative') {
           return 'Video description text';
         }
-        if (key === 'dc.description.audiovideo') {
-          return 'audiovideo';
+        if (key === 'dc.type') {
+          return 'audio+video';
         }
         return undefined;
       });

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -27,6 +27,7 @@ import {
   hasValue,
   isNotEmpty,
 } from '@dspace/shared/utils/empty.util';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
   TranslateModule,
   TranslateService,
@@ -103,11 +104,15 @@ export class FileDownloadLinkComponent implements OnInit {
   canDownloadWithToken$: Observable<boolean>;
   canRequestACopy$: Observable<boolean>;
 
+  modalTitle: string;
+  modalContent: string;
+
   constructor(
     private authorizationService: AuthorizationDataService,
     public dsoNameService: DSONameService,
     private route: ActivatedRoute,
     private translateService: TranslateService,
+    private modalService: NgbModal,
   ) {
   }
 
@@ -180,5 +185,57 @@ export class FileDownloadLinkComponent implements OnInit {
   getDownloadLinkTitle(canDownload: boolean,canDownloadWithToken: boolean, bitstreamName: string): string {
     return (canDownload || canDownloadWithToken ? this.translateService.instant('file-download-link.download') :
       this.translateService.instant('file-download-link.request-copy')) + bitstreamName;
+  }
+
+  /**
+   * Audio transcript metadata value (`dc.description.audiotranscript`), if present.
+   */
+  get audioTranscript(): string {
+    return this.bitstream?.firstMetadataValue('dc.description.audiotranscript');
+  }
+
+  /**
+   * Video description metadata value (`dc.description.videodescription`), if present.
+   */
+  get videoDescription(): string {
+    return this.bitstream?.firstMetadataValue('dc.description.videodescription');
+  }
+
+  /**
+   * Media type metadata value (`dc.description.audiovideo`), if present.
+   */
+  get mediaType(): string {
+    return this.bitstream?.firstMetadataValue('dc.description.audiovideo');
+  }
+
+  /**
+   * Indicates whether media type metadata contains "video" (case-insensitive).
+   */
+  get isVideoMediaType(): boolean {
+    return this.mediaType?.toLowerCase().includes('video');
+  }
+
+  /**
+   * Indicates whether media type metadata contains "audio" (case-insensitive).
+   */
+  get isAudioMediaType(): boolean {
+    return this.mediaType?.toLowerCase().includes('audio');
+  }
+
+  /**
+   * Opens a large, scrollable modal showing text metadata.
+   *
+   * @param template Modal template reference.
+   * @param titleKey Translation key for modal title.
+   * @param content Plain text content to render in the modal body.
+   */
+  openTextModal(template, titleKey: string, content: string) {
+    this.modalTitle = this.translateService.instant(titleKey);
+    this.modalContent = content;
+    this.modalService.open(template, {
+      ariaLabelledBy: 'file-download-link-text-modal-title',
+      size: 'lg',
+      scrollable: true,
+    });
   }
 }

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -188,24 +188,24 @@ export class FileDownloadLinkComponent implements OnInit {
   }
 
   /**
-   * Audio transcript metadata value (`dc.description.audiotranscript`), if present.
+   * Audio transcript metadata value (`dspace.bitstream.transcript`), if present.
    */
   get audioTranscript(): string {
-    return this.bitstream?.firstMetadataValue('dc.description.audiotranscript');
+    return this.bitstream?.firstMetadataValue('dspace.bitstream.transcript');
   }
 
   /**
-   * Video description metadata value (`dc.description.videodescription`), if present.
+   * Video description metadata value (`dspace.bitstream.textalternative`), if present.
    */
   get videoDescription(): string {
-    return this.bitstream?.firstMetadataValue('dc.description.videodescription');
+    return this.bitstream?.firstMetadataValue('dspace.bitstream.textalternative');
   }
 
   /**
-   * Media type metadata value (`dc.description.audiovideo`), if present.
+   * Media type metadata value (`dc.type`), if present.
    */
   get mediaType(): string {
-    return this.bitstream?.firstMetadataValue('dc.description.audiovideo');
+    return this.bitstream?.firstMetadataValue('dc.type');
   }
 
   /**

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -230,7 +230,11 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
       comp.formModel = compAsAny.buildFileEditForm();
 
-      const models = [DynamicCustomSwitchModel, DynamicFormGroupModel, DynamicFormArrayModel];
+      const models = [
+        DynamicCustomSwitchModel,
+        DynamicFormGroupModel,
+        DynamicFormArrayModel,
+      ];
 
       expect(comp.formModel).toBeDefined();
       expect(comp.formModel.length).toBe(models.length);
@@ -305,7 +309,11 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       compAsAny.isPrimary = null;
       formService.validateAllFormFields.and.callFake(() => null);
       formService.isValid.and.returnValue(of(true));
-      formService.getFormData.and.returnValue(of(mockFileFormData));
+      formService.getFormData.and.returnValue(of({
+        ...mockFileFormData,
+        audioTranscript: 'Audio transcript',
+        videoDescription: 'Video description',
+      }));
 
       const response = [
         Object.assign(mockSubmissionObject, {
@@ -343,6 +351,20 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       expect(operationsBuilder.add).toHaveBeenCalledWith(
         pathCombiner.getPath([...pathFragment, path]),
         mockFileFormData.metadata['dc.description'],
+        true,
+      );
+
+      path = 'metadata/dc.description.audiotranscript';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath([...pathFragment, path]),
+        [{ value: 'Audio transcript' }],
+        true,
+      );
+
+      path = 'metadata/dc.description.videodescription';
+      expect(operationsBuilder.add).toHaveBeenCalledWith(
+        pathCombiner.getPath([...pathFragment, path]),
+        [{ value: 'Video description' }],
         true,
       );
 
@@ -391,6 +413,40 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
 
     }));
 
+    it('should remove audio transcript and video description when empty', fakeAsync(() => {
+      compAsAny.formRef = { formGroup: null };
+      compAsAny.fileData = fileData;
+      compAsAny.pathCombiner = pathCombiner;
+      formService.validateAllFormFields.and.callFake(() => null);
+      formService.isValid.and.returnValue(of(true));
+      formService.getFormData.and.returnValue(of({
+        ...mockFileFormData,
+        audioTranscript: '',
+        videoDescription: null,
+      }));
+
+      const response = [
+        Object.assign(mockSubmissionObject, {
+          sections: {
+            upload: {
+              primary: true,
+              files: mockUploadFiles,
+            },
+          },
+        }),
+      ];
+      operationsService.jsonPatchByResourceID.and.returnValue(of(response));
+
+      comp.saveBitstreamData();
+      tick();
+
+      expect(operationsBuilder.remove).toHaveBeenCalledWith(
+        pathCombiner.getPath(['files', fileIndex, 'metadata/dc.description.audiotranscript']),
+      );
+      expect(operationsBuilder.remove).toHaveBeenCalledWith(
+        pathCombiner.getPath(['files', fileIndex, 'metadata/dc.description.videodescription']),
+      );
+    }));
   });
 });
 

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.spec.ts
@@ -354,14 +354,14 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
         true,
       );
 
-      path = 'metadata/dc.description.audiotranscript';
+      path = 'metadata/dspace.bitstream.transcript';
       expect(operationsBuilder.add).toHaveBeenCalledWith(
         pathCombiner.getPath([...pathFragment, path]),
         [{ value: 'Audio transcript' }],
         true,
       );
 
-      path = 'metadata/dc.description.videodescription';
+      path = 'metadata/dspace.bitstream.textalternative';
       expect(operationsBuilder.add).toHaveBeenCalledWith(
         pathCombiner.getPath([...pathFragment, path]),
         [{ value: 'Video description' }],
@@ -441,10 +441,10 @@ describe('SubmissionSectionUploadFileEditComponent test suite', () => {
       tick();
 
       expect(operationsBuilder.remove).toHaveBeenCalledWith(
-        pathCombiner.getPath(['files', fileIndex, 'metadata/dc.description.audiotranscript']),
+        pathCombiner.getPath(['files', fileIndex, 'metadata/dspace.bitstream.transcript']),
       );
       expect(operationsBuilder.remove).toHaveBeenCalledWith(
-        pathCombiner.getPath(['files', fileIndex, 'metadata/dc.description.videodescription']),
+        pathCombiner.getPath(['files', fileIndex, 'metadata/dspace.bitstream.textalternative']),
       );
     }));
   });

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -15,6 +15,7 @@ import { SubmissionObject } from '@dspace/core/submission/models/submission-obje
 import { WorkspaceitemSectionUploadObject } from '@dspace/core/submission/models/workspaceitem-section-upload.model';
 import { WorkspaceitemSectionUploadFileObject } from '@dspace/core/submission/models/workspaceitem-section-upload-file.model';
 import { SubmissionJsonPatchOperationsService } from '@dspace/core/submission/submission-json-patch-operations.service';
+import { VocabularyEntry } from '@dspace/core/submission/vocabularies/models/vocabulary-entry.model';
 import { dateToISOFormat } from '@dspace/shared/utils/date.util';
 import {
   hasNoValue,
@@ -36,7 +37,10 @@ import {
   MATCH_ENABLED,
   OR_OPERATOR,
 } from '@ng-dynamic-forms/core';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import {
   filter,
@@ -46,6 +50,7 @@ import {
 import { DynamicCustomSwitchModel } from 'src/app/shared/form/builder/ds-dynamic-form-ui/models/custom-switch/custom-switch.model';
 
 import { BtnDisabledDirective } from '../../../../../shared/btn-disabled.directive';
+import { DynamicScrollableDropdownModel } from '../../../../../shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model';
 import { FormBuilderService } from '../../../../../shared/form/builder/form-builder.service';
 import { FormComponent } from '../../../../../shared/form/form.component';
 import { FormService } from '../../../../../shared/form/form.service';
@@ -68,6 +73,7 @@ import {
   BITSTREAM_METADATA_FORM_GROUP_CONFIG,
   BITSTREAM_METADATA_FORM_GROUP_LAYOUT,
 } from './section-upload-file-edit.model';
+
 
 /**
  * This component represents the edit form for bitstream
@@ -204,6 +210,7 @@ implements OnInit, OnDestroy {
     private operationsBuilder: JsonPatchOperationsBuilder,
     private operationsService: SubmissionJsonPatchOperationsService,
     private uploadService: SectionUploadService,
+    protected translateService: TranslateService,
   ) {
   }
 
@@ -248,6 +255,8 @@ implements OnInit, OnDestroy {
   onChange(event: DynamicFormControlEvent) {
     if (event.model.id === 'name') {
       this.setOptions(event.model, event.control);
+    } else if (event.model.id === 'dc_description_audiovideo') {
+      this.hideOrShowAudioVideoMetadata(event.model, event.control);
     }
   }
 
@@ -287,11 +296,39 @@ implements OnInit, OnDestroy {
   }
 
   /**
+   * Shows or hides metadata fields related to audio/video accessibility based on the selected media type.
+   *
+   * The selected value can come from:
+   * - `control.value.value` when triggered by a form control change event, or
+   * - `model.value.value` when evaluated from an already initialized model (e.g. on component init).
+   *
+   * @param model - The dynamic form model for the `dc_description_audiovideo` field.
+   * @param control - The reactive form control that emitted the change event (can be `null` during initialization).
+   */
+  hideOrShowAudioVideoMetadata(model: DynamicFormControlModel, control: UntypedFormControl) {
+    const selectedMediaType = control?.value?.value ?? ((model as DynamicScrollableDropdownModel)?.value as unknown as VocabularyEntry)?.value;
+    const shouldShowAudioMetadata = selectedMediaType?.toLowerCase().includes('audio');
+    const shouldShowVideoMetadata = selectedMediaType?.toLowerCase().includes('video');
+    const audioTranscriptModel: any = this.formBuilderService.findById('dc_description_audiotranscript', this.formModel);
+    const videoDescriptionModel: any = this.formBuilderService.findById('dc_description_videodescription', this.formModel);
+    if (audioTranscriptModel) {
+      audioTranscriptModel.hidden = !shouldShowAudioMetadata;
+    }
+    if (videoDescriptionModel) {
+      videoDescriptionModel.hidden = !shouldShowVideoMetadata;
+    }
+  }
+
+  /**
    * Dispatch form model init
    */
   ngOnInit() {
     if (this.fileData && this.formId) {
       this.formModel = this.buildFileEditForm();
+      const mediaTypeModel: any = this.formBuilderService.findById('dc_description_audiovideo', this.formModel);
+      if (mediaTypeModel) {
+        this.hideOrShowAudioVideoMetadata(mediaTypeModel, null);
+      }
       this.cdr.detectChanges();
     }
   }
@@ -412,6 +449,7 @@ implements OnInit, OnDestroy {
       );
 
     }
+
     this.initModelData(formModel);
     return formModel;
   }
@@ -433,6 +471,27 @@ implements OnInit, OnDestroy {
       take(1),
       mergeMap((formData: any) => {
         this.uploadService.updatePrimaryBitstreamOperation(this.pathCombiner.getPath('primary'), this.isPrimary, formData.primary[0], this.fileId);
+
+        const mediaTypeValue = this.retrieveValueFromField(formData.mediaType) ?? formData.mediaType;
+        if (isNotEmpty(mediaTypeValue) && mediaTypeValue !== 'neither') {
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiovideo']), [{ value: mediaTypeValue }], true);
+        } else {
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiovideo']));
+        }
+
+        const audioTranscriptValue = this.retrieveValueFromField(formData.audioTranscript) ?? formData.audioTranscript;
+        if (isNotEmpty(audioTranscriptValue)) {
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiotranscript']), [{ value: audioTranscriptValue }], true);
+        } else {
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiotranscript']));
+        }
+
+        const videoDescriptionValue = this.retrieveValueFromField(formData.videoDescription) ?? formData.videoDescription;
+        if (isNotEmpty(videoDescriptionValue)) {
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.videodescription']), [{ value: videoDescriptionValue }], true);
+        } else {
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.videodescription']));
+        }
 
         // collect bitstream metadata
         Object.keys((formData.metadata))

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -15,7 +15,6 @@ import { SubmissionObject } from '@dspace/core/submission/models/submission-obje
 import { WorkspaceitemSectionUploadObject } from '@dspace/core/submission/models/workspaceitem-section-upload.model';
 import { WorkspaceitemSectionUploadFileObject } from '@dspace/core/submission/models/workspaceitem-section-upload-file.model';
 import { SubmissionJsonPatchOperationsService } from '@dspace/core/submission/submission-json-patch-operations.service';
-import { VocabularyEntry } from '@dspace/core/submission/vocabularies/models/vocabulary-entry.model';
 import { dateToISOFormat } from '@dspace/shared/utils/date.util';
 import {
   hasNoValue,
@@ -50,7 +49,6 @@ import {
 import { DynamicCustomSwitchModel } from 'src/app/shared/form/builder/ds-dynamic-form-ui/models/custom-switch/custom-switch.model';
 
 import { BtnDisabledDirective } from '../../../../../shared/btn-disabled.directive';
-import { DynamicScrollableDropdownModel } from '../../../../../shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model';
 import { FormBuilderService } from '../../../../../shared/form/builder/form-builder.service';
 import { FormComponent } from '../../../../../shared/form/form.component';
 import { FormService } from '../../../../../shared/form/form.service';
@@ -255,8 +253,6 @@ implements OnInit, OnDestroy {
   onChange(event: DynamicFormControlEvent) {
     if (event.model.id === 'name') {
       this.setOptions(event.model, event.control);
-    } else if (event.model.id === 'dc_type') {
-      this.hideOrShowAudioVideoMetadata(event.model, event.control);
     }
   }
 
@@ -296,39 +292,11 @@ implements OnInit, OnDestroy {
   }
 
   /**
-   * Shows or hides metadata fields related to audio/video accessibility based on the selected media type.
-   *
-   * The selected value can come from:
-   * - `control.value.value` when triggered by a form control change event, or
-   * - `model.value.value` when evaluated from an already initialized model (e.g. on component init).
-   *
-   * @param model - The dynamic form model for the `dc_type` field.
-   * @param control - The reactive form control that emitted the change event (can be `null` during initialization).
-   */
-  hideOrShowAudioVideoMetadata(model: DynamicFormControlModel, control: UntypedFormControl) {
-    const selectedMediaType = control?.value?.value ?? ((model as DynamicScrollableDropdownModel)?.value as unknown as VocabularyEntry)?.value;
-    const shouldShowAudioMetadata = selectedMediaType?.toLowerCase().includes('audio');
-    const shouldShowVideoMetadata = selectedMediaType?.toLowerCase().includes('video');
-    const audioTranscriptModel: any = this.formBuilderService.findById('dspace_bitstream_transcript', this.formModel);
-    const videoDescriptionModel: any = this.formBuilderService.findById('dspace_bitstream_textalternative', this.formModel);
-    if (audioTranscriptModel) {
-      audioTranscriptModel.hidden = !shouldShowAudioMetadata;
-    }
-    if (videoDescriptionModel) {
-      videoDescriptionModel.hidden = !shouldShowVideoMetadata;
-    }
-  }
-
-  /**
    * Dispatch form model init
    */
   ngOnInit() {
     if (this.fileData && this.formId) {
       this.formModel = this.buildFileEditForm();
-      const mediaTypeModel: any = this.formBuilderService.findById('dc_type', this.formModel);
-      if (mediaTypeModel) {
-        this.hideOrShowAudioVideoMetadata(mediaTypeModel, null);
-      }
       this.cdr.detectChanges();
     }
   }

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.ts
@@ -255,7 +255,7 @@ implements OnInit, OnDestroy {
   onChange(event: DynamicFormControlEvent) {
     if (event.model.id === 'name') {
       this.setOptions(event.model, event.control);
-    } else if (event.model.id === 'dc_description_audiovideo') {
+    } else if (event.model.id === 'dc_type') {
       this.hideOrShowAudioVideoMetadata(event.model, event.control);
     }
   }
@@ -302,15 +302,15 @@ implements OnInit, OnDestroy {
    * - `control.value.value` when triggered by a form control change event, or
    * - `model.value.value` when evaluated from an already initialized model (e.g. on component init).
    *
-   * @param model - The dynamic form model for the `dc_description_audiovideo` field.
+   * @param model - The dynamic form model for the `dc_type` field.
    * @param control - The reactive form control that emitted the change event (can be `null` during initialization).
    */
   hideOrShowAudioVideoMetadata(model: DynamicFormControlModel, control: UntypedFormControl) {
     const selectedMediaType = control?.value?.value ?? ((model as DynamicScrollableDropdownModel)?.value as unknown as VocabularyEntry)?.value;
     const shouldShowAudioMetadata = selectedMediaType?.toLowerCase().includes('audio');
     const shouldShowVideoMetadata = selectedMediaType?.toLowerCase().includes('video');
-    const audioTranscriptModel: any = this.formBuilderService.findById('dc_description_audiotranscript', this.formModel);
-    const videoDescriptionModel: any = this.formBuilderService.findById('dc_description_videodescription', this.formModel);
+    const audioTranscriptModel: any = this.formBuilderService.findById('dspace_bitstream_transcript', this.formModel);
+    const videoDescriptionModel: any = this.formBuilderService.findById('dspace_bitstream_textalternative', this.formModel);
     if (audioTranscriptModel) {
       audioTranscriptModel.hidden = !shouldShowAudioMetadata;
     }
@@ -325,7 +325,7 @@ implements OnInit, OnDestroy {
   ngOnInit() {
     if (this.fileData && this.formId) {
       this.formModel = this.buildFileEditForm();
-      const mediaTypeModel: any = this.formBuilderService.findById('dc_description_audiovideo', this.formModel);
+      const mediaTypeModel: any = this.formBuilderService.findById('dc_type', this.formModel);
       if (mediaTypeModel) {
         this.hideOrShowAudioVideoMetadata(mediaTypeModel, null);
       }
@@ -474,23 +474,23 @@ implements OnInit, OnDestroy {
 
         const mediaTypeValue = this.retrieveValueFromField(formData.mediaType) ?? formData.mediaType;
         if (isNotEmpty(mediaTypeValue) && mediaTypeValue !== 'neither') {
-          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiovideo']), [{ value: mediaTypeValue }], true);
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.type']), [{ value: mediaTypeValue }], true);
         } else {
-          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiovideo']));
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.type']));
         }
 
         const audioTranscriptValue = this.retrieveValueFromField(formData.audioTranscript) ?? formData.audioTranscript;
         if (isNotEmpty(audioTranscriptValue)) {
-          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiotranscript']), [{ value: audioTranscriptValue }], true);
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dspace.bitstream.transcript']), [{ value: audioTranscriptValue }], true);
         } else {
-          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.audiotranscript']));
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dspace.bitstream.transcript']));
         }
 
         const videoDescriptionValue = this.retrieveValueFromField(formData.videoDescription) ?? formData.videoDescription;
         if (isNotEmpty(videoDescriptionValue)) {
-          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.videodescription']), [{ value: videoDescriptionValue }], true);
+          this.operationsBuilder.add(this.pathCombiner.getPath([...pathFragment, 'metadata/dspace.bitstream.textalternative']), [{ value: videoDescriptionValue }], true);
         } else {
-          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dc.description.videodescription']));
+          this.operationsBuilder.remove(this.pathCombiner.getPath([...pathFragment, 'metadata/dspace.bitstream.textalternative']));
         }
 
         // collect bitstream metadata

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.model.ts
@@ -9,6 +9,7 @@ import {
   OR_OPERATOR,
 } from '@ng-dynamic-forms/core';
 
+
 export const BITSTREAM_METADATA_FORM_GROUP_CONFIG: DynamicFormGroupModelConfig = {
   id: 'metadata',
   group: [],

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1011,6 +1011,26 @@
 
   "bitstream.edit.form.iiifHeight.hint": "The canvas height should usually match the image height.",
 
+  "bitstream.edit.form.mediaType.label": "Audio or video media type",
+
+  "bitstream.edit.form.mediaType.hint": "Choose how this bitstream should be interpreted.",
+
+  "bitstream.edit.form.mediaType.option.neither": "Neither",
+
+  "bitstream.edit.form.mediaType.option.audio": "Audio",
+
+  "bitstream.edit.form.mediaType.option.video": "Video",
+
+  "bitstream.edit.form.mediaType.option.audio-video": "Audio and video",
+
+  "bitstream.edit.form.audioTranscript.label": "Audio transcript",
+
+  "bitstream.edit.form.audioTranscript.hint": "Provide a transcript for audio content.",
+
+  "bitstream.edit.form.videoDescription.label": "Video description",
+
+  "bitstream.edit.form.videoDescription.hint": "Provide a description for video content.",
+
   "bitstream.edit.notifications.saved.content": "Your changes to this bitstream were saved.",
 
   "bitstream.edit.notifications.saved.title": "Bitstream saved",
@@ -5865,6 +5885,26 @@
 
   "submission.sections.upload.edit.title": "Edit bitstream",
 
+  "submission.sections.upload.file.edit.form.file-type.label": "Audio or video media type",
+
+  "submission.sections.upload.file.edit.form.file-type.hint": "Choose how this bitstream should be interpreted.",
+
+  "submission.sections.upload.file.edit.form.file-type.option.audio-video": "Audio and video",
+
+  "submission.sections.upload.file.edit.form.file-type.option.neither": "Neither",
+
+  "submission.sections.upload.file.edit.form.file-type.option.audio": "Audio",
+
+  "submission.sections.upload.file.edit.form.file-type.option.video": "Video",
+
+  "submission.sections.upload.file.edit.form.audio-transcript.label": "Audio transcript",
+
+  "submission.sections.upload.file.edit.form.audio-transcript.hint": "Provide a transcript for audio content.",
+
+  "submission.sections.upload.file.edit.form.video-description.label": "Video description",
+
+  "submission.sections.upload.file.edit.form.video-description.hint": "Provide a description for video content.",
+
   "submission.sections.upload.form.access-condition-label": "Access condition type",
 
   "submission.sections.upload.form.access-condition-hint": "Select an access condition to apply on the bitstream once the item is deposited",
@@ -7478,6 +7518,18 @@
   "file-download-link.request-copy": "Request a copy of ",
 
   "file-download-button.request-copy": "Request a copy",
+
+  "file-download-link.audio-transcript.label": "Transcript",
+
+  "file-download-link.audio-transcript.title": "Audio transcript",
+
+  "file-download-link.audio-transcript.aria": "Open audio transcript",
+
+  "file-download-link.video-description.label": "Video description",
+
+  "file-download-link.video-description.title": "Video description",
+
+  "file-download-link.video-description.aria": "Open video description",
 
   "item.preview.organization.url": "URL",
 


### PR DESCRIPTION
## References
* Fixes #3807
* Fixes #3808
* Requires DSpace/DSpace#12250

## Description
Added new bitstream metadata in order to include an audio transcript and/or a video description to an audio/video bitstream. Managed such metadata in submission form and bitstream edit form. Introduced modals to show those values in the item page.

## Instructions for Reviewers
List of changes in this PR:
* Changed the bitstream submission form to accommodate the newly created metadata fields; 
* Applied a custom logic to show/hide fields relevant to the selected media type;
* Extended the current bitstream edit form to - again - accommodate these new metadata fields;
* Introduced clickable links to show audio transcripts and video descriptions in a modal above the item page.

**Include guidance for how to test or review your PR.**
* Create a new Item and upload a bitstream. Try to change its media type - an `audio` media should show the audio transcript textarea, a `video` media should show the video description textarea, and an `audio and video` media should show both;
* Confirm that these values are saved correctly as bitstream metadata;
* Confirm that changing the media type does **not** delete metadata that is not relevant anymore (e.g. selecting the `video` media type should not clear the audio transcript metadata value. This is expected - since these values can be quite long and tedious to write, changing the media type by accident should not clear them;
* After depositing the item, check that its bitstream metadata can be changed. The bitstream edit form should behave the same as the submission form;
* Check that the item page shows links relevant to the bitstream type. An audio bitstream with an audio transcript should show the _transcript_ link, etc;
* Check that clicking on those links open a modal with the metadata value shown inside.

<img width="1919" height="913" alt="image" src="https://github.com/user-attachments/assets/ec5be532-8496-439b-977e-514d28feffb9" />
<img width="1120" height="731" alt="image" src="https://github.com/user-attachments/assets/f45e07b7-0f94-4448-ac0f-46dfda6fdfc4" />
<img width="446" height="380" alt="image" src="https://github.com/user-attachments/assets/45d6b227-4393-4126-bc73-ec4e4b69cb88" />


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
