### PR TITLE
fix: improve contrast on homepage credits text

### DIFF
--- a/src/themes/dspace/app/home-page/home-news/home-news.component.scss
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.scss
@@ -51,7 +51,8 @@
         color: inherit;
       }
 
-      opacity: 0.3;
+      color: rgba(255, 255, 255, 0.7);
+      background-color: rgba(0, 0, 0, 0.1);
       position: absolute;
       right: var(--bs-spacer);
       bottom: 0;


### PR DESCRIPTION
## References
* Fixes #5487 

## Description
The "Photo by @inspiredimages" credits text on the homepage banner has `opacity: 0.3` on white text directly over the banner image, which fails WCAG AA contrast requirements (flagged by WAVE tool). This PR replaces the opacity with a semi-transparent text color and a minimal dark background to ensure readable contrast.


## Instructions for Reviewers

**CI note:** The `tests (22.x)` failure is pre-existing — `SubmissionService.redirectToEditItem` fails with a spy setup error in `submission.service.spec.ts`, unrelated to this CSS-only change. Tests pass on Node 20.

List of changes in this PR:
* Replaced `opacity: 0.3` with `color: rgba(255, 255, 255, 0.7)` — controls text subtlety without affecting the background
* Added `background-color: rgba(0, 0, 0, 0.1)` — minimal dark backdrop that provides enough contrast for WCAG compliance

**Why `color` instead of `opacity`:** `opacity` fades the entire element, including any background. Using `color` lets us dim the text independently while keeping the background at its intended strength.


**How to test:** 
1. Serve the app locally (`npm start`) and navigate to the homepage
2. Check the "Photo by @inspiredimages" text at the bottom-right of the banner
3. Confirm the text is readable but still subtle, visually close to the original
4. Run the WAVE browser extension on the homepage and verify the low-contrast error is resolved



## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
