### PR TITLE
Removal of translation key submission.sections.submit.progressbar.jiscPolicies

### DIFF
--- a/src/assets/i18n/ar.json5
+++ b/src/assets/i18n/ar.json5
@@ -8990,15 +8990,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "معلومات سياسة الوصول الحر للناشر",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "تحميل الملفات",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "معلومات سياسة الوصول الحر للناشر",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "لا تتوفر معلومات حول سياسة الناشر. إذا كان لعملك رقم ISSN مرتبط، يرجى إدخاله أعلاه للاطلاع على أي سياسة وصول حر للناشرين ذوي الصلة.",

--- a/src/assets/i18n/bn.json5
+++ b/src/assets/i18n/bn.json5
@@ -9106,15 +9106,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "প্রকাশক ওপেন অ্যাক্সেস নীতির তথ্য",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "ফাইল আপলোড",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "প্রকাশক ওপেন অ্যাক্সেস নীতির তথ্য",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "কোন প্রকাশক নীতি তথ্য উপলব্ধ নেই৷ যদি আপনার কাজের একটি সংশ্লিষ্ট ISSN থাকে, তাহলে অনুগ্রহ করে এটি উপরে লিখুন যে কোনো সম্পর্কিত প্রকাশক ওপেন অ্যাক্সেস নীতি দেখতে।",

--- a/src/assets/i18n/ca.json5
+++ b/src/assets/i18n/ca.json5
@@ -9146,15 +9146,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informació sobre polítiques editorials d'accés obert",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Pujar fitxers",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informació sobre polítiques editorials d'accés obert",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "No es troba disponible la informació sobre política editorial. Si teniu un ISSN associat, introduïu-lo a dalt per veure informació sobre polítiques editorials d'accés obert.",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -8848,15 +8848,11 @@
   // "submission.sections.submit.progressbar.describe.owner": "Owner",
   "submission.sections.submit.progressbar.describe.owner": "Vlastník",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informace o politice otevřeného přístupu vydavatele",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Nahrát soubory",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informace o politice otevřeného přístupu vydavatele",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Nejsou k dispozici žádné informace o politice vydavatele. Pokud má vaše práce přiřazené ISSN, zadejte jej výše, abyste viděli všechny související politiky otevřeného přístupu vydavatele.",

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -8826,15 +8826,11 @@
   // "submission.sections.submit.progressbar.describe.owner": "Owner",
   "submission.sections.submit.progressbar.describe.owner": "Besitzer",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informationen zur Open-Access-Richtlinie des Verlags",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Hochgeladene Dateien",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informationen zur Open-Access-Richtlinie des Verlags",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Keine Informationen zur Verlagsrichtlinie verfügbar. Wenn Ihr Werk eine zugehörige ISSN hat, geben Sie diese bitte oben ein, um die entsprechenden Open-Access-Richtlinien des Verlags anzuzeigen.",

--- a/src/assets/i18n/el.json5
+++ b/src/assets/i18n/el.json5
@@ -9921,15 +9921,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Πληροφορίες πολιτικής ανοιχτής πρόσβασης εκδότη",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Μεταφόρτωση αρχείων",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Πληροφορίες πολιτικής ανοιχτής πρόσβασης εκδότη",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Δεν υπάρχουν διαθέσιμες πληροφορίες πολιτικής εκδότη. Εάν η εργασία σας έχει συσχετισμένο ISSN, καταχωρίστε το παραπάνω για να δείτε τυχόν σχετικές πολιτικές ανοιχτής πρόσβασης εκδότη.",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5868,11 +5868,9 @@
 
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   "submission.sections.submit.progressbar.upload": "Upload files",
-
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
 

--- a/src/assets/i18n/es.json5
+++ b/src/assets/i18n/es.json5
@@ -9092,15 +9092,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Información sobre políticas editoriales de acceso abierto",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Subir archivos",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Información sobre políticas editoriales de acceso abierto",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "No se encuentra disponible la información sobre política editorial. Si tiene un ISSN asociado, introdúzcalo arriba para ver información sobre políticas editoriales de acceso abierto.",

