### PR TITLE
Fix modal accessible name

### DIFF
--- a/src/app/admin/admin-edit-user-agreement/admin-edit-user-agreement.component.html
+++ b/src/app/admin/admin-edit-user-agreement/admin-edit-user-agreement.component.html
@@ -19,7 +19,7 @@
 
 <ng-template #content let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title text-info">{{'admin.edit-user-agreement.confirm.title' | translate}}</h4>
+    <h4 id="modal-title" class="modal-title text-info">{{'admin.edit-user-agreement.confirm.title' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'admin.edit-user-agreement.confirm.info' | translate}}</p>

--- a/src/app/admin/admin-ldn-services/ldn-service-form/ldn-service-form.component.html
+++ b/src/app/admin/admin-ldn-services/ldn-service-form/ldn-service-form.component.html
@@ -312,10 +312,10 @@
   <ng-template #confirmModal>
     <div class="modal-header">
       @if (!isNewService) {
-        <h4>{{'service.overview.edit.modal' | translate }}</h4>
+        <h4 id="modal-title" class="modal-title">{{'service.overview.edit.modal' | translate }}</h4>
       }
       @if (isNewService) {
-        <h4>{{'service.overview.create.modal' | translate }}</h4>
+        <h4 id="modal-title" class="modal-title">{{'service.overview.create.modal' | translate }}</h4>
       }
       <button (click)="closeModal()" aria-label="Close" class="btn-close" type="button">
       </button>

--- a/src/app/admin/admin-ldn-services/ldn-services-directory/ldn-services-directory.component.html
+++ b/src/app/admin/admin-ldn-services/ldn-services-directory/ldn-services-directory.component.html
@@ -73,7 +73,7 @@
 
     <div class="modal-header">
       <div>
-        <h4>{{'service.overview.delete.header' | translate }}</h4>
+        <h4 id="modal-title" class="modal-title">{{'service.overview.delete.header' | translate }}</h4>
       </div>
       <button (click)="closeModal()" aria-label="Close"
         [attr.aria-label]="'ldn-service-overview-close-modal' | translate"

--- a/src/app/admin/admin-notify-dashboard/admin-notify-detail-modal/admin-notify-detail-modal.component.html
+++ b/src/app/admin/admin-notify-dashboard/admin-notify-detail-modal/admin-notify-detail-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">{{'notify-message-modal.title' | translate}}</h4>
+  <h4 id="modal-title" class="modal-title">{{'notify-message-modal.title' | translate}}</h4>
   <button type="button" class="btn-close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
   </button>
 </div>

