### PR TITLE
Fix metadata values and separators display

### DIFF
--- a/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.html
+++ b/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.html
@@ -1,6 +1,6 @@
 <div class="simple-view-element" [class.d-none]="hideIfNoTextContent && content.textContent.trim().length === 0">
   @if (label) {
-  <h2 class="simple-view-element-header">{{ label }}</h2>
+    <h2 class="simple-view-element-header">{{ label }}</h2>
   }
   <div #content class="simple-view-element-body">
     <ng-content></ng-content>

--- a/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.html
+++ b/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.html
@@ -1,8 +1,8 @@
 <div class="simple-view-element" [class.d-none]="hideIfNoTextContent && content.textContent.trim().length === 0">
   @if (label) {
-    <h2 class="simple-view-element-header">{{ label }}</h2>
+  <h2 class="simple-view-element-header">{{ label }}</h2>
   }
-  <div #content class="simple-view-element-body d-flex flex-column">
+  <div #content class="simple-view-element-body">
     <ng-content></ng-content>
   </div>
 </div>


### PR DESCRIPTION
## References
* Fixes #5440
* 
## Description
Removes unnecessary layout classes from the metadata field wrapper component to simplify the structure and avoid unintended styling behavior.

## Instructions for Reviewers
This PR removes redundant Bootstrap flex classes that were not required and could interfere with layout rendering.

**List of changes in this PR**:
* Removed `d-flex` and `flex-column` classes from `<div #content class="simple-view-element-body">` in metadata-field-wrapper.component.html
* Ensured no visual regressions in metadata value display and separators

**How to verify**:
- Open an item page, for example: https://sandbox.dspace.org/entities/publication/01c5f86f-806a-41a8-840d-8373e697eb20
- Check the Keywords section on the item page
- Verify that metadata values and separators are displayed correctly
- Confirm there are no layout issues or regressions in the metadata rendering

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
