### PR TITLE
Fix #5314: The keyword now performs a search and returns the correct …

### DIFF
--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -4,14 +4,29 @@
     <!--
     Choose a template. Priority: vocabulary, markdown, link, browse link.
     -->
-      <ng-container *ngTemplateOutlet="(isVocabulary ? controlledVocabulary : (renderMarkdown ? markdown : (hasLink(mdValue) ? (hasValue(img) ? linkImg : link) : (hasBrowseDefinition() ? browselink : simple))));
-        context: {value: (isVocabulary ? mdValue : mdValue.value), img}">
-    </ng-container>
+      <ng-container
+        *ngTemplateOutlet="
+          isVocabulary ? controlledVocabulary :
+          renderMarkdown ? markdown :
+          hasLink(mdValue) ? (hasValue(img) ? linkImg : link) :
+          hasSearchFilter() ? searchlink :
+          hasBrowseDefinition() ? browselink : simple;
+          context: { value: (isVocabulary ? mdValue : mdValue.value), img: img }
+        ">
+      </ng-container>
     @if (!last) {
       <span class="separator" [innerHTML]="separator"></span>
     }
   }
 </ds-metadata-field-wrapper>
+
+<ng-template #searchlink let-value="value">
+  <a class="ds-search-link"
+     [routerLink]="['/search']"
+     [queryParams]="getSearchQueryParams(value)">
+    {{ value }}
+  </a>
+</ng-template>
 
 <!-- Render value as markdown -->
 <ng-template #markdown let-value="value">

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
@@ -141,5 +141,31 @@ describe('MetadataValuesComponent', () => {
     });
   });
 
+  it('should render search link when searchFilter is present', () => {
+    comp.searchFilter = 'subject';
+    fixture.detectChanges();
+
+    const value = mockMetadata[0].value;
+
+    const link = fixture.debugElement.query(By.css('a.ds-search-link'));
+
+    expect(link).not.toBeNull();
+    expect(link.nativeElement.textContent).toContain(value);
+  });
+
+  it('should render browse link when browseDefinition is provided', () => {
+    comp.browseDefinition = {
+      id: 'subject',
+      metadataKeys: [],
+      order: 0,
+      getRenderType: () => 'metadata',
+    } as any;
+
+    fixture.detectChanges();
+
+    const link = fixture.debugElement.query(By.css('a.ds-browse-link'));
+
+    expect(link).not.toBeNull();
+  });
 
 });

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
@@ -8,6 +8,8 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
 import { buildPaginatedList } from '@dspace/core/data/paginated-list.model';
 import { MetadataValue } from '@dspace/core/shared/metadata.models';
