### PR TITLE
Change Identifier model class to a Typed Object

### DIFF
--- a/src/app/core/provide-core.ts
+++ b/src/app/core/provide-core.ts
@@ -4,6 +4,7 @@ import {
   makeEnvironmentProviders,
 } from '@angular/core';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
+import { Identifier } from '@dspace/core/shared/identifiers-data/identifier.model';
 import { SubmissionCustomUrl } from '@dspace/core/submission/models/submission-custom-url.model';
 
 import { Audit } from './audit/model/audit.model';
@@ -199,6 +200,7 @@ export const models =
     ResearcherProfile,
     OrcidQueue,
     OrcidHistory,
+    Identifier,
     IdentifierData,
     Subscription,
     ItemRequest,

--- a/src/app/core/shared/identifiers-data/identifier.model.ts
+++ b/src/app/core/shared/identifiers-data/identifier.model.ts
@@ -1,3 +1,5 @@
+import { typedObject } from '@dspace/core/cache/builders/build-decorators';
+import { IDENTIFIER } from '@dspace/core/shared/identifiers-data/identifier.resource-type';
 import { autoserialize } from 'cerialize';
 
 /**
@@ -5,14 +7,22 @@ import { autoserialize } from 'cerialize';
  *
  * @author Kim Shepherd
  */
+@typedObject
 export class Identifier {
+  static type = IDENTIFIER;
+
+  /**
+   * Unique ID for this identifier object
+   */
+  @autoserialize
+  id: string;
   /**
    * The value of the identifier, eg. http://hdl.handle.net/123456789/123 or https://doi.org/test/doi/1234
    */
   @autoserialize
   value: string;
   /**
-   * The type of identiifer, eg. "doi", or "handle", or "other"
+   * The type of identifier, eg. "doi", or "handle", or "other"
    */
   @autoserialize
   identifierType: string;

--- a/src/app/core/shared/identifiers-data/identifier.resource-type.ts
+++ b/src/app/core/shared/identifiers-data/identifier.resource-type.ts
@@ -1,0 +1,9 @@
+import { ResourceType } from '@dspace/core/shared/resource-type';
+
+/**
+ * The resource type for Identifier
+ *
+ * Needs to be in a separate file to prevent circular
+ * dependencies in webpack.
+ */
+export const IDENTIFIER = new ResourceType('identifier');

--- a/src/app/submission/sections/identifiers/section-identifiers.component.spec.ts
+++ b/src/app/submission/sections/identifiers/section-identifiers.component.spec.ts
@@ -88,12 +88,14 @@ const mockItem = Object.assign(new Item(), {
 // Mock identifier data to use with tests
 const identifierData: WorkspaceitemSectionIdentifiersObject = {
   identifiers: [{
+    id: 'https://doi.org/10.33515/dspace-61',
     value: 'https://doi.org/10.33515/dspace-61',
     identifierType: 'doi',
     identifierStatus: 'TO_BE_REGISTERED',
     type: 'identifier',
   },
   {
+    id: '123456789/418',
     value: '123456789/418',
     identifierType: 'handle',
     identifierStatus: null,


### PR DESCRIPTION
## Description
This PR adds the ability to receive data from endpoints using `IdentifierRest` by changing the `Identifier` model class to a `typedObject`.
This change was made to align with the other model classes in DSpace Angular that have a corresponding `...Rest` class in DSpace REST.
By changing `Identifier` to a typed object, it would make it possible to deserialize the response from any of the [identifier endpoints](https://github.com/DSpace/RestContract/blob/main/identifiers.md).

## Instructions for Reviewers
- Retrieve data from the `/api/pid/identifiers` endpoint
- Before PR changes:
    - received objects will not be able to be deserialized
- After PR changes:
    - received objects will be deserialized

List of changes in this PR:
- Changes the `Identifier` model class into a `typedObject`
- Adds a new `ResourceType`

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
