### PR TITLE
[e2e tests] Disable "aria-required-children" accessibility check on the Item Edit page, as it's gotten very flakey

### DIFF
--- a/cypress/e2e/item-edit.cy.ts
+++ b/cypress/e2e/item-edit.cy.ts
@@ -34,7 +34,16 @@ describe('Edit Item > Edit Metadata tab', () => {
     });
 
     // Analyze <ds-edit-item-page> for accessibility issues
-    testA11y('ds-edit-item-page');
+    testA11y('ds-edit-item-page',
+            {
+              rules: {
+                // Disable flakey "aria-required-children" test. While this test passes when run locally,
+                // in GitHub CI it will return random failures roughly 1/3 of the time saying that the
+                // "tablist" doesn't contain required "tab" elements, even though they do exist.
+                'aria-required-children': { enabled: false },
+              },
+            } as Options,
+    );
   });
 });
 


### PR DESCRIPTION
## Description
This small PR is disabling the `aria-required-children` accessibility rule from running on the Item Edit page (in `item-edit.cy.ts`).  This test always succeeds when run locally.  However, when in our CI environment in GitHub, it is randomly failing approximately 1/3 of the time.

When the test fails, it returns this:
```
Edit Item > Edit Metadata tab
...
1 accessibility violation was detected
[
  {
    id: 'aria-required-children',
    impact: 'critical',
    description: 'Ensure elements with an ARIA role that require child roles contain them',
    helpUrl: 'https://dequeuniversity.com/rules/axe/4.11/aria-required-children?application=axeAPI',
    nodes: 1,
    html: [
      '<ul role="tablist" class="nav nav-tabs justify-content-start ng-tns-c1571227584-1 ng-star-inserted">'
    ]
  }
]
```

The failure is essentially saying that the `role="tablist"` element (displayed in the error) doesn't contain any `role="tab"` elements.  However, our Tabs on that page all have the required `role="tab"` attribute and all appear as children of the `role="tablist"` element.

We've tried various workarounds (e.g. #5518) to attempt to wait for the page to fully load before running the accessibility scan.  But, these fixes don't have any impact on the random failures of the `aria-required-children` rule on this  page.

Therefore, this PR is disabling that `aria-required-children` rule **only for this single e2e test**.  It is active in all other tests and on all other pages.

**This PR should be backported to all active branches as all branches show the same flakey behavior in this test.**

## Instructions for Reviewers
* This is only testable via GitHub CI.  So, assuming that succeeds, this can be merged.