### PR TITLE
DURACOM-441 Provided fallback logic for page search, we now fallback to the highest available totalPages if we reach an out of bound search page

### DIFF
--- a/src/app/search-page/configuration-search-page.component.ts
+++ b/src/app/search-page/configuration-search-page.component.ts
@@ -14,6 +14,7 @@ import {
   AppConfig,
 } from '@dspace/config/app-config.interface';
 import { SearchManager } from '@dspace/core/browse/search-manager';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
 import { RouteService } from '@dspace/core/services/route.service';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -69,7 +70,8 @@ export class ConfigurationSearchPageComponent extends SearchComponent {
               @Inject(APP_CONFIG) protected appConfig: AppConfig,
               @Inject(PLATFORM_ID) public platformId: string,
               protected searchManager: SearchManager,
+              protected paginationService: PaginationService,
   ) {
-    super(service, sidebarService, windowService, searchConfigService, routeService, router, appConfig, platformId, searchManager);
+    super(service, sidebarService, windowService, searchConfigService, routeService, router, appConfig, platformId, searchManager, paginationService);
   }
 }

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -23,6 +23,7 @@ import {
 import { CommunityDataService } from '@dspace/core/data/community-data.service';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { APP_DATA_SERVICES_MAP } from '@dspace/core/data-services-map-type';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
 import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
 import {
   getCollectionPageRoute,
@@ -31,6 +32,7 @@ import {
 import { RouteService } from '@dspace/core/services/route.service';
 import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
 import { Item } from '@dspace/core/shared/item.model';
+import { PageInfo } from '@dspace/core/shared/page-info.model';
 import { FilterType } from '@dspace/core/shared/search/models/filter-type.model';
 import { PaginatedSearchOptions } from '@dspace/core/shared/search/models/paginated-search-options.model';
 import { SearchFilterConfig } from '@dspace/core/shared/search/models/search-filter-config.model';
@@ -39,6 +41,7 @@ import {
   SearchConfig,
   SortConfig,
 } from '@dspace/core/shared/search/search-filters/search-config.model';
+import { PaginationServiceStub } from '@dspace/core/testing/pagination-service.stub';
 import { SidebarServiceStub } from '@dspace/core/testing/sidebar-service.stub';
 import {
   createSuccessfulRemoteDataObject,
@@ -253,6 +256,7 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
       { provide: APP_DATA_SERVICES_MAP, useValue: {} },
       { provide: APP_CONFIG, useValue: environment },
       { provide: PLATFORM_ID, useValue: 'browser' },
+      { provide: PaginationService, useClass: PaginationServiceStub },
     ],
     schemas: [NO_ERRORS_SCHEMA],
   }).overrideComponent(compType, {
@@ -451,5 +455,72 @@ describe('SearchComponent', () => {
         expect(searchManagerStub.search).toHaveBeenCalled();
       }));
     });
