### PR TITLE
Make advanced attachment element visibility configurable (checksum admin-only by default)

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -738,6 +738,10 @@ layout:
   showDownloadLinkAsAttachment: false
   # Configuration for advanced attachment rendering in item pages. This controls how files are displayed when showDownloadLinkAsAttachment is enabled.
   # Defines which metadata/attributes to display for bitstream attachments.
+  # Each element may set an optional "visibility" controlling who can see it:
+  #   public (default when omitted) - visible to everyone, including anonymous users
+  #   admin                         - visible only to site administrators
+  # To hide an element from everyone, remove it from the metadata list entirely.
   advancedAttachmentRendering:
     # Metadata and attributes to display for each attachment
     metadata:
@@ -756,6 +760,7 @@ layout:
         type: attribute
       - name: checksum
         type: attribute
+        visibility: admin
 
 # Configuration for customization of search results
 searchResults:

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
@@ -19,7 +19,7 @@
     </div>
 
     <div class="order-lg-2 w-100 mb-3">
-      @for (attachmentConf of metadataConfig;  track $index) {
+      @for (attachmentConf of (visibleMetadataConfig$ | async);  track $index) {
         @if (attachment.firstMetadataValue(attachmentConf.name) || attachmentConf.type === AdvancedAttachmentElementType.Attribute) {
           <div class="content" [attr.data-test]="attachmentConf.name">
             <strong>{{ 'layout.advanced-attachment.' + attachmentConf.name | translate }}</strong>

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
@@ -6,6 +6,7 @@ import {
 import { provideRouter } from '@angular/router';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
+import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
 import { LocaleService } from '@dspace/core/locale/locale.service';
 import { Bitstream } from '@dspace/core/shared/bitstream.model';
 import { Item } from '@dspace/core/shared/item.model';
@@ -42,8 +43,13 @@ describe('BitstreamAttachmentComponent', () => {
     getCurrentLanguageCode: of('en'),
     getLanguageCodeList: of(languageList),
   });
+  let authorizationService: jasmine.SpyObj<AuthorizationDataService>;
 
   beforeEach(async () => {
+    authorizationService = jasmine.createSpyObj('AuthorizationDataService', {
+      isAuthorized: of(true),
+    });
+
     await TestBed.configureTestingModule({
       imports: [
         BitstreamAttachmentComponent,
@@ -60,6 +66,7 @@ describe('BitstreamAttachmentComponent', () => {
         { provide: BitstreamDataService, useValue: {} },
         { provide: APP_CONFIG, useValue: environment },
         { provide: LocaleService, useValue: mockLocaleService },
+        { provide: AuthorizationDataService, useValue: authorizationService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
@@ -111,5 +118,26 @@ describe('BitstreamAttachmentComponent', () => {
     fixture.detectChanges();
     const badge = fixture.nativeElement.querySelector('.badge.bg-primary');
     expect(badge).toBeNull();
+  });
+
+  it('should display admin-only elements (checksum) for administrators', () => {
+    authorizationService.isAuthorized.and.returnValue(of(true));
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test="checksum"]')).toBeTruthy();
+  });
+
+  it('should hide admin-only elements (checksum) from non-administrators', () => {
+    authorizationService.isAuthorized.and.returnValue(of(false));
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test="checksum"]')).toBeNull();
+  });
+
+  it('should always display public elements (format) regardless of admin status', () => {
+    authorizationService.isAuthorized.and.returnValue(of(false));
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test="format"]')).toBeTruthy();
   });
 });

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
@@ -14,6 +14,7 @@ import {
 } from '@angular/router';
 import {
   AdvancedAttachmentElementType,
+  AdvancedAttachmentVisibility,
   AttachmentMetadataConfig,
 } from '@dspace/config/advanced-attachment-rendering.config';
 import {
@@ -21,6 +22,8 @@ import {
   AppConfig,
 } from '@dspace/config/app-config.interface';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
+import { AuthorizationDataService } from '@dspace/core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '@dspace/core/data/feature-authorization/feature-id';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import {
   Bitstream,
@@ -68,6 +71,12 @@ export class BitstreamAttachmentComponent implements OnInit {
    * Environment variables configuring the fields to be viewed
    */
   metadataConfig: AttachmentMetadataConfig[];
+
+  /**
+   * The configured attachment elements that the current user is allowed to see.
+   * Elements with visibility "admin" are only emitted for site administrators.
+   */
+  visibleMetadataConfig$: Observable<AttachmentMetadataConfig[]>;
 
   /**
    * All item providers to show buttons of
@@ -120,6 +129,7 @@ export class BitstreamAttachmentComponent implements OnInit {
     protected readonly translateService: TranslateService,
     protected readonly router: Router,
     protected readonly route: ActivatedRoute,
+    protected readonly authorizationService: AuthorizationDataService,
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) {
     this.metadataConfig = this.appConfig.layout.advancedAttachmentRendering.metadata;
@@ -131,6 +141,11 @@ export class BitstreamAttachmentComponent implements OnInit {
     ).subscribe((thumbnail: RemoteData<Bitstream>) => {
       this.thumbnail$.next(thumbnail);
     });
+    this.visibleMetadataConfig$ = this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      map((isAdmin: boolean) => this.metadataConfig.filter(
+        (config: AttachmentMetadataConfig) => config.visibility !== AdvancedAttachmentVisibility.Admin || isAdmin,
+      )),
+    );
     this.allAttachmentProviders = this.attachment?.allMetadataValues('bitstream.viewer.provider');
     this.bitstreamFormat$ = this.getFormat(this.attachment);
     this.bitstreamSize = this.getSize(this.attachment);

--- a/src/config/advanced-attachment-rendering.config.ts
+++ b/src/config/advanced-attachment-rendering.config.ts
@@ -12,6 +12,12 @@ export interface AttachmentMetadataConfig {
   name: string;
   type: AdvancedAttachmentElementType;
   truncatable?: boolean;
+  /**
+   * Controls who can see this attachment element.
+   * When omitted, the element is treated as {@link AdvancedAttachmentVisibility.Public}.
+   * To hide an element from everyone, remove it from the metadata list entirely.
+   */
+  visibility?: AdvancedAttachmentVisibility;
 }
 
 /**
@@ -20,5 +26,19 @@ export interface AttachmentMetadataConfig {
 export enum AdvancedAttachmentElementType {
   Metadata = 'metadata',
   Attribute = 'attribute'
+}
+
+/**
+ * Controls the audience that can see an advanced attachment element.
+ */
+export enum AdvancedAttachmentVisibility {
+  /**
+   * Visible to everyone, including anonymous users (default when no visibility is configured).
+   */
+  Public = 'public',
+  /**
+   * Visible only to site administrators.
+   */
+  Admin = 'admin'
 }
 

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -5,7 +5,10 @@ import { AccessibilitySettingsConfig } from './accessibility-settings.config';
 import { ActuatorsConfig } from './actuators.config';
 import { AddToAnyPluginConfig } from './add-to-any-plugin-config';
 import { AdminNotifyMetricsRow } from './admin-notify-metrics.config';
-import { AdvancedAttachmentElementType } from './advanced-attachment-rendering.config';
+import {
+  AdvancedAttachmentElementType,
+  AdvancedAttachmentVisibility,
+} from './advanced-attachment-rendering.config';
 import { AppConfig } from './app-config.interface';
 import { AuthConfig } from './auth-config.interfaces';
 import { BrowseByConfig } from './browse-by-config.interface';
@@ -812,6 +815,7 @@ export class DefaultAppConfig implements AppConfig {
         {
           name: 'checksum',
           type: AdvancedAttachmentElementType.Attribute,
+          visibility: AdvancedAttachmentVisibility.Admin,
         },
       ],
     },

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,5 +1,8 @@
 // This configuration is only used for unit tests, end-to-end tests use environment.production.ts
-import { AdvancedAttachmentElementType } from '@dspace/config/advanced-attachment-rendering.config';
+import {
+  AdvancedAttachmentElementType,
+  AdvancedAttachmentVisibility,
+} from '@dspace/config/advanced-attachment-rendering.config';
 import { NotificationAnimationsType } from '@dspace/config/notifications-config.interfaces';
 import { RestRequestMethod } from '@dspace/config/rest-request-method';
 import { BuildConfig } from 'src/config/build-config.interface';
@@ -600,6 +603,7 @@ export const environment: BuildConfig = {
         {
           name: 'checksum',
           type: AdvancedAttachmentElementType.Attribute,
+          visibility: AdvancedAttachmentVisibility.Admin,
         },
       ],
     },


### PR DESCRIPTION
## References

Fixes #5822

## Description

Makes the visibility of advanced attachment elements (such as the bitstream checksum) configurable on the item page, and defaults the checksum to admin-only so it is no longer shown to anonymous and regular users.

## Instructions for Reviewers

This only affects the **advanced attachment rendering** used on the item page when `layout.showDownloadLinkAsAttachment: true` (the `ds-bitstream-attachment` cards), which is the only place the checksum is rendered.

List of changes in this PR:
* Added an optional `visibility` property to each `layout.advancedAttachmentRendering.metadata` element, with two values:
  * `public` (the default when omitted) - visible to everyone, including anonymous users
  * `admin` - visible only to site administrators (gated on `FeatureID.AdministratorOf`)
  * To hide an element from everyone entirely, remove it from the metadata list (existing behavior).
* `BitstreamAttachmentComponent` now filters the configured elements by the current user's admin status before rendering (`visibleMetadataConfig$`).
* Set the default `checksum` element to `visibility: admin` in `default-app-config.ts` and `config.example.yml` (and the test environment), so out of the box the checksum is admin-only.
* Added unit tests covering admin-visible, admin-hidden, and always-public elements.

**How to test:**
1. Set `layout.showDownloadLinkAsAttachment: true` in your `config.*.yml`.
2. Open an item with a file as an anonymous user: the **Checksum** line is no longer shown.
3. Log in as an administrator and reload: the **Checksum** line appears.
4. Optionally change the `checksum` element's `visibility` to `public` (visible to all) or remove it (hidden from all) to confirm the three states.

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.
- [x] My PR **passes lint** validation.
- [x] My PR **passes all tests and includes new/updated Unit Tests**.
- [x] My PR **includes details on how to test it**.
- [ ] If my PR includes new libraries/dependencies: n/a.
- [ ] If my PR modifies REST API endpoints: n/a.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself (and in `config.example.yml`).
- [x] If my PR fixes an issue ticket, I've linked them together.
