### PR TITLE
Fix #5336: General system alert visible to users in real time without…

### DIFF
--- a/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.spec.ts
+++ b/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.spec.ts
@@ -7,6 +7,10 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import {
+  NavigationEnd,
+  Router,
+} from '@angular/router';
 import { SystemWideAlertDataService } from '@dspace/core/data/system-wide-alert-data.service';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { SystemWideAlert } from '@dspace/core/shared/system-wide-alert.model';
@@ -16,10 +20,10 @@ import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote
 import { TranslateModule } from '@ngx-translate/core';
 import { utcToZonedTime } from 'date-fns-tz';
 import { getTestScheduler } from 'jasmine-marbles';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { SystemWideAlertBannerComponent } from './system-wide-alert-banner.component';
-
 
 describe('SystemWideAlertBannerComponent', () => {
   let comp: SystemWideAlertBannerComponent;
@@ -48,11 +52,16 @@ describe('SystemWideAlertBannerComponent', () => {
       searchBy: createSuccessfulRemoteDataObject$(createPaginatedList([systemWideAlert])),
     });
 
+    const routerStub = {
+      events: of(new NavigationEnd(0, '/test', '/test')),
+    };
+
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), SystemWideAlertBannerComponent],
       providers: [
         { provide: SystemWideAlertDataService, useValue: systemWideAlertDataService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: Router, useValue: routerStub }, // 👈 AQUÍ
       ],
     }).compileComponents();
   }));
@@ -67,17 +76,20 @@ describe('SystemWideAlertBannerComponent', () => {
     it('should init the comp', () => {
       expect(comp).toBeTruthy();
     });
+
     it('should set the time countdown parts in their respective behaviour subjects', fakeAsync(() => {
       spyOn(comp.countDownDays, 'next');
       spyOn(comp.countDownHours, 'next');
       spyOn(comp.countDownMinutes, 'next');
+
       comp.ngOnInit();
       tick(2000);
+
       expect(comp.countDownDays.next).toHaveBeenCalled();
       expect(comp.countDownHours.next).toHaveBeenCalled();
       expect(comp.countDownMinutes.next).toHaveBeenCalled();
-      discardPeriodicTasks();
 
+      discardPeriodicTasks();
     }));
   });
 

--- a/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.spec.ts
+++ b/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.spec.ts
@@ -11,6 +11,7 @@ import {
   NavigationEnd,
   Router,
 } from '@angular/router';
+import { APP_CONFIG } from '@dspace/config/app-config.interface';
 import { SystemWideAlertDataService } from '@dspace/core/data/system-wide-alert-data.service';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { SystemWideAlert } from '@dspace/core/shared/system-wide-alert.model';
@@ -24,6 +25,8 @@ import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { SystemWideAlertBannerComponent } from './system-wide-alert-banner.component';
+
+
 
 describe('SystemWideAlertBannerComponent', () => {
   let comp: SystemWideAlertBannerComponent;
@@ -52,16 +55,13 @@ describe('SystemWideAlertBannerComponent', () => {
       searchBy: createSuccessfulRemoteDataObject$(createPaginatedList([systemWideAlert])),
     });
 
-    const routerStub = {
-      events: of(new NavigationEnd(0, '/test', '/test')),
-    };
-
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), SystemWideAlertBannerComponent],
       providers: [
         { provide: SystemWideAlertDataService, useValue: systemWideAlertDataService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
-        { provide: Router, useValue: routerStub }, // 👈 AQUÍ
+        { provide: Router, useValue: { events: of(new NavigationEnd(0, '/test', '/test')) } },
+        { provide: APP_CONFIG, useValue: { systemWideAlert: { refreshIntervalMs: 300000 } } },
       ],
     }).compileComponents();
   }));
@@ -76,20 +76,17 @@ describe('SystemWideAlertBannerComponent', () => {
     it('should init the comp', () => {
       expect(comp).toBeTruthy();
     });
-
     it('should set the time countdown parts in their respective behaviour subjects', fakeAsync(() => {
       spyOn(comp.countDownDays, 'next');
       spyOn(comp.countDownHours, 'next');
       spyOn(comp.countDownMinutes, 'next');
-
       comp.ngOnInit();
       tick(2000);
-
       expect(comp.countDownDays.next).toHaveBeenCalled();
       expect(comp.countDownHours.next).toHaveBeenCalled();
       expect(comp.countDownMinutes.next).toHaveBeenCalled();
-
       discardPeriodicTasks();
+
     }));
   });
 

--- a/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.ts
+++ b/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.ts
@@ -9,6 +9,10 @@ import {
   OnInit,
   PLATFORM_ID,
 } from '@angular/core';
+import {
+  NavigationEnd,
+  Router,
+} from '@angular/router';
 import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { SystemWideAlertDataService } from '@dspace/core/data/system-wide-alert-data.service';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
