### PR TITLE
[Docker] Ensure `docker-deploy` waits for the backend to fully initialize before creating test content

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,8 +106,11 @@ jobs:
           sleep 10
           docker container ls
       # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
+      # NOTE: Before creating test data, we wait for the backend to become responsive by requesting it every 10 sec.
+      # Timeout after 5 minutes. This is done to ensure the backend is fully initialized before we create test data.
       - name: Load test data into Backend
         run: |
+          timeout 5m wget --retry-connrefused -t 0 --waitretry=10 http://127.0.0.1:8080/server/api
           docker compose -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
           docker compose -f docker/cli.yml -f docker/cli.ingest.yml run --rm dspace-cli
       # Verify backend started successfully.


### PR DESCRIPTION

## References
* Manual port of https://github.com/DSpace/DSpace/pull/12320 to `dspace-angular`

## Description
This small change to `docker-deploy` job ensures that we are waiting for the REST API backend to **fully initialize** before we create any test/demo content (like admin accounts or importing AIP data).

It is a port of the changes in  https://github.com/DSpace/DSpace/pull/12320 to ensure that the database is fully initialized before adding demo content.

## Instructions for Reviewers
* Verify that this passes all automated tests in GitHub