--- a/src/assets/i18n/fa.json5
+++ b/src/assets/i18n/fa.json5
@@ -10857,17 +10857,13 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.upload": "Upload files",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/fi.json5
+++ b/src/assets/i18n/fi.json5
@@ -9638,15 +9638,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Tietoa julkaisijan open access -käytännöistä",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Lataa tiedostoja",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Tietoa julkaisijan open access -käytännöistä",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Ei tietoa julkausijan käytännöistä. Jos työlläsi on ISSN-tunnus, syötä se alapuolella olevan kenttään nähdäksesi siihen liittyvät julkaisijan open access -käytännöt.",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -8973,15 +8973,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informations sur la politique de libre accès de l'éditeur",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Télécharger des fichiers",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informations sur la politique de libre accès de l'éditeur",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Aucune information sur la politique de libre accès de l'éditeur n'est disponible. Si votre œuvre possède un ISSN, veuillez le saisir ci-dessus pour consulter les politiques de libre accès de l'éditeur.",

--- a/src/assets/i18n/gd.json5
+++ b/src/assets/i18n/gd.json5
@@ -10134,16 +10134,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Luchdaich suas faidhlichean",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/gu.json5
+++ b/src/assets/i18n/gu.json5
@@ -9196,15 +9196,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "પ્રકાશક ઓપન ઍક્સેસ નીતિ માહિતી",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "ફાઇલો અપલોડ કરો",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "પ્રકાશક ઓપન ઍક્સેસ નીતિ માહિતી",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "કોઈ પ્રકાશક નીતિ માહિતી ઉપલબ્ધ નથી. જો તમારા કાર્ય સાથે સંકળાયેલ ISSN છે, તો કૃપા કરીને ઉપર દાખલ કરો જેથી સંબંધિત પ્રકાશક ઓપન ઍક્સેસ નીતિઓ જોઈ શકાય.",

--- a/src/assets/i18n/hi.json5
+++ b/src/assets/i18n/hi.json5
@@ -9212,15 +9212,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "प्रकाशक ओपन एक्सेस नीति जानकारी",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "फाइलें अपलोड करें",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "प्रकाशक ओपन एक्सेस नीति जानकारी",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "कोई प्रकाशक नीति जानकारी उपलब्ध नहीं है। यदि आपके कार्य से संबंधित कोई ISSN है, तो कृपया इसे ऊपर दर्ज करें ताकि संबंधित प्रकाशक ओपन एक्सेस नीतियों को देखा जा सके।",

--- a/src/assets/i18n/hu.json5
+++ b/src/assets/i18n/hu.json5
@@ -8811,14 +8811,11 @@
   // "submission.sections.submit.progressbar.describe.owner": "Owner",
   "submission.sections.submit.progressbar.describe.owner": "Tulajdonos",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder szabályzatok",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Kiadói nyílt hozzáférési szabályzat",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Fájlok feltöltése",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Kiadói nyílt hozzáférési szabályzat",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Nem áll rendelkezésre kiadói szabályzatinformáció.\nHa művéhez tartozik ISSN, kérjük, adja meg fentebb a kapcsolódó kiadói nyílt hozzáférési szabályzatok megtekintéséhez.",

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -9682,15 +9682,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informazioni sulla policy di open access dell'editore",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Carica file",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informazioni sulla policy di open access dell'editore",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Non sono disponibili informazioni sulle policy dell'editore. Se il lavoro ha un ISSN associato, si prega di inserirlo qui sopra per vedere le policy di open access dell'editore.",

--- a/src/assets/i18n/ja.json5
+++ b/src/assets/i18n/ja.json5
@@ -11734,17 +11734,13 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.upload": "Upload files",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/kk.json5
+++ b/src/assets/i18n/kk.json5
@@ -9921,15 +9921,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Баспагердің ашық қол жеткізу саясаты туралы ақпарат",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Файлдарды жүктеу",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Баспагердің ашық қол жеткізу саясаты туралы ақпарат",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Баспагердің саясаты туралы ақпарат жоқ. Егер сіздің жұмысыңыз ISSN-мен байланысты болса, баспагердің кез-келген тиісті ашық кіру саясатымен танысу үшін оны жоғарыда енгізіңіз.",

