### PR TITLE
fix(#5645): Use correct key value to block Space keypress in BtnDisabled

### DIFF
--- a/src/app/shared/btn-disabled.directive.ts
+++ b/src/app/shared/btn-disabled.directive.ts
@@ -53,7 +53,7 @@ export class BtnDisabledDirective {
      */
   @HostListener('keydown', ['$event'])
     handleKeydown(event: KeyboardEvent) {
-      if (this.isDisabled && (event.key === 'Enter' || event.key === 'Space')) {
+      if (this.isDisabled && (event.key === 'Enter' || event.key === ' ')) {
         event.preventDefault();
         event.stopImmediatePropagation();
       }

--- a/src/app/shared/disabled-directive.spec.ts
+++ b/src/app/shared/disabled-directive.spec.ts
@@ -78,7 +78,7 @@ describe('DisabledDirective', () => {
     button.nativeElement.addEventListener('keydown', () => keydownHandled = true);
 
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-    const spaceEvent = new KeyboardEvent('keydown', { key: 'Space' });
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
 
     button.nativeElement.dispatchEvent(enterEvent);
     button.nativeElement.dispatchEvent(spaceEvent);
@@ -96,7 +96,7 @@ describe('DisabledDirective', () => {
     button.nativeElement.click();
 
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-    const spaceEvent = new KeyboardEvent('keydown', { key: 'Space' });
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
 
     button.nativeElement.dispatchEvent(enterEvent);
     button.nativeElement.dispatchEvent(spaceEvent);


### PR DESCRIPTION
## References
* Fixes #5645

## Description
Fixes a global accessibility bug in `BtnDisabledDirective` where it failed to intercept and block the space bar keypress on visually disabled buttons due to an incorrect `KeyboardEvent.key` value check.

## Instructions for Reviewers
The `dsBtnDisabled` directive is intended to make HTML elements non-interactive while keeping them discoverable to screen readers (using `aria-disabled="true"`). However, the directive's `HostListener` was checking for the literal string `event.key === 'Space'` instead of the standard web browser value `' '`. This allowed keyboard-only users to bypass the directive using the Space bar and trigger actions unintentionally.

List of changes in this PR:
* Updated the `keydown` listener in `BtnDisabledDirective` to correctly intercept standard browser space character events (`event.key === ' '`).
* Updated the `disabled-directive.spec.ts` unit test mocks to use the correct space character string.

## How to Test
**Automated test:**
`npm run test -- --include='src/app/shared/disabled-directive.spec.ts'`

**Manual test:**
Because many components implement internal TypeScript safeguards (e.g., `if (form.invalid) return;`), this bug is often silently masked in production. 

To easily verify this fix without complex data setup, I created a clean `.patch` that adds an isolated dummy button to the Home Page.

### Step 1: Apply the Test Patch
Save the code below as `test.patch` and apply it locally using `git apply test.patch` (or manually apply the changes):

<details>
<summary><b>Click to expand the test.patch code</b></summary>

```diff
diff --git a/src/app/home-page/home-page.component.html b/src/app/home-page/home-page.component.html
index ac53ab33a..9904cd617 100644
--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -3,7 +3,16 @@
     <ds-markdown-viewer [value]="homeHeaderMetadataValue"></ds-markdown-viewer>
   </div>
 }
+<div class="container my-4 p-3 border border-warning rounded text-center">
+  <p class="fw-bold">Status: <span class="text-primary">{{ testMessage }}</span></p>

+  <button
+    class="btn btn-danger"
+    [dsBtnDisabled]="true"
+    (click)="testMessage = 'Button activated!'">
+    Dummy Test Button (Inactive)
+  </button>
+</div>
 <ds-home-coar></ds-home-coar>
 <ds-home-news></ds-home-news>

diff --git a/src/app/home-page/home-page.component.ts b/src/app/home-page/home-page.component.ts
index cf75770b9..dbc55ca6d 100644
--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -32,6 +32,7 @@ import { HomeCoarComponent } from './home-coar/home-coar.component';
 import { ThemedHomeNewsComponent } from './home-news/themed-home-news.component';
 import { RecentItemListComponent } from './recent-item-list/recent-item-list.component';
 import { ThemedTopLevelCommunityListComponent } from './top-level-community-list/themed-top-level-community-list.component';
+import { BtnDisabledDirective } from '../shared/btn-disabled.directive';

 @Component({
   selector: 'ds-base-home-page',
@@ -39,6 +40,7 @@ import { ThemedTopLevelCommunityListComponent } from './top-level-community-list
   templateUrl: './home-page.component.html',
   imports: [
     AsyncPipe,
+    BtnDisabledDirective,
     HomeCoarComponent,
     MarkdownViewerComponent,
     NgTemplateOutlet,
@@ -52,7 +54,7 @@ import { ThemedTopLevelCommunityListComponent } from './top-level-community-list
   ],
 })
 export class HomePageComponent implements OnInit {
-
+  public testMessage = 'Awaiting for activation...';
   site$: Observable<Site>;
   recentSubmissionspageSize: number;
   showDiscoverFilters: boolean;
diff --git a/src/themes/custom/app/home-page/home-page.component.ts b/src/themes/custom/app/home-page/home-page.component.ts
index 3d8f9f72a..2b70e0ac0 100644
--- a/src/themes/custom/app/home-page/home-page.component.ts
+++ b/src/themes/custom/app/home-page/home-page.component.ts
@@ -14,6 +14,7 @@ import { ThemedTopLevelCommunityListComponent } from '../../../../app/home-page/
 import { SuggestionsPopupComponent } from '../../../../app/notifications/suggestions/popup/suggestions-popup.component';
 import { ThemedConfigurationSearchPageComponent } from '../../../../app/search-page/themed-configuration-search-page.component';
 import { ThemedSearchFormComponent } from '../../../../app/shared/search-form/themed-search-form.component';
+import { BtnDisabledDirective } from '../../../../app/shared/btn-disabled.directive';

 @Component({
   selector: 'ds-themed-home-page',
@@ -23,6 +24,7 @@ import { ThemedSearchFormComponent } from '../../../../app/shared/search-form/th
   templateUrl: '../../../../app/home-page/home-page.component.html',
   imports: [
     AsyncPipe,
+    BtnDisabledDirective,
     HomeCoarComponent,
     MarkdownViewerComponent,
     NgTemplateOutlet,

```

</details>


### Step 2: Verify Behavior
1. Run the application and open the Home Page.
2. Press Tab until focus lands on the visually disabled Dummy Test Button.
3. Press the Space bar.
4. On main branch (Without fix): The status text changes to "Button activated!".
5. On this PR branch (With fix): The status text remains "Awaiting for activation...".

<img width="1437" height="443" alt="image" src="https://github.com/user-attachments/assets/2fd17336-7bc9-4398-b2e6-01a42c08412f" />

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
