### PR TITLE
fix #5488: add ARIA labeling to hide edit menu from screen readers wh…

### DIFF
--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.html
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.html
@@ -1,8 +1,11 @@
-<div class="dso-edit-menu d-flex" role="menubar">
+<div class="dso-edit-menu d-flex"
+     [attr.role]="(menuVisibleWithSections$ | async) ? 'menubar' : null"
+     [attr.aria-hidden]="(menuVisibleWithSections$ | async) === false ? 'true' : null">
   @for (section of (sections | async); track section) {
     <div class="ms-1">
       <ng-container
-      *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;"></ng-container>
+        *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;">
+      </ng-container>
     </div>
   }
 </div>

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.spec.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.spec.ts
@@ -45,12 +45,25 @@ describe('DsoEditMenuComponent', () => {
     index: 1,
   };
 
+  const subSection = {
+    id: 'edit-dso-sub',
+    active: false,
+    visible: true,
+    model: {
+      text: 'sub-section-text',
+      type: null,
+      disabled: false,
+    } as TextMenuItemModel,
+    icon: 'pencil',
+    index: 0,
+  };
 
   beforeEach(waitForAsync(() => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: of(true),
     });
     spyOn(menuService, 'getMenuTopSections').and.returnValue(of([section]));
+    spyOn(menuService, 'getSubSectionsByParentID').and.returnValue(of([subSection]));
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), RouterTestingModule, DsoEditMenuComponent],
       providers: [
@@ -65,17 +78,42 @@ describe('DsoEditMenuComponent', () => {
     }).compileComponents();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DsoEditMenuComponent);
-    comp = fixture.componentInstance;
-    comp.sections = of([]);
-    fixture.detectChanges();
-  });
-
   describe('onInit', () => {
     it('should create', () => {
+      fixture = TestBed.createComponent(DsoEditMenuComponent);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
       expect(comp).toBeTruthy();
+    });
+
+    it('should have role menubar when subsections exist', () => {
+      (menuService.getSubSectionsByParentID as jasmine.Spy).and.returnValue(of([subSection]));
+      fixture = TestBed.createComponent(DsoEditMenuComponent);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const menu = fixture.nativeElement.querySelector('.dso-edit-menu');
+      expect(menu.getAttribute('role')).toBe('menubar');
+    });
+
+    it('should NOT have role menubar when no subsections exist', () => {
+      (menuService.getSubSectionsByParentID as jasmine.Spy).and.returnValue(of([]));
+      fixture = TestBed.createComponent(DsoEditMenuComponent);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const menu = fixture.nativeElement.querySelector('.dso-edit-menu');
+      expect(menu.getAttribute('role')).toBeNull();
+    });
+
+    it('should have aria-hidden when no subsections exist', () => {
+      (menuService.getSubSectionsByParentID as jasmine.Spy).and.returnValue(of([]));
+      fixture = TestBed.createComponent(DsoEditMenuComponent);
+      comp = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const menu = fixture.nativeElement.querySelector('.dso-edit-menu');
+      expect(menu.getAttribute('aria-hidden')).toBe('true');
     });
   });
 });
-

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu.component.ts
@@ -8,15 +8,21 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
+import {
+  combineLatest,
+  Observable,
+  of,
+} from 'rxjs';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
 
 import { MenuComponent } from '../../menu/menu.component';
 import { MenuService } from '../../menu/menu.service';
 import { MenuID } from '../../menu/menu-id.model';
 import { ThemeService } from '../../theme-support/theme.service';
 
-/**
- * Component representing the edit menu and other menus on the dspace object pages
- */
 @Component({
   selector: 'ds-dso-edit-menu',
   styleUrls: ['./dso-edit-menu.component.scss'],
@@ -27,20 +33,32 @@ import { ThemeService } from '../../theme-support/theme.service';
   ],
 })
 export class DsoEditMenuComponent extends MenuComponent {
-  /**
-   * The menu ID of this component is DSO_EDIT
-   * @type {MenuID.DSO_EDIT}
-   */
+
   menuID = MenuID.DSO_EDIT;
 
+  menuVisibleWithSections$: Observable<boolean>;
 
-  constructor(protected menuService: MenuService,
-              protected injector: Injector,
-              public authorizationService: AuthorizationDataService,
-              public route: ActivatedRoute,
-              protected themeService: ThemeService,
+  constructor(
+    protected menuService: MenuService,
+    protected injector: Injector,
+    public authorizationService: AuthorizationDataService,
+    public route: ActivatedRoute,
+    protected themeService: ThemeService,
   ) {
     super(menuService, injector, authorizationService, route, themeService);
+    this.menuVisibleWithSections$ = this.menuService.getMenuTopSections(MenuID.DSO_EDIT).pipe(
+      switchMap((sections) => {
+        if (sections.length === 0) {return of(false);}
+        return combineLatest(
+          sections.map((section) =>
+            this.menuService.getSubSectionsByParentID(MenuID.DSO_EDIT, section.id).pipe(
+              map((subSections) => subSections.length > 0),
+            ),
+          ),
+        ).pipe(
+          map((results) => results.some((hasVisible) => hasVisible)),
+        );
+      }),
+    );
   }
-
 }


### PR DESCRIPTION
## References
Fixes #5488

## Description
Adds dynamic ARIA labeling to the DSO edit menu so that when a user has no edit permissions, the menu is hidden from screen readers and the role="menubar" attribute is removed, preventing the broken ARIA menu error detected by the WAVE accessibility tool.

## Instructions for Reviewers
List of changes in this PR:

- dso-edit-menu.component.html: role="menubar" is now dynamic — only applied when the menu has visible subsections. Added aria-hidden="true" when no subsections are visible.
- dso-edit-menu.component.ts: Added menuVisibleWithSections$ observable that checks real subsections with permissions via getSubSectionsByParentID.
- dso-edit-menu.component.spec.ts: Added tests to verify DOM behavior for both cases.

How to test:

1. Install the WAVE browser extension
2. Navigate to any community or item page without being logged in
3. Run WAVE — the Broken ARIA menu error should no longer appear
4. Log in as an admin and navigate to the same pages — the edit menu (three dots) should still appear and work correctly

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