--- a/src/assets/i18n/lv.json5
+++ b/src/assets/i18n/lv.json5
@@ -10757,16 +10757,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Augšupielādēt failus",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/ml.json5
+++ b/src/assets/i18n/ml.json5
@@ -9110,15 +9110,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "പ്രസാധകരുടെ ഓപ്പൺ ആക്സസ് പോളിസി വിവരം",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "ഫയലുകൾ അപ്ലോഡ് ചെയ്യുക",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "പ്രസാധകരുടെ ഓപ്പൺ ആക്സസ് പോളിസി വിവരം",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "പ്രസാധക പോളിസി വിവരം ലഭ്യമല്ല. നിങ്ങളുടെ ജോലിയുമായി ബന്ധപ്പെട്ട ഒരു ISSN ഉണ്ടെങ്കിൽ, ബന്ധപ്പെട്ട പ്രസാധക ഓപ്പൺ ആക്സസ് പോളിസികൾ കാണാൻ ദയവായി ഇത് മുകളിൽ നൽകുക.",

--- a/src/assets/i18n/mr.json5
+++ b/src/assets/i18n/mr.json5
@@ -9193,15 +9193,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "प्रकाशक खुले प्रवेश धोरण माहिती",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "फाइल्स अपलोड करा",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "प्रकाशक खुले प्रवेश धोरण माहिती",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "कोणतीही प्रकाशक धोरण माहिती उपलब्ध नाही. आपले कार्य संबंधित ISSN आहे, कृपया वरील प्रविष्ट करा जेणेकरून संबंधित प्रकाशक खुले प्रवेश धोरणे पाहता येतील.",

--- a/src/assets/i18n/nl.json5
+++ b/src/assets/i18n/nl.json5
@@ -11083,16 +11083,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Upload bestanden",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/od.json5
+++ b/src/assets/i18n/od.json5
@@ -9113,15 +9113,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "ପ୍ରକାଶକ ଖୋଲା ପ୍ରବେଶ ନୀତି ସୂଚନା",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "ଫାଇଲ୍ ଅପଲୋଡ୍ କରନ୍ତୁ",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "ପ୍ରକାଶକ ଖୋଲା ପ୍ରବେଶ ନୀତି ସୂଚନା",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "କୌଣସି ପ୍ରକାଶକ ନୀତି ସୂଚନା ଉପଲବ୍ଧ ନାହିଁ। ଯଦି ଆପଣଙ୍କ କାର୍ଯ୍ୟରେ ଏକ ସମ୍ବନ୍ଧିତ ISSN ଅଛି, ଦୟାକରି ଉପରେ ଏହାକୁ ପ୍ରବେଶ କରନ୍ତୁ ଯେପରିକି ସମ୍ବନ୍ଧିତ ପ୍ରକାଶକ ଖୋଲା ପ୍ରବେଶ ନୀତିଗୁଡିକ ଦେଖାଯାଇପାରିବ।",

--- a/src/assets/i18n/pl.json5
+++ b/src/assets/i18n/pl.json5
@@ -9063,15 +9063,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informacje o polityce open access wydawcy.",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Prześlij pliki",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informacje o polityce open access wydawcy.",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Nie wybrano ISSN i informacje o polityce wydawniczej czasopisma są niedostępne",

--- a/src/assets/i18n/pt-BR.json5
+++ b/src/assets/i18n/pt-BR.json5
@@ -8824,15 +8824,11 @@
   // "submission.sections.submit.progressbar.describe.owner": "Owner",
   "submission.sections.submit.progressbar.describe.owner": "Dono",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informações de políticas de acesso aberto do editor",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Enviar arquivos",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informações de políticas de acesso aberto do editor",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Nenhuma informação sobre a política da editora está disponível. Se seu trabalho tiver um ISSN associado, por favor, insira-o acima para ver quaisquer políticas de acesso aberto do editor relacionadas.",

--- a/src/assets/i18n/pt-PT.json5
+++ b/src/assets/i18n/pt-PT.json5
@@ -9153,15 +9153,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informação sobre a política de auto arquivo dos editores",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Carregar ficheiro(s)",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informação sobre a política de auto arquivo dos editores",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Não foi encontrada informação disponível sobre política desta editora. Se o seu trabalho tem um ISSN associado, por favor, introduza-o em cima para poder visualizar as políticas de auto arquivo associadas.",

--- a/src/assets/i18n/ru.json5
+++ b/src/assets/i18n/ru.json5
@@ -9194,15 +9194,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Информация о политиках открытого доступа издателя",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Загрузить файлы",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Информация о политиках открытого доступа издателя",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Информация о политике издателя недоступна. Если у вашей работы есть связанный ISSN, введите его выше, чтобы увидеть соответствующую информацию о политике открытого доступа издателя.",

