### PR TITLE
Fix #5532: return user to Admin Search after Make Non-Discoverable flow

### DIFF
--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.html
@@ -113,10 +113,10 @@
         </button>
 
         <button [dsBtnDisabled]="isDeleting$ | async"
-                [routerLink]="[itemPageRoute, 'edit']"
-                class="btn btn-outline-secondary cancel">
-          {{cancelMessage | translate}}
-        </button>
+              (click)="router.navigateByUrl(returnUrl)"
+              class="btn btn-outline-secondary cancel">
+              {{cancelMessage | translate}}
+      </button>
       </div>
 
     </div>

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.spec.ts
@@ -45,7 +45,6 @@ import { ListableObjectComponentLoaderComponent } from '../../../shared/object-c
 import { getMockThemeService } from '../../../shared/theme-support/test/theme-service.mock';
 import { ThemeService } from '../../../shared/theme-support/theme.service';
 import { VarDirective } from '../../../shared/utils/var.directive';
-import { getItemEditRoute } from '../../item-page-routing-paths';
 import { ModifyItemOverviewComponent } from '../modify-item-overview/modify-item-overview.component';
 import { ItemDeleteComponent } from './item-delete.component';
 
@@ -234,12 +233,12 @@ describe('ItemDeleteComponent', () => {
       }, 0);
     });
 
-    it('should show error notification and redirect to item edit page on failure', (done) => {
+    it('should show error notification and redirect to previous URL on failure', (done) => {
       scriptDataService.invoke.and.returnValue(createFailedRemoteDataObject$('Error', 500));
       comp.performAction();
       setTimeout(() => {
         expect(notificationsServiceStub.error).toHaveBeenCalled();
-        expect(router.navigate).toHaveBeenCalledWith([getItemEditRoute(mockItem)]);
+        expect(router.navigateByUrl).toHaveBeenCalledWith(comp.returnUrl);
         done();
       }, 0);
     });

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
@@ -466,7 +466,7 @@ export class ItemDeleteComponent
       this.router.navigateByUrl(getProcessDetailRoute(rd.payload.processId));
     } else {
       this.notificationsService.error(this.translateService.get('item.edit.delete.error'));
-      this.router.navigate([getItemEditRoute(this.item)]);
+      this.router.navigateByUrl(this.returnUrl);
     }
   }
 

--- a/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
+++ b/src/app/item-page/edit-item-page/item-delete/item-delete.component.ts
@@ -69,7 +69,6 @@ import { getProcessDetailRoute } from '../../../process-page/process-page-routin
 import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
 import { ListableObjectComponentLoaderComponent } from '../../../shared/object-collection/shared/listable-object/listable-object-component-loader.component';
 import { VarDirective } from '../../../shared/utils/var.directive';
-import { getItemEditRoute } from '../../item-page-routing-paths';
 import { ModifyItemOverviewComponent } from '../modify-item-overview/modify-item-overview.component';
 import { AbstractSimpleItemActionComponent } from '../simple-item-action/abstract-simple-item-action.component';
 import { VirtualMetadata } from '../virtual-metadata/virtual-metadata.component';

--- a/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.html
+++ b/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.html
@@ -7,11 +7,10 @@
           <div class="space-children-mr">
             <button (click)="performAction()" class="btn btn-outline-secondary perform-action">{{confirmMessage | translate}}
             </button>
-            <button [routerLink]="[itemPageRoute, 'edit']" class="btn btn-outline-secondary cancel">
-              {{cancelMessage| translate}}
+            <button (click)="router.navigateByUrl(returnUrl)" class="btn btn-outline-secondary cancel">
+              {{cancelMessage | translate}}
             </button>
           </div>
         </div>
     </div>
-
 </div>

