### PR TITLE
Fix #12303: Evaluating IIIF metadata values dspace.iiif.enabled and iiif.search.enabled correctly

### DIFF
--- a/src/app/core/utilities/item-iiif-utils.ts
+++ b/src/app/core/utilities/item-iiif-utils.ts
@@ -13,12 +13,12 @@ import { RouteService } from '../services/route.service';
 import { Item } from '../shared/item.model';
 
 export const isIiifEnabled = (item: Item) => {
-  return !!item.firstMetadataValue('dspace.iiif.enabled');
+  return String(item.firstMetadataValue('dspace.iiif.enabled')?.valueOf?.() || '').trim().toLowerCase() === 'true';
 
 };
 
 export const isIiifSearchEnabled = (item: Item) => {
-  return !!item.firstMetadataValue('iiif.search.enabled');
+  return String(item.firstMetadataValue('iiif.search.enabled')?.valueOf?.() || '').trim().toLowerCase() === 'true';
 
 };
 

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.html
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.html
@@ -1,8 +1,10 @@
-<p class="full-text-op">{{'iiifviewer.fullscreen.notice' | translate}}</p>
-@if (!isViewerAvailable) {
-  <p id="viewer-message">{{viewerMessage}}</p>
-}
-@if (isViewerAvailable) {
-  <iframe title="Mirador Viewer" allowtransparency="true" [src]="iframeViewerUrl | async" id="mirador-viewer"></iframe>
+@if (isIiifEnabled$ | async) {
+  <p class="full-text-op">{{'iiifviewer.fullscreen.notice' | translate}}</p>
+  @if (!isViewerAvailable) {
+    <p id="viewer-message">{{viewerMessage}}</p>
+  }
+  @if (isViewerAvailable) {
+    <iframe title="Mirador Viewer" allowtransparency="true" [src]="iframeViewerUrl | async" id="mirador-viewer"></iframe>
+  }
 }
 

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.spec.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.spec.ts
@@ -4,8 +4,11 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
 import { BundleDataService } from '@dspace/core/data/bundle-data.service';
+import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
+import { ConfigurationProperty } from '@dspace/core/shared/configuration-property.model';
 import { Item } from '@dspace/core/shared/item.model';
 import { MetadataMap } from '@dspace/core/shared/metadata.models';
 import { TranslateLoaderMock } from '@dspace/core/testing/translate-loader.mock';
@@ -16,12 +19,29 @@ import {
   TranslateModule,
 } from '@ngx-translate/core';
 import { of } from 'rxjs';
+import {
+  skip,
+  take,
+  toArray,
+} from 'rxjs/operators';
 
 import { HostWindowService } from '../../shared/host-window.service';
 import { createRelationshipsObservable } from '../simple/item-types/shared/item.component.spec';
 import { MiradorViewerComponent } from './mirador-viewer.component';
 import { MiradorViewerService } from './mirador-viewer.service';
 
+
+const noMetadata = new MetadataMap();
+
+const mockHostWindowService = {
+  // This isn't really testing mobile status, the return observable just allows the test to run.
+  widthCategory: of(true),
+};
+
+let comp: MiradorViewerComponent;
+let fixture: ComponentFixture<MiradorViewerComponent>;
+let configurationDataService: jasmine.SpyObj<ConfigurationDataService>;
+let viewerService: jasmine.SpyObj<MiradorViewerService>;
 
 function getItem(metadata: MetadataMap) {
   return Object.assign(new Item(), {
@@ -31,65 +51,87 @@ function getItem(metadata: MetadataMap) {
   });
 }
 
-const noMetadata = new MetadataMap();
+function setupTestBed(overrides?: {
+  showEmbedded?: boolean;
+  imageCount?: number;
+  iiifEnabled?: boolean;
+}) {
+  configurationDataService = jasmine.createSpyObj('ConfigurationDataService', [
+    'findByPropertyName',
+  ]);
 
-const mockHostWindowService = {
-  // This isn't really testing mobile status, the return observable just allows the test to run.
-  widthCategory: of(true),
-};
+  viewerService = jasmine.createSpyObj('MiradorViewerService', [
+    'showEmbeddedViewer',
+    'getImageCount',
+    'isIiifEnabled',
+  ]);
 
-describe('MiradorViewerComponent with search', () => {
-  let comp: MiradorViewerComponent;
-  let fixture: ComponentFixture<MiradorViewerComponent>;
-  const viewerService = jasmine.createSpyObj('MiradorViewerService', ['showEmbeddedViewer', 'getImageCount']);
+  viewerService.showEmbeddedViewer.and.returnValue(overrides?.showEmbedded ?? true);
+  viewerService.getImageCount.and.returnValue(of(overrides?.imageCount ?? 1));
+  viewerService.isIiifEnabled.and.returnValue(of(overrides?.iiifEnabled ?? true));
 
-  beforeEach(waitForAsync(() => {
-    viewerService.showEmbeddedViewer.and.returnValue(true);
-    TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot({
+  TestBed.configureTestingModule({
+    imports: [
+      TranslateModule.forRoot({
         loader: {
           provide: TranslateLoader,
           useClass: TranslateLoaderMock,
         },
-      }), MiradorViewerComponent],
-      providers: [
-        { provide: BitstreamDataService, useValue: {} },
-        { provide: BundleDataService, useValue: {} },
-        { provide: HostWindowService, useValue: mockHostWindowService },
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-    }).overrideComponent(MiradorViewerComponent, {
-      set: {
-        providers: [
-          { provide: MiradorViewerService, useValue: viewerService },
-        ],
-      },
-    }).compileComponents();
+      }),
+      MiradorViewerComponent,
+    ],
+    providers: [
+      { provide: BitstreamDataService, useValue: {} },
+      { provide: BundleDataService, useValue: {} },
+      { provide: ConfigurationDataService, useValue: configurationDataService },
+      { provide: HostWindowService, useValue: mockHostWindowService },
+      { provide: MiradorViewerService, useValue: viewerService },
+    ],
+    schemas: [NO_ERRORS_SCHEMA],
+  });
+}
+
+function createComponent(options?: {
+  searchable?: boolean;
+  object?: any;
+}) {
+  fixture = TestBed.createComponent(MiradorViewerComponent);
+  comp = fixture.componentInstance;
+  comp.object = options?.object ?? getItem(noMetadata);
+  comp.searchable = options?.searchable ?? false;
+  fixture.detectChanges();
+}
+
+function getViewerSrc(): string {
+  return fixture.debugElement.query(By.css('#mirador-viewer'))
+    .nativeElement.src;
+}
+
+describe('MiradorViewerComponent with search', () => {
+  beforeEach(waitForAsync(() => {
+    setupTestBed();
+    TestBed.compileComponents();
   }));
   describe('searchable item', () => {
-    beforeEach(waitForAsync(() => {
-      fixture = TestBed.createComponent(MiradorViewerComponent);
-      comp = fixture.componentInstance;
-      comp.object = getItem(noMetadata);
-      comp.searchable = true;
-      fixture.detectChanges();
-    }));
+    beforeEach(() => {
+      createComponent({ searchable: true });
+    });
 
     it('should set multi property to true', (() => {
       expect(comp.multi).toBe(true);
     }));
 
-    it('should set url "multi" param to true', (() => {
-      const value = fixture.debugElement
-        .nativeElement.querySelector('#mirador-viewer').src;
-      expect(value).toContain('multi=true');
-    }));
+    it('should set url "multi" param to true', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(getViewerSrc()).toContain('multi=true');
+    });
 
-    it('should set url "searchable" param to true', (() => {
-      const value = fixture.debugElement
-        .nativeElement.querySelector('#mirador-viewer').src;
-      expect(value).toContain('searchable=true');
-    }));
+    it('should set url "searchable" param to true', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(getViewerSrc()).toContain('searchable=true');
+    });
 
     it('should not call mirador service image count', () => {
       expect(viewerService.getImageCount).not.toHaveBeenCalled();
@@ -99,108 +141,52 @@ describe('MiradorViewerComponent with search', () => {
 });
 
 describe('MiradorViewerComponent with multiple images', () => {
-
-  let comp: MiradorViewerComponent;
-  let fixture: ComponentFixture<MiradorViewerComponent>;
-  const viewerService = jasmine.createSpyObj('MiradorViewerService', ['showEmbeddedViewer', 'getImageCount']);
-
   beforeEach(waitForAsync(() => {
-    viewerService.showEmbeddedViewer.and.returnValue(true);
-    viewerService.getImageCount.and.returnValue(of(2));
-    TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: TranslateLoaderMock,
-        },
-      }), MiradorViewerComponent],
-      providers: [
-        { provide: BitstreamDataService, useValue: {} },
-        { provide: BundleDataService, useValue: {} },
-        { provide: HostWindowService, useValue: mockHostWindowService  },
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-    }).overrideComponent(MiradorViewerComponent, {
-      set: {
-        providers: [
-          { provide: MiradorViewerService, useValue: viewerService },
-        ],
-      },
-    }).compileComponents();
+    setupTestBed({ imageCount: 2 });
+    TestBed.compileComponents();
   }));
 
   describe('non-searchable item with multiple images', () => {
-    beforeEach(waitForAsync(() => {
-      fixture = TestBed.createComponent(MiradorViewerComponent);
-      comp = fixture.componentInstance;
-      comp.object = getItem(noMetadata);
-      comp.searchable = false;
-      fixture.detectChanges();
-    }));
+    beforeEach(() => {
+      createComponent();
+    });
 
-    it('should set url "multi" param to true', (() => {
-      const value = fixture.debugElement
-        .nativeElement.querySelector('#mirador-viewer').src;
-      expect(value).toContain('multi=true');
-    }));
+    it('should set url "multi" param to true',  async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(getViewerSrc()).toContain('multi=true');
+    });
 
     it('should call mirador service image count', () => {
       expect(viewerService.getImageCount).toHaveBeenCalled();
     });
 
-    it('should omit "searchable" param from url', (() => {
-      const value = fixture.debugElement
-        .nativeElement.querySelector('#mirador-viewer').src;
-      expect(value).not.toContain('searchable=true');
-    }));
+    it('should omit "searchable" param from url',  async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(getViewerSrc()).not.toContain('searchable=true');
+    });
 
   });
 });
 
 
 describe('MiradorViewerComponent with a single image', () => {
-  let comp: MiradorViewerComponent;
-  let fixture: ComponentFixture<MiradorViewerComponent>;
-  const viewerService = jasmine.createSpyObj('MiradorViewerService', ['showEmbeddedViewer', 'getImageCount']);
-
   beforeEach(waitForAsync(() => {
-    viewerService.showEmbeddedViewer.and.returnValue(true);
-    viewerService.getImageCount.and.returnValue(of(1));
-    TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: TranslateLoaderMock,
-        },
-      }), MiradorViewerComponent],
-      providers: [
-        { provide: BitstreamDataService, useValue: {} },
-        { provide: BundleDataService, useValue: {} },
-        { provide: HostWindowService, useValue: mockHostWindowService },
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-    }).overrideComponent(MiradorViewerComponent, {
-      set: {
-        providers: [
-          { provide: MiradorViewerService, useValue: viewerService },
-        ],
-      },
-    }).compileComponents();
+    setupTestBed({ imageCount: 1 });
+    TestBed.compileComponents();
   }));
 
   describe('single image viewer', () => {
-    beforeEach(waitForAsync(() => {
-      fixture = TestBed.createComponent(MiradorViewerComponent);
-      comp = fixture.componentInstance;
-      comp.object = getItem(noMetadata);
-      fixture.detectChanges();
-    }));
+    beforeEach(() => {
+      createComponent();
+    });
 
-    it('should  omit "multi" param', (() => {
-      const value = fixture.debugElement
-        .nativeElement.querySelector('#mirador-viewer').src;
-      expect(value).not.toContain('multi=false');
-    }));
+    it('should  omit "multi" param',  async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(getViewerSrc()).not.toContain('multi=false');
+    });
 
     it('should call mirador service image count', () => {
       expect(viewerService.getImageCount).toHaveBeenCalled();
@@ -211,54 +197,99 @@ describe('MiradorViewerComponent with a single image', () => {
 });
 
 describe('MiradorViewerComponent in development mode', () => {
-  let comp: MiradorViewerComponent;
-  let fixture: ComponentFixture<MiradorViewerComponent>;
-  const viewerService = jasmine.createSpyObj('MiradorViewerService', ['showEmbeddedViewer', 'getImageCount']);
-
   beforeEach(waitForAsync(() => {
-    viewerService.showEmbeddedViewer.and.returnValue(false);
-    viewerService.getImageCount.and.returnValue(of(1));
-    TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot({
-        loader: {
-          provide: TranslateLoader,
-          useClass: TranslateLoaderMock,
-        },
-      }), MiradorViewerComponent],
-      providers: [
-        { provide: BitstreamDataService, useValue: {} },
-      ],
-      schemas: [NO_ERRORS_SCHEMA],
-    }).overrideComponent(MiradorViewerComponent, {
-      set: {
-        providers: [
-          { provide: MiradorViewerService, useValue: viewerService },
-          { provide: BundleDataService, useValue: {} },
-          { provide: HostWindowService, useValue: mockHostWindowService  },
-        ],
-      },
-    }).compileComponents();
+    setupTestBed({
+      showEmbedded: false,
+      imageCount: 1,
+    });
+    TestBed.compileComponents();
   }));
 
   describe('embedded viewer', () => {
-    beforeEach(waitForAsync(() => {
-      fixture = TestBed.createComponent(MiradorViewerComponent);
-      comp = fixture.componentInstance;
-      comp.object = getItem(noMetadata);
-      fixture.detectChanges();
-    }));
+    beforeEach(() => {
+      createComponent();
+    });
 
-    it('should not embed the viewer', (() => {
+    it('should not embed the viewer',  async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
       const value = fixture.debugElement
         .nativeElement.querySelector('#mirador-viewer');
       expect(value).toBeNull();
-    }));
+    });
 
-    it('should show message', (() => {
+    it('should show message',  async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
       const value = fixture.debugElement
         .nativeElement.querySelector('#viewer-message');
       expect(value).not.toBeNull();
-    }));
+    });
 
+  });
+});
+
+
+describe('MiradorViewerService whether IIIF is enabled in the repository', () => {
+  let miradorViewerService: MiradorViewerService;
+  function mockIiifEnabled(values: string[]): void {
+    configurationDataService.findByPropertyName.and.returnValue(
+      createSuccessfulRemoteDataObject$(
+        Object.assign(new ConfigurationProperty(), {
+          name: 'iiif.enabled',
+          values,
+        }),
+      ),
+    );
+  }
+  beforeEach(() => {
+    configurationDataService = jasmine.createSpyObj('ConfigurationDataService', [
+      'findByPropertyName',
+    ]);
+    miradorViewerService = new MiradorViewerService();
+  });
+  describe('isIiifEnabled', () => {
+    it('should return false initially and then true', (done) => {
+      mockIiifEnabled(['true']);
+      miradorViewerService.isIiifEnabled(configurationDataService)
+        .pipe(take(2), toArray())
+        .subscribe((results) => {
+          expect(results).toEqual([false, true]);
+          done();
+        });
+    });
+
+    it('should return true when iiif.enabled is true', (done) => {
+      mockIiifEnabled(['true']);
+
+      miradorViewerService.isIiifEnabled(configurationDataService)
+        .pipe(skip(1))
+        .subscribe((enabled) => {
+          expect(enabled).toBeTrue();
+          expect(configurationDataService.findByPropertyName)
+            .toHaveBeenCalledWith('iiif.enabled');
+          done();
+        });
+    });
+
+    it('should return false when iiif.enabled is false', (done) => {
+      mockIiifEnabled(['false']);
+      miradorViewerService.isIiifEnabled(configurationDataService)
+        .pipe(skip(1))
+        .subscribe((enabled) => {
+          expect(enabled).toBeFalse();
+          done();
+        });
+    });
+
+    it('should return false when configuration value is missing', (done) => {
+      mockIiifEnabled([]);
+      miradorViewerService.isIiifEnabled(configurationDataService)
+        .pipe(skip(1))
+        .subscribe((enabled) => {
+          expect(enabled).toBeFalse();
+          done();
+        });
+    });
   });
 });

