### PR TITLE
Make the “New collection” menu option visible for Community Admins

### DIFF
--- a/src/app/shared/menu/providers/new.menu.spec.ts
+++ b/src/app/shared/menu/providers/new.menu.spec.ts
@@ -38,7 +38,7 @@ describe('NewMenuProvider', () => {
       },
     },
     {
-      visible: false,
+      visible: true,
       model: {
         type: MenuItemType.ONCLICK,
         text: 'menu.section.new_collection',

--- a/src/app/shared/menu/providers/new.menu.ts
+++ b/src/app/shared/menu/providers/new.menu.ts
@@ -54,12 +54,11 @@ export class NewMenuProvider extends AbstractExpandableMenuProvider {
 
   public getSubSections(): Observable<PartialMenuSection[]> {
     return combineLatest([
-      this.authorizationService.isAuthorized(FeatureID.IsCollectionAdmin),
       this.authorizationService.isAuthorized(FeatureID.IsCommunityAdmin),
       this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
       this.authorizationService.isAuthorized(FeatureID.CanSubmit),
       this.authorizationService.isAuthorized(FeatureID.CoarNotifyEnabled),
-    ]).pipe(map(([isCollectionAdmin, isCommunityAdmin, isSiteAdmin, canSubmit, isCoarNotifyEnabled]: [boolean, boolean, boolean, boolean, boolean]) => {
+    ]).pipe(map(([isCommunityAdmin, isSiteAdmin, canSubmit, isCoarNotifyEnabled]: [boolean, boolean, boolean, boolean]) => {
 
       return [
         {
@@ -73,7 +72,7 @@ export class NewMenuProvider extends AbstractExpandableMenuProvider {
           },
         },
         {
-          visible: isCollectionAdmin,
+          visible: isCommunityAdmin,
           model: {
             type: MenuItemType.ONCLICK,
             text: 'menu.section.new_collection',


### PR DESCRIPTION
## References
* Reported in https://groups.google.com/g/dspace-tech/c/wZ3AaF4lJAQ
* Related to https://github.com/DSpace/dspace-angular/pull/3994

## Description
Currently, visibility of the “New Collection” menu option is restricted to Collection Administrators, but it should instead be restricted to Community Administrators.

## Instructions for Reviewers
Verify that the issue reported in the linked message is no longer reproducible. In particular, confirm that Community Administrators who do not have permissions to administrate a collection can now see the “New Collection” option in the menu.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
