### PR TITLE
fix(i18n): correct article usage in dso-selector placeholder

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1861,7 +1861,7 @@
 
   "dso-selector.no-results": "No {{ type }} found",
 
-  "dso-selector.placeholder": "Search for a {{ type }}",
+  "dso-selector.placeholder": "Search for {{ type }}",
 
   "dso-selector.placeholder.type.community": "community",
 
@@ -4726,7 +4726,7 @@
 
   "resource-policies.form.eperson-group-list.select.btn": "Select",
 
-  "resource-policies.form.eperson-group-list.tab.eperson": "Search for a ePerson",
+  "resource-policies.form.eperson-group-list.tab.eperson": "Search for an ePerson",
 
   "resource-policies.form.eperson-group-list.tab.group": "Search for a group",
 


### PR DESCRIPTION
Fixes #5528.

Two article-placement bugs in `src/assets/i18n/en.json5`:

**1. `dso-selector.placeholder`** was `"Search for a {{ type }}"`. When `type` is `item` (which starts with a vowel) the rendered text became "Search for a item". The selector is used across community / collection / item selections, so there's no single correct English article. Dropping the article makes the template grammatically neutral for all types:

```diff
- "dso-selector.placeholder": "Search for a {{ type }}",
+ "dso-selector.placeholder": "Search for {{ type }}",
```

Note: the `dso-selector.placeholder.type.{community,collection,item}` values (`"community"`, `"collection"`, `"item"`) are reused by `dso-selector.no-results` (`"No {{ type }} found"`), so embedding the article into those values would break that usage. Removing the article from the placeholder template is the smallest change that fixes all three rendered variants without disturbing other callers.

**2. `resource-policies.form.eperson-group-list.tab.eperson`** had "Search for a ePerson" (vowel-start noun again) — fixed to "Search for an ePerson".

Docs/translation only; no code or logic changes. Only `en.json5` touched — translators can decide how each locale handles article agreement.