@@ -29,6 +33,7 @@ import {
 import {
   filter,
   map,
+  startWith,
   switchMap,
 } from 'rxjs/operators';
 
@@ -75,18 +80,25 @@ export class SystemWideAlertBannerComponent implements OnInit, OnDestroy {
     @Inject(PLATFORM_ID) protected platformId: any,
     protected systemWideAlertDataService: SystemWideAlertDataService,
     protected notificationsService: NotificationsService,
+    protected router: Router,
   ) {
   }
 
   ngOnInit() {
-    this.subscriptions.push(this.systemWideAlertDataService.searchBy('active').pipe(
-      getAllSucceededRemoteDataPayload(),
-      map((payload: PaginatedList<SystemWideAlert>) => payload.page),
-      filter((page) => isNotEmpty(page)),
-      map((page) => page[0]),
-    ).subscribe((alert: SystemWideAlert) => {
-      this.systemWideAlert$.next(alert);
-    }));
+    this.subscriptions.push(
+      this.router.events.pipe(
+        filter(event => event instanceof NavigationEnd),
+        startWith(null),
+        switchMap(() =>
+          this.systemWideAlertDataService.searchBy('active', null, false, true),
+        ),
+        getAllSucceededRemoteDataPayload(),
+        map((payload: PaginatedList<SystemWideAlert>) => payload.page),
+        map((page) => isNotEmpty(page) ? page[0] : null),
+      ).subscribe((alert: SystemWideAlert) => {
+        this.systemWideAlert$.next(alert);
+      }),
+    );
 
     this.subscriptions.push(this.systemWideAlert$.pipe(
       switchMap((alert: SystemWideAlert) => {

--- a/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.ts
+++ b/src/app/system-wide-alert/alert-banner/system-wide-alert-banner.component.ts
@@ -13,6 +13,10 @@ import {
   NavigationEnd,
   Router,
 } from '@angular/router';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
 import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { SystemWideAlertDataService } from '@dspace/core/data/system-wide-alert-data.service';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
@@ -35,6 +39,7 @@ import {
   map,
   startWith,
   switchMap,
+  throttleTime,
 } from 'rxjs/operators';
 
 /**
@@ -78,6 +83,7 @@ export class SystemWideAlertBannerComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(PLATFORM_ID) protected platformId: any,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
     protected systemWideAlertDataService: SystemWideAlertDataService,
     protected notificationsService: NotificationsService,
     protected router: Router,
@@ -89,6 +95,7 @@ export class SystemWideAlertBannerComponent implements OnInit, OnDestroy {
       this.router.events.pipe(
         filter(event => event instanceof NavigationEnd),
         startWith(null),
+        throttleTime(this.appConfig.systemWideAlert?.refreshIntervalMs ?? 5 * 60 * 1000),
         switchMap(() =>
           this.systemWideAlertDataService.searchBy('active', null, false, true),
         ),
@@ -112,7 +119,6 @@ export class SystemWideAlertBannerComponent implements OnInit, OnDestroy {
             } else {
               return EMPTY;
             }
-
           }
         }
         // Reset the countDown times to 0 and return EMPTY to prevent unnecessary countdown calculations
@@ -132,7 +138,6 @@ export class SystemWideAlertBannerComponent implements OnInit, OnDestroy {
    */
   private setTimeDifference(countdownTo: string) {
     const date = zonedTimeToUtc(countdownTo, 'UTC');
-
     const timeDifference = date.getTime() - new Date().getTime();
     this.allocateTimeUnits(timeDifference);
   }

--- a/src/config/app-config.interface.ts
+++ b/src/config/app-config.interface.ts
@@ -77,6 +77,9 @@ interface AppConfig extends Config {
   searchResult: SearchResultConfig;
   addToAnyPlugin: AddToAnyPluginConfig;
   cms: CmsMetadata;
+  systemWideAlert?: {
+    refreshIntervalMs: number;
+  };
 }
 
 /**

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -140,6 +140,13 @@ export class DefaultAppConfig implements AppConfig {
     },
   };
 
+  // System-wide alert settings
+  systemWideAlert = {
+    // How often (in milliseconds) the system-wide alert is refreshed during navigation.
+    // Prevents spamming the endpoint on every route change.
+    refreshIntervalMs: 5 * 60 * 1000, // 5 minutes
+  };
+
   // Form settings
   form: FormConfig = {
     spellCheck: true,


### PR DESCRIPTION
## References
* Fixes #5336

## Description
Fixes an issue where system-wide alerts were not updated in real time for users already browsing the site. The alert banner now refreshes on navigation and properly handles deactivation without requiring a manual page reload.

## Instructions for Reviewers

This PR ensures that system-wide alerts are dynamically updated during normal navigation without requiring a full page reload.

### Changes
List of changes in this PR:
* Re-fetch system-wide alerts on every `NavigationEnd` router event
* Added `startWith(null)` to trigger initial fetch on component load
* Disabled cache usage in `searchBy` to ensure fresh data is retrieved
* Updated logic to handle empty responses (no active alerts) by emitting `null`
* Ensured banner is hidden when no active alert exists
* Added Router mock in unit tests to support new reactive flow

### How to test
1. Open DSpace in two browser sessions (or one normal + one incognito)
2. In Browser 1:
   - Navigate to any page (e.g. homepage)
3. In Browser 2 (admin user):
   - Go to System-Wide Alert settings
   - Enable a new alert and save
4. In Browser 1:
   - Navigate to another page (without refreshing)
   - ✅ The alert should now appear

5. Still in Browser 2:
   - Disable the alert and save
6. In Browser 1:
   - Navigate again
   - ✅ The alert should disappear

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
