### PR TITLE
fix #5544: enlarge dropdown for external source import

### DIFF
--- a/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.scss
+++ b/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.scss
@@ -13,8 +13,9 @@
 
 .scrollable-menu {
   height: auto;
-  max-height: calc(var(--ds-dropdown-menu-max-height) / 2);
+  max-height: calc(var(--ds-dropdown-menu-max-height) * 2);
   overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .scrollable-dropdown-loading {

--- a/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.spec.ts
+++ b/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.spec.ts
@@ -140,17 +140,25 @@ describe('SubmissionImportExternalSearchbarComponent test suite', () => {
       expect(comp.selectedElement).toEqual(selectedElement);
     });
 
+    it('Should use elementsPerPage of 20 on init', () => {
+      comp.initExternalSourceData = { entity: 'Publication', sourceId: '', query: '' };
+      scheduler.schedule(() => fixture.detectChanges());
+      scheduler.flush();
+
+      expect(compAsAny.findListOptions.elementsPerPage).toEqual(20);
+    });
+
     it('Should load additional external sources', () => {
       comp.initExternalSourceData = { entity: 'Publication', query: 'dummy', sourceId: 'ciencia' };
       comp.sourceListLoading = false;
       compAsAny.pageInfo = new PageInfo({
-        elementsPerPage: 3,
+        elementsPerPage: 20,
         totalElements: 6,
         totalPages: 2,
         currentPage: 0,
       });
       compAsAny.findListOptions = Object.assign({}, new FindListOptions(), {
-        elementsPerPage: 3,
+        elementsPerPage: 20,
         currentPage: 0,
         searchParams: [
           new RequestParam('entityType', 'Publication'),

--- a/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.ts
+++ b/src/app/submission/import-external/import-external-searchbar/submission-import-external-searchbar.component.ts
@@ -142,7 +142,7 @@ export class SubmissionImportExternalSearchbarComponent implements OnInit, OnDes
     this.searchString = '';
     this.sourceList = [];
     this.findListOptions = Object.assign({}, new FindListOptions(), {
-      elementsPerPage: 5,
+      elementsPerPage: 20,
       currentPage: 1,
       searchParams: [
         new RequestParam('entityType', this.initExternalSourceData.entity),
@@ -187,7 +187,7 @@ export class SubmissionImportExternalSearchbarComponent implements OnInit, OnDes
     if (!this.sourceListLoading && ((this.pageInfo.currentPage + 1) <= this.pageInfo.totalPages)) {
       this.sourceListLoading = true;
       this.findListOptions = Object.assign({}, new FindListOptions(), {
-        elementsPerPage: 5,
+        elementsPerPage: 20,
         currentPage: this.findListOptions.currentPage + 1,
         searchParams: [
           new RequestParam('entityType', this.initExternalSourceData.entity),


### PR DESCRIPTION
## References
Fixes #5544

## Description
Enlarges the external source dropdown in the Import from External Sources page by increasing the initial page size from 5 to 20 and fixing the dropdown max-height CSS to allow proper scrolling.

## Instructions for Reviewers

List of changes in this PR:

- Increased elementsPerPage from 5 to 20 in submission-import-external-searchbar.component.ts (both in ngOnInit and onScroll) so more sources are loaded initially.
- Updated .scrollable-menu max-height in submission-import-external-searchbar.component.scss from calc(var(--ds-dropdown-menu-max-height) / 2) to calc(var(--ds-dropdown-menu-max-height) * 2) and added overflow-y: auto to enable scrolling.
- Added/updated specs in submission-import-external-searchbar.component.spec.ts to reflect the new elementsPerPage value.

How to test:

1. Go to My DSpace
2. Click the import button (↵) and select "Publicación"
3. On the "Import a publication from an external source" page, click the source dropdown (e.g. "arXiv")
4. Verify the dropdown is larger and shows more than 5 options with scroll

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
