### PR TITLE
Fix OpenSearch service and search URL construction

### DIFF
--- a/src/app/shared/rss-feed/rss.component.ts
+++ b/src/app/shared/rss-feed/rss.component.ts
@@ -221,7 +221,7 @@ export class RSSComponent implements OnInit, OnDestroy, OnChanges {
     if (fixedFilter) {
       route += '&' + fixedFilter;
     }
-    route = '/' + opensearch + '?' + route;
+    route = '/' + opensearch + '/search' + '?' + route;
     return route;
   }
 


### PR DESCRIPTION
## References
* Requires Backend DSpace PR https://github.com/DSpace/DSpace/pull/12700

## Description
OpenSearch service URLs in DSpace 7.0 - 10.0 are broken, because they are prefixed with the full `opensearch/search` path instead of just `opensearch/`. This PR along with the related PR ensure that correct service and search URLs are constructed.

## Instructions for Reviewers

**Note to reviewers re: failing unit tests** - these failures are due to the fact that the main branch currently has `/opensearch/search` set as the svccontext value, so search URLs end up as `/opensearch/search/search` in current tests. Once https://github.com/DSpace/DSpace/pull/12700 is merged, these tests will pass.

**Changes**:
* Update `rss.component.ts` so that the `websvc.opensearch.svccontext` is treated as a true base path (matching the controller mapping)
* Change `updateRssLinks()` method so that it appends `/search` to the search URLs and `/service` to the service URL as appropriate

**To Test**:

Test instructions are the same as the backend PR: https://github.com/DSpace/DSpace/pull/12700

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.