### PR TITLE
Make CI workflow fork-friendly (skip GHCR login and Codecov on forks)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,11 @@ jobs:
       # Project name to use when running "docker compose" prior to e2e tests
       COMPOSE_PROJECT_NAME: 'ci'
       # Docker Registry to use for Docker compose scripts below.
-      # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
-      DOCKER_REGISTRY: ghcr.io
+      # On the upstream dspace/dspace-angular repository we use GitHub's Container Registry
+      # (ghcr.io) to avoid aggressive rate limits at DockerHub. Forks cannot authenticate
+      # against ghcr.io/dspace/* with their own GITHUB_TOKEN (and the images there require
+      # auth), so on forks we fall back to docker.io where the same images are public.
+      DOCKER_REGISTRY: ${{ github.repository == 'dspace/dspace-angular' && 'ghcr.io' || 'docker.io' }}
     strategy:
       # Create a matrix of Node versions to test against (in parallel)
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,12 @@ jobs:
           retention-days: 14
 
       # Login to our Docker registry, so that we can access private Docker images using "docker compose" below.
+      # Only attempt the login on the upstream repository: forks cannot authenticate against
+      # ghcr.io/dspace/* with their own GITHUB_TOKEN. The DSpace test images are public on GHCR,
+      # so anonymous pulls in the subsequent "docker compose" steps work fine on forks.
       - name: Login to ${{ env.DOCKER_REGISTRY }}
         uses: docker/login-action@v4
+        if: github.repository == 'dspace/dspace-angular'
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,11 @@ jobs:
           path: 'coverage/dspace-angular/lcov.info'
           retention-days: 14
 
-      # Login to our Docker registry, so that we can access private Docker images using "docker compose" below.
-      # Only attempt the login on the upstream repository: forks cannot authenticate against
-      # ghcr.io/dspace/* with their own GITHUB_TOKEN. The DSpace test images are public on GHCR,
-      # so anonymous pulls in the subsequent "docker compose" steps work fine on forks.
+      # Login to our Docker registry, so that we can access Docker images using "docker compose" below.
+      # This login is required on the upstream repository because DOCKER_REGISTRY is set to ghcr.io
+      # and pulling ghcr.io/dspace/* requires authentication. On forks, DOCKER_REGISTRY falls back to
+      # docker.io (see env block above) where the same images are publicly pullable without a login,
+      # and forks cannot authenticate against ghcr.io/dspace/* with their own GITHUB_TOKEN anyway.
       - name: Login to ${{ env.DOCKER_REGISTRY }}
         uses: docker/login-action@v4
         if: github.repository == 'dspace/dspace-angular'
@@ -321,6 +322,9 @@ jobs:
   codecov:
     # Must run after 'tests' job above
     needs: tests
+    # Only run on the upstream repository: forks do not have the CODECOV_TOKEN secret,
+    # and Codecov refuses to create a commit on a protected branch without a token.
+    if: github.repository == 'dspace/dspace-angular'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## References

* Related Slack thread: discussion with @tdonohue about forks failing at the Docker login / GHCR pull stage in CI.
* No related REST API PR required.

## Description

Make the `Build` GitHub Actions workflow fork-friendly: forks can now run the full CI (including e2e tests) without access to upstream-only secrets (`GITHUB_TOKEN` scoped to `dspace/*` packages, `CODECOV_TOKEN`).

## Instructions for Reviewers

Today, [.github/workflows/build.yml](cci:7://file:///d:/Projects/github/qultoltd/dspace-angular/.github/workflows/build.yml:0:0-0:0) always sets `DOCKER_REGISTRY=ghcr.io`, always runs `docker/login-action`, and always runs the `codecov` job. On forks this leads to two hard failures:

1. `Start DSpace REST Backend via Docker` fails with `unauthorized` when pulling `ghcr.io/dspace/dspace-solr`, `ghcr.io/dspace/dspace`, `ghcr.io/dspace/dspace-postgres-loadsql` — a fork's `GITHUB_TOKEN` cannot read packages from the `dspace` org.
2. `codecov` job fails with `Token required because branch is protected` because forks do not have the `CODECOV_TOKEN` secret.

This PR scopes those upstream-only operations to the upstream repository only, while preserving current behavior for `dspace/dspace-angular`.

### List of changes in this PR

* **`DOCKER_REGISTRY` is now conditional**: `ghcr.io` on `dspace/dspace-angular` (unchanged behavior, avoids Docker Hub rate limits), `docker.io` on forks (where the same `dspace/dspace-solr`, `dspace/dspace`, `dspace/dspace-postgres-loadsql` images are publicly pullable without authentication).
* **`Login to ${{ env.DOCKER_REGISTRY }}` step is guarded** by `if: github.repository == 'dspace/dspace-angular'`. On forks the login is skipped because the fallback registry (`docker.io`) does not require authentication for these images, and forks cannot authenticate against `ghcr.io/dspace/*` with their own `GITHUB_TOKEN` anyway.
* **`codecov` job is guarded** by `if: github.repository == 'dspace/dspace-angular'`. Forks do not have `CODECOV_TOKEN` and have no Codecov project to upload to, so running the job on forks produces only noise.

No changes to test logic, dependencies, build steps, or upstream behavior.

### How to test / review

**On the upstream repo (no behavior change expected):**
* CI should run exactly as before: `DOCKER_REGISTRY=ghcr.io`, GHCR login executes, `codecov` job runs and uploads coverage. The three new `if:` conditions all evaluate to `true` because `github.repository == 'dspace/dspace-angular'`.

**On a fork (the fix):**
* `DOCKER_REGISTRY` resolves to `docker.io`.
* The GHCR login step is skipped (visible as a skipped step in the job summary).
* `docker compose -f ./docker/docker-compose-ci.yml up -d` successfully pulls `docker.io/dspace/dspace-solr:latest`, `docker.io/dspace/dspace:latest-test`, `docker.io/dspace/dspace-postgres-loadsql:latest` anonymously.
* E2E tests, SSR verification, and all other steps run as normal.
* The `codecov` job is skipped on forks (visible as a skipped job).

Verified against a fork (`qultoltd/dspace-angular`): both the Node 20.x and Node 22.x matrix jobs now go fully green end-to-end, including the e2e/Cypress and SSR verification steps, where they previously failed at the Docker pull step.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
