### PR TITLE
Fix #5342 making cms edits configurable

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -400,6 +400,10 @@ homePage:
     pageSize: 5
   # Enable or disable the Discover filters on the homepage
   showDiscoverFilters: false
+  # Disable if you don't want users to edit the homeNews section on your home-page.
+  editHomeNews: true
+  # Disable if you don't want users to edit the home header.
+  editHomeHeader: true
 
 # Item Config
 item:

--- a/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.ts
+++ b/src/app/admin/admin-edit-cms-metadata/admin-edit-cms-metadata.component.ts
@@ -82,6 +82,12 @@ export class AdminEditCmsMetadataComponent implements OnInit {
       if (md === 'dspace.cms.footer' && !environment.homePage.showTopFooter) {
         return;
       }
+      if (md === 'dspace.cms.home-header' && !environment.homePage.editHomeHeader) {
+        return;
+      }
+      if (md === 'dspace.cms.home-news' && !environment.homePage.editHomeNews) {
+        return;
+      }
       this.metadataList.push(md);
     });
     this.siteService.find().subscribe((site) => {

--- a/src/app/home-page/home-news/home-news.component.ts
+++ b/src/app/home-page/home-news/home-news.component.ts
@@ -1,9 +1,14 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  Inject,
   OnInit,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
 import { LocaleService } from '@dspace/core/locale/locale.service';
 import { Site } from '@dspace/core/shared/site.model';
 import {
@@ -32,20 +37,23 @@ export class HomeNewsComponent implements OnInit {
   homeNewsMetadataValue$: Observable<string>;
 
   constructor(
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
     protected route: ActivatedRoute,
     private locale: LocaleService,
   ) {}
 
   ngOnInit() {
-    this.homeNewsMetadataValue$ = combineLatest({
-      site$: this.route.data.pipe(
-        map((data) => data.site as Site),
-      ),
-      language$: this.locale.getCurrentLanguageCode(),
-    }).pipe(
-      take(1),
-      map(({ site$, language$ }) => site$?.firstMetadataValue('dspace.cms.home-news', { language: language$ })),
-    );
+    if (this.appConfig.homePage.editHomeNews) {
+      this.homeNewsMetadataValue$ = combineLatest({
+        site$: this.route.data.pipe(
+          map((data) => data.site as Site),
+        ),
+        language$: this.locale.getCurrentLanguageCode(),
+      }).pipe(
+        take(1),
+        map(({ site$, language$ }) => site$?.firstMetadataValue('dspace.cms.home-news', { language: language$ })),
+      );
+    }
   }
 
 }

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -77,7 +77,7 @@ export class HomePageComponent implements OnInit {
         language: this.locale.getCurrentLanguageCode(),
       }).pipe(
         take(1),
-        map(({site, language}) => site?.firstMetadataValue('dspace.cms.home-header', {language})),
+        map(({ site, language }) => site?.firstMetadataValue('dspace.cms.home-header', { language })),
       );
     }
   }

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -71,14 +71,15 @@ export class HomePageComponent implements OnInit {
     this.site$ = this.route.data.pipe(
       map((data) => data.site as Site),
     );
-
-    this.homeHeaderMetadataValue$ = combineLatest({
-      site: this.site$,
-      language: this.locale.getCurrentLanguageCode(),
-    }).pipe(
-      take(1),
-      map(({ site, language }) => site?.firstMetadataValue('dspace.cms.home-header', { language })),
-    );
+    if (this.appConfig.homePage.editHomeHeader) {
+      this.homeHeaderMetadataValue$ = combineLatest({
+        site: this.site$,
+        language: this.locale.getCurrentLanguageCode(),
+      }).pipe(
+        take(1),
+        map(({site, language}) => site?.firstMetadataValue('dspace.cms.home-header', {language})),
+      );
+    }
   }
 
 }

--- a/src/app/shared/menu/providers/edit-cms-metadata.menu.ts
+++ b/src/app/shared/menu/providers/edit-cms-metadata.menu.ts
@@ -6,7 +6,14 @@
  * http://www.dspace.org/license/
  */
 
-import { Injectable } from '@angular/core';
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '@dspace/config/app-config.interface';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '@dspace/core/data/feature-authorization/feature-id';
 import {
@@ -28,6 +35,7 @@ import {
 export class EditCMSMetadataMenuProvider extends AbstractMenuProvider {
   constructor(
     protected authorizationService: AuthorizationDataService,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) {
     super();
   }
@@ -39,7 +47,7 @@ export class EditCMSMetadataMenuProvider extends AbstractMenuProvider {
       map(([isSiteAdmin]) => {
         return [
           {
-            visible: isSiteAdmin,
+            visible: isSiteAdmin && (this.appConfig.homePage.editHomeHeader || this.appConfig.homePage.editHomeHeader || this.appConfig.homePage.showTopFooter),
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.edit-cms-metadata',

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -371,6 +371,8 @@ export class DefaultAppConfig implements AppConfig {
       pageSize: 5,
     },
     showDiscoverFilters: false,
+    editHomeNews: true,
+    editHomeHeader: true,
   };
 
   // Item Config

--- a/src/config/homepage-config.interface.ts
+++ b/src/config/homepage-config.interface.ts
@@ -28,4 +28,14 @@ export interface HomeConfig extends Config {
   * Enable or disable the Discover filters on the homepage
   */
   showDiscoverFilters: boolean;
+
+  /**
+   * Disable if you don't want users to edit the homeNews section on your home-page.
+   */
+  editHomeNews: boolean;
+
+  /**
+   * Disable if you don't want users to edit the home header.
+   */
+  editHomeHeader: boolean;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -278,6 +278,8 @@ export const environment: BuildConfig = {
       pageSize: 5,
     },
     showDiscoverFilters: false,
+    editHomeNews: true,
+    editHomeHeader: true,
   },
   item: {
     edit: {


### PR DESCRIPTION
## References

* Fixes #5342

## Description
As described in the connected issue, this PR aims to make it configurable whether the CMS-fields home-news and home-header should be shown by adding to new config parameters:
```yml
homePage:
  editHomeNews: true
  editHomeHeader: true
```
Currently those default to _true_. If they are set to false, the content of the metadata will not shown on the UI and the field won't be editable via the Admin-UI. Additionally the _Edit CMS Metadata_-Menu section will disappear completly, if both fields are set to false as well as the _showTopFooter_ field.

## Instructions for Reviewers

List of changes in this PR:
* Added new config fields _editHomeNews_ and _editHomeHeader_ and set the default values
* Made display of the CMS metadata configurable based on those settings
* Added condition whether to display the cms-metadata fields in the edit dropdown.


**Include guidance for how to test or review your PR.** 
1. Add a value to the english field of the dspace.cms.homeheader and dspace.cms.homenews and make sure they are displayed correctly
2. Set the config parameters _editHomeNews_ and _editHomeHeader_ to false and restart the angular ui.
3. Make sure the cms values are no longer displayed.
4. Logging as an admin and verify the  _Edit CMS Metadata_ menu section disappeared from the admin-sidebar
5. Open the CMS-Metadata menu directly via http://localhost:4000/admin/edit-cms-metadata and make sure the dropdown is an empty-list.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] ~If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