+  });
+
+  describe('Fallback pagination logic', () => {
+    let paginationServiceStub: PaginationServiceStub;
+
+    beforeEach(() => {
+      paginationServiceStub = TestBed.inject(PaginationService) as any;
+    });
+
+    afterEach(() => {
+      searchManagerStub.search.and.returnValue(mockResultsRD$);
+      paginationServiceStub.updateRoute.calls.reset();
+    });
+
+    it('should navigate to last available page when requested page exceeds total pages', fakeAsync(() => {
+      // Mock search to return empty results with totalPages = 3
+      const emptySearchResults: SearchObjects<DSpaceObject> = Object.assign(new SearchObjects(), {
+        page: [],
+        pageInfo: Object.assign(new PageInfo(), { totalPages: 3, totalElements: 25, elementsPerPage: 10, currentPage: 5 }),
+      });
+      const emptyResultsRD = createSuccessfulRemoteDataObject(emptySearchResults);
+      searchManagerStub.search.and.returnValue(of(emptyResultsRD));
+
+      fixture.detectChanges();
+      tick(100);
+
+      // Reset updateRoute spy to only track calls after the page change
+      paginationServiceStub.updateRoute.calls.reset();
+
+      // Emit new search options with currentPage = 5 (exceeding totalPages = 3)
+      const paginationOptions = Object.assign(new PaginationComponentOptions(), {
+        id: paginationId,
+        currentPage: 5,
+        pageSize: 10,
+      });
+      paginatedSearchOptions$.next(new PaginatedSearchOptions({ pagination: paginationOptions }));
+      tick(100);
+
+      expect(paginationServiceStub.updateRoute).toHaveBeenCalledWith(paginationId, { page: 3 });
+    }));
+
+    it('should NOT navigate when requested page is within total pages', fakeAsync(() => {
+      // Mock search to return results on page 2
+      const searchResultsPage2: SearchObjects<DSpaceObject> = Object.assign(new SearchObjects(), {
+        page: [mockDso],
+        pageInfo: Object.assign(new PageInfo(), { totalPages: 3, totalElements: 25, elementsPerPage: 10, currentPage: 2 }),
+      });
+      const resultsRD = createSuccessfulRemoteDataObject(searchResultsPage2);
+      searchManagerStub.search.and.returnValue(of(resultsRD));
+
+      fixture.detectChanges();
+      tick(100);
+
+      // Reset updateRoute spy
+      paginationServiceStub.updateRoute.calls.reset();
+
+      // Emit new search options with currentPage = 2 (within totalPages = 3)
+      const paginationOptions = Object.assign(new PaginationComponentOptions(), {
+        id: paginationId,
+        currentPage: 2,
+        pageSize: 10,
+      });
+      paginatedSearchOptions$.next(new PaginatedSearchOptions({ pagination: paginationOptions }));
+      tick(100);
+
+      expect(paginationServiceStub.updateRoute).not.toHaveBeenCalled();
+    }));
   });
 });

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -26,6 +26,7 @@ import { SearchManager } from '@dspace/core/browse/search-manager';
 import { SortOptions } from '@dspace/core/cache/models/sort-options.model';
 import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { RemoteData } from '@dspace/core/data/remote-data';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
 import {
   COLLECTION_MODULE_PATH,
   COMMUNITY_MODULE_PATH,
@@ -356,6 +357,7 @@ export class SearchComponent implements OnDestroy, OnInit {
               @Inject(APP_CONFIG) protected appConfig: AppConfig,
               @Inject(PLATFORM_ID) public platformId: string,
               protected searchManager: SearchManager,
+              protected paginationService: PaginationService,
   ) {
     this.isXsOrSm$ = this.windowService.isXsOrSm();
   }
@@ -555,6 +557,15 @@ export class SearchComponent implements OnDestroy, OnInit {
       ...followLinks,
     ).pipe(getFirstCompletedRemoteData())
       .subscribe((results: RemoteData<SearchObjects<DSpaceObject>>) => {
+        // Fallback logic: if no results and requested page > 1, navigate to the last available page
+        if (results.hasSucceeded && results.payload?.page?.length === 0 && searchOptionsWithHidden.pagination.currentPage > 1) {
+          const totalPages = results.payload?.pageInfo?.totalPages;
+          if (totalPages && totalPages > 0 && searchOptionsWithHidden.pagination.currentPage > totalPages) {
+            // Update the route to the last available page
+            this.paginationService.updateRoute(this.paginationId, { page: totalPages });
+            return;
+          }
+        }
         if (results.hasSucceeded) {
           if (this.trackStatistics) {
             this.service.trackSearch(searchOptionsWithHidden, results.payload);


### PR DESCRIPTION

## Description
Provided fallback logic for page search, we now fallback to the highest available totalPages if we reach an out of bound search page
The practical use case for it can be described by this example: "I copy a link to the last page of a search with a single result; in the meantime, an item related to the same search is deleted — at that point, the link leads to an empty page."

## Instructions for Reviewers
Implemented a fallback logic when reaching out of bounds pages

List of changes in this PR:
* Implemented fallback logic
* Provided tests

## Include guidance for how to test or review your PR.
In homepage run a search, go to the highest available page, go up one more and the fallback pagination logic will be triggered and you will be brought back to the highest available page

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