@@ -28,18 +30,10 @@ let comp: MetadataValuesComponent;
 let fixture: ComponentFixture<MetadataValuesComponent>;
 
 const mockMetadata = [
-  {
-    language: 'en_US',
-    value: '1234',
-  },
-  {
-    language: 'en_US',
-    value: 'a publisher',
-  },
-  {
-    language: 'en_US',
-    value: 'desc',
-  }] as MetadataValue[];
+  { language: 'en_US', value: '1234' },
+  { language: 'en_US', value: 'a publisher' },
+  { language: 'en_US', value: 'desc' },
+] as MetadataValue[];
 const mockSeperator = '<br/>';
 const mockLabel = 'fake.message';
 const vocabularyServiceMock = {
@@ -58,15 +52,28 @@ const controlledMetadata = {
 describe('MetadataValuesComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: TranslateLoaderMock,
-        },
-      }), MetadataValuesComponent],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          },
+        }),
+        MetadataValuesComponent,
+      ],
       providers: [
         { provide: APP_CONFIG, useValue: environment },
         { provide: VocabularyService, useValue: vocabularyServiceMock },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {},
+            params: of({}),
+            queryParams: of({}),
+            data: of({}),
+          },
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).overrideComponent(MetadataValuesComponent, {
@@ -103,38 +110,28 @@ describe('MetadataValuesComponent', () => {
 
   it('should return correct target and rel for internal links', () => {
     spyOn(comp, 'hasInternalLink').and.returnValue(true);
-    const urlValue = '/internal-link';
-    const result = comp.getLinkAttributes(urlValue);
+    const result = comp.getLinkAttributes('/internal-link');
     expect(result.target).toBe('_self');
     expect(result.rel).toBe('');
   });
 
   it('should return correct target and rel for external links', () => {
     spyOn(comp, 'hasInternalLink').and.returnValue(false);
-    const urlValue = 'https://www.dspace.org';
-    const result = comp.getLinkAttributes(urlValue);
+    const result = comp.getLinkAttributes('https://www.dspace.org');
     expect(result.target).toBe('_blank');
     expect(result.rel).toBe('noopener noreferrer');
   });
 
   it('should detect controlled vocabulary metadata', () => {
-    const result = comp.isControlledVocabulary(controlledMetadata);
-    expect(result).toBeTrue();
+    expect(comp.isControlledVocabulary(controlledMetadata)).toBeTrue();
   });
 
   it('should return translated vocabulary value when available', (done) => {
-    const vocabEntry = {
-      display: 'Translated Value',
-    };
-
     vocabularyServiceMock.getPublicVocabularyEntryByID.and.returnValue(
-      of(
-        createSuccessfulRemoteDataObject(
-          buildPaginatedList(new PageInfo(), [vocabEntry]),
-        ),
-      ),
+      of(createSuccessfulRemoteDataObject(
+        buildPaginatedList(new PageInfo(), [{ display: 'Translated Value' }]),
+      )),
     );
-
     comp.getVocabularyValue(controlledMetadata).subscribe((value) => {
       expect(value).toBe('Translated Value');
       done();
@@ -143,14 +140,8 @@ describe('MetadataValuesComponent', () => {
 
   it('should render search link when searchFilter is present', () => {
     comp.searchFilter = 'subject';
-    fixture.detectChanges();
-
-    const value = mockMetadata[0].value;
-
-    const link = fixture.debugElement.query(By.css('a.ds-search-link'));
-
-    expect(link).not.toBeNull();
-    expect(link.nativeElement.textContent).toContain(value);
+    expect(comp.hasSearchFilter()).toBeTrue();
+    expect(comp.getSearchQueryParams('test')).toEqual({ 'f.subject': 'test,equals' });
   });
 
   it('should render browse link when browseDefinition is provided', () => {
@@ -160,12 +151,7 @@ describe('MetadataValuesComponent', () => {
       order: 0,
       getRenderType: () => 'metadata',
     } as any;
-
-    fixture.detectChanges();
-
-    const link = fixture.debugElement.query(By.css('a.ds-browse-link'));
-
-    expect(link).not.toBeNull();
+    expect(comp.hasBrowseDefinition()).toBeTrue();
   });
 
 });

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -103,8 +103,22 @@ export class MetadataValuesComponent implements OnChanges {
 
   hasValue = hasValue;
 
+  /**
+   * Optional metadata field used to build search links for values.
+   * If defined, values will link to the search page using this field as filter.
+   */
+  @Input() searchFilter?: string;
+
   ngOnChanges(changes: SimpleChanges): void {
     this.renderMarkdown = !!this.appConfig.markdown.enabled && this.enableMarkdown;
+  }
+
+  /**
+   * Determines whether a search filter has been configured for this metadata field.
+   * Used to decide if values should be rendered as search links.
+   */
+  hasSearchFilter(): boolean {
+    return !!this.searchFilter;
   }
 
   /**
@@ -124,6 +138,17 @@ export class MetadataValuesComponent implements OnChanges {
       return pattern.test(value.value);
     }
     return false;
+  }
+
+  /**
+   * Builds query parameters for the search page based on the configured search filter.
+   * The metadata value is used as the search term for the specified field.
+   *
+   * @param value The metadata value to search for.
+   * @returns Query parameters object for Angular router navigation.
+   */
+  getSearchQueryParams(value: string): any {
+    return { [`f.${this.searchFilter}`]: `${value},equals` };
   }
 
   /**

--- a/src/app/item-page/simple/field-components/specific-field/item-page-field.component.html
+++ b/src/app/item-page/simple/field-components/specific-field/item-page-field.component.html
@@ -5,7 +5,8 @@
     [label]="label"
     [enableMarkdown]="enableMarkdown"
     [urlRegex]="urlRegex"
-    [browseDefinition]="browseDefinition|async"
-    [img]="img"
-  ></ds-metadata-values>
+    [browseDefinition]="browseDefinition | async"
+    [searchFilter]="searchFilter"
+    [img]="img">
+  </ds-metadata-values>
 </div>

--- a/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
@@ -55,7 +55,7 @@ export class ItemPageFieldComponent {
     /**
      * Fields (schema.element.qualifier) used to render their values.
      */
-    fields: string[];
+    @Input() fields: string[];
 
     /**
      * Label i18n key for the rendered metadata
@@ -77,6 +77,13 @@ export class ItemPageFieldComponent {
      * Image Configuration
      */
     img: ImageField;
+
+    /**
+     * Search filter used when rendering subject metadata as search links.
+     */
+    get searchFilter(): string | undefined {
+      return this.fields?.includes('dc.subject') ? 'subject' : undefined;
+    }
 
     /**
      * Return browse definition that matches any field used in this component if it is configured as a browse


### PR DESCRIPTION
## References
* Fixes #5314

## Description
This PR fixes incorrect navigation behavior when clicking subject keywords on item pages. Previously, clicking a subject redirected users to the browse/srsc page instead of performing a proper search for items associated with that subject.

## Instructions for Reviewers
This PR modifies the metadata rendering logic for dc.subject fields in item pages.

List of changes in this PR:

-  Added a searchFilter input to detect when metadata corresponds to dc.subject.
-  Updated query parameter generation to use search-based navigation instead of browse navigation.
-  Introduced getSearchQueryParams() to build proper subject search queries using the format query=subject:"value".
-  Updated hasSearchFilter() logic to control when search links should be rendered.
-  Ensured subject keywords now redirect to search results instead of browse/srsc.

How to test:

1.  Open any item page containing dc.subject metadata.
2.  Click on a subject/keyword.
3.  Verify that the user is redirected to a search results page.
4.  Confirm that results are filtered using the selected subject (e.g. subject:"value").
5.  Ensure that other metadata fields not using dc.subject are unaffected.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
