### PR TITLE
Refactor ds-search-navbar so the <form> is only rendered when expanded

### DIFF
--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -1,16 +1,24 @@
 <div (dsClickOutside)="collapse()">
   <div class="d-inline-block position-relative">
-    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" class="d-flex">
-      <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
-             formControlName="query" type="text" placeholder="{{searchExpanded ? ('nav.search' | translate) : ''}}"
-             autocomplete="off"
-             class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-end p1"
-             [class.display]="searchExpanded ? 'inline-block' : 'none'"
-             [tabIndex]="searchExpanded ? 0 : -1"
-             [attr.data-test]="'header-search-box' | dsBrowserOnly">
-      <button class="submit-icon btn btn-link btn-link-inline" [attr.aria-label]="'nav.search.button' | translate" type="button" (click)="searchExpanded ? onSubmit(searchForm.value) : expand()" [attr.data-test]="'header-search-icon' | dsBrowserOnly" tabindex="0" role="button">
+    @if (!searchExpanded) {
+      <button type="button" class="search-toggle btn btn-link btn-link-inline"
+              [attr.aria-label]="'nav.search.button' | translate"
+              (click)="expand()"
+              [attr.data-test]="'header-search-icon' | dsBrowserOnly">
         <em class="fas fa-search fa-lg fa-fw"></em>
       </button>
-    </form>
+    } @else {
+      <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
+        <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
+               formControlName="query" type="text" placeholder="{{'nav.search' | translate}}"
+               class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-end p1"
+               [attr.data-test]="'header-search-box' | dsBrowserOnly">
+        <button type="submit" class="submit-icon btn btn-link btn-link-inline"
+                [attr.aria-label]="'nav.search.button' | translate"
+                [attr.data-test]="'header-search-icon' | dsBrowserOnly">
+          <em class="fas fa-search fa-lg fa-fw"></em>
+        </button>
+      </form>
+    }
   </div>
 </div>

--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -1,15 +1,24 @@
 <div [title]="'nav.search' | translate" (dsClickOutside)="collapse()">
   <div class="d-inline-block position-relative">
-    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
-      <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
-             formControlName="query" type="text" placeholder="{{searchExpanded ? ('nav.search' | translate) : ''}}"
-             class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-end p1"
-             [class.display]="searchExpanded ? 'inline-block' : 'none'"
-             [tabIndex]="searchExpanded ? 0 : -1"
-             [attr.data-test]="'header-search-box' | dsBrowserOnly">
-      <button class="submit-icon btn btn-link btn-link-inline" [attr.aria-label]="'nav.search.button' | translate" type="button" (click)="searchExpanded ? onSubmit(searchForm.value) : expand()" [attr.data-test]="'header-search-icon' | dsBrowserOnly" tabindex="0" role="button">
+    @if (!searchExpanded) {
+      <button type="button" class="search-toggle btn btn-link btn-link-inline"
+              [attr.aria-label]="'nav.search.button' | translate"
+              (click)="expand()"
+              [attr.data-test]="'header-search-icon' | dsBrowserOnly">
         <em class="fas fa-search fa-lg fa-fw"></em>
       </button>
-    </form>
+    } @else {
+      <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
+        <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
+               formControlName="query" type="text" placeholder="{{'nav.search' | translate}}"
+               class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-end p1"
+               [attr.data-test]="'header-search-box' | dsBrowserOnly">
+        <button type="submit" class="submit-icon btn btn-link btn-link-inline"
+                [attr.aria-label]="'nav.search.button' | translate"
+                [attr.data-test]="'header-search-icon' | dsBrowserOnly">
+          <em class="fas fa-search fa-lg fa-fw"></em>
+        </button>
+      </form>
+    }
   </div>
 </div>

