### PR TITLE
Fix ARIA issues on Navbar and Edit menu found via Pa11y / axe

### DIFF
--- a/src/app/header/context-help-toggle/context-help-toggle.component.html
+++ b/src/app/header/context-help-toggle/context-help-toggle.component.html
@@ -1,12 +1,11 @@
 @if (buttonVisible$ | async) {
   <div>
-    <a href="javascript:void(0);"
-      role="menuitem"
+    <button type="button"
+      class="ds-context-help-toggle-button"
       (click)="onClick()"
       [attr.aria-label]="'nav.context-help-toggle' | translate"
-      [title]="'nav.context-help-toggle' | translate"
-      >
+      [title]="'nav.context-help-toggle' | translate">
       <i class="fas fa-lg fa-fw fa-question-circle ds-context-help-toggle"></i>
-    </a>
+    </button>
   </div>
 }

--- a/src/app/header/context-help-toggle/context-help-toggle.component.scss
+++ b/src/app/header/context-help-toggle/context-help-toggle.component.scss
@@ -1,3 +1,10 @@
+.ds-context-help-toggle-button {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
 .ds-context-help-toggle {
   color: var(--ds-header-icon-color);
   background-color: var(--ds-header-bg);

--- a/src/app/header/context-help-toggle/context-help-toggle.component.spec.ts
+++ b/src/app/header/context-help-toggle/context-help-toggle.component.spec.ts
@@ -56,10 +56,17 @@ describe('ContextHelpToggleComponent', () => {
     });
 
     it('clicking the button should toggle context help icon visibility', fakeAsync(() => {
-      fixture.debugElement.query(By.css('a')).nativeElement.click();
+      fixture.debugElement.query(By.css('button')).nativeElement.click();
       tick();
       expect(contextHelpService.toggleIcons).toHaveBeenCalled();
     }));
+
+    it('the toggle should be a real <button> without an orphan role="menuitem"', () => {
+      const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+      expect(toggle.tagName).toBe('BUTTON');
+      expect(toggle.getAttribute('role')).toBeNull();
+      expect(toggle.getAttribute('type')).toBe('button');
+    });
   });
 
 });

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html
@@ -4,7 +4,7 @@
     (mouseenter)="onMouseEnter($event)"
     (mouseleave)="onMouseLeave($event)"
     data-test="navbar-section-wrapper">
-    <a href="javascript:void(0);" routerLinkActive="active"
+    <button type="button"
       role="menuitem"
       (keyup.enter)="toggleSection($event)"
       (keyup.space)="toggleSection($event)"
@@ -21,7 +21,7 @@
         *ngComponentOutlet="(sectionMap$ | async).get(section.id).component; injector: (sectionMap$ | async).get(section.id).injector;"></ng-container>
       </span>
       <i class="fas fa-caret-down fa-xs toggle-menu-icon" aria-hidden="true"></i>
-    </a>
+    </button>
     @if ((active$ | async).valueOf() === true) {
       <div (click)="deactivateSection($event)"
         [id]="expandableNavbarSectionId()"

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.scss
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.scss
@@ -3,6 +3,16 @@
     position: relative; // align dropdown menu with respect to this element
   }
 
