### PR TITLE
Fix flaky SubmissionService test

### DIFF
--- a/src/app/submission/submission.service.spec.ts
+++ b/src/app/submission/submission.service.spec.ts
@@ -32,6 +32,7 @@ import { SubmissionJsonPatchOperationsService } from '@dspace/core/submission/su
 import { SubmissionRestService } from '@dspace/core/submission/submission-rest.service';
 import { SubmissionScopeType } from '@dspace/core/submission/submission-scope-type';
 import { MockActivatedRoute } from '@dspace/core/testing/active-router.mock';
+import { ItemDataServiceStub } from '@dspace/core/testing/item-data.service.stub';
 import { getMockRequestService } from '@dspace/core/testing/request.service.mock';
 import { RouterMock } from '@dspace/core/testing/router.mock';
 import { getMockSearchService } from '@dspace/core/testing/search-service.mock';
@@ -41,7 +42,6 @@ import { TranslateLoaderMock } from '@dspace/core/testing/translate-loader.mock'
 import {
   createFailedRemoteDataObject,
   createSuccessfulRemoteDataObject,
-  createSuccessfulRemoteDataObject$,
 } from '@dspace/core/utilities/remote-data.utils';
 import { StoreModule } from '@ngrx/store';
 import {
@@ -82,7 +82,7 @@ import {
   mockSubmissionRestResponse,
 } from './utils/submission.mock';
 
-describe('SubmissionService test suite', () => {
+describe('SubmissionService', () => {
   const collectionId = '43fe1f8c-09a6-4fcf-9c78-5d4fed8f2c8f';
   const submissionId = '826';
   const sectionId = 'test';
@@ -401,9 +401,7 @@ describe('SubmissionService test suite', () => {
     },
   };
   const restService = new SubmissionRestServiceStub();
-  const itemService: ItemDataService = jasmine.createSpyObj('itemService', {
-    findById: createSuccessfulRemoteDataObject$(new Item()),
-  });;
+  let itemService: ItemDataServiceStub;
   const router = new RouterMock();
   const selfUrl = 'https://rest.api/dspace-spring-rest/api/submission/workspaceitems/826';
   const submissionDefinition: any = mockSubmissionDefinition;
@@ -417,6 +415,7 @@ describe('SubmissionService test suite', () => {
   const requestServce = getMockRequestService();
 
   beforeEach(waitForAsync(() => {
+    itemService = new ItemDataServiceStub();
 
     TestBed.configureTestingModule({
       imports: [
@@ -978,10 +977,6 @@ describe('SubmissionService test suite', () => {
   });
 
   describe('redirectToEditItem', () => {
-    beforeEach(() => {
-      (itemService.findById as jasmine.Spy).calls.reset();
-    });
-
     it('should redirect to Item page', fakeAsync(() => {
       scheduler = getTestScheduler();
 


### PR DESCRIPTION
## References
* Fixes #5553

## Description
Fixed flaky `SubmissionService` test by using a stub class instead of a `SpyObj` to prevent the method to be spied on twice (during init & in the test where the value is explicitly set to a certain value).

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
