### PR TITLE
[Port dspace-9_x] fix: silently fail when we cannot get visitorId from matomo for bitsream download

### DIFF
--- a/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
+++ b/src/app/bitstream-page/bitstream-download-page/bitstream-download-page.component.spec.ts
@@ -116,6 +116,7 @@ describe('BitstreamDownloadPageComponent', () => {
     matomoService = jasmine.createSpyObj('MatomoService', {
       appendVisitorId: of(''),
       isMatomoEnabled$: of(true),
+      isMatomoScriptLoaded$: of(true),
     });
     matomoService.appendVisitorId.and.callFake((link) => of(link));
   }

--- a/src/app/statistics/matomo.factory.spec.ts
+++ b/src/app/statistics/matomo.factory.spec.ts
@@ -1,0 +1,49 @@
+import { Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { OrejimeService } from '@dspace/core/cookies/orejime.service';
+import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
+import { NativeWindowService } from '@dspace/core/services/window.service';
+import {
+  MatomoInitializerService,
+  MatomoTracker,
+} from 'ngx-matomo-client';
+import { firstValueFrom } from 'rxjs';
+
+import { customMatomoScriptFactory } from './matomo.factory';
+import { MatomoService } from './matomo.service';
+
+describe('customMatomoScriptFactory', () => {
+  let service: MatomoService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MatomoTracker, useValue: {} },
+        { provide: MatomoInitializerService, useValue: {} },
+        { provide: OrejimeService, useValue: {} },
+        { provide: NativeWindowService, useValue: {} },
+        { provide: ConfigurationDataService, useValue: {} },
+        { provide: Injector, useValue: TestBed },
+      ],
+    });
+
+    service = TestBed.inject(MatomoService);
+  });
+
+  it('should notify when the script loads', async () => {
+    const script = customMatomoScriptFactory(service)('', document);
+
+    script.dispatchEvent(new Event('load'));
+    const isMatomoScriptLoaded = await firstValueFrom(service.isMatomoScriptLoaded$());
+
+    expect(isMatomoScriptLoaded).toBeTruthy();
+  });
+
+  it('should notify when the script fails', async () => {
+    const script = customMatomoScriptFactory(service)('', document);
+
+    script.dispatchEvent(new Event('error'));
+    const isMatomoScriptLoaded = await firstValueFrom(service.isMatomoScriptLoaded$());
+
+    expect(isMatomoScriptLoaded).toBeFalsy();
+  });
+});

