### PR TITLE
[Port dspace-7_x] Fix browse-by pages sending unnecessary request to author index

### DIFF
--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.spec.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.spec.ts
@@ -74,8 +74,8 @@ describe('BrowseByDatePageComponent', () => {
     findById: () => createSuccessfulRemoteDataObject$(mockCommunity)
   };
 
-  const activatedRouteStub = Object.assign(new ActivatedRouteStub(), {
-    params: observableOf({}),
+  const activatedRouteStub = Object.assign(new ActivatedRouteStub({ id: 'dateissued' }), {
+    params: observableOf({ id: 'dateissued' }),
     queryParams: observableOf({}),
     data: observableOf({ metadata: 'dateissued', metadataField: 'dc.date.issued' })
   });
@@ -110,9 +110,8 @@ describe('BrowseByDatePageComponent', () => {
     fixture = TestBed.createComponent(BrowseByDatePageComponent);
     const browseService = fixture.debugElement.injector.get(BrowseService);
     spyOn(browseService, 'getFirstItemFor')
-      // ok to expect the default browse as first param since we just need the mock items obtained via sort direction.
-      .withArgs('author', undefined, SortDirection.ASC).and.returnValue(createSuccessfulRemoteDataObject$(firstItem))
-      .withArgs('author', undefined, SortDirection.DESC).and.returnValue(createSuccessfulRemoteDataObject$(lastItem));
+      .withArgs('dateissued', undefined, SortDirection.ASC).and.returnValue(createSuccessfulRemoteDataObject$(firstItem))
+      .withArgs('dateissued', undefined, SortDirection.DESC).and.returnValue(createSuccessfulRemoteDataObject$(lastItem));
     comp = fixture.componentInstance;
     route = (comp as any).route;
     fixture.detectChanges();

--- a/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
+++ b/src/app/browse-by/browse-by-date-page/browse-by-date-page.component.ts
@@ -75,7 +75,7 @@ export class BrowseByDatePageComponent extends BrowseByMetadataPageComponent {
         this.currentSort$,
       ]).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
         const metadataKeys = params.browseDefinition ? params.browseDefinition.metadataKeys : this.defaultMetadataKeys;
-        this.browseId = params.id || this.defaultBrowseId;
+        this.browseId = params.id;
         this.startsWith = +params.startsWith || params.startsWith;
         const searchOptions = browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails);
         this.updatePageWithItems(searchOptions, this.value, undefined);

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.spec.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.spec.ts
@@ -95,8 +95,8 @@ describe('BrowseByMetadataPageComponent', () => {
     findById: () => createSuccessfulRemoteDataObject$(mockCommunity)
   };
 
-  const activatedRouteStub = Object.assign(new ActivatedRouteStub(), {
-    params: observableOf({})
+  const activatedRouteStub = Object.assign(new ActivatedRouteStub({ id: 'author' }), {
+    params: observableOf({ id: 'author' }),
   });
 
   paginationService = new PaginationServiceStub();

--- a/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
+++ b/src/app/browse-by/browse-by-metadata-page/browse-by-metadata-page.component.ts
@@ -84,14 +84,9 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
   subs: Subscription[] = [];
 
   /**
-   * The default browse id to resort to when none is provided
-   */
-  defaultBrowseId = 'author';
-
-  /**
    * The current browse id
    */
-  browseId = this.defaultBrowseId;
+  browseId: string;
 
   /**
    * The type of StartsWith options to render
@@ -177,7 +172,7 @@ export class BrowseByMetadataPageComponent implements OnInit, OnDestroy {
         this.currentPagination$,
         this.currentSort$,
       ]).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
-        this.browseId = params.id || this.defaultBrowseId;
+        this.browseId = params.id;
           this.authority = params.authority;
 
           if (typeof params.value === 'string'){

--- a/src/app/browse-by/browse-by-title-page/browse-by-title-page.component.spec.ts
+++ b/src/app/browse-by/browse-by-title-page/browse-by-title-page.component.spec.ts
@@ -62,8 +62,8 @@ describe('BrowseByTitlePageComponent', () => {
     findById: () => createSuccessfulRemoteDataObject$(mockCommunity)
   };
 
-  const activatedRouteStub = Object.assign(new ActivatedRouteStub(), {
-    params: observableOf({}),
+  const activatedRouteStub = Object.assign(new ActivatedRouteStub({ id: 'title' }), {
+    params: observableOf({ id: 'title' }),
     queryParams: observableOf({}),
     data: observableOf({ metadata: 'title' }),
   });

--- a/src/app/browse-by/browse-by-title-page/browse-by-title-page.component.ts
+++ b/src/app/browse-by/browse-by-title-page/browse-by-title-page.component.ts
@@ -62,7 +62,7 @@ export class BrowseByTitlePageComponent extends BrowseByMetadataPageComponent {
         this.currentSort$,
       ]).subscribe(([params, currentPage, currentSort]: [Params, PaginationComponentOptions, SortOptions]) => {
         this.startsWith = +params.startsWith || params.startsWith;
-        this.browseId = params.id || this.defaultBrowseId;
+        this.browseId = params.id;
         this.updatePageWithItems(browseParamsToOptions(params, currentPage, currentSort, this.browseId, this.fetchThumbnails), undefined, undefined);
         this.updateParent(params.scope);
         this.updateLogo();


### PR DESCRIPTION
## References
* Fixes #3572
* Port of #5382 to `dspace-7_x`.

## Description
Removes hardcoded default initialization to 'author' browse index that caused unnecessary failed requests when visiting browse-by pages on systems where the 'author' index is disabled.

**Before this PR:**
- `BrowseByMetadataComponent` initialized with a hardcoded request to 'author' browse index
- When visiting any browse-by page (title, date, subject, etc.), two requests were made:
  1. First to `/api/discover/browses/author/entries` (unnecessary and would fail if disabled)
  2. Then to the correct browse index (e.g., `/api/discover/browses/title/entries`)

**After this PR:**
- Components wait for route parameters to be available
- Only one request is made to the correct browse index
- `browseEntries$` remains undefined until properly initialized
- Loading indicator displays while parameters are being resolved

## Instructions for Reviewers
1. Start the application: npm start:dev
2. Open browser DevTools (F12) → Network tab
3. Filter by XHR/Fetch requests
4. Visit different browse-by pages:
- http://localhost:4000/browse/title 
- http://localhost:4000/browse/dateissued
- http://localhost:4000/browse/subject

**Expected behavior:**
- Only ONE request should be made to the correct browse index
- NO request should be made to /api/discover/browses/author/entries
- Loading indicator should display briefly while route parameters are resolved
- Page should load successfully without errors

List of changes in this PR:
* Removed hardcoded 'author' default from `BrowseByMetadataComponent` - the component now waits for route parameters before initializing browse requests
* Updated `BrowseByDateComponent.ngOnInit()` to properly use browse ID from route parameters instead of relying on parent's default
* Updated `BrowseByTitleComponent.ngOnInit()` to properly use browse ID from route parameters instead of relying on parent's default
* Fixed `BrowseByDateComponent` test spy to expect 'dateissued' instead of 'author'
* Improved loading state handling - `loading$` properly initialized to show loading indicator while waiting for route parameters

## Checklist


- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).