### PR TITLE
[Dependabot] Pin `sass` version for DSpace 8.x as later versions do not support Node 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -436,6 +436,9 @@ updates:
         - "minor"
         - "patch"
     ignore:
+      # 8.x cannot update sass to v1.100.0 or later as those versions do not support Node v18
+      - dependency-name: "sass"
+        versions: [">=1.100.0"]
       # Restrict zone.js updates to patch level to avoid dependency conflicts with @angular/core
       - dependency-name: "zone.js"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## References
* Related to #5749 which failed because DSpace 8.x still supports Node 18.

## Description
Small PR which pins `sass` version to <1.100.0 for DSpace 8.x (only).  Version 1.100.0 now requires Node 20.19.0+, while DSpace 8.x still will support Node 18.
