### PR TITLE
[dspace-10_x] Update homepage news to reference DSpace 10 Release Notes

### DIFF
--- a/src/themes/dspace/app/home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.html
@@ -11,8 +11,8 @@
       @else {
         <div class="d-flex flex-wrap">
           <div>
-            <h1 class="display-2">DSpace Sandbox</h1>
-            <p><i class="fas fa-circle-info"></i> This site is running unreleased code which will eventually become DSpace 10. For more information, see the <a href="https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+10.0+Status" role="link" tabindex="0">DSpace 10 Release Status</a>.</p>
+            <h1 class="display-2">DSpace 10</h1>
+            <p><i class="fas fa-circle-info"></i> This site is running DSpace 10. For more information, see the <a href="https://wiki.lyrasis.org/display/DSDOC10x/Release+Notes" role="link" tabindex="0">DSpace 10 Release Notes</a>.</p>
             <p class="lead">DSpace is the world leading open source repository platform that enables
               organisations to:</p>
           </div>


### PR DESCRIPTION
## Description
Small PR to update the `dspace-10_x` branch homepage news to reference the DSpace 10 Release Notes

This is essentially a companion PR to  #5770, which similarly updates the `main` branch homepage news to reference DSpace 11.
