### PR TITLE
Fix #5519: Authors with invalid Authority entries not displayed properly

### DIFF
--- a/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.html
+++ b/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.html
@@ -1,10 +1,13 @@
 <ds-metadata-field-wrapper [label]="label">
   @for (objectPage of objects; track objectPage; let i = $index) {
     <ng-container *ngVar="(objectPage | async) as representations">
-      @for (rep of representations; track rep) {
+      @for (rep of representations; track rep; let last = $last) {
         <ds-metadata-representation-loader
           [mdRepresentation]="rep">
         </ds-metadata-representation-loader>
+        @if (!last) {
+          <span class="separator"><br/></span>
+        }
       }
       @if ((i + 1) === objects.length && (i > 0) && (!representations || representations?.length === 0)) {
         <ds-loading message="{{'loading.default' | translate}}"></ds-loading>

--- a/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
+++ b/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.spec.ts
@@ -166,4 +166,10 @@ describe('MetadataRepresentationListComponent', () => {
     });
   });
 
+  it('should render separators between metadata representation loaders', () => {
+    const separators = fixture.debugElement.queryAll(By.css('span.separator'));
+    const loaders = fixture.debugElement.queryAll(By.css('ds-metadata-representation-loader'));
+    expect(separators.length).toBe(loaders.length - 1);
+  });
+
 });

--- a/src/app/shared/metadata-link-view/metadata-link-view.component.html
+++ b/src/app/shared/metadata-link-view/metadata-link-view.component.html
@@ -1,9 +1,12 @@
-<div  class="d-inline-block" *ngVar="(metadataView$ | async) as metadataView">
+<ng-container *ngVar="(metadataView$ | async) as metadataView">
   @if (metadataView) {
-    <ng-container [ngTemplateOutlet]="metadataView?.authority ? linkToAuthority : (metadataView?.entityType ? textWithIcon : textWithoutIcon)"
-    [ngTemplateOutletContext]="{metadataView: metadataView}"></ng-container>
+    <div class="d-inline-block">
+      <ng-container [ngTemplateOutlet]="metadataView?.authority ? linkToAuthority : (metadataView?.entityType ? textWithIcon : textWithoutIcon)"
+      [ngTemplateOutletContext]="{metadataView: metadataView}"></ng-container>
+    </div>
   }
-</div>
+</ng-container>
+
 <ng-template class="d-flex" #linkToAuthority let-metadataView="metadataView">
   <span [dsStickyPopover]="popContent"
     [openDelay]="100"
@@ -49,4 +52,3 @@
 <ng-template #popContent>
   <ds-metadata-link-view-popover [item]="relatedItem"></ds-metadata-link-view-popover>
 </ng-template>
-

--- a/src/app/shared/metadata-link-view/metadata-link-view.component.spec.ts
+++ b/src/app/shared/metadata-link-view/metadata-link-view.component.spec.ts
@@ -194,20 +194,23 @@ describe('MetadataLinkViewComponent', () => {
     });
 
     describe('when item is not found', () => {
-      beforeEach(() => {
+      beforeEach(waitForAsync(() => {
         fixture = TestBed.createComponent(MetadataLinkViewComponent);
         itemService.findById.and.returnValue(createFailedRemoteDataObject$());
         component = fixture.componentInstance;
         component.metadata = testMetadataValueWithAuthority;
         fixture.detectChanges();
-      });
+        fixture.whenStable().then(() => fixture.detectChanges());
+      }));
 
       it('should create', () => {
         expect(component).toBeTruthy();
       });
 
-      it('should render the span element', () => {
-        const text = fixture.debugElement.query(By.css('[data-test="textWithIcon"]'));
+      it('should render the span element', async () => {
+        await fixture.whenStable();
+        fixture.detectChanges();
+        const text = fixture.debugElement.query(By.css('[data-test="textWithoutIcon"]'));
         const link = fixture.debugElement.query(By.css('[data-test="linkToAuthority"]'));
 
         expect(text).toBeTruthy();

--- a/src/app/shared/metadata-link-view/metadata-link-view.component.ts
+++ b/src/app/shared/metadata-link-view/metadata-link-view.component.ts
@@ -170,7 +170,7 @@ export class MetadataLinkViewComponent implements OnInit {
         authority: null,
         value: metadataValue.value,
         orcidAuthenticated: null,
-        entityType: 'PRIVATE',
+        entityType: null,
       };
     }
   }


### PR DESCRIPTION
## References
Fixes #5519

## Description
Authors with invalid Authority entries were appearing smashed together on Item pages. This fix ensures proper separation between authors regardless of whether they have a valid or invalid Authority value.

## Instructions for Reviewers


Instructions for Reviewers
List of changes in this PR:

- metadata-representation-list.component.html — Added separator <br/> between each ds-metadata-representation-loader in the @for loop so authors are always visually separated.
- metadata-link-view.component.ts — Changed entityType: 'PRIVATE' to entityType: null in the else branch of createMetadataView, so authors with an invalid authority are rendered as plain text instead of triggering the textWithIcon template.
- metadata-link-view.component.html — Moved d-inline-block div inside the @if (metadataView) block so no empty div is rendered when metadataView is null.
- metadata-link-view.component.spec.ts — Updated existing test when item is not found to expect textWithoutIcon instead of textWithIcon, reflecting the corrected behavior.
- metadata-representation-list.component.spec.ts — Added test to verify that separators are rendered between ds-metadata-representation-loader components.

How to test:

1. Find an Item with multiple authors in dc.contributor.author
2. Go to Administer → Metadata tab
3. Add a fake UUID like 94466ca9-b8d2-4c8e-9898-3ae87be9b116 in the Authority column for each author
4. Save and go back to the Item page
5. Authors should appear separated on individual lines, not smashed together

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
