### PR TITLE
Render the item-page thumbnail only once

### DIFF
--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.html
@@ -1,10 +1,6 @@
 @if (attachment) {
   <div class="d-flex flex-row flex-wrap flex-lg-nowrap card-container mt-1 mb-3 gap-3" data-test="attachment-info">
 
-    <div class="order-lg-1 thumbnail-wrapper">
-      <ds-thumbnail [thumbnail]="thumbnail$ | async"></ds-thumbnail>
-    </div>
-
     <div class="order-lg-3 ml-auto">
       <div class="d-flex flex-column align-items-end gap-3">
         <div class="text-nowrap">

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.scss
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.scss
@@ -24,10 +24,6 @@ i.custom-icon {
   vertical-align: middle;
 }
 
-.thumbnail-wrapper {
-  min-width: 120px;
-}
-
 .word-break {
   word-break: break-word;
 }

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.spec.ts
@@ -16,7 +16,6 @@ import {
   TranslateModule,
 } from '@ngx-translate/core';
 import { of } from 'rxjs';
-import { ThemedThumbnailComponent } from 'src/app/thumbnail/themed-thumbnail.component';
 
 import { environment } from '../../../environments/environment';
 import { TruncatableComponent } from '../truncatable/truncatable.component';
@@ -34,7 +33,6 @@ describe('BitstreamAttachmentComponent', () => {
         checkSumAlgorithm: 'MD5',
         value: 'checksum',
       },
-      thumbnail: createSuccessfulRemoteDataObject$(new Bitstream()),
     },
   );
   const languageList = ['en;q=1', 'de;q=0.8'];
@@ -63,7 +61,7 @@ describe('BitstreamAttachmentComponent', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
-      .overrideComponent(BitstreamAttachmentComponent, { remove: { imports: [ThemedThumbnailComponent, TruncatableComponent, TruncatablePartComponent, FileDownloadButtonComponent] } }).compileComponents();
+      .overrideComponent(BitstreamAttachmentComponent, { remove: { imports: [TruncatableComponent, TruncatablePartComponent, FileDownloadButtonComponent] } }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
+++ b/src/app/shared/bitstream-attachment/bitstream-attachment.component.ts
@@ -28,19 +28,16 @@ import {
 } from '@dspace/core/shared/bitstream.model';
 import { BitstreamFormat } from '@dspace/core/shared/bitstream-format.model';
 import { Item } from '@dspace/core/shared/item.model';
-import { getFirstCompletedRemoteData } from '@dspace/core/shared/operators';
 import {
   TranslateModule,
   TranslateService,
 } from '@ngx-translate/core';
 import {
-  BehaviorSubject,
   map,
   Observable,
   take,
 } from 'rxjs';
 
-import { ThemedThumbnailComponent } from '../../thumbnail/themed-thumbnail.component';
 import { TruncatableComponent } from '../truncatable/truncatable.component';
 import { TruncatablePartComponent } from '../truncatable/truncatable-part/truncatable-part.component';
 import { FileSizePipe } from '../utils/file-size-pipe';
@@ -55,7 +52,6 @@ import { FileDownloadButtonComponent } from './attachment-render/types/file-down
     AsyncPipe,
     FileDownloadButtonComponent,
     FileSizePipe,
-    ThemedThumbnailComponent,
     TitleCasePipe,
     TranslateModule,
     TruncatableComponent,
@@ -108,8 +104,6 @@ export class BitstreamAttachmentComponent implements OnInit {
    */
   checksumInfo: ChecksumInfo;
 
-  thumbnail$: BehaviorSubject<RemoteData<Bitstream>> = new BehaviorSubject<RemoteData<Bitstream>>(null);
-
   /**
    * Configuration type enum
    */
@@ -126,11 +120,6 @@ export class BitstreamAttachmentComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.attachment.thumbnail.pipe(
-      getFirstCompletedRemoteData(),
-    ).subscribe((thumbnail: RemoteData<Bitstream>) => {
-      this.thumbnail$.next(thumbnail);
-    });
     this.allAttachmentProviders = this.attachment?.allMetadataValues('bitstream.viewer.provider');
     this.bitstreamFormat$ = this.getFormat(this.attachment);
     this.bitstreamSize = this.getSize(this.attachment);


### PR DESCRIPTION
## References

Fixes #5821

## Description

Removes the duplicate thumbnail on the item page: the advanced attachment cards rendered their own thumbnail in addition to the item thumbnail already shown in the item-page sidebar.

## Instructions for Reviewers

This affects the **advanced attachment rendering** used on the item page when `layout.showDownloadLinkAsAttachment: true` (the `ds-bitstream-attachment` cards). Each card rendered a thumbnail (or the "no thumbnail" placeholder) for its bitstream, which duplicated the item-level thumbnail already rendered in the left sidebar (`col-md-4`), spending prime above-the-fold space on a second copy.

List of changes in this PR:
* Removed the per-attachment thumbnail block from `BitstreamAttachmentComponent`'s template.
* Removed the now-unused `thumbnail$` subject, its `ngOnInit` subscription, the `ThemedThumbnailComponent` import, and the dead `.thumbnail-wrapper` style.
* Updated the unit test setup accordingly.

The single item thumbnail rendered in the sidebar is retained; the attachment cards keep their file metadata and download button.

**How to test:**
1. Set `layout.showDownloadLinkAsAttachment: true` in your `config.*.yml`.
2. Open an item that has an attached file: only one thumbnail (the sidebar one) is shown; the attachment card no longer renders its own thumbnail/placeholder.
3. Confirm with a multi-file item and with an item that has no thumbnail (the placeholder also appears only once).

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.
- [x] My PR **passes lint** validation.
- [x] My PR **passes all tests** (existing Unit Tests updated).
- [x] My PR **includes details on how to test it**.
- [ ] If my PR includes new libraries/dependencies: n/a.
- [ ] If my PR modifies REST API endpoints: n/a.
- [ ] If my PR includes new configurations: n/a.
- [x] If my PR fixes an issue ticket, I've linked them together.