+  // The toggler is a <button> so user agents do not apply native button chrome
+  button.ds-menu-toggler-wrapper {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+  }
+
   .dropdown-menu {
     overflow: hidden;
     min-width: 100%;

--- a/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
+++ b/src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts
@@ -57,6 +57,15 @@ describe('ExpandableNavbarSectionComponent', () => {
       fixture.detectChanges();
     });
 
+    describe('toggler element', () => {
+      it('should be a real <button> rather than an anchor with href="javascript:void(0)"', () => {
+        const toggler = fixture.debugElement.query(By.css('[data-test="navbar-section-toggler"]')).nativeElement;
+        expect(toggler.tagName).toBe('BUTTON');
+        expect(toggler.getAttribute('type')).toBe('button');
+        expect(toggler.getAttribute('role')).toBe('menuitem');
+      });
+    });
+
     describe('when the mouse enters the section header (while inactive)', () => {
       beforeEach(() => {
         spyOn(component, 'onMouseEnter').and.callThrough();

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.html
@@ -9,9 +9,8 @@
         <div ngbDropdown #loginDrop="ngbDropdown" display="dynamic" placement="bottom-right" class="d-inline-block" @fadeInOut>
           <button class="dropdownLogin btn btn-link px-0" [attr.aria-label]="'nav.login' |translate"
                   (click)="$event.preventDefault()" [attr.data-test]="'login-menu' | dsBrowserOnly"
-                  role="button"
-                  tabindex="0"
-                  aria-haspopup="menu"
+                  type="button"
+                  aria-haspopup="dialog"
                   aria-controls="loginDropdownMenu"
                   [attr.aria-expanded]="loginDrop.isOpen()"
                   ngbDropdownToggle>

--- a/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
+++ b/src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts
@@ -234,6 +234,12 @@ describe('AuthNavMenuComponent', () => {
           const loginDropdownMenu = deNavMenuItem.query(By.css('div#loginDropdownMenu'));
           expect(loginDropdownMenu.nativeElement).toBeDefined();
         });
+
+        it('the login toggle should declare aria-haspopup="dialog" so it matches the role of the popup it controls', () => {
+          const loginToggle = deNavMenuItem.query(By.css('button.dropdownLogin'));
+          expect(loginToggle.nativeElement.getAttribute('aria-haspopup')).toBe('dialog');
+          expect(loginToggle.nativeElement.getAttribute('aria-controls')).toBe('loginDropdownMenu');
+        });
       });
 
       describe('when user is authenticated', () => {

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.html
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.html
@@ -3,13 +3,14 @@
     [ngbTooltip]="itemModel.text | translate">
     @if (!section.model.disabled) {
       <a class="btn btn-dark btn-sm"
+        role="menuitem"
         [routerLink]="itemModel.link">
         <i class="fas fa-{{section.icon}} fa-fw" aria-hidden="true"></i>
         <span class="sr-only">{{itemModel.text | translate}}</span>
       </a>
     }
     @if (section.model.disabled) {
-      <button class="btn btn-dark btn-sm" [dsBtnDisabled]="true">
+      <button class="btn btn-dark btn-sm" role="menuitem" [dsBtnDisabled]="true">
         <i class="fas fa-{{section.icon}} fa-fw" aria-hidden="true"></i>
         <span class="sr-only">{{itemModel.text | translate}}</span>
       </button>
@@ -20,7 +21,7 @@
 @if (canActivate) {
   <div class="dso-button-menu mb-1"
     [ngbTooltip]="itemModel.text | translate">
-    <button class="btn btn-dark btn-sm" [dsBtnDisabled]="section.model.disabled"
+    <button class="btn btn-dark btn-sm" role="menuitem" [dsBtnDisabled]="section.model.disabled"
       (click)="activate($event)">
       <i class="fas fa-{{section.icon}} fa-fw" aria-hidden="true"></i>
       <span class="sr-only">{{itemModel.text | translate}}</span>

--- a/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.spec.ts
+++ b/src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.spec.ts
@@ -109,6 +109,11 @@ describe('DsoEditMenuSectionComponent', () => {
       expect(button.nativeElement.innerHTML).toContain('fa-' + iconString);
     });
 
+    it('should declare role="menuitem" so the parent menubar satisfies aria-required-children', () => {
+      const button = fixture.debugElement.query(By.css('.btn-dark'));
+      expect(button.nativeElement.getAttribute('role')).toBe('menuitem');
+    });
+
     describe('when the section model in a disabled link or text', () => {
       it('should show just the button', () => {
         const textButton = fixture.debugElement.query(By.css('div a'));


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/5639
* References #5488
* Builds on #5514 (also referencing #5488), which addresses the empty/hidden `role="menubar"` case in `dso-edit-menu`. This PR is complementary; both can merge to fully close #5488.

## Description
Fix the four remaining ARIA bugs from the WAVE / Pa11y / axe findings on #5488 that #5514 does not cover.

## Instructions for Reviewers

List of changes in this PR:

1. **`src/app/shared/auth-nav-menu/auth-nav-menu.component.html`** — login dropdown trigger.
   - Was: `aria-haspopup="menu"` on the button, but the popup it controls is a `<div role="dialog" aria-modal="true">`. Screen readers announced "has popup, menu" then revealed a dialog.
   - Now: `aria-haspopup="dialog"`. Also dropped the redundant `role="button"` / `tabindex="0"` on a real `<button>` and added an explicit `type="button"`.

2. **`src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.html`** — top-level navbar section toggler.
   - Was: `<a href="javascript:void(0);" role="menuitem">`.
   - Now: `<button type="button" role="menuitem">`. The navbar wrapper has `role="menubar"` (`navbar.component.html`), so the `menuitem` nesting is valid; the only issue was the `href="javascript:void(0)"` antipattern. A small SCSS reset (`expandable-navbar-section.component.scss`) keeps the button looking like the previous anchor (no native button chrome).

3. **`src/app/header/context-help-toggle/context-help-toggle.component.html`** — header help button.
   - Was: `<a href="javascript:void(0);" role="menuitem">`. This control is **not nested in any `role="menu"` / `role="menubar"`** , so its `role="menuitem"` was an orphan, flagged by axe (`aria-required-parent`).
   - Now: a plain `<button type="button">` with no `role` attribute. Added a small SCSS reset for the same reason as above.

4. **`src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.html`** — each rendered section button under `role="menubar"`.
   - Was: the descendant `<a class="btn">` / `<button class="btn">` had no `role`. axe's `aria-required-children` fires on the parent menubar.
   - Now: each rendered control declares `role="menuitem"`.

Specs were updated for each component:
* `auth-nav-menu.component.spec.ts` asserts the login toggle has `aria-haspopup="dialog"`.
* `expandable-navbar-section.component.spec.ts` asserts the toggler is a real `<button type="button" role="menuitem">`.
* `context-help-toggle.component.spec.ts` asserts the toggle is a `<button type="button">` with no orphan `role`.
* `dso-edit-menu-section.component.spec.ts` asserts the rendered control declares `role="menuitem"`.

How to test:
1. Start the UI (`yarn start` or `pm2 start config/dspace-ui-test.json`).
2. With a screen reader (VoiceOver, NVDA), focus the navbar **Login** trigger - announcement should say "has popup, dialog" rather than "menu".
3. Tab to a top-level expandable navbar section ("Browse" by default). The element should be a button (right-click → Inspect to confirm `<button type="button">`); pressing `Enter` / `Space` / `ArrowDown` still toggles / activates the dropdown.
4. Visit `/info/accessibility`, focus the context-help icon in the header. Inspect: it should be a `<button>`, not an anchor.
5. As a logged-in admin, visit any item or community page that renders the dso-edit-menu (`<div role="menubar">`). Inspect each section's icon button - it should declare `role="menuitem"`.
6. `npm run test -- --include='src/app/shared/auth-nav-menu/auth-nav-menu.component.spec.ts' --include='src/app/navbar/expandable-navbar-section/expandable-navbar-section.component.spec.ts' --include='src/app/header/context-help-toggle/context-help-toggle.component.spec.ts' --include='src/app/shared/dso-page/dso-edit-menu/dso-edit-menu-section/dso-edit-menu-section.component.spec.ts'` shows 37 specs pass.
7. Re-run axe / Pa11y on a community page, an item page, the login form, and `/info/accessibility`. The `aria-haspopup="menu"` on login button, `aria-required-parent` on the help toggle, and the `aria-required-children` on the visible dso-edit-menu should all clear.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (10 files, 56 insertions, 13 deletions).
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. (n/a - no method changes)
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations. (existing keys retained)
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (n/a)
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself. (n/a)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
