### PR TITLE
fix #5542: display Primary badge on Download button component for pri…

### DIFF
--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
@@ -8,7 +8,12 @@
     <div class="order-lg-3 ml-auto">
       <div class="d-flex flex-column align-items-end gap-3">
         <div class="text-nowrap">
-          <div class="text-nowrap">
+          <div class="text-nowrap d-flex align-items-center gap-2">
+            @if (primaryBitstreamId === attachment.id) {
+              <span class="badge bg-primary">
+                {{ 'item.page.bitstreams.primary' | translate }}
+              </span>
+            }
             <ds-file-download-button [bitstream]="attachment" [item]="item"></ds-file-download-button>
           </div>
         </div>

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
@@ -8,15 +8,13 @@
     <div class="order-lg-3 ml-auto">
       <div class="d-flex flex-column align-items-end gap-3">
         <div class="text-nowrap">
-          <div class="text-nowrap d-flex align-items-center gap-2">
-            @if (primaryBitstreamId === attachment.id) {
-              <span class="badge bg-primary">
-                {{ 'item.page.bitstreams.primary' | translate }}
-              </span>
-            }
-            <ds-file-download-button [bitstream]="attachment" [item]="item"></ds-file-download-button>
-          </div>
+          <ds-file-download-button [bitstream]="attachment" [item]="item"></ds-file-download-button>
         </div>
+        @if (primaryBitstreamId === attachment.id) {
+          <span class="badge bg-primary">
+            {{ 'item.page.bitstreams.primary' | translate }}
+          </span>
+        }
       </div>
     </div>
 

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
@@ -98,4 +98,18 @@ describe('BitstreamAttachmentComponent', () => {
     expect(component.checksumInfo.value).toBe('abc123');
     expect(component.allAttachmentProviders).toEqual(['provider1']);
   });
+
+  it('should display the primary badge when primaryBitstreamId matches attachment id', () => {
+    component.primaryBitstreamId = attachmentMock.id;
+    fixture.detectChanges();
+    const badge = fixture.nativeElement.querySelector('.badge.bg-primary');
+    expect(badge).toBeTruthy();
+  });
+
+  it('should not display the primary badge when primaryBitstreamId does not match', () => {
+    component.primaryBitstreamId = 'other-id';
+    fixture.detectChanges();
+    const badge = fixture.nativeElement.querySelector('.badge.bg-primary');
+    expect(badge).toBeNull();
+  });
 });

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
@@ -90,6 +90,11 @@ export class BitstreamAttachmentComponent implements OnInit {
   @Input() item: Item;
 
   /**
+   * The ID of the primary bitstream, used to display the Primary badge
+   */
+  @Input() primaryBitstreamId: string;
+
+  /**
    * Format of the bitstream
    */
   bitstreamFormat$: Observable<string>;

--- a/src/app/shared/bitstream-attachment/section/attachment-section.component.html
+++ b/src/app/shared/bitstream-attachment/section/attachment-section.component.html
@@ -5,7 +5,7 @@
       <div class="file-section">
 
         @for (file of bitstreams; track file) {
-          <ds-bitstream-attachment [item]="item" [attachment]="file"></ds-bitstream-attachment>
+          <ds-bitstream-attachment [item]="item" [attachment]="file" [primaryBitstreamId]="primaryBitstreamId"></ds-bitstream-attachment>
         }
         @if (isLoading) {
           <ds-loading message="{{'loading.default' | translate}}" [showMessage]="false"></ds-loading>


### PR DESCRIPTION
## References
* Fixes #5542

## Description
Adds the "Primary" badge to the Download button component so users can identify the primary bitstream on the item page when showDownloadLinkAsAttachment is enabled.

## Instructions for Reviewers
List of changes in this PR:

- Added @Input() primaryBitstreamId: string to BitstreamAttachmentComponent
- Added the Primary badge in bitstream-attachment.component.html next to the Download button
- Passed primaryBitstreamId from AttachmentSectionComponent (which already inherits it from FileSectionComponent) down to BitstreamAttachmentComponent
- Added unit tests to verify the badge displays correctly

How to test:

1. In config/config.yml, set layout.showDownloadLinkAsAttachment: true
2. Go to an item with multiple files where one is marked as Primary
3. Confirm the Primary badge appears next to the correct Download button
4. Confirm no badge appears on the non-primary file 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
