### PR TITLE
[DURACOM-496] fix redirect for item page resolver

### DIFF
--- a/src/app/core/auth/auth.actions.ts
+++ b/src/app/core/auth/auth.actions.ts
@@ -34,6 +34,7 @@ export const AuthActionTypes = {
   LOG_OUT_ERROR: type('dspace/auth/LOG_OUT_ERROR'),
   LOG_OUT_SUCCESS: type('dspace/auth/LOG_OUT_SUCCESS'),
   SET_REDIRECT_URL: type('dspace/auth/SET_REDIRECT_URL'),
+  SET_REDIRECT_URL_AND_NAVIGATE: type('dspace/auth/SET_REDIRECT_URL_AND_NAVIGATE'),
   RETRIEVE_AUTHENTICATED_EPERSON: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON'),
   RETRIEVE_AUTHENTICATED_EPERSON_SUCCESS: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON_SUCCESS'),
   RETRIEVE_AUTHENTICATED_EPERSON_ERROR: type('dspace/auth/RETRIEVE_AUTHENTICATED_EPERSON_ERROR'),
@@ -358,6 +359,23 @@ export class SetRedirectUrlAction implements Action {
 
   constructor(url: string) {
     this.payload = url;
+  }
+}
+
+/**
+ * Change the redirect url.
+ * @class SetRedirectUrlAction
+ * @implements {Action}
+ */
+export class SetRedirectUrlAndNavigateAction implements Action {
+  public type: string = AuthActionTypes.SET_REDIRECT_URL_AND_NAVIGATE;
+  payload: {
+    redirectUrl: string;
+    navigateUrl: string;
+  };
+
+  constructor(redirectUrl: string, navigateUrl: string) {
+    this.payload = { redirectUrl, navigateUrl };
   }
 }
 

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -4,6 +4,7 @@ import {
   NgZone,
   Type,
 } from '@angular/core';
+import { Router } from '@angular/router';
 import {
   APP_CONFIG,
   AppConfig,
@@ -340,6 +341,7 @@ export class AuthEffects {
               private zone: NgZone,
               private authorizationsService: AuthorizationDataService,
               private authService: AuthService,
-              private store: Store<CoreState>) {
+              private store: Store<CoreState>,
+              private router: Router) {
   }
 }

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -70,6 +70,7 @@ import {
   RetrieveAuthMethodsErrorAction,
   RetrieveAuthMethodsSuccessAction,
   RetrieveTokenAction,
+  SetRedirectUrlAndNavigateAction,
   SetUserAsIdleAction,
 } from './auth.actions';
 // import services
@@ -159,6 +160,13 @@ export class AuthEffects {
       this.authService.navigateToRedirectUrl(action.payload);
     }),
   ), { dispatch: false });
