### PR TITLE
Fix #5534: allow multiple accordions to stay open in Collection Filte…

### DIFF
--- a/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.html
+++ b/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.html
@@ -5,7 +5,7 @@
       <h1 id="header" class="border-bottom pb-2">{{ "admin.reports.collections.head" | translate }}</h1>
 
       <div id="metadatadiv">
-        <ngb-accordion [closeOthers]="true" activeIds="filters" #acc="ngbAccordion">
+        <ngb-accordion [closeOthers]="false" activeIds="filters" #acc="ngbAccordion">
           <ngb-panel id="filters">
             <ng-template ngbPanelTitle>
               {{ "admin.reports.commons.filters" | translate }}

--- a/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.spec.ts
+++ b/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.spec.ts
@@ -83,6 +83,7 @@ describe('FiltersComponent', () => {
       spyOn(component, 'getFilteredCollections').and.returnValue(of(expected));
       spyOn(component.results, 'deserialize');
       spyOn(component.accordionComponent, 'expand').and.callThrough();
+      spyOn(component.accordionComponent, 'collapse').and.callThrough();
       component.submit();
       fixture.detectChanges();
     });
@@ -93,5 +94,19 @@ describe('FiltersComponent', () => {
         expect(component.accordionComponent.isExpanded('collections')).toBeTrue();
       });
     }));
+
+    it('should collapse the filters panel after submitting', waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        expect(component.accordionComponent.isExpanded('filters')).toBeFalse();
+      });
+    }));
+  });
+
+  it('should allow both accordions to be open at the same time', () => {
+    let accordion: NgbAccordion = component.accordionComponent;
+    accordion.expand('filters');
+    accordion.expand('collections');
+    expect(accordion.isExpanded('filters')).toBeTrue();
+    expect(accordion.isExpanded('collections')).toBeTrue();
   });
 });

--- a/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.ts
+++ b/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.ts
@@ -66,6 +66,7 @@ export class FilteredCollectionsComponent implements OnInit {
       .subscribe(
         response => {
           this.results.deserialize(response.payload);
+          this.accordionComponent.collapse('filters'); // ← agregar esto
           this.accordionComponent.expand('collections');
         },
       );

--- a/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.ts
+++ b/src/app/admin/admin-reports/filtered-collections/filtered-collections.component.ts
@@ -66,7 +66,7 @@ export class FilteredCollectionsComponent implements OnInit {
       .subscribe(
         response => {
           this.results.deserialize(response.payload);
-          this.accordionComponent.collapse('filters'); // ← agregar esto
+          this.accordionComponent.collapse('filters');
           this.accordionComponent.expand('collections');
         },
       );


### PR DESCRIPTION
## References
Fixes #5534

## Description
Allows multiple accordions to stay open simultaneously in the Collection Filter Report. 
The "Show Collections" button behavior is preserved, closing the Filters accordion and opening the Collections accordion automatically.

## Instructions for Reviewers

List of changes in this PR:

- Set [closeOthers]="false" in the ngb-accordion component to allow multiple panels to be open at the same time.
- Added explicit collapse('filters') call in the submit() method to preserve the original UX behavior when clicking "Show Collections".
- Added unit tests to cover: filters collapsing on submit, and both accordions being open simultaneously.

Steps to test:

1. Open the Collection Filter Report in the admin menu.
2. Expand the Filters accordion, then manually expand the Collections accordion — both should stay open.
3. Close one accordion — the other should remain unaffected.
4. With Filters open, press "Show Collections" — Filters should close and Collections should open with results.
5. With both open, press "Show Collections" — Filters should close and Collections should refresh with results.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