--- a/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.component.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/platform-browser';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
 import { BundleDataService } from '@dspace/core/data/bundle-data.service';
+import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
 import { WidthCategory } from '@dspace/core/shared/host-window-type';
 import { Item } from '@dspace/core/shared/item.model';
 import { TranslateModule } from '@ngx-translate/core';
@@ -62,6 +63,11 @@ export class MiradorViewerComponent implements OnInit {
   isViewerAvailable = true;
 
   /**
+   * Check if IIIF is enabled in the repository.
+   */
+  isIiifEnabled$: Observable<boolean>;
+
+  /**
    * The url for the iframe.
    */
   iframeViewerUrl: Observable<SafeResourceUrl>;
@@ -83,6 +89,7 @@ export class MiradorViewerComponent implements OnInit {
               private bitstreamDataService: BitstreamDataService,
               private bundleDataService: BundleDataService,
               private hostWindowService: HostWindowService,
+              private configurationDataService: ConfigurationDataService,
               @Inject(PLATFORM_ID) private platformId: any) {
   }
 
@@ -163,5 +170,7 @@ export class MiradorViewerComponent implements OnInit {
         );
       }
     }
+    // Set the property whether IIIF is enabled in the repository
+    this.isIiifEnabled$ =  this.viewerService.isIiifEnabled(this.configurationDataService);
   }
 }

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular/core';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
 import { BundleDataService } from '@dspace/core/data/bundle-data.service';
