### PR TITLE
fix #3956: replace ngDoCheck with override getter/setter for showErro…

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -11,7 +11,6 @@ import {
   Component,
   ComponentFactoryResolver,
   ContentChildren,
-  DoCheck,
   EventEmitter,
   Inject,
   inject,
@@ -158,7 +157,7 @@ import { NameVariantService } from './relation-lookup-modal/name-variant.service
   ],
 })
 export class DsDynamicFormControlContainerComponent extends DynamicFormControlContainerComponent
-  implements OnInit, OnChanges, OnDestroy, AfterViewInit, DoCheck {
+  implements OnInit, OnChanges, OnDestroy, AfterViewInit {
   @ContentChildren(DynamicTemplateDirective) contentTemplateList: QueryList<DynamicTemplateDirective>;
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('templates') inputTemplateList: QueryList<DynamicTemplateDirective>;
@@ -205,6 +204,9 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
    * Determines whether to request embedded thumbnail.
    */
   fetchThumbnail: boolean;
+
+  // Propiedad privada para el valor real
+  private _showErrorMessages = false;
 
   get componentType(): Type<DynamicFormControl> | null {
     return this.dynamicFormControlFn(this.model);
@@ -361,10 +363,17 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     }
   }
 
-  ngDoCheck() {
-    if (isNotUndefined(this.showErrorMessagesPreviousStage) && this.showErrorMessagesPreviousStage !== this.showErrorMessages) {
-      this.showErrorMessagesPreviousStage = this.showErrorMessages;
-      this.forceShowErrorDetection();
+  override get showErrorMessages(): boolean {
+    return this._showErrorMessages;
+  }
+
+  override set showErrorMessages(value: boolean) {
+    if (this._showErrorMessages !== value) {
+      this._showErrorMessages = value;
+      if (isNotUndefined(this.showErrorMessagesPreviousStage)) {
+        this.showErrorMessagesPreviousStage = value;
+        this.forceShowErrorDetection();
+      }
     }
   }
 


### PR DESCRIPTION
## References
Fixes #3956

## Description
Replaces the `ngDoCheck` lifecycle hook with an `override` getter/setter for `showErrorMessages`, eliminating the ESLint warning caused by implementing both `DoCheck` and `OnChanges` simultaneously.

## Instructions for Reviewers

List of changes in this PR:

- Removed `DoCheck` from the `implements` clause and its import in `DsDynamicFormControlContainerComponent`
- Removed the `ngDoCheck()` method entirely
- Added a private `_showErrorMessages` backing field
- Added `override get showErrorMessages()` and `override set showErrorMessages()` to replace the change-detection logic previously handled by `ngDoCheck`
- Simplified `ngAfterViewInit` to initialize `showErrorMessagesPreviousStage` using `this.showErrorMessages`

**How to test:**

1. Open a submission form in DSpace
2. Fill in required fields and attempt to save without completing them — verify that validation error messages still appear correctly
3. Verify that error messages disappear after correcting the fields
4. Run `npm run lint` and confirm the `Implementing DoCheck and OnChanges in a class is not recommended` warning is no longer present for this component


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
