### PR TITLE
Fix #5386: Fix range filter freeze by using isChecked$ observable and…

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.html
@@ -1,12 +1,18 @@
-@if (isVisible | async) {
-  <a class="d-flex flex-row"
-    (click)="filterService.minimizeAll()"
-    [routerLink]="[searchLink]"
-    [queryParams]="changeQueryParams" queryParamsHandling="merge"
-    role="button" tabindex="0">
-    <span class="filter-value px-1">{{filterValue.label}}</span>
-    <span class="float-end filter-value-count ms-auto">
-      <span class="badge bg-secondary rounded-pill">{{filterValue.count | dsShortNumber}}</span>
+<a class="d-flex flex-row"
+  [routerLink]="[searchLink]"
+  [queryParams]="(isChecked$ | async) ? removeQueryParams : changeQueryParams"
+  queryParamsHandling="merge"
+  [class.selected]="isChecked$ | async"
+  role="button" tabindex="0">
+  <span class="filter-value px-1">
+    {{ filterValue.label }}
+    @if (isChecked$ | async) {
+      <span aria-label="Activo"> ✕</span>
+    }
+  </span>
+  <span class="float-end filter-value-count ms-auto">
+    <span class="badge bg-secondary rounded-pill">
+      {{ filterValue.count | dsShortNumber }}
     </span>
-  </a>
-}
+  </span>
+</a>

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
@@ -153,11 +153,12 @@ describe('SearchFacetRangeOptionComponent', () => {
   });
 
   describe('when isVisible emits false', () => {
-    it('the facet option should not be visible', () => {
+    it('the facet option should still be visible (active filter can be deselected)', () => {
       comp.isVisible = of(false);
       fixture.detectChanges();
       const linkEl = fixture.debugElement.query(By.css('a'));
-      expect(linkEl).toBeNull();
+      expect(linkEl).not.toBeNull();
+      expect(linkEl.nativeElement.classList).toContain('selected');
     });
   });
 });

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
@@ -83,6 +83,16 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
    */
   searchLink: string;
 
+  /**
+   * UI parameters when this filter is removed (deselect)
+   */
+  removeQueryParams: Params;
+
+  /**
+   * Observable que indica si esta opción de filtro está actualmente activa
+   */
+  isChecked$: Observable<boolean>;
+
   constructor(protected searchService: SearchService,
               protected filterService: SearchFilterService,
               protected searchConfigService: SearchConfigurationService,
@@ -95,6 +105,7 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
    * Initializes all observable instance variables and starts listening to them
    */
   ngOnInit(): void {
+    this.isChecked$ = this.isChecked();
     this.searchLink = this.getSearchLink();
     this.isVisible = this.isChecked().pipe(map((checked: boolean) => !checked));
     this.sub = this.searchConfigService.searchOptions.subscribe(() => {
@@ -130,6 +141,11 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
     this.changeQueryParams = {
       [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: [min],
       [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: max === new Date().getUTCFullYear() ? null : [max],
+      [page]: 1,
+    };
+    this.removeQueryParams = {
+      [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: null,
+      [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: null,
       [page]: 1,
     };
   }


### PR DESCRIPTION
## References
* Fixes #5386

## Description
This PR fixes a problem in the range filters of the search page, where clicking on a range (e.g., date 2000–2008) caused the filter panels to freeze. The solution introduces an isChecked$ observable to track whether each filter option is active, removing the need for using an async pipe directly in the (click) handler.

## Instructions for Reviewers
Changes made in this PR:

- Added the isChecked$: Observable<boolean> property to represent whether the filter option is currently active.
- Removed async pipes from the (click) handler to prevent UI freezing.
- Updated changeQueryParams and removeQueryParams to correctly handle activating and deactivating the filter without affecting other functionality.
- Updated the HTML template of search-facet-range-option to use isChecked$ | async safely in bindings, avoiding direct operations in the (click).

How to test:

1. Navigate to the search page and open the range filters, e.g., date filters.
2. Click on a range (2000–2008, etc.).
3. Verify that the filter panels collapse correctly and the UI no longer freezes.
4. Ensure that other filters and selections continue to function as expected.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