+import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
 import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { Bitstream } from '@dspace/core/shared/bitstream.model';
@@ -14,13 +15,17 @@ import {
   FollowLinkConfig,
 } from '@dspace/core/shared/follow-link-config.model';
 import { Item } from '@dspace/core/shared/item.model';
-import { getFirstCompletedRemoteData } from '@dspace/core/shared/operators';
+import {
+  getFirstCompletedRemoteData,
+  getFirstSucceededRemoteDataPayload,
+} from '@dspace/core/shared/operators';
 import { Observable } from 'rxjs';
 import {
   filter,
   last,
   map,
   mergeMap,
+  startWith,
   switchMap,
 } from 'rxjs/operators';
 
@@ -37,6 +42,22 @@ export class MiradorViewerService {
    */
   showEmbeddedViewer (): boolean {
     return !isDevMode();
+  }
+
+  /**
+   * Returns observable of boolean whether IIIF is enabled in the repository.
+   * The default value is false.
+   * @param configurationDataService
+   * @returns the configuration value of iiif.enabled
+   */
+  isIiifEnabled (configurationDataService: ConfigurationDataService): Observable<boolean> {
+    return configurationDataService.findByPropertyName('iiif.enabled')
+      .pipe(getFirstSucceededRemoteDataPayload(),
+        map((configurationProperty) =>
+          configurationProperty.values?.[0] === 'true',
+        ),
+        startWith(false),
+      );
   }
 
   /**


### PR DESCRIPTION
Using the double negation (!!) in https://github.com/DSpace/dspace-angular/blob/ffcca7d6505056dc1be355f57660a2a68a8fcfe9/src/app/core/utilities/item-iiif-utils.ts#L16  converts the value into a strict boolean. In case of `dspace.iiif.enabled = false` the check will incorrectly treat `false` as `enabled` resulting to the error described in https://github.com/DSpace/DSpace/issues/12303
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/12303

## Description
`False/false`, `null`, and `undefined` are handled safely. Only `True\true` is matched.

## Instructions for Reviewers
Edit an existing or create an item with a metadata value `dspace.iiif.enabled = false`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