--- a/src/assets/i18n/sr-cyr.json5
+++ b/src/assets/i18n/sr-cyr.json5
@@ -9684,15 +9684,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Информације о политици отвореног приступа издавача",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Додај фајлове",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Информације о политици отвореног приступа издавача",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Нема доступних информација о смерницама за издаваче. Ако ваш рад има придружени ISSN, унесите га изнад да бисте видели све повезане смернице отвореног приступа за издаваче.",

--- a/src/assets/i18n/sr-lat.json5
+++ b/src/assets/i18n/sr-lat.json5
@@ -9682,15 +9682,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informacije o politici otvorenog pristupa izdavača",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Dodaj fajlove",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Informacije o politici otvorenog pristupa izdavača",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Nema dostupnih informacija o smernicama za izdavače. Ako vaš rad ima pridruženi ISSN, unesite ga iznad da biste videli sve povezane smernice otvorenog pristupa za izdavače.",

--- a/src/assets/i18n/sv.json5
+++ b/src/assets/i18n/sv.json5
@@ -10200,16 +10200,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Ladda upp filer",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/sw.json5
+++ b/src/assets/i18n/sw.json5
@@ -11734,17 +11734,13 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.upload": "Upload files",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/ta.json5
+++ b/src/assets/i18n/ta.json5
@@ -9237,15 +9237,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "பதிப்பாளர் திறந்த அணுகல் கொள்கை தகவல்",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "கோப்புகளைப் பதிவேற்றவும்",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "பதிப்பாளர் திறந்த அணுகல் கொள்கை தகவல்",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "பதிப்பாளர் கொள்கை தகவல் கிடைக்கவில்லை. உங்கள் வேலைக்கு தொடர்புடைய ISSN இருந்தால், மேலே அதை உள்ளிடவும்.",

--- a/src/assets/i18n/te.json5
+++ b/src/assets/i18n/te.json5
@@ -9170,15 +9170,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "ప్రచురణకర్త ఓపెన్ యాక్సెస్ విధాన సమాచారం",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "ఫైళ్ళను అప్లోడ్ చేయండి",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "ప్రచురణకర్త ఓపెన్ యాక్సెస్ విధాన సమాచారం",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "ప్రచురణకర్త విధాన సమాచారం అందుబాటులో లేదు. మీ పనికి సంబంధించిన ISSN ఉంటే, దయచేసి సంబంధిత ప్రచురణకర్త ఓపెన్ యాక్సెస్ విధానాలను చూడటానికి దాన్ని పైన నమోదు చేయండి.",

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -10353,16 +10353,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Dosyaları yükle",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/uk.json5
+++ b/src/assets/i18n/uk.json5
@@ -10382,16 +10382,12 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
   // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Завантажені файли",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   // TODO New key - Add a translation

--- a/src/assets/i18n/vi.json5
+++ b/src/assets/i18n/vi.json5
@@ -9807,15 +9807,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Chính sách truy cập mở của nhà xuất bản",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "Tải tệp lên",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "Chính sách truy cập mở của nhà xuất bản",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "Không có chính sách của nhà xuất bản. Nếu tác phẩm của bạn có ISSN liên quan vui lòng nhập nó ở trên để xem các chính sách truy cập mở của nhà xuất bản (nếu có)",

--- a/src/assets/i18n/zh-TW.json5
+++ b/src/assets/i18n/zh-TW.json5
@@ -9293,15 +9293,11 @@
   // TODO New key - Add a translation
   "submission.sections.submit.progressbar.describe.owner": "Owner",
 
-  // "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.opfpolicy": "Jisc Open Policy Finder policies",
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "出版商開放獲取政策訊息",
 
   // "submission.sections.submit.progressbar.upload": "Upload files",
   "submission.sections.submit.progressbar.upload": "上傳文件",
-
-  // "submission.sections.submit.progressbar.jiscPolicies": "Publisher open access policy information",
-  "submission.sections.submit.progressbar.jiscPolicies": "出版商開放獲取政策訊息",
 
   // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
   "submission.sections.jisc-policy.title-empty": "沒有可用的發布者政策資訊。如果您的作品有關聯的 ISSN，請在上方輸入以查看任何相關的出版商開放取用政策。",


### PR DESCRIPTION
## Description

This PR removes the obsolete translation key `submission.sections.submit.progressbar.jiscPolicies` in all translation resources. The submission step `jiscPolicies` was renamed to `opfpolicy` in the DSpace backend configuration.