### PR TITLE
fix #5494: enable rotate to show surrounding pages on navigation

### DIFF
--- a/src/app/core/pagination/pagination-component-options.model.ts
+++ b/src/app/core/pagination/pagination-component-options.model.ts
@@ -20,6 +20,12 @@ export class PaginationComponentOptions extends NgbPaginationConfig {
   maxSize = 10;
 
   /**
+   * Whether to rotate pages towards the current page.
+   * Ensures the active page is always visible in the pagination control.
+   */
+  rotate = true;
+
+  /**
    * A number array that represents options for a context pagination limit.
    */
   pageSizeOptions: number[] = [1, 5, 10, 20, 40, 60, 80, 100];

--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -64,7 +64,7 @@
               [page]="(currentPage$|async)"
               (pageChange)="doPageChange($event)"
               [pageSize]="(pageSize$ |async)"
-              [rotate]="true"
+              [rotate]="paginationOptions.rotate"
               [size]="(isXs)?'sm':paginationOptions.size">
             </ngb-pagination>
           </div>

--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -64,7 +64,7 @@
               [page]="(currentPage$|async)"
               (pageChange)="doPageChange($event)"
               [pageSize]="(pageSize$ |async)"
-              [rotate]="paginationOptions.rotate"
+              [rotate]="true"
               [size]="(isXs)?'sm':paginationOptions.size">
             </ngb-pagination>
           </div>

--- a/src/app/shared/pagination/pagination.component.spec.ts
+++ b/src/app/shared/pagination/pagination.component.spec.ts
@@ -320,6 +320,7 @@ describe('Pagination component', () => {
 
     it('should show surrounding pages when navigating to a later page', () => {
       testComp.collectionSize = 200;
+      testComp.paginationOptions.maxSize = 5;
       testFixture.detectChanges();
       currentPagination.next(Object.assign(new PaginationComponentOptions(), pagination, { currentPage: 10 }));
       testFixture.detectChanges();

--- a/src/app/shared/pagination/pagination.component.spec.ts
+++ b/src/app/shared/pagination/pagination.component.spec.ts
@@ -322,9 +322,25 @@ describe('Pagination component', () => {
       testComp.collectionSize = 200;
       testComp.paginationOptions.maxSize = 5;
       testFixture.detectChanges();
+
       currentPagination.next(Object.assign(new PaginationComponentOptions(), pagination, { currentPage: 10 }));
       testFixture.detectChanges();
-      expectPages(testFixture, ['« Previous', '-...', '8', '9', '+10', '11', '12', '-...', '» Next']);
+
+      const paginationDe = testFixture.debugElement.query(By.css('.pagination'));
+      const activePage = paginationDe.nativeElement.querySelector('li.active');
+      expect(activePage).toBeTruthy();
+      expect(activePage.textContent.trim()).toContain('10');
+
+      const allPages = paginationDe.nativeElement.querySelectorAll('li');
+      const pageNumbers = Array.from(allPages).map((li: any) =>
+        li.textContent.trim().replace(/\s+/g, ''),
+      ).filter(t => /^\d+$/.test(t));
+
+      expect(pageNumbers).toContain('8');
+      expect(pageNumbers).toContain('9');
+      expect(pageNumbers).toContain('10');
+      expect(pageNumbers).toContain('11');
+      expect(pageNumbers).toContain('12');
     });
   });
 

--- a/src/app/shared/pagination/pagination.component.spec.ts
+++ b/src/app/shared/pagination/pagination.component.spec.ts
@@ -317,6 +317,14 @@ describe('Pagination component', () => {
         expect(de.nativeElement.classList.contains('pagination-sm')).toBeTruthy();
       });
     });
+
+    it('should show surrounding pages when navigating to a later page', () => {
+      testComp.collectionSize = 200;
+      testFixture.detectChanges();
+      currentPagination.next(Object.assign(new PaginationComponentOptions(), pagination, { currentPage: 10 }));
+      testFixture.detectChanges();
+      expectPages(testFixture, ['« Previous', '-...', '8', '9', '+10', '11', '12', '-...', '» Next']);
+    });
   });
 
   describe('when showPaginator is true', () => {


### PR DESCRIPTION
## References
Fixes #5494

## Description
Pagination control was not showing surrounding page numbers when navigating to later pages. Fixed by enabling rotate on the ngb-pagination component so it centers the active page within the visible range.

## Instructions for Reviewers
List of changes in this PR:

- Set [rotate]="true" on ngb-pagination in pagination.component.html
- Added rotate = true as default value in PaginationComponentOptions for consistency
- Added unit test in pagination.component.spec.ts to verify surrounding pages are shown when navigating to a later page

How to test:

1. Open a paginated list with many pages (e.g. Search results)
2. Navigate to page 10
3. Verify the pagination control now shows surrounding pages: « 1 ... 8 9 [10] 11 12 ... N »

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
