### PR TITLE
[Port dspace-8_x] Add singular/plural support for QA notification messages

### DIFF
--- a/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.html
+++ b/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.html
@@ -9,7 +9,11 @@
       </div>
       <div class="w-100 d-flex justify-content-between">
         <div class="pl-4 align-self-center">
-          {{'item.qa-event-notification.check.notification-info' | translate : {num: source.totalEvents } }}
+          @if (source.totalEvents === 1) {
+            {{'item.qa-event-notification.check.notification-info.singular' | translate : {num: source.totalEvents } }}
+          } @else {
+            {{'item.qa-event-notification.check.notification-info.plural' | translate : {num: source.totalEvents } }}
+          }
         </div>
         <button [routerLink]="[ getQualityAssuranceRoute(), (source.id | dsSplit: ':')[0], 'target', item.id]"
                 [queryParams]="{ forward: true }"

--- a/src/app/my-dspace-page/my-dspace-qa-events-notifications/my-dspace-qa-events-notifications.component.html
+++ b/src/app/my-dspace-page/my-dspace-qa-events-notifications/my-dspace-qa-events-notifications.component.html
@@ -14,7 +14,11 @@
     </div>
       <div class="w-100 d-flex justify-content-between">
         <div class="pl-4 align-self-center">
-          {{ "mydspace.qa-event-notification.check.notification-info" | translate : { num: source.totalEvents } }}
+          @if (source.totalEvents === 1) {
+            {{ "mydspace.qa-event-notification.check.notification-info.singular" | translate : { num: source.totalEvents } }}
+          } @else {
+            {{ "mydspace.qa-event-notification.check.notification-info.plural" | translate : { num: source.totalEvents } }}
+          }
         </div>
         <button
           [routerLink]="[getQualityAssuranceRoute(), source.id]"

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2753,11 +2753,15 @@
 
   "item.truncatable-part.show-less": "Collapse",
 
-  "item.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "item.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+
+  "item.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
 
   "item.qa-event-notification-info.check.button": "View",
 
-  "mydspace.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "mydspace.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+
+  "mydspace.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
 
   "mydspace.qa-event-notification-info.check.button": "View",
 


### PR DESCRIPTION
## References
* Fixes #4202 
* Port of #5344 to `dspace-8_x`.

## Description
This PR fixes the incorrect pluralization in QA notification messages. Previously, when exactly 1 suggestion was present, the message incorrectly displayed "There are 1 pending suggestions" instead of the grammatically correct singular form.

## Instructions for Reviewers
1. Log in as an administrator
2. Navigate to My DSpace page
3. Verify QA notification messages:
   * Sources with 1 suggestion should display: "There is 1 pending suggestion related to your account"
   * Sources with 2+ suggestions should display: "There are X pending suggestions related to your account"

List of changes in this PR:
* Added separate translation keys with .one and .other suffixes for singular/plural forms in en.json5 and de.json5
* Updated qa-event-notification.component.html to conditionally select the correct translation key based on totalEvents count
* Updated my-dspace-qa-events-notifications.component.html with the same pluralization logic

**Note: Testing requires QA events configured in the backend.**

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
