### PR TITLE
Add additional OA fee in OPF components

### DIFF
--- a/src/app/core/submission/models/opf-policies-details.model.ts
+++ b/src/app/core/submission/models/opf-policies-details.model.ts
@@ -81,6 +81,7 @@ export interface PermittedVersions {
   locations: string[];
   licenses: string[];
   embargo: Embargo;
+  additionalOpenAccessFee: boolean;
 }
 
 export interface Embargo {

--- a/src/app/submission/sections/opf-policies/content-accordion/content-accordion.component.html
+++ b/src/app/submission/sections/opf-policies/content-accordion/content-accordion.component.html
@@ -17,6 +17,13 @@
       'submission.sections.jisc.publisher.policy.noembargo' | translate }}</span>
     }
 
+    @if (version.additionalOpenAccessFee) {
+      <span class="m-1 ms-4">
+        <i class="fa-solid fa-dollar-sign pe-2"></i>
+        {{ 'submission.sections.jisc.publisher.policy.additional-oa-fee' | translate }}
+      </span>
+    }
+
     <span class="m-1 ms-4">
       <i class="far fa-folder-open"></i>
       @if (!!version?.locations && version.locations.length > 0) {

--- a/src/app/submission/sections/opf-policies/content-accordion/content-accordion.component.spec.ts
+++ b/src/app/submission/sections/opf-policies/content-accordion/content-accordion.component.spec.ts
@@ -59,4 +59,25 @@ describe('ContentAccordionComponent', () => {
     fixture.detectChanges();
     expect(de.queryAll(By.css('.row')).length).toEqual(5);
   });
+
+  it('should show additional OA fee icon when additionalOpenAccessFee is true', () => {
+    component.version = OpfDataResponse.opfResponse.journals[0].policies[0].permittedVersions[0];
+    (component.version as any).additionalOpenAccessFee = true;
+    fixture.detectChanges();
+    expect(de.query(By.css('.fa-dollar-sign'))).toBeTruthy();
+  });
+
+  it('should not show additional OA fee icon when additionalOpenAccessFee is false', () => {
+    component.version = OpfDataResponse.opfResponse.journals[0].policies[0].permittedVersions[0];
+    (component.version as any).additionalOpenAccessFee = false;
+    fixture.detectChanges();
+    expect(de.query(By.css('.fa-dollar-sign'))).toBeFalsy();
+  });
+
+  it('should not show additional OA fee icon when additionalOpenAccessFee is missing', () => {
+    component.version = OpfDataResponse.opfResponse.journals[0].policies[0].permittedVersions[0];
+    delete (component.version as any).additionalOpenAccessFee;
+    fixture.detectChanges();
+    expect(de.query(By.css('.fa-dollar-sign'))).toBeFalsy();
+  });
 });

--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -9317,6 +9317,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "تحديث",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "رسوم إضافية للوصول المفتوح",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "معلومات التسجيلة",
 

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -9436,6 +9436,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "রিফ্রেশ",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "অতিরিক্ত উন্মুক্ত প্রবেশাধিকার ফি",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": " তথ্য রেকর্ড করুন",
 

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -9473,6 +9473,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Refrescar",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Preu addicional per a l'accés obert",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informació del registre",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -9172,6 +9172,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Aktualizovat",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Dodatečný poplatek za otevřený přístup",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informace o záznamu",
 

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -9150,6 +9150,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Aktualisieren",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Zusätzliche OA-Gebühr",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Datensatz-Informationen",
 

--- a/src/assets/i18n/el.json5
+++ b/src/assets/i18n/el.json5
@@ -10257,6 +10257,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Ανανέωση",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Επιπλέον χρέωση Ανοικτής Πρόσβασης",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Πληροφορίες εγγραφής",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6076,6 +6076,8 @@
 
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   "submission.sections.jisc.record.information": "Record Information",
 
   "submission.sections.jisc.record.information.id": "ID",

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -9419,6 +9419,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Refrescar",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Tarifa adicional por acceso abierto",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informacion del registro",
 

--- a/src/assets/i18n/fa.json5
+++ b/src/assets/i18n/fa.json5
@@ -11273,6 +11273,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -9971,6 +9971,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Päivitä",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Lisämaksu avoimesta julkaisemisesta",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Tietueen tiedot",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -9298,6 +9298,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Rafraîchir",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Prix ​​supplémentaire pour l'accès libre",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Information",
 

--- a/src/assets/i18n/gd.json5
+++ b/src/assets/i18n/gd.json5
@@ -10514,6 +10514,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/gu.json5
+++ b/src/assets/i18n/gu.json5
@@ -9527,6 +9527,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "રીફ્રેશ",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "વધારાની ઓપન એક્સેસ ફી",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "રેકોર્ડ માહિતી",
 

--- a/src/assets/i18n/hi.json5
+++ b/src/assets/i18n/hi.json5
@@ -9541,6 +9541,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "ताज़ा करें",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "अतिरिक्त ओपन एक्सेस शुल्क",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "रिकॉर्ड जानकारी",
 

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -9133,6 +9133,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Frissítés",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "További nyílt hozzáférési díjak",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Rekordinformáció",
 

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -10015,6 +10015,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Ricarica",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Costi aggiuntivi per l'accesso aperto",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informazioni sulla registrazione",
 

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -12150,6 +12150,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -10255,6 +10255,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Жаңарту",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Қосымша ашық кіру ақысы",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Жазуға арналған ақпарат",
 

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -11151,6 +11151,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/ml.json5
+++ b/src/assets/i18n/ml.json5
@@ -9440,6 +9440,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "റിഫ്രഷ്",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "അധിക ഓപ്പൺ ആക്‌സസ് ഫീസ്",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "റെക്കോർഡ് വിവരം",
 

