### PR TITLE
Use node:crypto instead of third-party md5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,6 @@
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "^1.5.0",
         "karma-mocha-reporter": "2.2.5",
-        "md5": "^2.3.0",
         "ng-mocks": "^14.15.2",
         "ngx-mask": "^16.0.0",
         "postcss": "^8.5",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,6 @@
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
     "karma-mocha-reporter": "2.2.5",
-    "md5": "^2.3.0",
     "ng-mocks": "^14.15.2",
     "ngx-mask": "^16.0.0",
     "postcss": "^8.5",

--- a/webpack/helpers.ts
+++ b/webpack/helpers.ts
@@ -1,7 +1,6 @@
 import { readFileSync, readdirSync, statSync, Stats } from 'fs';
 import { join, resolve } from 'path';
-
-const md5 = require('md5');
+import { createHash } from 'node:crypto';
 
 export const projectRoot = (relativePath) => {
   return resolve(__dirname, '..', relativePath);
@@ -21,7 +20,7 @@ export const globalCSSImports = () => {
  */
 export function calculateFileHash(filePath: string): string {
   const fileContent: Buffer = readFileSync(filePath);
-  return md5(fileContent);
+  return createHash('md5').update(fileContent).digest('hex');
 }
 
 /**


### PR DESCRIPTION
# Description
Use Node.js native crypto API to calculate md5 hashes instead of third-party md5 library. This is used during production builds to calculate hashes of i18n language files.

Note: this could be backported to DSpace 9, 8, and 7 because it is very simple and I think the Node.js APIs have been around long enough to be in all versions we use. See `crypto.createHash` docs: https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options

# Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, remove md5 library
* Second, use Node.js native crypto API

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

Run the build in production mode with `npm run build:prod` and then `npm run serve:ssr` and make sure that language switching in the UI works.

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