--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workspace-item/supervision-order-group-selector/supervision-order-group-selector.component.html
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workspace-item/supervision-order-group-selector/supervision-order-group-selector.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{'supervision-group-selector.header' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'supervision-group-selector.header' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -134,6 +134,8 @@ export class AppComponent implements OnInit, AfterViewInit {
       return true;
     };
 
+    this.modalConfig.ariaLabelledBy = 'modal-title';
+
     this.isAuthBlocking$ = this.store.pipe(
       select(isAuthenticationBlocking),
       distinctUntilChanged(),

--- a/src/app/entity-groups/research-entities/submission/name-variant-modal/name-variant-modal.component.html
+++ b/src/app/entity-groups/research-entities/submission/name-variant-modal/name-variant-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-    <h4 class="modal-title">New name variant</h4>
+    <h4 id="modal-title" class="modal-title">New name variant</h4>
     <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss('Cross click')">
     </button>
 </div>

--- a/src/app/external-log-in/external-log-in/external-log-in.component.html
+++ b/src/app/external-log-in/external-log-in/external-log-in.component.html
@@ -32,7 +32,7 @@
 
 <ng-template #loginModal let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title text-info"> {{ 'external-login.connect-to-existing-account.label' | translate }}</h4>
+    <h4 id="modal-title" class="modal-title text-info"> {{ 'external-login.connect-to-existing-account.label' | translate }}</h4>
   </div>
   <div class="modal-body">
     <div class="row justify-content-center">

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
@@ -88,7 +88,7 @@
         <div class="modal-header bg-light text-dark">
           <h4 id="modal-title" class="modal-title">
             {{'item.edit.delete.confirmation-title' | translate}}
-          </h5>
+          </h4>
           <button type="button" class="btn-close" aria-label="Close" (click)="modalRef.close()"></button>
         </div>
         <div class="modal-body">

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
@@ -45,7 +45,7 @@
                           <ng-template #virtualMetadataModal>
                             <div class="thumb-font-1">
                               <div class="modal-header">
-                                {{'virtual-metadata.delete-item.modal-head' | translate}}
+                                <h4 id="modal-title" class="modal-title h4 mb-0">{{'virtual-metadata.delete-item.modal-head' | translate}}</h4>
                                 <button type="button" class="btn-close"
                                   (click)="closeVirtualMetadataModal()" aria-label="Close">
                                 </button>
@@ -86,7 +86,7 @@
 
       <ng-template #deleteConfirmationModal>
         <div class="modal-header bg-light text-dark">
-          <h5 class="modal-title">
+          <h4 id="modal-title" class="modal-title">
             {{'item.edit.delete.confirmation-title' | translate}}
           </h5>
           <button type="button" class="btn-close" aria-label="Close" (click)="modalRef.close()"></button>

--- a/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.html
+++ b/src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.html
@@ -1,5 +1,6 @@
 <div [ngClass]="showThumbnails ? 'hide-modal-thumbnail-column' : ''">
-  <div class="modal-header">{{'virtual-metadata.delete-relationship.modal-head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'virtual-metadata.delete-relationship.modal-head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close.emit()" aria-label="Close">
     </button>
   </div>

--- a/src/app/item-page/versions/item-versions-delete-modal/item-versions-delete-modal.component.html
+++ b/src/app/item-page/versions/item-versions-delete-modal/item-versions-delete-modal.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{'item.version.delete.modal.header' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'item.version.delete.modal.header' | translate}}</h4>
     <button type="button" class="btn-close" (click)="onModalClose()" aria-label="Close">
     </button>
   </div>

--- a/src/app/item-page/versions/item-versions-summary-modal/item-versions-summary-modal.component.html
+++ b/src/app/item-page/versions/item-versions-summary-modal/item-versions-summary-modal.component.html
@@ -38,7 +38,7 @@
     </div>
   </div>
 } @else {
-  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.version.create.modal.submitted.header' | translate}}</h2></div>
+  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.version.create.modal.submitted.header' | translate}}</h4></div>
   <div class="modal-body">
     <p>{{'item.version.create.modal.submitted.text' | translate}}</p>
     <div class="d-flex justify-content-center">

--- a/src/app/item-page/versions/item-versions-summary-modal/item-versions-summary-modal.component.html
+++ b/src/app/item-page/versions/item-versions-summary-modal/item-versions-summary-modal.component.html
@@ -1,6 +1,7 @@
 @if ((this.submitted$ | async) !== true) {
   <div>
-    <div class="modal-header">{{'item.version.create.modal.header' | translate}}
+    <div class="modal-header">
+      <h4 id="modal-title" class="modal-title h4 mb-0">{{'item.version.create.modal.header' | translate}}</h4>
       <button type="button" class="btn-close" (click)="onModalClose()" aria-label="Close">
       </button>
     </div>
@@ -37,7 +38,7 @@
     </div>
   </div>
 } @else {
-  <div class="modal-header">{{'item.version.create.modal.submitted.header' | translate}}</div>
+  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.version.create.modal.submitted.header' | translate}}</h2></div>
   <div class="modal-body">
     <p>{{'item.version.create.modal.submitted.text' | translate}}</p>
     <div class="d-flex justify-content-center">

--- a/src/app/my-dspace-page/collection-selector/collection-selector.component.html
+++ b/src/app/my-dspace-page/collection-selector/collection-selector.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{'dso-selector.create.submission.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.create.submission.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -296,7 +296,7 @@
 
 <ng-template #acceptModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title" id="acceptModal">{{'quality-assurance.event.sure' | translate}}</h4>
+    <h4 class="modal-title" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.accept.description' | translate}}</p>
@@ -314,7 +314,7 @@
 
 <ng-template #ignoreModal let-modal>
   <div class="modal-header">
-    <h1 class="modal-title h4" id="ignoreModal">{{'quality-assurance.event.sure' | translate}}</h1>
+    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.ignore.description' | translate}}</p>
@@ -331,7 +331,7 @@
 
 <ng-template #rejectModal let-modal>
   <div class="modal-header">
-    <h1 class="modal-title h4" id="rejectModal">{{'quality-assurance.event.sure' | translate}}</h1>
+    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.reject.description' | translate}}</p>
@@ -348,7 +348,7 @@
 
 <ng-template #undoModal let-modal>
   <div class="modal-header">
-    <h1 class="modal-title h4" id="undoModal">{{'quality-assurance.event.sure' | translate}}</h1>
+    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.undo.description' | translate}}</p>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -296,7 +296,7 @@
 
 <ng-template #acceptModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
+    <h4 class="modal-title" id="acceptModal">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.accept.description' | translate}}</p>
@@ -314,7 +314,7 @@
 
 <ng-template #ignoreModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
+    <h4 class="modal-title h4" id="ignoreModal">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.ignore.description' | translate}}</p>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -218,7 +218,7 @@
                                   ngbTooltip="{{'quality-assurance.event.action.import' | translate}}"
                                   container="body"
                                   [dsBtnDisabled]="eventElement.isRunning"
-                                  (click)="modalChoice('ACCEPTED', eventElement, acceptModal)"
+                                  (click)="modalChoice('ACCEPTED', eventElement, acceptModal, 'acceptModal')"
                                   [attr.aria-label]="'quality-assurance.event.action.import' | translate"
                                   >
                                   <i class="fas fa-check"></i>
@@ -240,7 +240,7 @@
                                 ngbTooltip="{{'quality-assurance.event.action.ignore' | translate}}"
                                 container="body"
                                 [dsBtnDisabled]="eventElement.isRunning"
-                                (click)="openModal('DISCARDED', eventElement, ignoreModal)"
+                                (click)="openModal('DISCARDED', eventElement, ignoreModal, 'ignoreModal')"
                                 [attr.aria-label]="'quality-assurance.event.action.ignore' | translate"
                                 >
                                 <i class="fas fa-ban"></i>
@@ -250,7 +250,7 @@
                                   ngbTooltip="{{'quality-assurance.event.action.reject' | translate}}"
                                   container="body"
                                   [dsBtnDisabled]="eventElement.isRunning"
-                                  (click)="openModal('REJECTED', eventElement, rejectModal)"
+                                  (click)="openModal('REJECTED', eventElement, rejectModal, 'rejectModal')"
                                   [attr.aria-label]="'quality-assurance.event.action.reject' | translate"
                                   >
                                   <i class="fas fa-trash-alt"></i>
@@ -262,7 +262,7 @@
                                   container="body"
                                   [dsBtnDisabled]="eventElement.isRunning"
                                   [attr.aria-label]="'quality-assurance.event.action.undo' | translate"
-                                  (click)="openModal('UNDO', eventElement, undoModal)">
+                                  (click)="openModal('UNDO', eventElement, undoModal, 'undoModal')">
                                   <i class="fas fa-trash-alt"></i>
                                 </button>
                               }
@@ -275,7 +275,7 @@
                                 container="body"
                                 [dsBtnDisabled]="eventElement.isRunning"
                                 [attr.aria-label]="'quality-assurance.event.action.undo' | translate"
-                                (click)="openModal('UNDO', eventElement, undoModal)">
+                                (click)="openModal('UNDO', eventElement, undoModal, 'undoModal')">
                                 <i class="fas fa-trash-alt"></i>
                               </button>
                             </div>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -331,7 +331,7 @@
 
 <ng-template #rejectModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
+    <h4 class="modal-title h4" id="rejectModal">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.reject.description' | translate}}</p>
@@ -348,7 +348,7 @@
 
 <ng-template #undoModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title h4" id="modal-title">{{'quality-assurance.event.sure' | translate}}</h4>
+    <h4 class="modal-title h4" id="undoModal">{{'quality-assurance.event.sure' | translate}}</h4>
   </div>
   <div class="modal-body">
     <p>{{'quality-assurance.event.undo.description' | translate}}</p>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.spec.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.spec.ts
@@ -1,18 +1,18 @@
 import { CommonModule } from '@angular/common';
 import {
-  Component,
-  NO_ERRORS_SCHEMA,
+    Component,
+    NO_ERRORS_SCHEMA,
 } from '@angular/core';
 import {
-  ComponentFixture,
-  inject,
-  TestBed,
-  waitForAsync,
+    ComponentFixture,
+    inject,
+    TestBed,
+    waitForAsync,
 } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import {
-  SortDirection,
-  SortOptions,
+    SortDirection,
+    SortOptions,
 } from '@dspace/core/cache/models/sort-options.model';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { FindListOptions } from '@dspace/core/data/find-list-options.model';
@@ -20,39 +20,39 @@ import { ItemDataService } from '@dspace/core/data/item-data.service';
 import { buildPaginatedList } from '@dspace/core/data/paginated-list.model';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { QualityAssuranceEventDataService } from '@dspace/core/notifications/qa/events/quality-assurance-event-data.service';
-import { QualityAssuranceEventObject } from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
 import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
-import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import { QualityAssuranceEventObject } from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
 import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { PageInfo } from '@dspace/core/shared/page-info.model';
 import { ActivatedRouteStub } from '@dspace/core/testing/active-router.stub';
-import {
-  getMockQualityAssuranceEventRestService,
-  ItemMockPid8,
-  ItemMockPid9,
-  ItemMockPid10,
-  NotificationsMockDspaceObject,
-  qualityAssuranceEventObjectMissingProjectFound,
-  qualityAssuranceEventObjectMissingProjectNotFound,
-} from '@dspace/core/testing/notifications.mock';
 import { NotificationsServiceStub } from '@dspace/core/testing/notifications-service.stub';
+import {
+    getMockQualityAssuranceEventRestService,
+    ItemMockPid10,
+    ItemMockPid8,
+    ItemMockPid9,
+    NotificationsMockDspaceObject,
+    qualityAssuranceEventObjectMissingProjectFound,
+    qualityAssuranceEventObjectMissingProjectNotFound,
+} from '@dspace/core/testing/notifications.mock';
 import { PaginationServiceStub } from '@dspace/core/testing/pagination-service.stub';
 import { getMockTranslateService } from '@dspace/core/testing/translate.service.mock';
 import { createTestComponent } from '@dspace/core/testing/utils.test';
 import {
-  createNoContentRemoteDataObject$,
-  createSuccessfulRemoteDataObject,
-  createSuccessfulRemoteDataObject$,
+    createNoContentRemoteDataObject$,
+    createSuccessfulRemoteDataObject,
+    createSuccessfulRemoteDataObject$,
 } from '@dspace/core/utilities/remote-data.utils';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
-  TranslateModule,
-  TranslateService,
+    TranslateModule,
+    TranslateService,
 } from '@ngx-translate/core';
 import {
-  cold,
-  getTestScheduler,
+    cold,
+    getTestScheduler,
 } from 'jasmine-marbles';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
@@ -197,26 +197,27 @@ describe('QualityAssuranceEventsComponent test suite', () => {
 
       it('should call executeAction if a project is present', () => {
         const action = 'ACCEPTED';
-        comp.modalChoice(action, getQualityAssuranceEventData1(), modalStub);
+        comp.modalChoice(action, getQualityAssuranceEventData1(), modalStub, 'acceptModal');
         expect(comp.executeAction).toHaveBeenCalledWith(action, getQualityAssuranceEventData1());
       });
 
       it('should call openModal if a project is not present', () => {
         const action = 'ACCEPTED';
-        comp.modalChoice(action, getQualityAssuranceEventData2(), modalStub);
-        expect(comp.openModal).toHaveBeenCalledWith(action, getQualityAssuranceEventData2(), modalStub);
+        comp.modalChoice(action, getQualityAssuranceEventData2(), modalStub, 'acceptModal');
+        expect(comp.openModal).toHaveBeenCalledWith(action, getQualityAssuranceEventData2(), modalStub, 'acceptModal');
       });
     });
 
     describe('openModal', () => {
       it('should call modalService.open', () => {
         const action = 'ACCEPTED';
+        const labelledBy = 'acceptModal';
         comp.selectedReason = null;
         spyOn(compAsAny.modalService, 'open').and.returnValue({ result: new Promise((res, rej) => 'do' ) });
         spyOn(comp, 'executeAction');
 
-        comp.openModal(action, getQualityAssuranceEventData1(), modalStub);
-        expect(compAsAny.modalService.open).toHaveBeenCalled();
+        comp.openModal(action, getQualityAssuranceEventData1(), modalStub, labelledBy);
+        expect(compAsAny.modalService.open).toHaveBeenCalledWith(modalStub, { ariaLabelledBy: labelledBy });
       });
     });
 

--- a/src/app/notifications/qa/events/quality-assurance-events.component.spec.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.spec.ts
@@ -1,18 +1,18 @@
 import { CommonModule } from '@angular/common';
 import {
-    Component,
-    NO_ERRORS_SCHEMA,
+  Component,
+  NO_ERRORS_SCHEMA,
 } from '@angular/core';
 import {
-    ComponentFixture,
-    inject,
-    TestBed,
-    waitForAsync,
+  ComponentFixture,
+  inject,
+  TestBed,
+  waitForAsync,
 } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import {
-    SortDirection,
-    SortOptions,
+  SortDirection,
+  SortOptions,
 } from '@dspace/core/cache/models/sort-options.model';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { FindListOptions } from '@dspace/core/data/find-list-options.model';
@@ -20,39 +20,39 @@ import { ItemDataService } from '@dspace/core/data/item-data.service';
 import { buildPaginatedList } from '@dspace/core/data/paginated-list.model';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { QualityAssuranceEventDataService } from '@dspace/core/notifications/qa/events/quality-assurance-event-data.service';
-import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
 import { QualityAssuranceEventObject } from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
-import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
+import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
 import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { PageInfo } from '@dspace/core/shared/page-info.model';
 import { ActivatedRouteStub } from '@dspace/core/testing/active-router.stub';
-import { NotificationsServiceStub } from '@dspace/core/testing/notifications-service.stub';
 import {
-    getMockQualityAssuranceEventRestService,
-    ItemMockPid10,
-    ItemMockPid8,
-    ItemMockPid9,
-    NotificationsMockDspaceObject,
-    qualityAssuranceEventObjectMissingProjectFound,
-    qualityAssuranceEventObjectMissingProjectNotFound,
+  getMockQualityAssuranceEventRestService,
+  ItemMockPid8,
+  ItemMockPid9,
+  ItemMockPid10,
+  NotificationsMockDspaceObject,
+  qualityAssuranceEventObjectMissingProjectFound,
+  qualityAssuranceEventObjectMissingProjectNotFound,
 } from '@dspace/core/testing/notifications.mock';
+import { NotificationsServiceStub } from '@dspace/core/testing/notifications-service.stub';
 import { PaginationServiceStub } from '@dspace/core/testing/pagination-service.stub';
 import { getMockTranslateService } from '@dspace/core/testing/translate.service.mock';
 import { createTestComponent } from '@dspace/core/testing/utils.test';
 import {
-    createNoContentRemoteDataObject$,
-    createSuccessfulRemoteDataObject,
-    createSuccessfulRemoteDataObject$,
+  createNoContentRemoteDataObject$,
+  createSuccessfulRemoteDataObject,
+  createSuccessfulRemoteDataObject$,
 } from '@dspace/core/utilities/remote-data.utils';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
-    TranslateModule,
-    TranslateService,
+  TranslateModule,
+  TranslateService,
 } from '@ngx-translate/core';
 import {
-    cold,
-    getTestScheduler,
+  cold,
+  getTestScheduler,
 } from 'jasmine-marbles';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';

--- a/src/app/notifications/qa/events/quality-assurance-events.component.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.ts
@@ -1,16 +1,16 @@
 import { AsyncPipe } from '@angular/common';
 import {
-    Component,
-    OnDestroy,
-    OnInit,
+  Component,
+  OnDestroy,
+  OnInit,
 } from '@angular/core';
 import {
-    ActivatedRoute,
-    RouterLink,
+  ActivatedRoute,
+  RouterLink,
 } from '@angular/router';
 import {
-    SortDirection,
-    SortOptions,
+  SortDirection,
+  SortOptions,
 } from '@dspace/core/cache/models/sort-options.model';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '@dspace/core/data/feature-authorization/feature-id';
@@ -20,13 +20,13 @@ import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { QualityAssuranceEventDataService } from '@dspace/core/notifications/qa/events/quality-assurance-event-data.service';
-import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
 import {
-    QualityAssuranceEventObject,
-    SourceQualityAssuranceEventMessageObject,
+  QualityAssuranceEventObject,
+  SourceQualityAssuranceEventMessageObject,
 } from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
-import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
+import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
 import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
 import { getItemPageRoute } from '@dspace/core/router/utils/dso-route.utils';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { Item } from '@dspace/core/shared/item.model';
@@ -34,35 +34,35 @@ import { Metadata } from '@dspace/core/shared/metadata.utils';
 import { NoContent } from '@dspace/core/shared/NoContent.model';
 import { ItemSearchResult } from '@dspace/core/shared/object-collection/item-search-result.model';
 import {
-    getFirstCompletedRemoteData,
-    getRemoteDataPayload,
+  getFirstCompletedRemoteData,
+  getRemoteDataPayload,
 } from '@dspace/core/shared/operators';
 import { hasValue } from '@dspace/shared/utils/empty.util';
 import {
-    NgbModal,
-    NgbTooltip,
+  NgbModal,
+  NgbTooltip,
 } from '@ng-bootstrap/ng-bootstrap';
 import {
-    TranslateModule,
-    TranslateService,
+  TranslateModule,
+  TranslateService,
 } from '@ngx-translate/core';
 import {
-    BehaviorSubject,
-    combineLatest,
-    from,
-    Observable,
-    of,
-    Subscription,
+  BehaviorSubject,
+  combineLatest,
+  from,
+  Observable,
+  of,
+  Subscription,
 } from 'rxjs';
 import {
-    distinctUntilChanged,
-    last,
-    map,
-    mergeMap,
-    scan,
-    switchMap,
-    take,
-    tap,
+  distinctUntilChanged,
+  last,
+  map,
+  mergeMap,
+  scan,
+  switchMap,
+  take,
+  tap,
 } from 'rxjs/operators';
 
 import { environment } from '../../../../environments/environment';

--- a/src/app/notifications/qa/events/quality-assurance-events.component.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.ts
@@ -1,16 +1,16 @@
 import { AsyncPipe } from '@angular/common';
 import {
-  Component,
-  OnDestroy,
-  OnInit,
+    Component,
+    OnDestroy,
+    OnInit,
 } from '@angular/core';
 import {
-  ActivatedRoute,
-  RouterLink,
+    ActivatedRoute,
+    RouterLink,
 } from '@angular/router';
 import {
-  SortDirection,
-  SortOptions,
+    SortDirection,
+    SortOptions,
 } from '@dspace/core/cache/models/sort-options.model';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '@dspace/core/data/feature-authorization/feature-id';
@@ -20,13 +20,13 @@ import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { QualityAssuranceEventDataService } from '@dspace/core/notifications/qa/events/quality-assurance-event-data.service';
-import {
-  QualityAssuranceEventObject,
-  SourceQualityAssuranceEventMessageObject,
-} from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
 import { QualityAssuranceEventData } from '@dspace/core/notifications/qa/models/quality-assurance-event-data.model';
-import { PaginationService } from '@dspace/core/pagination/pagination.service';
+import {
+    QualityAssuranceEventObject,
+    SourceQualityAssuranceEventMessageObject,
+} from '@dspace/core/notifications/qa/models/quality-assurance-event.model';
 import { PaginationComponentOptions } from '@dspace/core/pagination/pagination-component-options.model';
+import { PaginationService } from '@dspace/core/pagination/pagination.service';
 import { getItemPageRoute } from '@dspace/core/router/utils/dso-route.utils';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { Item } from '@dspace/core/shared/item.model';
@@ -34,35 +34,35 @@ import { Metadata } from '@dspace/core/shared/metadata.utils';
 import { NoContent } from '@dspace/core/shared/NoContent.model';
 import { ItemSearchResult } from '@dspace/core/shared/object-collection/item-search-result.model';
 import {
-  getFirstCompletedRemoteData,
-  getRemoteDataPayload,
+    getFirstCompletedRemoteData,
+    getRemoteDataPayload,
 } from '@dspace/core/shared/operators';
 import { hasValue } from '@dspace/shared/utils/empty.util';
 import {
-  NgbModal,
-  NgbTooltip,
+    NgbModal,
+    NgbTooltip,
 } from '@ng-bootstrap/ng-bootstrap';
 import {
-  TranslateModule,
-  TranslateService,
+    TranslateModule,
+    TranslateService,
 } from '@ngx-translate/core';
 import {
-  BehaviorSubject,
-  combineLatest,
-  from,
-  Observable,
-  of,
-  Subscription,
+    BehaviorSubject,
+    combineLatest,
+    from,
+    Observable,
+    of,
+    Subscription,
 } from 'rxjs';
 import {
-  distinctUntilChanged,
-  last,
-  map,
-  mergeMap,
-  scan,
-  switchMap,
-  take,
-  tap,
+    distinctUntilChanged,
+    last,
+    map,
+    mergeMap,
+    scan,
+    switchMap,
+    take,
+    tap,
 } from 'rxjs/operators';
 
 import { environment } from '../../../../environments/environment';
@@ -278,11 +278,11 @@ export class QualityAssuranceEventsComponent implements OnInit, OnDestroy {
    * @param {any} content
    *    Reference to the modal
    */
-  public modalChoice(action: string, eventData: QualityAssuranceEventData, content: any): void {
+  public modalChoice(action: string, eventData: QualityAssuranceEventData, content: any, labelledBy: string): void {
     if (eventData.hasProject) {
       this.executeAction(action, eventData);
     } else {
-      this.openModal(action, eventData, content);
+      this.openModal(action, eventData, content, labelledBy);
     }
   }
 
@@ -296,8 +296,8 @@ export class QualityAssuranceEventsComponent implements OnInit, OnDestroy {
    * @param {any} content
    *    Reference to the modal
    */
-  public openModal(action: string, eventData: QualityAssuranceEventData, content: any): void {
-    this.modalService.open(content, { ariaLabelledBy: 'modal-basic-title' }).result.then(
+  public openModal(action: string, eventData: QualityAssuranceEventData, content: any, labelledBy: string): void {
+    this.modalService.open(content, { ariaLabelledBy: labelledBy }).result.then(
       (result) => {
         if (result === 'do') {
           eventData.reason = this.selectedReason;

--- a/src/app/process-page/detail/process-detail.component.html
+++ b/src/app/process-page/detail/process-detail.component.html
@@ -102,7 +102,7 @@
     <div>
       <div class="modal-header">
         <div>
-          <h4>{{'process.detail.delete.header' | translate }}</h4>
+          <h4 id="modal-title" class="modal-title">{{'process.detail.delete.header' | translate }}</h4>
         </div>
         <button type="button" class="btn-close"
           (click)="closeModal()" aria-label="Close">

--- a/src/app/process-page/overview/process-overview.component.html
+++ b/src/app/process-page/overview/process-overview.component.html
@@ -53,7 +53,7 @@ class="fas fa-plus pe-2"></i>{{'process.overview.new' | translate}}</button>
 
     <div class="modal-header">
       <div>
-        <h4>{{'process.overview.delete.header' | translate }}</h4>
+        <h4 id="modal-title" class="modal-title">{{'process.overview.delete.header' | translate }}</h4>
       </div>
       <button type="button" class="btn-close"
         (click)="closeModal()" aria-label="Close">

--- a/src/app/profile-page/profile-claim-item-modal/profile-claim-item-modal.component.html
+++ b/src/app/profile-page/profile-claim-item-modal/profile-claim-item-modal.component.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="modal-header"><h4>{{'dso-selector.claim.item.head' | translate}}</h4>
+  <div class="modal-header"><h4 id="modal-title" class="modal-title">{{'dso-selector.claim.item.head' | translate}}</h4>
   <button type="button" class="btn-close" (click)="close()" aria-label="Close">
   </button>
 </div>

--- a/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.html
+++ b/src/app/shared/access-control-form-container/item-access-control-select-bitstreams-modal/item-access-control-select-bitstreams-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">
+  <h4 id="modal-title" class="modal-title">
     {{'access-control-select-bitstreams-modal.title' | translate}}
   </h4>
   <button type="button" class="btn-close" aria-label="Close"

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{ headerLabel | translate:{ dsoName: name } }}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{ headerLabel | translate:{ dsoName: name } }}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>

--- a/src/app/shared/correction-suggestion/item-withdrawn-reinstate-modal.component.html
+++ b/src/app/shared/correction-suggestion/item-withdrawn-reinstate-modal.component.html
@@ -2,14 +2,14 @@
   <div>
     @if (this.canWithdraw) {
       <div class="modal-header">
-        {{ 'item.qa.withdrawn.modal.header' | translate }}
+        <h4 id="modal-title" class="modal-title h4 mb-0">{{ 'item.qa.withdrawn.modal.header' | translate }}</h4>
         <button type="button" class="btn-close" (click)="onModalClose()" aria-label="Close">
         </button>
       </div>
     } @else {
       @if (!this.canWithdraw) {
         <div class="modal-header">
-          {{'item.qa.reinstate.modal.header' | translate}}
+          <h4 id="modal-title" class="modal-title h4 mb-0">{{'item.qa.reinstate.modal.header' | translate}}</h4>
           <button type="button" class="btn-close" (click)="onModalClose()" aria-label="Close">
           </button>
         </div>
@@ -46,7 +46,7 @@
     </div>
   </div>
 } @else {
-  <div class="modal-header">{{'item.qa.withdrawn.modal.submitted.header' | translate}}</div>
+  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.qa.withdrawn.modal.submitted.header' | translate}}</h2></div>
   <div class="modal-body">
     <div class="d-flex justify-content-center">
       <ds-loading [showMessage]="false"></ds-loading>

--- a/src/app/shared/correction-suggestion/item-withdrawn-reinstate-modal.component.html
+++ b/src/app/shared/correction-suggestion/item-withdrawn-reinstate-modal.component.html
@@ -46,7 +46,7 @@
     </div>
   </div>
 } @else {
-  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.qa.withdrawn.modal.submitted.header' | translate}}</h2></div>
+  <div class="modal-header"><h4 id="modal-title" class="modal-title h4 mb-0">{{'item.qa.withdrawn.modal.submitted.header' | translate}}</h4></div>
   <div class="modal-body">
     <div class="d-flex justify-content-center">
       <ds-loading [showMessage]="false"></ds-loading>

--- a/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-collection-parent-selector/create-collection-parent-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if (header) {
       <span class="h5 px-2">{{header | translate}}</span>
     }

--- a/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-community-parent-selector/create-community-parent-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if ((isAdmin$ | async)) {
       <div data-test="admin-div">
         <button class="btn btn-outline-primary btn-lg btn-block w-100" (click)="selectObject(undefined)">{{'dso-selector.create.community.top-level' | translate}}</button>

--- a/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/create-item-parent-selector/create-item-parent-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if (header) {
       <span class="h5 px-2">{{header | translate}}</span>
     }

--- a/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/dso-selector-modal-wrapper.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>

--- a/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-collection-selector/edit-collection-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if (header) {
       <span class="h5 px-2">{{header | translate}}</span>
     }

--- a/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-community-selector/edit-community-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if (header) {
       <span class="h5 px-2">{{header | translate}}</span>
     }

--- a/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.html
+++ b/src/app/shared/dso-selector/modal-wrappers/edit-item-selector/edit-item-selector.component.html
@@ -1,9 +1,10 @@
 <div>
-  <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="close()" aria-label="Close">
     </button>
   </div>
-  <div class="modal-body">
+    <div class="modal-body">
     @if (header) {
       <span class="h5 px-2">{{header | translate}}</span>
     }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-content">
   <div class="modal-header">
-    <h5 class="modal-title">{{ getHeader() }}</h5>
+    <h4 id="modal-title" class="modal-title">{{ getHeader() }}</h4>
   </div>
   <div class="modal-body">
 

--- a/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
+++ b/src/app/shared/form/vocabulary-treeview-modal/vocabulary-treeview-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">{{'vocabulary-treeview.header' | translate}}</h4>
+  <h4 id="modal-title" class="modal-title">{{'vocabulary-treeview.header' | translate}}</h4>
   <button type="button" class="btn-close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
   </button>
 </div>

--- a/src/app/shared/idle-modal/idle-modal.component.html
+++ b/src/app/shared/idle-modal/idle-modal.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header" id="idle-modal.header">{{ "idle-modal.header" | translate }}
+  <div class="modal-header">
+    <h4 id="idle-modal.header" class="modal-title h4 mb-0">{{ "idle-modal.header" | translate }}</h4>
     <button type="button" class="btn-close" (click)="closePressed()" aria-label="Close">
     </button>
   </div>

--- a/src/app/shared/mydspace-actions/claimed-task/reject/claimed-task-actions-reject.component.html
+++ b/src/app/shared/mydspace-actions/claimed-task/reject/claimed-task-actions-reject.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #rejectModal let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title">{{'submission.workflow.tasks.claimed.reject.reason.title' | translate}}</h4>
+    <h4 id="modal-title" class="modal-title">{{'submission.workflow.tasks.claimed.reject.reason.title' | translate}}</h4>
     <button type="button"
       class="btn-close"
       aria-label="Close"

--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
@@ -36,7 +36,7 @@
 
 <ng-template #content let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <div class="modal-title text-danger h4">{{'submission.general.discard.confirm.title' | translate}}</div>
+    <h4 id="modal-title" class="modal-title text-danger h4">{{'submission.general.discard.confirm.title' | translate}}</h4>
     <button type="button" id="delete_close" class="btn-close" aria-label="Close" (click)="d('cancel')">
     </button>
   </div>

--- a/src/app/shared/resource-policies/form/resource-policy-form.component.html
+++ b/src/app/shared/resource-policies/form/resource-policy-form.component.html
@@ -59,7 +59,7 @@
 
   <ng-template #content let-modal>
     <div class="modal-header">
-      <h4 class="modal-title" id="modal-basic-title">{{ 'resource-policies.form.eperson-group-list.modal.header' | translate }}</h4>
+      <h4 class="modal-title" id="modal-title">{{ 'resource-policies.form.eperson-group-list.modal.header' | translate }}</h4>
       <button type="button" class="btn-close" aria-label="Close" (click)="modal.close()">
       </button>
     </div>

--- a/src/app/shared/search-form/scope-selector-modal/scope-selector-modal.component.html
+++ b/src/app/shared/search-form/scope-selector-modal/scope-selector-modal.component.html
@@ -1,5 +1,6 @@
 <div>
-    <div class="modal-header">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}
+    <div class="modal-header">
+        <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.'+ action + '.' + objectType.toString().toLowerCase() + '.head' | translate}}</h4>
         <button type="button" class="btn-close" (click)="selectObject(undefined)" aria-label="Close">
         </button>
     </div>

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.html
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.html
@@ -1,7 +1,7 @@
 @if (subscriptionForm) {
   <form [formGroup]="subscriptionForm" (ngSubmit)="submit()" data-test="subscription-form">
     <div class="modal-header">
-      <h4 class="modal-title">{{'subscriptions.modal.title' | translate}}</h4>
+      <h4 id="modal-title" class="modal-title">{{'subscriptions.modal.title' | translate}}</h4>
       <button type="button" class="btn-close" aria-label="Close" (click)="activeModal.close()">
       </button>
     </div>

--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -88,7 +88,7 @@
 
 <ng-template #content let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title text-danger">{{'submission.general.discard.confirm.title' | translate}}</h4>
+    <h4 id="modal-title" class="modal-title text-danger">{{'submission.general.discard.confirm.title' | translate}}</h4>
     <button type="button" class="btn-close" aria-label="Close" (click)="d('cancel')">
     </button>
   </div>

--- a/src/app/submission/import-external/import-external-collection/submission-import-external-collection.component.html
+++ b/src/app/submission/import-external/import-external-collection/submission-import-external-collection.component.html
@@ -1,5 +1,6 @@
 <div>
-  <div class="modal-header">{{'dso-selector.select.collection.head' | translate}}
+  <div class="modal-header">
+    <h4 id="modal-title" class="modal-title h4 mb-0">{{'dso-selector.select.collection.head' | translate}}</h4>
     <button type="button" class="btn-close" (click)="closeCollectionModal()" aria-label="Close">
     </button>
   </div>

--- a/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.html
+++ b/src/app/submission/import-external/import-external-preview/submission-import-external-preview.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h2>{{'submission.import-external.preview.title.' + labelPrefix | translate}}</h2>
+  <h4 id="modal-title" class="modal-title h4 mb-0">{{'submission.import-external.preview.title.' + labelPrefix | translate}}</h4>
   <button type="button" class="btn-close"
     (click)="closeMetadataModal()" aria-label="Close">
   </button>

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
@@ -53,7 +53,7 @@
         <div>
           <div class="modal-header mb-4 ">
             <div>
-              <h4>
+              <h4 id="modal-title" class="modal-title">
                 {{ field.label }}
               </h4>
               <div [innerHTML]="field.description"></div>

--- a/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.html
+++ b/src/app/submission/sections/upload/file/edit/section-upload-file-edit.component.html
@@ -1,6 +1,6 @@
 <div>
   <div class="modal-header">
-    <h4 class="modal-title">{{'submission.sections.upload.edit.title' | translate}}</h4>
+    <h4 id="modal-title" class="modal-title">{{'submission.sections.upload.edit.title' | translate}}</h4>
     <button type="button" class="btn-close" (click)="onModalClose()" aria-label="Close" [dsBtnDisabled]="isSaving">
     </button>
   </div>

--- a/src/app/submission/sections/upload/file/section-upload-file.component.html
+++ b/src/app/submission/sections/upload/file/section-upload-file.component.html
@@ -57,7 +57,7 @@
 
 <ng-template #content let-c="close" let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title text-danger">{{ 'submission.sections.upload.delete.confirm.title' | translate }}</h4>
+    <h4 id="modal-title" class="modal-title text-danger">{{ 'submission.sections.upload.delete.confirm.title' | translate }}</h4>
     <button type="button" class="btn-close" aria-label="Close" (click)="d('cancel')">
     </button>
   </div>

--- a/src/app/workspaceitems-edit-page/workspaceitems-delete-page/workspaceitems-delete-page.component.html
+++ b/src/app/workspaceitems-edit-page/workspaceitems-delete-page/workspaceitems-delete-page.component.html
@@ -9,7 +9,7 @@
 
 <ng-template #content let-c="close" let-d="dismiss" id="delete-modal">
   <div class="modal-header">
-    <div class="modal-title text-danger h4">{{ 'workspace-item.delete.header' | translate }}</div>
+    <h4 id="modal-title" class="modal-title text-danger h4">{{ 'workspace-item.delete.header' | translate }}</h4>
     <button type="button" id="delete_close" class="btn-close" aria-label="Close" (click)="d('cancel')">
     </button>
   </div>


### PR DESCRIPTION
## References
* Fixes #5502

## Description
Fix accessibility issue where modal dialogs were missing an accessible name by ensuring all modals correctly use `aria-labelledby`.

## Instructions for Reviewers

List of changes in this PR:
* Added a global default for `ariaLabelledBy` in `app.component.ts` to ensure all modals have an accessible name (The goal of this approach is to **avoid modifying many files in a single commit/PR**, reducing review complexity and minimizing the likelihood of widespread regressions.).
* Normalized modal templates by wrapping header text in semantic heading elements (`<h4>`) where necessary.
* Added `id="modal-title"` to modal headings to match the global configuration.

## Steps to Test:

**Scenario 1: Search Results Modal**

1. Open the search results page.
2. Click on **“All of DSpace”**.
3. Inspect the modal element in the DOM or run an accessibility audit.
4. Verify that the `ngb-modal-window` element (with `role="dialog"`) correctly references the `id` of the `<h4>` element inside `.modal-header`.

**Scenario 2: Add Entity Modal (Item/Collection/Community)**

1. Log in as a user with permission to add an Item, Collection, or Community.
2. Click on **“Add Item”**, **“Add Collection”**, or **“Add Community”**.
3. Inspect the modal element in the DOM or run an accessibility audit.
4. Verify that the `ngb-modal-window` element (with `role="dialog"`) correctly references the `id` of the `<h4>` element inside `.modal-header`.

### Additional Notes
- Part of the changes were initially suggested using GitHub Copilot.
- All modifications were manually reviewed and validated to ensure correctness and consistency across the codebase.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
