### PR TITLE
Fix #5454: Group edits are immediately reflected in the user interface

### DIFF
--- a/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.spec.ts
@@ -3,7 +3,9 @@ import { HttpClient } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import {
   ComponentFixture,
+  fakeAsync,
   TestBed,
+  tick,
   waitForAsync,
 } from '@angular/core/testing';
 import {
@@ -343,6 +345,19 @@ describe('GroupFormComponent', () => {
         spyOn(groupsDataServiceStub, 'patch').and.returnValue(createSuccessfulRemoteDataObject$(expected2));
         component.ngOnInit();
       });
+
+      it('should update the form fields with the new values after successful edit', fakeAsync(() => {
+        component.groupName.setValue('newGroupName');
+        component.groupDescription.setValue(groupDescription);
+
+        component.onSubmit();
+        tick();
+
+        expect(component.formGroup.value.groupName).toBe(expected2.name);
+        expect(component.formGroup.value.groupDescription).toBe(
+          expected2.firstMetadataValue('dc.description'),
+        );
+      }));
 
       it('should edit with name and description operations', () => {
         component.groupName.setValue('newGroupName');

--- a/src/app/access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.ts
@@ -416,6 +416,16 @@ export class GroupFormComponent implements OnInit, OnDestroy {
       getFirstCompletedRemoteData(),
     ).subscribe((rd: RemoteData<Group>) => {
       if (rd.hasSucceeded) {
+
+        const updatedGroup = rd.payload;
+
+        this.groupRegistryService.editGroup(updatedGroup);
+
+        this.formGroup.patchValue({
+          groupName: updatedGroup.name,
+          groupDescription: updatedGroup.firstMetadataValue('dc.description'),
+        });
+
         this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.edited.success', { name: this.dsoNameService.getName(rd.payload) }));
         this.submitForm.emit(rd.payload);
       } else {


### PR DESCRIPTION
## References
Fixes #5454

## Description
Fixes an issue where edited group details were not immediately reflected in the UI after saving, requiring a manual page refresh.

## Instructions for Reviewers
List of changes in this PR:

- Updated GroupFormComponent to refresh the active group state after a successful edit.
- Ensured the form fields are updated immediately using the response payload from the backend.
- Added a unit test to verify that the form reflects updated values after editing a group.

How to test this PR:

1. Log in to DSpace as an administrator.
2. Navigate to Admin → Access Control → Groups.
3. Create a new test group (or use an existing non-system group).
4. Click Edit on the group.
5. Change the group name (e.g. test_group → test_group_updated).
6. Click Save.

✅ Expected behavior:
A success message appears with the updated group name.
The "Group name" field updates immediately without requiring a page refresh.

❌ Previous behavior:
The success message showed the updated name.
The input field still displayed the old name until the page was refreshed.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