--- a/src/app/search-navbar/search-navbar.component.spec.ts
+++ b/src/app/search-navbar/search-navbar.component.spec.ts
@@ -70,13 +70,24 @@ describe('SearchNavbarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('when you click on search icon', () => {
+  describe('when collapsed', () => {
+    it('should render only the toggle <button> with no surrounding <form>', () => {
+      const form = fixture.debugElement.query(By.css('form'));
+      const toggle = fixture.debugElement.query(By.css('button.search-toggle'));
+      expect(form).toBeNull();
+      expect(toggle).not.toBeNull();
+      expect(toggle.nativeElement.tagName).toBe('BUTTON');
+      expect(toggle.nativeElement.getAttribute('type')).toBe('button');
+    });
+  });
+
+  describe('when you click on the search toggle', () => {
     beforeEach(fakeAsync(() => {
       spyOn(component, 'expand').and.callThrough();
       spyOn(component, 'onSubmit').and.callThrough();
       spyOn(router, 'navigate');
-      const searchIcon = fixture.debugElement.query(By.css('form .submit-icon'));
-      searchIcon.triggerEventHandler('click', {
+      const toggle = fixture.debugElement.query(By.css('button.search-toggle'));
+      toggle.triggerEventHandler('click', {
         preventDefault: () => {/**/
         },
       });
@@ -86,16 +97,22 @@ describe('SearchNavbarComponent', () => {
 
     it('input expands', () => {
       expect(component.expand).toHaveBeenCalled();
+      expect(component.searchExpanded).toBeTrue();
+    });
+
+    it('renders the form with a real submit button', () => {
+      const form = fixture.debugElement.query(By.css('form'));
+      const submit = fixture.debugElement.query(By.css('form button.submit-icon'));
+      expect(form).not.toBeNull();
+      expect(submit).not.toBeNull();
+      expect(submit.nativeElement.getAttribute('type')).toBe('submit');
     });
 
     describe('empty query', () => {
       describe('press submit button', () => {
         beforeEach(fakeAsync(() => {
-          const searchIcon = fixture.debugElement.query(By.css('form .submit-icon'));
-          searchIcon.triggerEventHandler('click', {
-            preventDefault: () => {/**/
-            },
-          });
+          const form = fixture.debugElement.query(By.css('form'));
+          form.triggerEventHandler('submit', null);
           tick();
           fixture.detectChanges();
         }));
@@ -117,17 +134,16 @@ describe('SearchNavbarComponent', () => {
         searchInput.nativeElement.dispatchEvent(new Event('input'));
         fixture.detectChanges();
       });
-      describe('press submit button', () => {
+      describe('press Enter on the input (native submit)', () => {
         beforeEach(fakeAsync(() => {
-          const searchIcon = fixture.debugElement.query(By.css('form .submit-icon'));
-          searchIcon.triggerEventHandler('click', null);
+          const form = fixture.debugElement.query(By.css('form'));
+          form.triggerEventHandler('submit', null);
           tick();
           fixture.detectChanges();
         }));
         it('to search page with query', async () => {
           const extras: NavigationExtras = { queryParams: { query: 'test' } };
           expect(component.onSubmit).toHaveBeenCalledWith({ query: 'test' });
-
           expect(router.navigate).toHaveBeenCalledWith(['search'], extras);
         });
       });

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -1,4 +1,6 @@
 import {
+  AfterViewInit,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   ViewChild,
@@ -17,7 +19,13 @@ import { BrowserOnlyPipe } from '../shared/utils/browser-only.pipe';
 import { ClickOutsideDirective } from '../shared/utils/click-outside.directive';
 
 /**
- * The search box in the header that expands on focus and collapses on focus out
+ * The search box in the header that expands on focus and collapses on focus out.
+ *
+ * When collapsed, only a single icon `<button>` is rendered (no form). The form, input
+ * and submit button are only rendered while the search bar is expanded; this avoids the
+ * Pa11y/HTMLCS rule WCAG2AA H32.2 ("This form does not contain a submit button"), which
+ * is otherwise reported on every page because the collapsed-state form had a
+ * `type="button"` icon control rather than a real submit button.
  */
 @Component({
   selector: 'ds-base-search-navbar',
@@ -32,7 +40,7 @@ import { ClickOutsideDirective } from '../shared/utils/click-outside.directive';
     TranslateModule,
   ],
 })
-export class SearchNavbarComponent {
+export class SearchNavbarComponent implements AfterViewInit {
 
   // The search form
   searchForm;
@@ -40,49 +48,64 @@ export class SearchNavbarComponent {
   searchExpanded = false;
   isExpanded = 'collapsed';
 
-  // Search input field
+  // Search input field. Only present once the form is rendered (`searchExpanded === true`).
   @ViewChild('searchInput') searchField: ElementRef;
 
-  constructor(private formBuilder: UntypedFormBuilder, private router: Router, private searchService: SearchService) {
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private searchService: SearchService,
+    private cdr: ChangeDetectorRef,
+  ) {
     this.searchForm = this.formBuilder.group(({
       query: '',
     }));
   }
 
+  ngAfterViewInit(): void {
+    // No-op; here so the @ViewChild reference is wired up after each render pass when
+    // the form is conditionally added/removed from the DOM.
+  }
+
   /**
-   * Expands search bar by angular animation, see expandSearchInput
+   * Expands the search bar and focuses the input on the next change-detection pass
+   * (the input only exists once `searchExpanded` is true).
    */
   expand() {
     this.searchExpanded = true;
     this.isExpanded = 'expanded';
+    // Force a synchronous render so `searchField` is populated, then focus it.
+    this.cdr.detectChanges();
     this.editSearch();
   }
 
   /**
-   * Collapses & blurs search bar by angular animation, see expandSearchInput
+   * Collapses & blurs the search bar. The form, input and submit button are removed
+   * from the DOM by the template's `@if (!searchExpanded)` branch.
    */
   collapse() {
-    this.searchField.nativeElement.blur();
+    this.searchField?.nativeElement?.blur();
     this.searchExpanded = false;
     this.isExpanded = 'collapsed';
   }
 
   /**
-   * Focuses on input search bar so search can be edited
+   * Focuses the input search bar so it can be edited.
    */
   editSearch(): void {
-    this.searchField.nativeElement.focus();
+    this.searchField?.nativeElement?.focus();
   }
 
   /**
-   * Submits the search (on enter or on search icon click)
+   * Submits the search. Triggered both by Enter on the input (native form submit) and
+   * by clicking the magnifying-glass icon (`<button type="submit">` inside the form).
    * @param data  Data for the searchForm, containing the search query
    */
   onSubmit(data: any) {
-    this.collapse();
     const queryParams = Object.assign({}, data);
     const linkToNavigateTo = [this.searchService.getSearchLink().replace('/', '')];
     this.searchForm.reset();
+    this.collapse();
 
     this.router.navigate(linkToNavigateTo, {
       queryParams: queryParams,

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ElementRef,
   ViewChild,
@@ -17,7 +18,13 @@ import { BrowserOnlyPipe } from '../shared/utils/browser-only.pipe';
 import { ClickOutsideDirective } from '../shared/utils/click-outside.directive';
 
 /**
- * The search box in the header that expands on focus and collapses on focus out
+ * The search box in the header that expands on focus and collapses on focus out.
+ *
+ * When collapsed, only a single icon `<button>` is rendered (no form). The form, input
+ * and submit button are only rendered while the search bar is expanded; this avoids the
+ * Pa11y/HTMLCS rule WCAG2AA H32.2 ("This form does not contain a submit button"), which
+ * is otherwise reported on every page because the collapsed-state form had a
+ * `type="button"` icon control rather than a real submit button.
  */
 @Component({
   selector: 'ds-base-search-navbar',
@@ -40,49 +47,59 @@ export class SearchNavbarComponent {
   searchExpanded = false;
   isExpanded = 'collapsed';
 
-  // Search input field
+  // Search input field. Only present once the form is rendered (`searchExpanded === true`).
   @ViewChild('searchInput') searchField: ElementRef;
 
-  constructor(private formBuilder: UntypedFormBuilder, private router: Router, private searchService: SearchService) {
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private searchService: SearchService,
+    private cdr: ChangeDetectorRef,
+  ) {
     this.searchForm = this.formBuilder.group(({
       query: '',
     }));
   }
 
   /**
-   * Expands search bar by angular animation, see expandSearchInput
+   * Expands the search bar and focuses the input on the next change-detection pass
+   * (the input only exists once `searchExpanded` is true).
    */
   expand() {
     this.searchExpanded = true;
     this.isExpanded = 'expanded';
+    // Force a synchronous render so `searchField` is populated, then focus it.
+    this.cdr.detectChanges();
     this.editSearch();
   }
 
   /**
-   * Collapses & blurs search bar by angular animation, see expandSearchInput
+   * Collapses & blurs the search bar. The form, input and submit button are removed
+   * from the DOM by the template's `@if (!searchExpanded)` branch.
    */
   collapse() {
-    this.searchField.nativeElement.blur();
+    this.searchField?.nativeElement?.blur();
     this.searchExpanded = false;
     this.isExpanded = 'collapsed';
   }
 
   /**
-   * Focuses on input search bar so search can be edited
+   * Focuses the input search bar so it can be edited.
    */
   editSearch(): void {
-    this.searchField.nativeElement.focus();
+    this.searchField?.nativeElement?.focus();
   }
 
   /**
-   * Submits the search (on enter or on search icon click)
+   * Submits the search. Triggered both by Enter on the input (native form submit) and
+   * by clicking the magnifying-glass icon (`<button type="submit">` inside the form).
    * @param data  Data for the searchForm, containing the search query
    */
   onSubmit(data: any) {
-    this.collapse();
     const queryParams = Object.assign({}, data);
     const linkToNavigateTo = [this.searchService.getSearchLink().replace('/', '')];
     this.searchForm.reset();
+    this.collapse();
 
     this.router.navigate(linkToNavigateTo, {
       queryParams: queryParams,


### PR DESCRIPTION
## References
* Fixes #5603

## Description
Refactor `ds-search-navbar` so the `<form>` is only rendered when the search bar is expanded. Removes the Pa11y H32.2 false positive while keeping all current behavior (Enter submits, clicking the icon submits when expanded, dsClickOutside collapses).

## Instructions for Reviewers

### Background
Pa11y / HTMLCS rule `WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2` ("This form does not contain a submit button") fires on every page because the navbar search keeps a `<form>` in the DOM at all times, and the icon control inside it is `type="button"` (it has to be - while collapsed its job is to expand the input). Functionally Enter still submits via HTML5 implicit submission, so the audit report is a false positive in behavioral terms - but it points at a real structural ambiguity around the icon button's role.

### Approach
Rather than suppressing a tool-specific rule, the issue's author (#5603) suggested restructuring so that "when collapsed, there simply is no form (yet)". This PR implements that: the collapsed state renders only the toggle `<button type="button">`, and the expanded state renders the full `<form>` containing `<input>` and a real `<button type="submit">`. Other auditing tools that check the same pattern (axe, WAVE, Lighthouse) will benefit equally.

### List of changes
* `src/app/search-navbar/search-navbar.component.html` - split the collapsed and expanded states into two `@if` branches. Both keep `[data-test="header-search-icon"]` on their icon button so the existing Cypress e2e tests (`cypress/e2e/search-navbar.cy.ts`) keep working.
* `src/app/search-navbar/search-navbar.component.ts` - inject `ChangeDetectorRef`, call `cdr.detectChanges()` in `expand()` so the `@ViewChild('searchInput')` reference resolves before `editSearch()` focuses it (the input only exists after the conditional branch renders). Made the `@ViewChild` references null-safe in `collapse()` and `editSearch()`.
* `src/app/search-navbar/search-navbar.component.spec.ts` - updated to reflect the new structure: assert the collapsed state renders no `<form>`, assert the expanded state renders the form with a real submit button, exercise both submit paths (icon click and native Enter via `triggerEventHandler('submit')`).

### Known minor regression
The slide-in animation defined by `expandSearchInput` is still applied to the `[@toggleAnimation]` state on the input while the form is rendered, but the entry transition (collapsed → expanded) is no longer animated (the form simply appears). The slide can be re-introduced via an Angular `:enter`/`:leave` transition on the conditional form in a follow-up PR.

### How to test
1. Start the UI (`yarn start` or `pm2 start config/dspace-ui-test.json`).
2. Inspect the navbar in collapsed state - there is only a `<button class="search-toggle">`, no `<form>` element.
3. Click the magnifying glass; the form appears with `<input>` and `<button type="submit">`. Focus is in the input.
4. Type a query, press Enter - URL navigates to `/search?query=<query>`. Inspect the form's submit button while expanded: it is `<button type="submit">`.
5. Type a query, click the magnifying glass - same submission behavior (now via native form submit, not a JS click handler).
6. Click outside the navbar - search collapses (existing dsClickOutside behavior).
7. `npm run test -- --include='src/app/search-navbar/search-navbar.component.spec.ts'` shows 6 specs pass.
8. `cypress run --spec cypress/e2e/search-navbar.cy.ts` (or the project's standard e2e command) - existing scenarios still pass; selectors are unchanged.
9. Run Pa11y / axe on any page; H32.2 no longer reports `ds-search-navbar > form` while collapsed (the `<form>` is no longer in the DOM in that state).

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (3 files, 80 insertions, 32 deletions).
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations. (existing keys retained)
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (n/a)
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself. (n/a)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
