### PR TITLE
Render skip-to-main-content as a link instead of a button

### DIFF
--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -1,6 +1,6 @@
-<button (click)="skipToMainContent()" class="sr-only" id="skip-to-main-content">
+<a href="#main-content" class="sr-only" id="skip-to-main-content">
   {{ 'root.skip-to-content' | translate }}
-</button>
+</a>
 
 <div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [ngClass]="browserOsClasses.asObservable() | async" [@slideSidebarPadding]="{
      value: ((isSidebarVisible$ | async) !== true ? 'hidden' : (slideSidebarOver$ | async) ? 'unpinned' : 'pinned'),
@@ -11,7 +11,7 @@
     <ds-system-wide-alert-banner></ds-system-wide-alert-banner>
     <ds-header-navbar-wrapper></ds-header-navbar-wrapper>
     <ds-breadcrumbs></ds-breadcrumbs>
-    <main class="my-cs" id="main-content">
+    <main class="my-cs" id="main-content" tabindex="-1">
 
       @if (shouldShowRouteLoader) {
         <div class="container d-flex justify-content-center align-items-center h-100">

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -1,6 +1,6 @@
-<button (click)="skipToMainContent()" class="sr-only" id="skip-to-main-content">
+<a [routerLink]="[]" class="sr-only" fragment="main-content" id="skip-to-main-content" queryParamsHandling="preserve">
   {{ 'root.skip-to-content' | translate }}
-</button>
+</a>
 
 <div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [ngClass]="browserOsClasses.asObservable() | async" [@slideSidebarPadding]="{
      value: ((isSidebarVisible$ | async) !== true ? 'hidden' : (slideSidebarOver$ | async) ? 'unpinned' : 'pinned'),
@@ -11,7 +11,7 @@
     <ds-system-wide-alert-banner></ds-system-wide-alert-banner>
     <ds-header-navbar-wrapper></ds-header-navbar-wrapper>
     <ds-breadcrumbs></ds-breadcrumbs>
-    <main class="my-cs" id="main-content">
+    <main class="my-cs" id="main-content" tabindex="-1">
 
       @if (shouldShowRouteLoader) {
         <div class="container d-flex justify-content-center align-items-center h-100">

--- a/src/app/root/root.component.spec.ts
+++ b/src/app/root/root.component.spec.ts
@@ -72,4 +72,20 @@ describe('RootComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('skip-to-main-content link', () => {
+    it('should be rendered as an anchor pointing to #main-content', () => {
+      const skipLink = fixture.nativeElement.querySelector('#skip-to-main-content');
+      expect(skipLink).not.toBeNull();
+      expect(skipLink.tagName).toBe('A');
+      expect(skipLink.getAttribute('href')).toBe('#main-content');
+    });
+
+    it('should target a <main> element with tabindex="-1" so the anchor can move focus', () => {
+      const mainContent = fixture.nativeElement.querySelector('#main-content');
+      expect(mainContent).not.toBeNull();
+      expect(mainContent.tagName).toBe('MAIN');
+      expect(mainContent.getAttribute('tabindex')).toBe('-1');
+    });
+  });
 });

--- a/src/app/root/root.component.spec.ts
+++ b/src/app/root/root.component.spec.ts
@@ -1,20 +1,21 @@
-import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import {
+  Router,
+  RouterModule,
+} from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { AccessibilitySettingsService } from '../accessibility/accessibility-settings.service';
-import { AccessibilitySettingsServiceStub } from '../accessibility/accessibility-settings.service.stub';
 import { ThemedAdminSidebarComponent } from '../admin/admin-sidebar/themed-admin-sidebar.component';
 import { ThemedBreadcrumbsComponent } from '../breadcrumbs/themed-breadcrumbs.component';
 import { ThemedFooterComponent } from '../footer/themed-footer.component';
 import { ThemedHeaderNavbarWrapperComponent } from '../header-nav-wrapper/themed-header-navbar-wrapper.component';
 import { HostWindowService } from '../shared/host-window.service';
+import { LiveRegionComponent } from '../shared/live-region/live-region.component';
 import { ThemedLoadingComponent } from '../shared/loading/themed-loading.component';
 import { MenuService } from '../shared/menu/menu.service';
 import { RouterMock } from '../shared/mocks/router.mock';
@@ -33,8 +34,8 @@ describe('RootComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        CommonModule,
         NoopAnimationsModule,
+        RouterModule.forRoot([]),
         TranslateModule.forRoot(),
         RootComponent,
       ],
@@ -43,24 +44,24 @@ describe('RootComponent', () => {
         { provide: MenuService, useValue: new MenuServiceStub() },
         { provide: CSSVariableService, useClass: CSSVariableServiceStub },
         { provide: HostWindowService, useValue: new HostWindowServiceStub(800) },
-        { provide: AccessibilitySettingsService, useValue: new AccessibilitySettingsServiceStub() },
       ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    })
