### PR TITLE
Fix #5435: show permission denied message when 403 on collection mapper

### DIFF
--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.spec.ts
@@ -180,6 +180,13 @@ describe('ItemCollectionMapperComponent', () => {
       expect(notificationsService.success).not.toHaveBeenCalled();
       expect(notificationsService.error).toHaveBeenCalled();
     });
+
+    it('should display a permission error message if mapping returns 403', () => {
+      spyOn(itemDataService, 'mapToCollection').and.returnValue(createFailedRemoteDataObject$('Forbidden', 403));
+      comp.mapCollections(ids);
+      expect(notificationsService.success).not.toHaveBeenCalled();
+      expect(notificationsService.error).toHaveBeenCalled();
+    });
   });
 
   describe('removeMappings', () => {
@@ -193,6 +200,13 @@ describe('ItemCollectionMapperComponent', () => {
 
     it('should display an error message if the removal of at least one mapping was unsuccessful', () => {
       spyOn(itemDataService, 'removeMappingFromCollection').and.returnValue(createFailedRemoteDataObject$('Not Found', 404));
+      comp.removeMappings(ids);
+      expect(notificationsService.success).not.toHaveBeenCalled();
+      expect(notificationsService.error).toHaveBeenCalled();
+    });
+
+    it('should display a permission error message if removal returns 403', () => {
+      spyOn(itemDataService, 'removeMappingFromCollection').and.returnValue(createFailedRemoteDataObject$('Forbidden', 403));
       comp.removeMappings(ids);
       expect(notificationsService.success).not.toHaveBeenCalled();
       expect(notificationsService.error).toHaveBeenCalled();

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.ts
@@ -287,14 +287,28 @@ export class ItemCollectionMapperComponent implements OnInit {
         this.shouldUpdate$.next(true);
       }
       if (unsuccessful.length > 0) {
-        const unsuccessMessages = observableCombineLatest([
-          this.translateService.get(`${messagePrefix}.error.head`),
-          this.translateService.get(`${messagePrefix}.error.content`, { amount: unsuccessful.length }),
-        ]);
+        const forbidden = unsuccessful.filter((response: RemoteData<NoContent>) => response.statusCode === 403);
+        const otherErrors = unsuccessful.filter((response: RemoteData<NoContent>) => response.statusCode !== 403);
 
-        unsuccessMessages.subscribe(([head, content]) => {
-          this.notificationsService.error(head, content);
-        });
+        if (forbidden.length > 0) {
+          const forbiddenMessages = observableCombineLatest([
+            this.translateService.get(`${messagePrefix}.error.forbidden.head`),
+            this.translateService.get(`${messagePrefix}.error.forbidden.content`),
+          ]);
+          forbiddenMessages.subscribe(([head, content]) => {
+            this.notificationsService.error(head, content);
+          });
+        }
+
+        if (otherErrors.length > 0) {
+          const unsuccessMessages = observableCombineLatest([
+            this.translateService.get(`${messagePrefix}.error.head`),
+            this.translateService.get(`${messagePrefix}.error.content`, { amount: otherErrors.length }),
+          ]);
+          unsuccessMessages.subscribe(([head, content]) => {
+            this.notificationsService.error(head, content);
+          });
+        }
       }
       this.switchToFirstTab();
     });

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2643,6 +2643,10 @@
 
   "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
 
+  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Permission denied",
+
+  "item.edit.item-mapper.notifications.add.error.forbidden.content": "You do not have permission to map this item to a collection.",
+
   "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
 
   "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
@@ -2650,6 +2654,10 @@
   "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
 
   "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+
+  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Permission denied",
+
+  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "You do not have permission to remove this item from a collection.",
 
   "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
 


### PR DESCRIPTION
## References
Fixes #5435

## Description
When a user without permission attempts to change a mapped collection, the UI now shows a clear "Permission denied" message instead of a generic error when the backend returns a 403 Forbidden response.

## Instructions for Reviewers
List of changes in this PR:

-  Added 403 status code check in `showNotifications` method in `item-collection-mapper.component.ts` to differentiate permission errors from other errors
- Added i18n keys for permission denied messages in `en.json5` for both map and remove operations
- Added new specs to cover the 403 case in both `mapCollections` and `removeMappings`

How to test:
1. Log in as a user without permission to change a mapped collection
2. Navigate to an item → Administer → Collection Mapper
3. Attempt to map or remove a collection
4. Verify the error message now says "Permission denied" instead 
   of a generic error message

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