--- a/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
+++ b/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
@@ -83,6 +83,11 @@ describe('AbstractSimpleItemActionComponent', () => {
     itemPageUrl = `fake-url/${mockItem.id}`;
     routerStub = Object.assign(new RouterStub(), {
       url: `${itemPageUrl}/edit`,
+      lastSuccessfulNavigation: {
+        previousNavigation: {
+          finalUrl: { toString: () => '/admin/search' },
+        },
+      },
     });
 
     mockItemDataService = jasmine.createSpyObj({
@@ -148,18 +153,28 @@ describe('AbstractSimpleItemActionComponent', () => {
     expect(comp.performAction).toHaveBeenCalled();
   });
 
-  it('should process a RemoteData to navigate and display success notification', () => {
+  it('should navigate to previous URL and show success notification on success', () => {
     comp.processRestResponse(successfulRemoteData);
 
     expect(notificationsServiceStub.success).toHaveBeenCalled();
-    expect(routerStub.navigate).toHaveBeenCalledWith([getItemEditRoute(mockItem)]);
+    expect(routerStub.navigateByUrl).toHaveBeenCalledWith('/admin/search');
   });
 
-  it('should process a RemoteData to navigate and display success notification', () => {
+  it('should navigate to previous URL and show error notification on failure', () => {
     comp.processRestResponse(failedRemoteData);
 
     expect(notificationsServiceStub.error).toHaveBeenCalled();
-    expect(routerStub.navigate).toHaveBeenCalledWith([getItemEditRoute(mockItem)]);
+    expect(routerStub.navigateByUrl).toHaveBeenCalledWith('/admin/search');
+  });
+
+  it('should navigate to item edit route when no previous URL exists', () => {
+    routerStub.lastSuccessfulNavigation = null;
+    comp.ngOnInit();
+    fixture.detectChanges();
+
+    comp.processRestResponse(failedRemoteData);
+
+    expect(routerStub.navigateByUrl).toHaveBeenCalledWith(getItemEditRoute(mockItem));
   });
 
 });

--- a/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
+++ b/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.spec.ts
@@ -89,6 +89,7 @@ describe('AbstractSimpleItemActionComponent', () => {
         },
       },
     });
+    routerStub.navigateByUrl = jasmine.createSpy('navigateByUrl');
 
     mockItemDataService = jasmine.createSpyObj({
       findById: createSuccessfulRemoteDataObject$(mockItem),

--- a/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
+++ b/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
@@ -27,7 +27,6 @@ import {
 import { getItemEditRoute } from '../../item-page-routing-paths';
 import { findSuccessfulAccordingTo } from '../edit-item-operators';
 import { ModifyItemOverviewComponent } from '../modify-item-overview/modify-item-overview.component';
-
 /**
  * Component to render and handle simple item edit actions such as withdrawal and reinstatement.
  * This component is not meant to be used itself but to be extended.
@@ -57,6 +56,8 @@ export class AbstractSimpleItemActionComponent implements OnInit {
    */
   itemPageRoute: string;
 
+  returnUrl: string;
+
   protected predicate: Predicate<RemoteData<Item>>;
 
   constructor(protected route: ActivatedRoute,
@@ -67,22 +68,28 @@ export class AbstractSimpleItemActionComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const previousUrl = this.router.lastSuccessfulNavigation?.previousNavigation?.finalUrl?.toString();
+    this.returnUrl = previousUrl ?? getItemEditRoute(this.item);
+
     this.itemRD$ = this.route.data.pipe(
       map((data) => data.dso),
       getFirstSucceededRemoteData(),
-    )as Observable<RemoteData<Item>>;
+    ) as Observable<RemoteData<Item>>;
 
     this.itemRD$.pipe(first()).subscribe((rd) => {
       this.item = rd.payload;
       this.itemPageRoute = getItemPageRoute(this.item);
-    },
-    );
+      if (!this.returnUrl) {
+        this.returnUrl = getItemEditRoute(this.item);
+      }
+    });
 
     this.confirmMessage = 'item.edit.' + this.messageKey + '.confirm';
     this.cancelMessage = 'item.edit.' + this.messageKey + '.cancel';
     this.headerMessage = 'item.edit.' + this.messageKey + '.header';
     this.descriptionMessage = 'item.edit.' + this.messageKey + '.description';
   }
+
   /**
    * Perform the operation linked to this action
    */
@@ -100,11 +107,11 @@ export class AbstractSimpleItemActionComponent implements OnInit {
         findSuccessfulAccordingTo((itemRd: RemoteData<Item>) => this.predicate(itemRd)),
       ).subscribe(() => {
         this.notificationsService.success(this.translateService.get('item.edit.' + this.messageKey + '.success'));
-        this.router.navigate([getItemEditRoute(this.item)]);
+        this.router.navigateByUrl(this.returnUrl);
       });
     } else {
       this.notificationsService.error(this.translateService.get('item.edit.' + this.messageKey + '.error'));
-      this.router.navigate([getItemEditRoute(this.item)]);
+      this.router.navigateByUrl(this.returnUrl);
     }
   }
 

--- a/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
+++ b/src/app/item-page/edit-item-page/simple-item-action/abstract-simple-item-action.component.ts
@@ -69,7 +69,7 @@ export class AbstractSimpleItemActionComponent implements OnInit {
 
   ngOnInit(): void {
     const previousUrl = this.router.lastSuccessfulNavigation?.previousNavigation?.finalUrl?.toString();
-    this.returnUrl = previousUrl ?? getItemEditRoute(this.item);
+    this.returnUrl = previousUrl ?? null;
 
     this.itemRD$ = this.route.data.pipe(
       map((data) => data.dso),


### PR DESCRIPTION
## References
Fixes #5532

## Description
When clicking Cancel or Make Non-Discoverable in the Make Non-Discoverable flow, 
the user was being redirected to the item's administer page instead of returning 
to Admin Search. This fix returns the user to the previous page (Admin Search) 
after completing or cancelling the action.

## Instructions for Reviewers

List of changes in this PR:

- Modified `abstract-simple-item-action.component.ts` to capture the previous URL 
-   using `router.lastSuccessfulNavigation` and use it as the redirect destination 
-   after the action completes or fails.
- Modified `abstract-simple-item-action.component.html` to use `navigateByUrl(returnUrl)` 
-   on the Cancel button instead of a hardcoded routerLink to the item edit page.
- Updated `abstract-simple-item-action.component.spec.ts` to reflect the new 
-   navigation behavior.

Steps to test:
1. Go to Admin Search from the management sidebar.
2. Search for any item.
3. Click Make non-discoverable.
4. Click Cancel — you should be returned to Admin Search.
5. Repeat steps 1-3 and click Make it non-discoverable — you should also be returned to Admin Search.
6. Verify that accessing the Make Non-Discoverable page directly (not from Admin Search) 
   still redirects to the item edit page after the action.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