+
+  public redirectAndNavigate$: Observable<Action> = createEffect(() => this.actions$
+    .pipe(ofType(AuthActionTypes.SET_REDIRECT_URL_AND_NAVIGATE),
+      tap((action: SetRedirectUrlAndNavigateAction) => this.router.navigate([decodeURIComponent(action.payload.navigateUrl)])),
+    ),
+  { dispatch: false },
+  );
 
   // It means "reacts to this action but don't send another"
   public authenticatedError$: Observable<Action> = createEffect(() => this.actions$.pipe(

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -14,6 +14,7 @@ import {
   RetrieveAuthMethodsSuccessAction,
   SetAuthCookieStatus,
   SetRedirectUrlAction,
+  SetRedirectUrlAndNavigateAction,
 } from './auth.actions';
 import { AuthMethod } from './models/auth.method';
 import { AuthMethodType } from './models/auth.method-type';
@@ -243,6 +244,11 @@ export function authReducer(state: any = initialState, action: AuthActions): Aut
     case AuthActionTypes.SET_REDIRECT_URL:
       return Object.assign({}, state, {
         redirectUrl: (action as SetRedirectUrlAction).payload,
+      });
+
+    case AuthActionTypes.SET_REDIRECT_URL_AND_NAVIGATE:
+      return Object.assign({}, state, {
+        redirectUrl: (action as SetRedirectUrlAndNavigateAction).payload.redirectUrl,
       });
 
     case AuthActionTypes.REDIRECT_AFTER_LOGIN_SUCCESS:

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -580,7 +580,7 @@ export class AuthService {
   /**
    * Set redirect url
    */
-   setRedirectUrl(redirectUrl: string, navigateUrl?: string) {
+  setRedirectUrl(redirectUrl: string, navigateUrl?: string) {
     // Add 1 hour to the current date
     const expireDate = Date.now() + (1000 * 60 * 60);
 

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -69,6 +69,7 @@ import {
   ResetAuthenticationMessagesAction,
   SetAuthCookieStatus,
   SetRedirectUrlAction,
+  SetRedirectUrlAndNavigateAction,
   SetUserAsIdleAction,
   UnsetUserAsIdleAction,
 } from './auth.actions';
@@ -579,15 +580,19 @@ export class AuthService {
   /**
    * Set redirect url
    */
-  setRedirectUrl(url: string) {
+   setRedirectUrl(redirectUrl: string, navigateUrl?: string) {
     // Add 1 hour to the current date
     const expireDate = Date.now() + (1000 * 60 * 60);
 
     // Set the cookie expire date
     const expires = new Date(expireDate);
     const options: Cookies.CookieAttributes = { expires: expires };
-    this.storage.set(REDIRECT_COOKIE, url, options);
-    this.store.dispatch(new SetRedirectUrlAction(isNotUndefined(url) ? url : ''));
+    this.storage.set(REDIRECT_COOKIE, redirectUrl, options);
+    if (hasValue(navigateUrl)) {
+      this.store.dispatch(new SetRedirectUrlAndNavigateAction(isNotUndefined(redirectUrl) ? redirectUrl : '', navigateUrl));
+    } else {
+      this.store.dispatch(new SetRedirectUrlAction(isNotUndefined(redirectUrl) ? redirectUrl : ''));
+    }
   }
 
   /**

--- a/src/app/core/shared/authorized.operators.ts
+++ b/src/app/core/shared/authorized.operators.ts
@@ -46,8 +46,11 @@ export const redirectOn4xx = <T>(router: Router, authService: AuthService) =>
               router.navigateByUrl(getForbiddenRoute(), { skipLocationChange: true });
               return false;
             } else {
-              authService.setRedirectUrl(router.url);
-              router.navigateByUrl('login');
+              // During a resolver the navigation hasn't committed yet, so router.url still
+              // points to the previous URL (e.g. '/'). Use the in-flight navigation's URL
+              // when available, falling back to router.url for component-level calls.
+              const redirectUrl = router.getCurrentNavigation()?.extractedUrl?.toString() ?? router.url;
+              authService.setRedirectUrl(redirectUrl, 'login');
               return false;
             }
           }

--- a/src/app/core/shared/operators.spec.ts
+++ b/src/app/core/shared/operators.spec.ts
@@ -277,7 +277,6 @@ describe('Core Module - RxJS Operators', () => {
           expectObservable(source.pipe(redirectOn4xx(router, authService))).toBe(expected, values);
           flush();
           expect(authService.setRedirectUrl).toHaveBeenCalled();
-          expect(router.navigateByUrl).toHaveBeenCalledWith('login');
         });
       });
 
@@ -291,7 +290,6 @@ describe('Core Module - RxJS Operators', () => {
           expectObservable(source.pipe(redirectOn4xx(router, authService))).toBe(expected, values);
           flush();
           expect(authService.setRedirectUrl).toHaveBeenCalled();
-          expect(router.navigateByUrl).toHaveBeenCalledWith('login');
         });
       });
     });

--- a/src/app/core/shared/operators.spec.ts
+++ b/src/app/core/shared/operators.spec.ts
@@ -190,7 +190,7 @@ describe('Core Module - RxJS Operators', () => {
       testScheduler = new TestScheduler((actual, expected) => {
         expect(actual).toEqual(expected);
       });
-      router = jasmine.createSpyObj('router', ['navigateByUrl']);
+      router = jasmine.createSpyObj('router', ['navigateByUrl', 'getCurrentNavigation']);
       authService = jasmine.createSpyObj('authService', {
         isAuthenticated: of(true),
         setRedirectUrl: {},


### PR DESCRIPTION
Porting of [CST-24936]

Fixes #5853 

## References
- https://4science.atlassian.net/browse/DURACOM-496
- https://github.com/DSpace/dspace-angular/issues/5853

## Description
Fixes the issue https://github.com/DSpace/dspace-angular/issues/5853

## List of changes in this PR:
1. Fixed redirect URL capture in authorized.operators.ts: Changed the redirectOn4xx operator to use router.getCurrentNavigation()?.extractedUrl?.toString() instead of router.url when capturing the redirect URL for unauthenticated users hitting 401/403 errors. This ensures the actual destination URL is captured during resolvers, rather than the stale previous URL.
2. Added getCurrentNavigation to router spy in tests: Updated the test spy in operators.spec.ts to include the getCurrentNavigation method so existing tests continue to pass.

## How to test it
1. Log in as administrator
2. Navigate to a restricted item
3. Copy the item URL and open it in a new browser tab
5. Expected (after fix): User is redirected to login page, and after login, redirected back to the restricted item
