### PR TITLE
[GitHub Actions] Update dependabot to monitor dspace-10_x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,6 +108,109 @@ updates:
     cooldown:
       default-days: 7
   #####################
+  ## dspace-10_x branch
+  #####################
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: dspace-10_x
+    # Monthly dependency updates (NOTE: "schedule" doesn't apply to security updates)
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together Angular package upgrades
+    groups:
+      # Group together all minor/patch version updates for Angular in a single PR
+      angular:
+        applies-to: version-updates
+        patterns:
+        - "@angular*"
+        - "@ngtools/webpack"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all minor/patch version updates for NgRx in a single PR
+      ngrx:
+        applies-to: version-updates
+        patterns:
+        - "@ngrx*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together all patch version updates for eslint in a single PR
+      eslint:
+        applies-to: version-updates
+        patterns:
+        - "@typescript-eslint*"
+        - "eslint*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any testing related version updates
+      testing:
+        applies-to: version-updates
+        patterns:
+        - "@cypress*"
+        - "axe-*"
+        - "cypress*"
+        - "jasmine*"
+        - "karma*"
+        - "ng-mocks"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any postcss related version updates
+      postcss:
+        applies-to: version-updates
+        patterns:
+        - "postcss*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any sass related version updates
+      sass:
+        applies-to: version-updates
+        patterns:
+        - "sass*"
+        update-types:
+        - "minor"
+        - "patch"
+      # Group together any webpack related version updates
+      webpack:
+        applies-to: version-updates
+        patterns:
+        - "webpack*"
+        update-types:
+        - "minor"
+        - "patch"
+    ignore:
+      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Restrict typescript updates to patch level because that's what our package.json says
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the dspace-10_x branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dspace-10_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "05:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
+  #####################
   ## dspace-9_x branch
   #####################
   - package-ecosystem: "npm"
@@ -304,103 +407,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: dspace-8_x
-    # Monthly dependency updates
-    schedule:
-      interval: "monthly"
-      time: "05:00"
-    # Allow updates to be delayed for a configurable number of days to mitigate
-    # some classes of supply chain attacks
-    cooldown:
-      default-days: 7
-  #####################
-  ## dspace-7_x branch
-  #####################
-  - package-ecosystem: "npm"
-    directory: "/"
-    target-branch: dspace-7_x
-    schedule:
-      interval: "monthly"
-      time: "05:00"
-    # Allow updates to be delayed for a configurable number of days to mitigate
-    # some classes of supply chain attacks
-    cooldown:
-      default-days: 7
-    # Allow up to 10 open PRs for dependencies
-    open-pull-requests-limit: 10
-    # Group together Angular package upgrades
-    groups:
-      # Group together all minor/patch version updates for Angular in a single PR
-      angular:
-        applies-to: version-updates
-        patterns:
-        - "@angular*"
-        - "@ngtools/webpack"
-        update-types:
-        - "minor"
-        - "patch"
-      # Group together all minor/patch version updates for NgRx in a single PR
-      ngrx:
-        applies-to: version-updates
-        patterns:
-        - "@ngrx*"
-        update-types:
-        - "minor"
-        - "patch"
-      # Group together all patch version updates for eslint in a single PR
-      eslint:
-        applies-to: version-updates
-        patterns:
-        - "@typescript-eslint*"
-        - "eslint*"
-        update-types:
-        - "minor"
-        - "patch"
-      # Group together any testing related version updates
-      testing:
-        applies-to: version-updates
-        patterns:
-        - "@cypress*"
-        - "axe-*"
-        - "cypress*"
-        - "jasmine*"
-        - "karma*"
-        - "ng-mocks"
-        update-types:
-        - "minor"
-        - "patch"
-      # Group together any postcss related version updates
-      postcss:
-        applies-to: version-updates
-        patterns:
-        - "postcss*"
-        update-types:
-        - "minor"
-        - "patch"
-      # Group together any sass related version updates
-      sass:
-        applies-to: version-updates
-        patterns:
-        - "sass*"
-        update-types:
-        - "minor"
-        - "patch"
-    ignore:
-      # 7.x Cannot update Webpack past v5.76.1 as later versions not supported by Angular 15
-      # See also https://github.com/DSpace/dspace-angular/pull/3283#issuecomment-2372488489
-      - dependency-name: "webpack"
-      # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
-      - dependency-name: "zone.js"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Restrict typescript updates to patch level because that's what our package.json says
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-  # Also automatically update all our GitHub actions on the dspace-7_x branch
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: dspace-7_x
     # Monthly dependency updates
     schedule:
       interval: "monthly"

--- a/src/themes/dspace/app/home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.html
@@ -12,7 +12,7 @@
         <div class="d-flex flex-wrap">
           <div>
             <h1 class="display-2">DSpace Sandbox</h1>
-            <p><i class="fas fa-circle-info"></i> This site is running unreleased code which will eventually become DSpace 10. For more information, see the <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+10.0+Status" role="link" tabindex="0">DSpace 10 Release Status</a>.</p>
+            <p><i class="fas fa-circle-info"></i> This site is running unreleased code which will eventually become DSpace 11. For more information, see the <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+11.0+Status" role="link" tabindex="0">DSpace 11 Release Status</a>.</p>
             <p class="lead">DSpace is the world leading open source repository platform that enables
               organisations to:</p>
           </div>


### PR DESCRIPTION
## Description
This PR represents post-10.0 release cleanup.  A corresponding PR exists for the backend, see https://github.com/DSpace/DSpace/pull/12602

It makes the following setting updates:
* Updates `dependabot` settings to *add* monitoring of the `dspace-10_x` branch and *remove* monitoring of the `dspace-7_x` branch.
* Updates the homepage news for `main` branch to reference DSpace 11 instead of 10.

## Instructions for Reviewers
* These updates are all configuration of our automated tooling.  They can only be tested by merging.