-      .overrideComponent(RootComponent, {
-        remove: {
-          imports: [
-            ThemedAdminSidebarComponent,
-            SystemWideAlertBannerComponent,
-            ThemedHeaderNavbarWrapperComponent,
-            ThemedBreadcrumbsComponent,
-            ThemedLoadingComponent,
-            ThemedFooterComponent,
-            NotificationsBoardComponent,
-          ],
-        },
-      })
-      .compileComponents();
+    }).overrideComponent(RootComponent, {
+      add: {
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      },
+      remove: {
+        imports: [
+          LiveRegionComponent,
+          ThemedAdminSidebarComponent,
+          SystemWideAlertBannerComponent,
+          ThemedHeaderNavbarWrapperComponent,
+          ThemedBreadcrumbsComponent,
+          ThemedLoadingComponent,
+          ThemedFooterComponent,
+          NotificationsBoardComponent,
+        ],
+      },
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -71,5 +72,21 @@ describe('RootComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('skip-to-main-content link', () => {
+    it('should be rendered as an anchor pointing to #main-content', () => {
+      const skipLink = fixture.nativeElement.querySelector('#skip-to-main-content');
+      expect(skipLink).not.toBeNull();
+      expect(skipLink.tagName).toBe('A');
+      expect(skipLink.getAttribute('fragment')).toBe('main-content');
+    });
+
+    it('should target a <main> element with tabindex="-1" so the anchor can move focus', () => {
+      const mainContent = fixture.nativeElement.querySelector('#main-content');
+      expect(mainContent).not.toBeNull();
+      expect(mainContent.tagName).toBe('MAIN');
+      expect(mainContent.getAttribute('tabindex')).toBe('-1');
+    });
   });
 });

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -134,14 +134,6 @@ export class RootComponent implements OnInit {
     }
   }
 
-  skipToMainContent() {
-    const mainContent = document.getElementById('main-content');
-    if (mainContent) {
-      mainContent.tabIndex = -1;
-      mainContent.focus();
-    }
-  }
-
   getBrowserName(): string {
     const userAgent = this._window.nativeWindow.navigator?.userAgent;
     if (/Firefox/.test(userAgent)) {

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import {
   Router,
+  RouterLink,
   RouterOutlet,
 } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -59,6 +60,7 @@ import { SystemWideAlertBannerComponent } from '../system-wide-alert/alert-banne
     LiveRegionComponent,
     NgClass,
     NotificationsBoardComponent,
+    RouterLink,
     RouterOutlet,
     SystemWideAlertBannerComponent,
     ThemedAdminSidebarComponent,
@@ -132,14 +134,6 @@ export class RootComponent implements OnInit {
 
     if (this.router.url === getPageInternalServerErrorRoute()) {
       this.shouldShowRouteLoader = false;
-    }
-  }
-
-  skipToMainContent() {
-    const mainContent = document.getElementById('main-content');
-    if (mainContent) {
-      mainContent.tabIndex = -1;
-      mainContent.focus();
     }
   }
 

--- a/src/themes/custom/app/root/root.component.ts
+++ b/src/themes/custom/app/root/root.component.ts
@@ -3,7 +3,10 @@ import {
   NgClass,
 } from '@angular/common';
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import {
+  RouterLink,
+  RouterOutlet,
+} from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ThemedAdminSidebarComponent } from '../../../../app/admin/admin-sidebar/themed-admin-sidebar.component';
@@ -30,6 +33,7 @@ import { SystemWideAlertBannerComponent } from '../../../../app/system-wide-aler
     LiveRegionComponent,
     NgClass,
     NotificationsBoardComponent,
+    RouterLink,
     RouterOutlet,
     SystemWideAlertBannerComponent,
     ThemedAdminSidebarComponent,


### PR DESCRIPTION
## References
* Fixes #5605

## Description
Render the skip-to-main-content control as routerLink instead of a `<button>`. Aligns with the canonical WAI-ARIA Authoring Practices skip-link pattern and removes the JS click-handler dependency.

## Instructions for Reviewers

List of changes in this PR:
  * `src/app/root/root.component.html` - modified the skip control to becomes a `routerLink`. Added `tabindex="-1"` to `<main id="main-content">` so the fragment navigation reliably moves focus across browsers (without `tabindex`, some browsers do not move focus to non-form elements after fragment navigation).
* `src/app/root/root.component.ts` - removed the now-unused `skipToMainContent()` method that previously focused `#main-content` programmatically.
* `src/app/root/root.component.spec.ts` - added specs asserting (1) the skip link is an `<a>`, and (2) the `<main>` target carries `tabindex="-1"`.

**How to test:**
Test the following scenario in both prod mode & dev mode and try it out on at least 2 different tabs:
1. Reload a page and press `Tab`. The screenreader should focus on the "Skip to main content"
2. Press `Enter`. The URL should gain `#main-content` and keyboard focus should land on the `<main>` element. A subsequent `Tab` should move focus to the first interactive element inside the page content rather than back to a navbar item.

This is **not** fixing a current WCAG failure (the existing button works for any user who reaches the running SPA, since DSpace requires JS to render). It aligns the implementation with the canonical pattern - see #5605 for full rationale.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (3 files, 19 insertions, 11 deletions).
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. (n/a - method removed, no new methods)
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations. (existing key `root.skip-to-content` retained)
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (n/a)
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself. (n/a)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
