### PR TITLE
fix #5525: add independent scroll to filters bar

### DIFF
--- a/src/app/shared/search/search-filters/search-filters.component.html
+++ b/src/app/shared/search/search-filters/search-filters.component.html
@@ -4,21 +4,22 @@
   <h2>{{filterLabel+'.filters.head' | translate}}</h2>
 }
 
-@if ((filters | async)?.hasSucceeded) {
-  <div [class.visually-hidden]="getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length">
-    @for (filter of (filters | async)?.payload; track filter.name) {
-      <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
-    }
-  </div>
-}
+<div class="filters-scrollable">
+  @if ((filters | async)?.hasSucceeded) {
+    <div [class.visually-hidden]="getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length">
+      @for (filter of (filters | async)?.payload; track filter.name) {
+        <ds-search-filter (isVisibilityComputed)="countFiltersWithComputedVisibility($event)" [scope]="currentScope" [filter]="filter" [inPlaceSearch]="inPlaceSearch" [refreshFilters]="refreshFilters"></ds-search-filter>
+      }
+    </div>
+  }
 
-@if(getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length) {
-  <ngx-skeleton-loader [count]="defaultFilterCount"/>
-}
+  @if(getCurrentFiltersComputed(this.currentConfiguration) < (filters | async)?.payload?.length) {
+    <ngx-skeleton-loader [count]="defaultFilterCount"/>
+  }
+</div>
 
 @if (inPlaceSearch) {
   <button class="btn btn-primary" [routerLink]="[searchLink]" [queryParams]="clearParams | async" (click)="minimizeFilters()" queryParamsHandling="merge" role="button">
     <i class="fas fa-undo"></i> {{"search.filters.reset" | translate}}
   </button>
 }
-

--- a/src/app/shared/search/search-filters/search-filters.component.scss
+++ b/src/app/shared/search/search-filters/search-filters.component.scss
@@ -1,6 +1,13 @@
 @import '../../../../styles/variables';
 @import '../../../../styles/mixins';
 
+:host {
+  display: block;
+  max-height: 80vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 :host ::ng-deep {
   ngx-skeleton-loader .skeleton-loader {
     height: var(--ds-filters-skeleton-height);

--- a/src/app/shared/search/search-filters/search-filters.component.scss
+++ b/src/app/shared/search/search-filters/search-filters.component.scss
@@ -3,7 +3,11 @@
 
 :host {
   display: block;
-  max-height: 80vh;
+  overscroll-behavior: contain;
+}
+
+.filters-scrollable {
+  max-height: 60vh;
   overflow-y: auto;
   overscroll-behavior: contain;
 }


### PR DESCRIPTION
## References
Fixes #5525

## Description
The filters bar was causing the whole page to scroll when interacting 
with it. Added independent scroll behavior to the filters sidebar so 
it scrolls on its own without moving the entire page.

## Instructions for Reviewers
List of changes in this PR:

- Added `overflow-y: auto` to the `:host` selector in search-filters.component.scss to enable independent scrolling
- Added `overscroll-behavior: contain` to prevent scroll events from propagating to the parent page

To test:

1. Go to the Search page (/search)
2. Hover over the filters sidebar (Autor/a, Materias, Fecha, etc.)
3. Scroll with the mouse wheel
4. Expected: only the filters area scrolls, the results list stays still

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