--- a/src/assets/i18n/mr.json5
+++ b/src/assets/i18n/mr.json5
@@ -9523,6 +9523,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "रिफ्रेश",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "अतिरिक्त खुला प्रवेश शुल्क",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "रेकॉर्ड माहिती",
 

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -11477,6 +11477,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/od.json5
+++ b/src/assets/i18n/od.json5
@@ -9443,6 +9443,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "ରିଫ୍ରେସ୍ କରନ୍ତୁ",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "ଅତିରିକ୍ତ ଖୋଲା ପ୍ରବେଶ ଶୁଳ୍କ",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "ରେକର୍ଡ ସୂଚନା",
 

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -9391,6 +9391,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Odśwież",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Dodatkowa opłata za otwarty dostęp",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informacje o rekordzie",
 

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -9148,6 +9148,9 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Atualizar",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Taxa adicional de acesso aberto ",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Registrar Informação",
 

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -9481,6 +9481,9 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Atualizar",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Taxa adicional de acesso aberto",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Informação do registo",
 

--- a/src/assets/i18n/ru.json5
+++ b/src/assets/i18n/ru.json5
@@ -9522,6 +9522,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Обновить",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Дополнительная плата за открытый доступ",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Информация записи",
 

--- a/src/assets/i18n/sr-cyr.json5
+++ b/src/assets/i18n/sr-cyr.json5
@@ -10020,6 +10020,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Освежите",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Додатна накнада за отворени приступ",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Запишите информацију",
 

--- a/src/assets/i18n/sr-lat.json5
+++ b/src/assets/i18n/sr-lat.json5
@@ -10018,6 +10018,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Osvežite",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Dodatna naknada za otvoreni pristup",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Zapišite informaciju",
 

--- a/src/assets/i18n/sv.json5
+++ b/src/assets/i18n/sv.json5
@@ -10560,6 +10560,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -12150,6 +12150,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/ta.json5
+++ b/src/assets/i18n/ta.json5
@@ -9573,6 +9573,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "புதுப்பிக்கவும்",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "கூடுதல் திறந்த அணுகல் கட்டணம்",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "பதிவு தகவல்",
 

--- a/src/assets/i18n/te.json5
+++ b/src/assets/i18n/te.json5
@@ -9500,6 +9500,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "రిఫ్రెష్ చేయండి",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "అదనపు ఓపెన్ యాక్సెస్ రుసుము",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "రికార్డ్ సమాచారం",
 

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -10745,6 +10745,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/uk.json5
+++ b/src/assets/i18n/uk.json5
@@ -10774,6 +10774,10 @@
   // TODO New key - Add a translation
   "submission.sections.jisc.publisher.policy.refresh": "Refresh",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO New key - Add a translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+
   // "submission.sections.jisc.record.information": "Record Information",
   // TODO New key - Add a translation
   "submission.sections.jisc.record.information": "Record Information",

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -10143,6 +10143,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "Làm mới",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "Phí truy cập mở bổ sung",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "Thông tin biểu ghi",
 

--- a/src/assets/i18n/zh-TW.json5
+++ b/src/assets/i18n/zh-TW.json5
@@ -9623,6 +9623,10 @@
   // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
   "submission.sections.jisc.publisher.policy.refresh": "重新整理",
 
+  // "submission.sections.jisc.publisher.policy.additional-oa-fee": "Additional OA fee",
+  // TODO Source message changed - Revise the translation
+  "submission.sections.jisc.publisher.policy.additional-oa-fee": "额外开放获取费用",
+
   // "submission.sections.jisc.record.information": "Record Information",
   "submission.sections.jisc.record.information": "記錄資訊",
 


### PR DESCRIPTION
## References

Related back-end PR: https://github.com/DSpace/DSpace/pull/12629

## Description

Adds information about additional OA fee in the OPF components.

When a version in the OPF response contains an additional OA fee, renders an icon and text showing it.

### Example

[In OPF](https://openpolicyfinder.jisc.ac.uk/publication/19923?from=single_hit):

<img width="640" height="auto" alt="image" src="https://github.com/user-attachments/assets/226f7f3e-8924-4486-9cfb-987e1f48d45b" />

In the forms:

<img width="640" height="auto" alt="image" src="https://github.com/user-attachments/assets/daf283c6-5a3b-4f81-a358-2cdd656ef504" />

## Instructions for Reviewers

With the related [back-end PR](https://github.com/DSpace/DSpace/pull/12629) running, start a new submission and enter some ISSN containing an additional OA fee. 

It should now be displayed in the OPF section in the form.

List of changes in this PR:
* Adds property `additionalOpenAccessFee` in the OPF response
* Conditionally renders icon + text in a version that contains additional OA fee
* Adds new i18n tag `submission.sections.jisc.publisher.policy.additional-oa-fee`
  - Translations added in `en.json5`, `pt-BR.json5` and `pt-PT.json5`
  - For languages **without** translations to other JISC related tags, the new tag was added with the comment `// TODO New key - Add a translation` and english text
  - For languages **with** translations to other JISC related tags, the new tag was added with the comment `// TODO Source message changed - Revise the translation` and translated text using Google Translate. 

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
