### PR TITLE
Fix irregular whitespace for MetadataRepresentationListComponent

### DIFF
--- a/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.html
+++ b/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.html
@@ -1,28 +1,33 @@
 <ds-metadata-field-wrapper [label]="label">
-  @for (objectPage of objects; track objectPage; let i = $index) {
+  @for (objectPage of objects; track objectPage; let i = $index; let lastPage = $last) {
     <ng-container *ngVar="(objectPage | async) as representations">
-      @for (rep of representations; track rep) {
-        <ds-metadata-representation-loader
-          [mdRepresentation]="rep">
-        </ds-metadata-representation-loader>
+      @for (rep of representations; track rep; let last = $last) {
+        <div class="d-inline">
+          <ds-metadata-representation-loader [mdRepresentation]="rep"
+                                             class="d-inline-block">
+          </ds-metadata-representation-loader>
+          @if (!last || !lastPage) {
+            <span [innerHTML]="separator"></span>
+          }
+        </div>
       }
-      @if ((i + 1) === objects.length && (i > 0) && (!representations || representations?.length === 0)) {
+      @if (lastPage && (i > 0) && (!representations || representations?.length === 0)) {
         <ds-loading message="{{'loading.default' | translate}}"></ds-loading>
       }
-      @if ((i + 1) === objects.length && representations?.length > 0) {
-        <div class="d-inline-block w-100 mt-2">
-          @if ((objects.length * incrementBy) < total) {
-            <div class="float-start">
-              <button class="btn btn-link btn-link-inline" (click)="increase()">{{'item.page.related-items.view-more' |
-              translate:{ amount: (total - (objects.length * incrementBy) < incrementBy) ? total - (objects.length * incrementBy) : incrementBy } }}</button>
-            </div>
-          }
-          @if (objects.length > 1) {
-            <div class="float-end">
-              <button class="btn btn-link btn-link-inline" (click)="decrease()">{{'item.page.related-items.view-less' |
-              translate:{ amount: representations?.length } }}</button>
-            </div>
-          }
+      @if (lastPage && representations?.length > 0 && ((objects.length * incrementBy) < total || objects.length > 1)) {
+        <div class="d-flex justify-content-between w-100 mt-2">
+          <div>
+            @if ((objects.length * incrementBy) < total) {
+                <button class="btn btn-link btn-link-inline" (click)="increase()">{{'item.page.related-items.view-more' |
+                  translate:{ amount: (total - (objects.length * incrementBy) < incrementBy) ? total - (objects.length * incrementBy) : incrementBy } }}</button>
+            }
+          </div>
+          <div>
+            @if (objects.length > 1) {
+                <button class="btn btn-link btn-link-inline" (click)="decrease()">{{'item.page.related-items.view-less' |
+                  translate:{ amount: representations?.length } }}</button>
+            }
+          </div>
         </div>
       }
     </ng-container>

--- a/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
+++ b/src/app/item-page/simple/metadata-representation-list/metadata-representation-list.component.ts
@@ -73,6 +73,11 @@ export class MetadataRepresentationListComponent extends AbstractIncrementalList
   @Input() incrementBy = 10;
 
   /**
+   * The separator used to split the metadata values (can contain HTML)
+   */
+  @Input() separator = '<br>';
+
+  /**
    * The total amount of metadata values available
    */
   total: number;

--- a/src/app/item-page/simple/metadata-representation-list/themed-metadata-representation-list.component.ts
+++ b/src/app/item-page/simple/metadata-representation-list/themed-metadata-representation-list.component.ts
@@ -17,7 +17,14 @@ import { MetadataRepresentationListComponent } from './metadata-representation-l
   ],
 })
 export class ThemedMetadataRepresentationListComponent extends ThemedComponent<MetadataRepresentationListComponent> {
-  protected inAndOutputNames: (keyof MetadataRepresentationListComponent & keyof this)[] = ['parentItem', 'itemType', 'metadataFields', 'label', 'incrementBy'];
+  protected inAndOutputNames: (keyof MetadataRepresentationListComponent & keyof this)[] = [
+    'parentItem',
+    'itemType',
+    'metadataFields',
+    'label',
+    'incrementBy',
+    'separator',
+  ];
 
   @Input() parentItem: Item;
 
@@ -28,6 +35,8 @@ export class ThemedMetadataRepresentationListComponent extends ThemedComponent<M
   @Input() label: string;
 
   @Input() incrementBy: number;
+
+  @Input() separator: string;
 
   protected getComponentName(): string {
     return 'MetadataRepresentationListComponent';


### PR DESCRIPTION
## Description
Removed the trailing whitespace below the `MetadataRepresentationListComponent` when the page size is smaller than 10. Also reduced the spacing below the load more/hide last buttons to match the default spacing between item page fields.

## Instructions for Reviewers
List of changes in this PR:
- Hide the `mt-2` spacing from the load more/hide last buttons when the page size is smaller than 10
- Replaced the `float-start` & `float-end` styling on the load more/hide last buttons with flex box with `justify-content: between`. This will remove the additional spacing generated by the float logic underneath the buttons.
- Made the separator for this item page field configurable as well

**Guidance for how to test and review this PR:**
- Create a publication with 1 author
  - Verify that the spacing between the authors field & the next field is now the same as the other fields:
     <img width="174" height="234" alt="image" src="https://github.com/user-attachments/assets/8933fd9e-9b67-47ac-942d-2deb44817b50" /> → <img width="174" height="234" alt="image" src="https://github.com/user-attachments/assets/a5c32525-6361-4899-b820-8cf9108be7e2" />
- Create a publication with 10+ authors
  - Verify that the spacing between the authors field & the next field is now the same as the other fields:
     <img width="267" height="467" alt="image" src="https://github.com/user-attachments/assets/8c7464e2-7431-4e43-bed8-9659027f0603" /> → <img width="267" height="467" alt="image" src="https://github.com/user-attachments/assets/9927a890-b1a8-41b1-9060-f63ea08fa6fa" />

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