--- a/src/app/statistics/matomo.factory.spec.ts
+++ b/src/app/statistics/matomo.factory.spec.ts
@@ -1,8 +1,8 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { OrejimeService } from '@dspace/core/cookies/orejime.service';
-import { ConfigurationDataService } from '@dspace/core/data/configuration-data.service';
-import { NativeWindowService } from '@dspace/core/services/window.service';
+import { OrejimeService } from '../shared/cookies/orejime.service';
+import { ConfigurationDataService } from '../core/data/configuration-data.service';
+import { NativeWindowService } from '../core/services/window.service';
 import {
   MatomoInitializerService,
   MatomoTracker,

--- a/src/app/statistics/matomo.factory.spec.ts
+++ b/src/app/statistics/matomo.factory.spec.ts
@@ -1,14 +1,14 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { OrejimeService } from '../shared/cookies/orejime.service';
-import { ConfigurationDataService } from '../core/data/configuration-data.service';
-import { NativeWindowService } from '../core/services/window.service';
 import {
   MatomoInitializerService,
   MatomoTracker,
 } from 'ngx-matomo-client';
 import { firstValueFrom } from 'rxjs';
 
+import { ConfigurationDataService } from '../core/data/configuration-data.service';
+import { NativeWindowService } from '../core/services/window.service';
+import { OrejimeService } from '../shared/cookies/orejime.service';
 import { customMatomoScriptFactory } from './matomo.factory';
 import { MatomoService } from './matomo.service';
 

--- a/src/app/statistics/matomo.factory.ts
+++ b/src/app/statistics/matomo.factory.ts
@@ -2,6 +2,20 @@ import { createDefaultMatomoScriptElement } from 'ngx-matomo-client';
 
 import { MatomoService } from './matomo.service';
 
+/**
+ * Creates a custom script factory function that integrates with the `MatomoService`.
+ *
+ * @param matomoService - The instance of `MatomoService` used to track the loading state.
+ * @returns A function to initialize script to listen onload/onerror events by MatomoService
+ *
+ * @example
+ * // In your app config or module providers:
+ * {
+ * provide: MATOMO_SCRIPT_FACTORY,
+ * useFactory: customMatomoScriptFactory,
+ * deps: [MatomoService]
+ * }
+ */
 export function customMatomoScriptFactory(matomoService: MatomoService) {
   return (scriptUrl: string, document: Document): HTMLScriptElement => {
     const script = createDefaultMatomoScriptElement(scriptUrl, document);

--- a/src/app/statistics/matomo.factory.ts
+++ b/src/app/statistics/matomo.factory.ts
@@ -1,0 +1,14 @@
+import { createDefaultMatomoScriptElement } from 'ngx-matomo-client';
+
+import { MatomoService } from './matomo.service';
+
+export function customMatomoScriptFactory(matomoService: MatomoService) {
+  return (scriptUrl: string, document: Document): HTMLScriptElement => {
+    const script = createDefaultMatomoScriptElement(scriptUrl, document);
+
+    script.onload = () => matomoService.markAsLoaded();
+    script.onerror = () => matomoService.markAsError();
+
+    return script;
+  };
+}

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -176,6 +176,10 @@ export class MatomoService {
       );
   }
 
+  /**
+   * Checks if Matomo script loaded correctly
+   * @returns An Observable that emits a boolean indicating whether Matomo script loaded correctly.
+   */
   isMatomoScriptLoaded$(): Observable<boolean> {
     return this.status$.pipe(
       map(status => status === 'loaded'),

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -68,10 +68,16 @@ export class MatomoService {
     this.statusSubject.next('loading');
   }
 
+  /**
+   * This method indicates that the Matomo script loaded successfully thus we set state to loaded
+   */
   markAsLoaded() {
     this.statusSubject.next('loaded');
   }
 
+  /**
+   * This method indicates that the Matomo script failed to download or execute and sets state to error
+   */
   markAsError() {
     this.statusSubject.next('error');
   }

--- a/src/app/statistics/matomo.service.ts
+++ b/src/app/statistics/matomo.service.ts
@@ -13,6 +13,7 @@ import {
   from as fromPromise,
   Observable,
   of,
+  ReplaySubject,
 } from 'rxjs';
 import {
   map,
@@ -45,7 +46,6 @@ export const MATOMO_ENABLED = 'matomo.enabled';
  * Provides methods for initializing tracking, managing consent, and appending visitor identifiers.
  */
 export class MatomoService {
-
   /** Injects the MatomoInitializerService to initialize the Matomo tracker. */
   matomoInitializer: MatomoInitializerService;
 
@@ -61,8 +61,19 @@ export class MatomoService {
   /** Injects the ConfigurationService. */
   configService = inject(ConfigurationDataService);
 
-  constructor(private injector: EnvironmentInjector) {
+  private statusSubject = new ReplaySubject<'loading' | 'loaded' | 'error'>(1);
+  private status$ = this.statusSubject.asObservable();
 
+  constructor(private injector: EnvironmentInjector) {
+    this.statusSubject.next('loading');
+  }
+
+  markAsLoaded() {
+    this.statusSubject.next('loaded');
+  }
+
+  markAsError() {
+    this.statusSubject.next('error');
   }
 
   /**
@@ -163,6 +174,12 @@ export class MatomoService {
             res.payload.values[0]?.toLowerCase() === 'true';
         }),
       );
+  }
+
+  isMatomoScriptLoaded$(): Observable<boolean> {
+    return this.status$.pipe(
+      map(status => status === 'loaded'),
+    );
   }
 
   /**

--- a/src/modules/app/browser-app.config.ts
+++ b/src/modules/app/browser-app.config.ts
@@ -33,10 +33,13 @@ import {
   Angulartics2RouterlessModule,
 } from 'angulartics2';
 import {
+  MATOMO_SCRIPT_FACTORY,
   provideMatomo,
   withRouteData,
   withRouter,
 } from 'ngx-matomo-client';
+import { customMatomoScriptFactory } from 'src/app/statistics/matomo.factory';
+import { MatomoService } from 'src/app/statistics/matomo.service';
 
 import { commonAppConfig } from '../../app/app.config';
 import { storeModuleConfig } from '../../app/app.reducer';
@@ -169,5 +172,10 @@ export const browserAppConfig: ApplicationConfig = mergeApplicationConfig({
       withRouter(),
       withRouteData(),
     ),
+    {
+      provide: MATOMO_SCRIPT_FACTORY,
+      useFactory: customMatomoScriptFactory,
+      deps: [MatomoService],
+    },
   ],
 }, commonAppConfig);


### PR DESCRIPTION
## References

Manual backport of https://github.com/DSpace/dspace-angular/pull/5001
Replaces https://github.com/DSpace/dspace-angular/pull/5623

## Description

I have changed imports to relative since it looks it cannot do module resolution via `@dspace`.

## Instructions for Reviewers

1. I have cherry-picked the commits from https://github.com/DSpace/dspace-angular/pull/5001
2. I have changed imports to relative path so test runner can pick them up


