### PR TITLE
[e2e tests] Attempt to enhance stability of `item-edit.cy.ts`

### DIFF
--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -23,6 +23,11 @@ describe('Edit Item > Edit Metadata tab', () => {
     // <ds-edit-item-page> tag must be loaded
     cy.get('ds-edit-item-page').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
+
     // wait for all the ds-dso-edit-metadata-value components to be rendered
     cy.get('ds-dso-edit-metadata-value div[role="row"]').each(($row: HTMLDivElement) => {
       cy.wrap($row).find('div[role="cell"]').should('be.visible');
@@ -46,6 +51,11 @@ describe('Edit Item > Status tab', () => {
     // <ds-item-status> tag must be loaded
     cy.get('ds-item-status').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
+
     // Analyze for accessibility issues
     testA11y('ds-item-status');
   });
@@ -64,6 +74,10 @@ describe('Edit Item > Bitstreams tab', () => {
     // <ds-item-bitstreams> tag must be loaded
     cy.get('ds-item-bitstreams').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
     // Table of item bitstreams must also be loaded
     cy.get('div.item-bitstreams').should('be.visible');
 
@@ -93,6 +107,11 @@ describe('Edit Item > Curate tab', () => {
     // <ds-item-curate> tag must be loaded
     cy.get('ds-item-curate').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
+
     // Analyze for accessibility issues
     testA11y('ds-item-curate');
   });
@@ -110,6 +129,11 @@ describe('Edit Item > Relationships tab', () => {
 
     // <ds-item-relationships> tag must be loaded
     cy.get('ds-item-relationships').should('be.visible');
+
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
 
     // Analyze for accessibility issues
     testA11y('ds-item-relationships');
@@ -129,6 +153,11 @@ describe('Edit Item > Version History tab', () => {
     // <ds-item-version-history> tag must be loaded
     cy.get('ds-item-version-history').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
+
     // Analyze for accessibility issues
     testA11y('ds-item-version-history');
   });
@@ -147,6 +176,11 @@ describe('Edit Item > Access Control tab', () => {
     // <ds-item-access-control> tag must be loaded
     cy.get('ds-item-access-control').should('be.visible');
 
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
+
     // Analyze for accessibility issues
     testA11y('ds-item-access-control');
   });
@@ -164,6 +198,11 @@ describe('Edit Item > Collection Mapper tab', () => {
 
     // <ds-item-collection-mapper> tag must be loaded
     cy.get('ds-item-collection-mapper').should('be.visible');
+
+    // wait for all the tabs to be rendered on this page
+    cy.get('ds-edit-item-page ul[role="tablist"]').each(($row: HTMLUListElement) => {
+      cy.wrap($row).find('a[role="tab"]').should('be.visible');
+    });
 
     // Analyze entire page for accessibility issues
     testA11y('ds-item-collection-mapper');


### PR DESCRIPTION
## References
* Cherry-picked from #5453, which applied this stabilization change to the `dspace-8_x` branch

## Description
Update `item-edit.cy.ts` e2e tests to ensure we wait on tabs to load before performing the accessibility scan. Currently we're seeing random errors if the accessibility scan runs _before_ tabs finish loading.

Should be ported also to 9.x and 7.x to ensure consistency across all supported releases.

## Instructions for Reviewers
* Verify tests pass.