### PR TITLE
[Dependabot] For GitHub Actions, group together all actions officially built by GitHub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,6 +107,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+        - "actions/*"
+        - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
   #####################
   ## dspace-10_x branch
   #####################
@@ -210,6 +224,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+        - "actions/*"
+        - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
   #####################
   ## dspace-9_x branch
   #####################
@@ -313,6 +341,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+        - "actions/*"
+        - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
   #####################
   ## dspace-8_x branch
   #####################
@@ -415,3 +457,17 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+        - "actions/*"
+        - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## Description
Improves our configuration of `dependabot` for GitHub Actions by doing the following:
* Automatically group all actions officially created by GitHub into a single PR.
* Only update actions officially created by GitHub when a new **major** version is released.  
    * This is because we use a "rolling tag" (e.g. `@v2`) for officially GitHub actions.  For instance `@v2` means run the latest `2.x.x` version...so, it auto-updates already.  We only need to update our GitHub action when version 3 would be released.
    * NOTE: We do not use "rolling tag" versions for non-official actions, just for safety.  So, this only impacts official actions from GitHub.

This PR should be ported to `DSpace/DSpace` backend repo as well.  It only needs to be applied to the `main` branch though as that branch contains all dependabot rules.