### PR TITLE
Fix CMS metadata editor language field saving

### DIFF
--- a/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.spec.ts
+++ b/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.spec.ts
@@ -135,10 +135,10 @@ describe('AdminEditCmsMetadataComponent', () => {
 
       it('should call method patch of service', () => {
         component.selectedMetadata = environment.cms.metadataList[0];
+        component.site = site;
         component.selectedMetadataValues.set(environment.languages[0].code, 'Test English Text');
         component.selectedMetadataValues.set(environment.languages[1].code, 'Test Second Language Text');
-        const saveButton = fixture.debugElement.query(By.css('#save-metadata-btn'));
-        saveButton.nativeElement.click();
+        component.saveMetadata();
 
         const operations = [];
         if (site.hasMetadata && site.hasMetadata(component.selectedMetadata)) {

--- a/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.spec.ts
+++ b/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.spec.ts
@@ -10,6 +10,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { NotificationsServiceStub } from '@dspace/core/testing/notifications-service.stub';
 import { TranslateLoaderMock } from '@dspace/core/testing/translate-loader.mock';
+import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
 import {
   TranslateLoader,
   TranslateModule,
@@ -26,11 +27,12 @@ describe('AdminEditCmsMetadataComponent', () => {
   let component: AdminEditCmsMetadataComponent;
   let fixture: ComponentFixture<AdminEditCmsMetadataComponent>;
   const site = Object.assign(new Site(), {
-    metadata: { },
+    metadata: {},
   });
 
   const siteServiceStub = jasmine.createSpyObj('SiteDataService', {
     find: jasmine.createSpy('find'),
+    findByHref: jasmine.createSpy('findByHref'),
     patch: jasmine.createSpy('patch'),
   });
 
@@ -70,6 +72,7 @@ describe('AdminEditCmsMetadataComponent', () => {
     fixture = TestBed.createComponent(AdminEditCmsMetadataComponent);
     component = fixture.componentInstance;
     siteServiceStub.find.and.returnValue(of(site));
+    siteServiceStub.findByHref.and.returnValue(createSuccessfulRemoteDataObject$(site));
     siteServiceStub.patch.and.returnValue(of(site));
   });
 
@@ -132,28 +135,29 @@ describe('AdminEditCmsMetadataComponent', () => {
 
       it('should call method patch of service', () => {
         component.selectedMetadata = environment.cms.metadataList[0];
+        component.selectedMetadataValues.set(environment.languages[0].code, 'Test English Text');
+        component.selectedMetadataValues.set(environment.languages[1].code, 'Test Second Language Text');
         const saveButton = fixture.debugElement.query(By.css('#save-metadata-btn'));
         saveButton.nativeElement.click();
+
         const operations = [];
-        operations.push({
-          op: 'replace',
-          path: '/metadata/' + component.selectedMetadata,
-          value: {
-            value: component.selectedMetadataValues.get(environment.languages[0].code),
-            language: environment.languages[0].code,
-          },
-        });
-        component.selectedMetadataValues.forEach((value, key) => {
-          if (key !== environment.languages[0].code) {
-            operations.push({
-              op: 'add',
-              path: '/metadata/' + component.selectedMetadata,
-              value: {
-                value: value,
-                language: key,
-              },
-            });
-          }
+        if (site.hasMetadata && site.hasMetadata(component.selectedMetadata)) {
+          operations.push({
+            op: 'remove',
+            path: '/metadata/' + component.selectedMetadata,
+          });
+        }
+        const nonEmptyValues = Array.from(component.selectedMetadataValues.entries())
+          .filter(([, text]) => text && text.trim().length > 0);
+        nonEmptyValues.forEach(([language, value]) => {
+          operations.push({
+            op: 'add',
+            path: '/metadata/' + component.selectedMetadata + '/-',
+            value: {
+              value,
+              language,
+            },
+          });
         });
         expect(siteServiceStub.patch).toHaveBeenCalledWith(site, operations);
       });

--- a/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.ts
+++ b/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.ts
@@ -84,9 +84,7 @@ export class AdminEditCmsMetadataComponent implements OnInit {
       }
       this.metadataList.push(md);
     });
-    this.siteService.find().subscribe((site) => {
-      this.site = site;
-    });
+    this.refreshSiteWithAllLanguages();
   }
 
   /**
@@ -106,10 +104,23 @@ export class AdminEditCmsMetadataComponent implements OnInit {
           this.notificationsService.error(this.translateService.get('admin.edit-cms-metadata.error'));
         }
         this.siteService.setStale();
-        this.siteService.find().subscribe((site) => {
-          this.site = site;
-        });
+        this.refreshSiteWithAllLanguages();
       });
+  }
+
+  /**
+   * Reload site metadata including all language variants.
+   */
+  private refreshSiteWithAllLanguages() {
+    this.siteService.find().subscribe((site) => {
+      this.siteService.findByHref(`${site.self}?projection=allLanguages`, false, true).pipe(
+        getFirstCompletedRemoteData(),
+      ).subscribe((response) => {
+        if (response?.hasSucceeded) {
+          this.site = response.payload;
+        }
+      });
+    });
   }
 
   /**
@@ -147,16 +158,38 @@ export class AdminEditCmsMetadataComponent implements OnInit {
    * @returns List of operations to send to backend to edit selected metadata
    */
   private getOperationsToEditText(): Operation[] {
-    const entries = Array.from(this.selectedMetadataValues.entries());
+    const operations: Operation[] = [];
+    const nonEmptyValues = Array.from(this.selectedMetadataValues.entries())
+      .filter(([, text]) => text && text.trim().length > 0);
 
-    // First entry should form a 'replace' operation, then the rest should be an 'add' operation
-    return entries.map(([language, text], index) => ({
-      op: index === 0 ? 'replace' : 'add',
-      path: `/metadata/${this.selectedMetadata}`,
-      value: {
-        value: text ?? '',
-        language: language,
-      },
-    }));
+    if (nonEmptyValues.length === 0) {
+      if (this.site.hasMetadata(this.selectedMetadata)) {
+        operations.push({
+          op: 'remove',
+          path: `/metadata/${this.selectedMetadata}`,
+        });
+      }
+      return operations;
+    }
+
+    if (this.site.hasMetadata(this.selectedMetadata)) {
+      operations.push({
+        op: 'remove',
+        path: `/metadata/${this.selectedMetadata}`,
+      });
+    }
+
+    nonEmptyValues.forEach(([language, text]) => {
+      operations.push({
+        op: 'add',
+        path: `/metadata/${this.selectedMetadata}/-`,
+        value: {
+          value: text,
+          language,
+        },
+      });
+    });
+
+    return operations;
   }
 }


### PR DESCRIPTION
## References
* Fixes #5397

## Description
This PR fixes the CMS metadata editor so it no longer persists empty metadata entries for unfilled languages, and it now reloads the editor with metadata from all languages instead of only the active locale. As a result, the edit form correctly shows existing values for all configured languages and saves only the languages that were actually filled.

## Instructions for Reviewers
This PR updates the CMS metadata edit flow to address problem 1 (empty metadata entries being saved) and problem 2 (the edit form loading only the active language value).

**List of changes in this PR:**

- First, the PATCH payload generation in the CMS metadata editor was changed to ignore empty language values.
- Second, existing metadata is cleared with a remove operation and then recreated with one [add](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) operation per non-empty language value, preventing empty metadata rows from being stored.
- Third, the CMS metadata editor now reloads the [Site](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) object using projection=allLanguages, so the form is populated with values for all available languages instead of only the locale-filtered value.
- Fourth, the same all-languages reload behavior is applied after save, ensuring the editor reflects the persisted multilingual values immediately.
- Fifth, the unit test for the CMS metadata editor was updated to cover the new PATCH operation format and the all-languages reload behavior.
- Sixth, reviewers should note that issue https://github.com/DSpace/dspace-angular/issues/5397#issuecomment-4200677573 still has a remaining open item: region-specific locale resolution (pt-BR, pt-PT) is still not handled correctly in metadata display/query flows outside the editor fix included here. 

**Steps to Test:**
1. Verify that the desired locales are listed in `webui.supported.locales` config (`dspace.cfg` or `local.cfg`).
2. Fill only one language in the editor and save:
   - Only that language entry should be persisted (no additional empty metadata entries).
3. Fill multiple language inputs in the editor and save:
   - The entered values should be persisted for each filled language.
4. Open the edit form for metadata that already has multiple languages:
   - All language fields should be pre-filled with their corresponding existing values.
5. Fill `pt-BR` and `pt-PT` with different texts:
   - This is currently not working. Each locale should display its own value, but region-specific locales are still not resolved correctly.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
