### PR TITLE
Support multiple search instances on a single page (main)

### DIFF
--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -90,6 +90,7 @@ describe('SearchConfigurationService', () => {
     }));
 
     service = new SearchConfigurationService(routeService, paginationService as any, activatedRoute as any, linkService, halService, requestService, rdb, environment);
+    service.searchInstanceId = defaults.pagination.id;
   });
 
   describe('when the scope is called', () => {
@@ -181,7 +182,7 @@ describe('SearchConfigurationService', () => {
 
     describe('when subscribeToSearchOptions is called', () => {
       beforeEach(() => {
-        (service as any).subscribeToSearchOptions(defaults);
+        (service as any).subscribeToSearchOptions(defaults.pagination.id, defaults);
       });
       it('should call all getters it needs, but not call any others', () => {
         expect(service.getCurrentPagination).not.toHaveBeenCalled();
@@ -198,14 +199,14 @@ describe('SearchConfigurationService', () => {
       beforeEach(() => {
         (service as any).subscribeToPaginatedSearchOptions(defaults.pagination.id, defaults);
       });
-      it('should call all getters it needs', () => {
+      it('should call the pagination-specific getters it needs', () => {
         expect(service.getCurrentPagination).toHaveBeenCalled();
         expect(service.getCurrentSort).toHaveBeenCalled();
-        expect(service.getCurrentScope).toHaveBeenCalled();
-        expect(service.getCurrentConfiguration).toHaveBeenCalled();
-        expect(service.getCurrentQuery).toHaveBeenCalled();
-        expect(service.getCurrentDSOType).toHaveBeenCalled();
-        expect(service.getCurrentFilters).toHaveBeenCalled();
+        expect(service.getCurrentScope).not.toHaveBeenCalled();
+        expect(service.getCurrentConfiguration).not.toHaveBeenCalled();
+        expect(service.getCurrentQuery).not.toHaveBeenCalled();
+        expect(service.getCurrentDSOType).not.toHaveBeenCalled();
+        expect(service.getCurrentFilters).not.toHaveBeenCalled();
       });
     });
   });
@@ -314,13 +315,13 @@ describe('SearchConfigurationService', () => {
     it('should return all params except the applied filter', () => {
       service.unselectAppliedFilterParams(appliedFilter.filter, appliedFilter.value, appliedFilter.operator);
 
-      expect(routeService.getParamsExceptValue).toHaveBeenCalledWith('f.author', '1282121b-5394-4689-ab93-78d537764052,authority');
+      expect(routeService.getParamsExceptValue).toHaveBeenCalledWith(`${defaults.pagination.id}.f.author`, '1282121b-5394-4689-ab93-78d537764052,authority');
     });
 
     it('should be able to remove AppliedFilter without operator', () => {
       service.unselectAppliedFilterParams('dateIssued.max', '2000');
 
-      expect(routeService.getParamsExceptValue).toHaveBeenCalledWith('f.dateIssued.max', '2000');
+      expect(routeService.getParamsExceptValue).toHaveBeenCalledWith(`${defaults.pagination.id}.f.dateIssued.max`, '2000');
     });
 
     it('should reset the page to 1', (done: DoneFn) => {
@@ -346,13 +347,13 @@ describe('SearchConfigurationService', () => {
     it('should return all params with the applied filter', () => {
       service.selectNewAppliedFilterParams(appliedFilter.filter, appliedFilter.value, appliedFilter.operator);
 
-      expect(routeService.getParamsWithAdditionalValue).toHaveBeenCalledWith('f.author', '1282121b-5394-4689-ab93-78d537764052,authority');
+      expect(routeService.getParamsWithAdditionalValue).toHaveBeenCalledWith(`${defaults.pagination.id}.f.author`, '1282121b-5394-4689-ab93-78d537764052,authority');
     });
 
     it('should be able to add AppliedFilter without operator', () => {
       service.selectNewAppliedFilterParams('dateIssued.max', '2000');
 
-      expect(routeService.getParamsWithAdditionalValue).toHaveBeenCalledWith('f.dateIssued.max', '2000');
+      expect(routeService.getParamsWithAdditionalValue).toHaveBeenCalledWith(`${defaults.pagination.id}.f.dateIssued.max`, '2000');
     });
 
     it('should reset the page to 1', (done: DoneFn) => {

--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -300,6 +300,29 @@ describe('SearchConfigurationService', () => {
     });
   });
 
+  describe('isLegacySearchParam', () => {
+    it('should return true for unprefixed scoped search params', () => {
+      ['configuration', 'scope', 'query', 'dsoType', 'view'].forEach((param: string) => {
+        expect(service.isLegacySearchParam(param)).toBeTrue();
+      });
+    });
+
+    it('should return true for unprefixed filter params', () => {
+      expect(service.isLegacySearchParam('f.author')).toBeTrue();
+      expect(service.isLegacySearchParam('f.dateIssued.max')).toBeTrue();
+    });
+
+    it('should return false for params that are already prefixed with a search instance id', () => {
+      expect(service.isLegacySearchParam(`${defaults.pagination.id}.query`)).toBeFalse();
+      expect(service.isLegacySearchParam(`${defaults.pagination.id}.f.author`)).toBeFalse();
+    });
+
+    it('should return false for unrelated params', () => {
+      expect(service.isLegacySearchParam('page')).toBeFalse();
+      expect(service.isLegacySearchParam('spc.page')).toBeFalse();
+    });
+  });
+
   describe('unselectAppliedFilterParams', () => {
     let appliedFilter: AppliedFilter;
 

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -90,6 +90,13 @@ export class SearchConfigurationService implements OnDestroy {
   public searchInstanceId = 'spc';
 
   /**
+   * The names of the query parameters that are scoped to a search instance, but that still accept a
+   * legacy (unprefixed) value for backwards compatibility. Filter parameters (prefixed with `f.`) are
+   * handled separately, see {@link isLegacySearchParam}.
+   */
+  protected readonly legacyScopedQueryParams: string[] = ['configuration', 'scope', 'query', 'dsoType', 'view'];
+
+  /**
    * Emits the current search options
    */
   public searchOptions: BehaviorSubject<SearchOptions>;
@@ -346,6 +353,18 @@ export class SearchConfigurationService implements OnDestroy {
 
   getSearchInstanceFilterParamPrefix(searchInstanceId = this.searchInstanceId): string {
     return this.getSearchInstanceParam(searchInstanceId, 'f.');
+  }
+
+  /**
+   * Whether the given query parameter is a legacy (unprefixed) search parameter that has a
+   * search-instance-prefixed equivalent (e.g. `query`, `scope` or a `f.xxx` filter). These
+   * parameters are still read for backwards compatibility, but should be migrated to their
+   * prefixed form so they don't get mixed with newly added prefixed parameters.
+   *
+   * @param paramName The query parameter name
+   */
+  isLegacySearchParam(paramName: string): boolean {
+    return this.legacyScopedQueryParams.includes(paramName) || paramName.startsWith('f.');
   }
 
   getCurrentPageParam(): string {

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -85,9 +85,9 @@ export class SearchConfigurationService implements OnDestroy {
   private facetLinkPathPrefix = 'discover/facets/';
 
   /**
-   * Default pagination id
+   * Default search instance id
    */
-  public paginationID = 'spc';
+  public searchInstanceId = 'spc';
 
   /**
    * Emits the current search options
@@ -103,7 +103,7 @@ export class SearchConfigurationService implements OnDestroy {
    * Default pagination settings
    */
   protected defaultPagination = Object.assign(new PaginationComponentOptions(), {
-    id: this.paginationID,
+    id: this.searchInstanceId,
     pageSize: 10,
     currentPage: 1,
   });
@@ -158,13 +158,15 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current configuration string
    */
-  getCurrentConfiguration(defaultConfiguration: string) {
+  getCurrentConfiguration(defaultConfiguration: string, searchInstanceId = this.searchInstanceId) {
     return observableCombineLatest([
+      this.routeService.getQueryParameterValue(this.getSearchInstanceParam(searchInstanceId, 'configuration')).pipe(startWith(undefined)),
+      this.routeService.getRouteParameterValue(this.getSearchInstanceParam(searchInstanceId, 'configuration')).pipe(startWith(undefined)),
       this.routeService.getQueryParameterValue('configuration').pipe(startWith(undefined)),
       this.routeService.getRouteParameterValue('configuration').pipe(startWith(undefined)),
     ]).pipe(
-      map(([queryConfig, routeConfig]) => {
-        return queryConfig || routeConfig || defaultConfiguration;
+      map(([instanceQueryConfig, instanceRouteConfig, queryConfig, routeConfig]) => {
+        return instanceQueryConfig || instanceRouteConfig || queryConfig || routeConfig || defaultConfiguration;
       }),
     );
   }
@@ -172,8 +174,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current scope's identifier
    */
-  getCurrentScope(defaultScope: string) {
-    return this.routeService.getQueryParameterValue('scope').pipe(map((scope) => {
+  getCurrentScope(defaultScope: string, searchInstanceId = this.searchInstanceId) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'scope').pipe(map((scope) => {
       return scope || defaultScope;
     }));
   }
@@ -181,17 +183,17 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current query string
    */
-  getCurrentQuery(defaultQuery: string) {
-    return this.routeService.getQueryParameterValue('query').pipe(map((query) => {
-      return query || defaultQuery;
+  getCurrentQuery(defaultQuery: string, searchInstanceId = this.searchInstanceId) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'query').pipe(map((query) => {
+      return hasValue(query) ? query : defaultQuery;
     }));
   }
 
   /**
    * @returns {Observable<number>} Emits the current DSpaceObject type as a number
    */
-  getCurrentDSOType(): Observable<DSpaceObjectType> {
-    return this.routeService.getQueryParameterValue('dsoType').pipe(
+  getCurrentDSOType(searchInstanceId = this.searchInstanceId): Observable<DSpaceObjectType> {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'dsoType').pipe(
       filter((type) => isNotEmpty(type) && hasValue(DSpaceObjectType[type.toUpperCase()])),
       map((type) => DSpaceObjectType[type.toUpperCase()]));
   }
@@ -213,20 +215,21 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<Params>} Emits the current active filters with their values as they are sent to the backend
    */
-  getCurrentFilters(): Observable<SearchFilter[]> {
-    return this.routeService.getQueryParamsWithPrefix('f.').pipe(map((filterParams) => {
+  getCurrentFilters(searchInstanceId = this.searchInstanceId): Observable<SearchFilter[]> {
+    return this.getCurrentFrontendFilters(searchInstanceId).pipe(map((filterParams) => {
       if (isNotEmpty(filterParams)) {
         const filters = [];
-        Object.keys(filterParams).forEach((key) => {
+        const backendFilterParams = this.getBackendFilterParams(filterParams, searchInstanceId);
+        Object.keys(backendFilterParams).forEach((key) => {
           if (key.endsWith('.min') || key.endsWith('.max')) {
             const realKey = key.slice(0, -4);
             if (hasNoValue(filters.find((f) => f.key === realKey))) {
-              const min = filterParams[realKey + '.min'] ? filterParams[realKey + '.min'][0] : '*';
-              const max = filterParams[realKey + '.max'] ? filterParams[realKey + '.max'][0] : '*';
+              const min = backendFilterParams[realKey + '.min'] ? backendFilterParams[realKey + '.min'][0] : '*';
+              const max = backendFilterParams[realKey + '.max'] ? backendFilterParams[realKey + '.max'][0] : '*';
               filters.push(new SearchFilter(realKey, ['[' + min + ' TO ' + max + ']'], 'equals'));
             }
           } else {
-            filters.push(new SearchFilter(key, filterParams[key]));
+            filters.push(new SearchFilter(key, backendFilterParams[key]));
           }
         });
         return filters;
@@ -238,22 +241,32 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current fixed filter as a string
    */
-  getCurrentFixedFilter(): Observable<string> {
-    return this.routeService.getRouteParameterValue('fixedFilterQuery');
+  getCurrentFixedFilter(searchInstanceId = this.searchInstanceId): Observable<string> {
+    return observableCombineLatest([
+      this.routeService.getRouteParameterValue(this.getSearchInstanceParam(searchInstanceId, 'fixedFilterQuery')).pipe(startWith(undefined)),
+      this.routeService.getRouteParameterValue('fixedFilterQuery').pipe(startWith(undefined)),
+    ]).pipe(
+      map(([instanceFixedFilter, fixedFilter]) => instanceFixedFilter || fixedFilter),
+    );
   }
 
   /**
    * @returns {Observable<Params>} Emits the current active filters with their values as they are displayed in the frontend URL
    */
-  getCurrentFrontendFilters(): Observable<Params> {
-    return this.routeService.getQueryParamsWithPrefix('f.');
+  getCurrentFrontendFilters(searchInstanceId = this.searchInstanceId): Observable<Params> {
+    return observableCombineLatest([
+      this.routeService.getQueryParamsWithPrefix(this.getSearchInstanceFilterParamPrefix(searchInstanceId)).pipe(startWith({})),
+      this.routeService.getQueryParamsWithPrefix('f.').pipe(startWith({})),
+    ]).pipe(map(([instanceFilters, legacyFilters]) => {
+      return isNotEmpty(instanceFilters) ? instanceFilters : legacyFilters;
+    }));
   }
 
   /**
    * @returns {Observable<string>} Emits the current view mode
    */
-  getCurrentViewMode(defaultViewMode: ViewMode) {
-    return this.routeService.getQueryParameterValue('view').pipe(map((viewMode) => {
+  getCurrentViewMode(defaultViewMode: ViewMode, searchInstanceId = this.searchInstanceId) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'view').pipe(map((viewMode) => {
       return viewMode || defaultViewMode;
     }));
   }
@@ -296,22 +309,66 @@ export class SearchConfigurationService implements OnDestroy {
     );
   }
 
-  setPaginationId(paginationId): void {
-    if (isNotEmpty(paginationId)) {
+  setSearchInstanceId(searchInstanceId): void {
+    if (isNotEmpty(searchInstanceId)) {
       const currentValue: PaginatedSearchOptions = this.paginatedSearchOptions.getValue();
       const updatedValue: PaginatedSearchOptions = Object.assign(new PaginatedSearchOptions({}), currentValue, {
         pagination: Object.assign({}, currentValue.pagination, {
-          id: paginationId,
+          id: searchInstanceId,
         }),
       });
-      // unsubscribe from subscription related to old pagination id
-      this.unsubscribeFromSearchOptions(this.paginationID);
+      // unsubscribe from subscription related to old search instance id
+      this.unsubscribeFromSearchOptions(this.searchInstanceId);
 
-      // change to the new pagination id
-      this.paginationID = paginationId;
+      // change to the new search instance id
+      this.searchInstanceId = searchInstanceId;
       this.paginatedSearchOptions.next(updatedValue);
-      this.setSearchSubscription(this.paginationID, this.paginatedSearchOptions.value);
+      this.setSearchSubscription(this.searchInstanceId, this.paginatedSearchOptions.value);
     }
+  }
+
+  getSearchInstanceParam(searchInstanceId: string, parameterName: string): string {
+    return `${searchInstanceId}.${parameterName}`;
+  }
+
+  getCurrentSearchInstanceParam(parameterName: string): string {
+    return this.getSearchInstanceParam(this.searchInstanceId, parameterName);
+  }
+
+  getSearchInstanceFilterParam(filterName: string, searchInstanceId = this.searchInstanceId): string {
+    const filterParamName = filterName.startsWith('f.') ? filterName : `f.${filterName}`;
+    return this.getSearchInstanceParam(searchInstanceId, filterParamName);
+  }
+
+  getCurrentSearchInstanceFilterParam(filterName: string): string {
+    return this.getSearchInstanceFilterParam(filterName, this.searchInstanceId);
+  }
+
+  getSearchInstanceFilterParamPrefix(searchInstanceId = this.searchInstanceId): string {
+    return this.getSearchInstanceParam(searchInstanceId, 'f.');
+  }
+
+  getCurrentPageParam(): string {
+    return this.paginationService.getPageParam(this.searchInstanceId);
+  }
+
+  private getCurrentSearchInstanceQueryParam(searchInstanceId: string, parameterName: string): Observable<string> {
+    return observableCombineLatest([
+      this.routeService.getQueryParameterValue(this.getSearchInstanceParam(searchInstanceId, parameterName)).pipe(startWith(undefined)),
+      this.routeService.getQueryParameterValue(parameterName).pipe(startWith(undefined)),
+    ]).pipe(
+      map(([instanceValue, legacyValue]) => hasValue(instanceValue) ? instanceValue : legacyValue),
+    );
+  }
+
+  private getBackendFilterParams(filterParams: Params, searchInstanceId: string): Params {
+    const backendFilterParams = {};
+    const instancePrefix = `${searchInstanceId}.`;
+    Object.keys(filterParams).forEach((key) => {
+      const backendKey = key.startsWith(instancePrefix) ? key.substring(instancePrefix.length) : key;
+      backendFilterParams[backendKey] = filterParams[key];
+    });
+    return backendFilterParams;
   }
 
   /**
@@ -337,17 +394,18 @@ export class SearchConfigurationService implements OnDestroy {
         const defs = defRD.payload;
         this.paginatedSearchOptions = new BehaviorSubject<PaginatedSearchOptions>(defs);
         this.searchOptions = new BehaviorSubject<SearchOptions>(defs);
-        this.setSearchSubscription(this.paginationID, defs);
+        this.setSearchSubscription(this.searchInstanceId, defs);
       });
   }
 
-  private setSearchSubscription(paginationID: string, defaults: PaginatedSearchOptions) {
-    this.unsubscribeFromSearchOptions(paginationID);
+  private setSearchSubscription(searchInstanceId: string, defaults: PaginatedSearchOptions) {
+    const instanceId = searchInstanceId || defaults.pagination.id;
+    this.unsubscribeFromSearchOptions(instanceId);
     const subs = [
-      this.subscribeToSearchOptions(defaults),
-      this.subscribeToPaginatedSearchOptions(paginationID || defaults.pagination.id, defaults),
+      this.subscribeToSearchOptions(instanceId, defaults),
+      this.subscribeToPaginatedSearchOptions(instanceId, defaults),
     ];
-    this.subs.set(this.paginationID, subs);
+    this.subs.set(instanceId, subs);
   }
 
   /**
@@ -355,39 +413,38 @@ export class SearchConfigurationService implements OnDestroy {
    * @param {SearchOptions} defaults Default values for when no parameters are available
    * @returns {Subscription} The subscription to unsubscribe from
    */
-  private subscribeToSearchOptions(defaults: SearchOptions): Subscription {
+  private subscribeToSearchOptions(searchInstanceId: string, defaults: SearchOptions): Subscription {
     return observableMerge(
-      this.getConfigurationPart(defaults.configuration),
-      this.getScopePart(defaults.scope),
-      this.getQueryPart(defaults.query),
-      this.getDSOTypePart(),
-      this.getFiltersPart(),
-      this.getFixedFilterPart(),
-      this.getViewModePart(defaults.view),
+      this.getConfigurationPart(searchInstanceId, defaults.configuration),
+      this.getScopePart(searchInstanceId, defaults.scope),
+      this.getQueryPart(searchInstanceId, defaults.query),
+      this.getDSOTypePart(searchInstanceId),
+      this.getFiltersPart(searchInstanceId),
+      this.getFixedFilterPart(searchInstanceId),
+      this.getViewModePart(searchInstanceId, defaults.view),
     ).subscribe((update) => {
       const currentValue: SearchOptions = this.searchOptions.getValue();
-      const updatedValue: SearchOptions = Object.assign(new PaginatedSearchOptions({}), currentValue, update);
+      const updatedValue: SearchOptions = Object.assign(new SearchOptions({}), currentValue, update);
       this.searchOptions.next(updatedValue);
     });
   }
 
   /**
    * Sets up a subscription to all necessary parameters to make sure the paginatedSearchOptions emits a new value every time they update
-   * @param {string} paginationId The pagination ID
+   * @param {string} searchInstanceId The search instance id
    * @param {PaginatedSearchOptions} defaults Default values for when no parameters are available
    * @returns {Subscription} The subscription to unsubscribe from
    */
-  private subscribeToPaginatedSearchOptions(paginationId: string, defaults: PaginatedSearchOptions): Subscription {
+  private subscribeToPaginatedSearchOptions(searchInstanceId: string, defaults: PaginatedSearchOptions): Subscription {
     return observableMerge(
-      this.getConfigurationPart(defaults.configuration),
-      this.getPaginationPart(paginationId, defaults.pagination),
-      this.getSortPart(paginationId, defaults.sort),
-      this.getScopePart(defaults.scope),
-      this.getQueryPart(defaults.query),
-      this.getDSOTypePart(),
-      this.getFiltersPart(),
-      this.getFixedFilterPart(),
-      this.getViewModePart(defaults.view),
+      this.searchOptions.pipe(map((searchOptions: any) => {
+        const update = Object.assign({}, searchOptions);
+        delete update.pagination;
+        delete update.sort;
+        return update;
+      })),
+      this.getPaginationPart(searchInstanceId, defaults.pagination),
+      this.getSortPart(searchInstanceId, defaults.sort),
     ).subscribe((update) => {
       const currentValue: PaginatedSearchOptions = this.paginatedSearchOptions.getValue();
       const updatedValue: PaginatedSearchOptions = Object.assign(new PaginatedSearchOptions({}), currentValue, update);
@@ -396,23 +453,23 @@ export class SearchConfigurationService implements OnDestroy {
   }
 
   /**
-   * Unsubscribe from all subscriptions related to the given paginationID
-   * @param paginationId The pagination id
+   * Unsubscribe from all subscriptions related to the given search instance id
+   * @param searchInstanceId The search instance id
    */
-  private unsubscribeFromSearchOptions(paginationId: string): void {
-    if (this.subs.has(this.paginationID)) {
-      this.subs.get(this.paginationID)
+  private unsubscribeFromSearchOptions(searchInstanceId: string): void {
+    if (this.subs.has(searchInstanceId)) {
+      this.subs.get(searchInstanceId)
         .filter((sub) => hasValue(sub))
         .forEach((sub) => sub.unsubscribe());
-      this.subs.delete(paginationId);
+      this.subs.delete(searchInstanceId);
     }
   }
 
   /**
    * @returns {Observable<string>} Emits the current configuration settings as a partial SearchOptions object
    */
-  private getConfigurationPart(defaultConfiguration: string): Observable<any> {
-    return this.getCurrentConfiguration(defaultConfiguration).pipe(map((configuration) => {
+  private getConfigurationPart(searchInstanceId: string, defaultConfiguration: string): Observable<any> {
+    return this.getCurrentConfiguration(defaultConfiguration, searchInstanceId).pipe(map((configuration) => {
       return { configuration };
     }));
   }
@@ -420,8 +477,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current scope's identifier
    */
-  private getScopePart(defaultScope: string): Observable<any> {
-    return this.getCurrentScope(defaultScope).pipe(map((scope) => {
+  private getScopePart(searchInstanceId: string, defaultScope: string): Observable<any> {
+    return this.getCurrentScope(defaultScope, searchInstanceId).pipe(map((scope) => {
       return { scope };
     }));
   }
@@ -429,8 +486,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current query string as a partial SearchOptions object
    */
-  private getQueryPart(defaultQuery: string): Observable<any> {
-    return this.getCurrentQuery(defaultQuery).pipe(map((query) => {
+  private getQueryPart(searchInstanceId: string, defaultQuery: string): Observable<any> {
+    return this.getCurrentQuery(defaultQuery, searchInstanceId).pipe(map((query) => {
       return { query };
     }));
   }
@@ -438,8 +495,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current query string as a partial SearchOptions object
    */
-  private getDSOTypePart(): Observable<any> {
-    return this.getCurrentDSOType().pipe(map((dsoType) => {
+  private getDSOTypePart(searchInstanceId: string): Observable<any> {
+    return this.getCurrentDSOType(searchInstanceId).pipe(map((dsoType) => {
       return { dsoType };
     }));
   }
@@ -465,8 +522,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<Params>} Emits the current active filters as a partial SearchOptions object
    */
-  private getFiltersPart(): Observable<any> {
-    return this.getCurrentFilters().pipe(map((filters) => {
+  private getFiltersPart(searchInstanceId: string): Observable<any> {
+    return this.getCurrentFilters(searchInstanceId).pipe(map((filters) => {
       return { filters };
     }));
   }
@@ -474,8 +531,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<string>} Emits the current fixed filter as a partial SearchOptions object
    */
-  private getFixedFilterPart(): Observable<any> {
-    return this.getCurrentFixedFilter().pipe(
+  private getFixedFilterPart(searchInstanceId: string): Observable<any> {
+    return this.getCurrentFixedFilter(searchInstanceId).pipe(
       isNotEmptyOperator(),
       map((fixedFilter) => {
         return { fixedFilter };
@@ -579,9 +636,11 @@ export class SearchConfigurationService implements OnDestroy {
    * @param operator The {@link AppliedFilter}'s optional operator
    */
   unselectAppliedFilterParams(filterName: string, value: string, operator?: string): Observable<Params> {
-    return this.routeService.getParamsExceptValue(`f.${filterName}`, hasValue(operator) ? addOperatorToFilterValue(value, operator) : value).pipe(
+    const filterParam: string = this.getCurrentSearchInstanceFilterParam(filterName);
+    return this.routeService.getParamsExceptValue(filterParam, hasValue(operator) ? addOperatorToFilterValue(value, operator) : value).pipe(
       map((params: Params) => Object.assign(params, {
-        [this.paginationService.getPageParam(this.paginationID)]: 1,
+        [`f.${filterName}`]: null,
+        [this.paginationService.getPageParam(this.searchInstanceId)]: 1,
       })),
     );
   }
@@ -594,9 +653,11 @@ export class SearchConfigurationService implements OnDestroy {
    * @param operator The {@link AppliedFilter}'s optional operator
    */
   selectNewAppliedFilterParams(filterName: string, value: string, operator?: string): Observable<Params> {
-    return this.routeService.getParamsWithAdditionalValue(`f.${filterName}`, hasValue(operator) ? addOperatorToFilterValue(value, operator) : value).pipe(
+    const filterParam: string = this.getCurrentSearchInstanceFilterParam(filterName);
+    return this.routeService.getParamsWithAdditionalValue(filterParam, hasValue(operator) ? addOperatorToFilterValue(value, operator) : value).pipe(
       map((params: Params) => Object.assign(params, {
-        [this.paginationService.getPageParam(this.paginationID)]: 1,
+        [`f.${filterName}`]: null,
+        [this.paginationService.getPageParam(this.searchInstanceId)]: 1,
       })),
     );
   }
@@ -604,8 +665,8 @@ export class SearchConfigurationService implements OnDestroy {
   /**
    * @returns {Observable<Params>} Emits the current view mode as a partial SearchOptions object
    */
-  private getViewModePart(defaultViewMode: ViewMode): Observable<any> {
-    return this.getCurrentViewMode(defaultViewMode).pipe(map((view) => {
+  private getViewModePart(searchInstanceId: string, defaultViewMode: ViewMode): Observable<any> {
+    return this.getCurrentViewMode(defaultViewMode, searchInstanceId).pipe(map((view) => {
       return { view };
     }));
   }

--- a/src/app/core/shared/search/search-filter.service.ts
+++ b/src/app/core/shared/search/search-filter.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { Params } from '@angular/router';
 import {
   createSelector,
   MemoizedSelector,
@@ -75,7 +74,14 @@ export class SearchFilterService {
    * @param {string} filterValue The value for which to search
    * @returns {Observable<boolean>} Emit true when the filter is active with the given value
    */
-  isFilterActiveWithValue(paramName: string, filterValue: string): Observable<boolean> {
+  isFilterActiveWithValue(paramName: string, filterValue: string, searchInstanceId?: string): Observable<boolean> {
+    if (hasValue(searchInstanceId)) {
+      return observableCombineLatest(
+        this.routeService.hasQueryParamWithValue(this.getSearchInstanceParam(searchInstanceId, paramName), filterValue),
+        this.routeService.getQueryParamsWithPrefix(this.getSearchInstanceParam(searchInstanceId, 'f.')),
+        this.routeService.hasQueryParamWithValue(paramName, filterValue),
+      ).pipe(map(([instanceActive, instanceFilters, legacyActive]) => instanceActive || (!isNotEmpty(instanceFilters) && legacyActive)));
+    }
     return this.routeService.hasQueryParamWithValue(paramName, filterValue);
   }
 
@@ -84,7 +90,14 @@ export class SearchFilterService {
    * @param {string} paramName The parameter name of the filter's configuration for which to search
    * @returns {Observable<boolean>} Emit true when the filter is active with any value
    */
-  isFilterActive(paramName: string): Observable<boolean> {
+  isFilterActive(paramName: string, searchInstanceId?: string): Observable<boolean> {
+    if (hasValue(searchInstanceId)) {
+      return observableCombineLatest(
+        this.routeService.hasQueryParam(this.getSearchInstanceParam(searchInstanceId, paramName)),
+        this.routeService.getQueryParamsWithPrefix(this.getSearchInstanceParam(searchInstanceId, 'f.')),
+        this.routeService.hasQueryParam(paramName),
+      ).pipe(map(([instanceActive, instanceFilters, legacyActive]) => instanceActive || (!isNotEmpty(instanceFilters) && legacyActive)));
+    }
     return this.routeService.hasQueryParam(paramName);
   }
 
@@ -92,16 +105,16 @@ export class SearchFilterService {
    * Fetch the current active scope from the query parameters
    * @returns {Observable<string>}
    */
-  getCurrentScope(): Observable<string> {
-    return this.routeService.getQueryParameterValue('scope');
+  getCurrentScope(searchInstanceId?: string) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'scope');
   }
 
   /**
    * Fetch the current query from the query parameters
    * @returns {Observable<string>}
    */
-  getCurrentQuery(): Observable<string> {
-    return this.routeService.getQueryParameterValue('query');
+  getCurrentQuery(searchInstanceId?: string) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'query');
   }
 
   /**
@@ -142,7 +155,13 @@ export class SearchFilterService {
    * Fetch the current active filters from the query parameters
    * @returns {Observable<Params>}
    */
-  getCurrentFilters(): Observable<Params> {
+  getCurrentFilters(searchInstanceId?: string) {
+    if (hasValue(searchInstanceId)) {
+      return observableCombineLatest(
+        this.routeService.getQueryParamsWithPrefix(this.getSearchInstanceParam(searchInstanceId, 'f.')),
+        this.routeService.getQueryParamsWithPrefix('f.'),
+      ).pipe(map(([instanceFilters, legacyFilters]) => isNotEmpty(instanceFilters) ? instanceFilters : legacyFilters));
+    }
     return this.routeService.getQueryParamsWithPrefix('f.');
   }
 
@@ -150,8 +169,8 @@ export class SearchFilterService {
    * Fetch the current view from the query parameters
    * @returns {Observable<string>}
    */
-  getCurrentView(): Observable<string> {
-    return this.routeService.getQueryParameterValue('view');
+  getCurrentView(searchInstanceId?: string) {
+    return this.getCurrentSearchInstanceQueryParam(searchInstanceId, 'view');
   }
 
   /**
@@ -188,6 +207,20 @@ export class SearchFilterService {
    */
   getDisplayValue(facet: FacetValue, query: string): string {
     return `${new EmphasizePipe().transform(facet.value, query)} (${facet.count})`;
+  }
+
+  private getSearchInstanceParam(searchInstanceId: string, parameterName: string): string {
+    return `${searchInstanceId}.${parameterName}`;
+  }
+
+  private getCurrentSearchInstanceQueryParam(searchInstanceId: string | undefined, parameterName: string): Observable<string> {
+    if (hasValue(searchInstanceId)) {
+      return observableCombineLatest(
+        this.routeService.getQueryParameterValue(this.getSearchInstanceParam(searchInstanceId, parameterName)),
+        this.routeService.getQueryParameterValue(parameterName),
+      ).pipe(map(([instanceValue, legacyValue]) => hasValue(instanceValue) ? instanceValue : legacyValue));
+    }
+    return this.routeService.getQueryParameterValue(parameterName);
   }
 
   /**

--- a/src/app/core/shared/search/search.service.spec.ts
+++ b/src/app/core/shared/search/search.service.spec.ts
@@ -98,13 +98,13 @@ describe('SearchService', () => {
     it('should call the navigate method on the Router with view mode list parameter as a parameter when setViewMode is called', () => {
       service.setViewMode(ViewMode.ListElement);
 
-      expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('test-id', ['/search'], { page: 1 }, { view: ViewMode.ListElement });
+      expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('test-id', ['/search'], { page: 1 }, { 'test-id.view': ViewMode.ListElement });
     });
 
     it('should call the navigate method on the Router with view mode grid parameter as a parameter when setViewMode is called', () => {
       service.setViewMode(ViewMode.GridElement);
 
-      expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('test-id', ['/search'], { page: 1 }, { view: ViewMode.GridElement });
+      expect(paginationService.updateRouteWithUrl).toHaveBeenCalledWith('test-id', ['/search'], { page: 1 }, { 'test-id.view': ViewMode.GridElement });
     });
   });
 

--- a/src/app/core/shared/search/search.service.ts
+++ b/src/app/core/shared/search/search.service.ts
@@ -342,8 +342,10 @@ export class SearchService {
    */
   getViewMode(): Observable<ViewMode> {
     return this.routeService.getQueryParamMap().pipe(map((params) => {
-      if (isNotEmpty(params.get('view')) && hasValue(params.get('view'))) {
-        return params.get('view');
+      const viewParam = this.searchConfigurationService.getCurrentSearchInstanceParam('view');
+      const view = hasValue(params.get(viewParam)) ? params.get(viewParam) : params.get('view');
+      if (isNotEmpty(view) && hasValue(view)) {
+        return view;
       } else {
         return ViewMode.ListElement;
       }
@@ -356,16 +358,16 @@ export class SearchService {
    * @param {string[]} searchLinkParts
    */
   setViewMode(viewMode: ViewMode, searchLinkParts?: string[]) {
-    this.paginationService.getCurrentPagination(this.searchConfigurationService.paginationID, new PaginationComponentOptions()).pipe(take(1))
+    this.paginationService.getCurrentPagination(this.searchConfigurationService.searchInstanceId, new PaginationComponentOptions()).pipe(take(1))
       .subscribe((config) => {
         let pageParams = { page: 1 };
-        const queryParams = { view: viewMode };
+        const queryParams = { [this.searchConfigurationService.getCurrentSearchInstanceParam('view')]: viewMode };
         if (viewMode === ViewMode.DetailedListElement) {
           pageParams = Object.assign(pageParams, { pageSize: 1 });
         } else if (config.pageSize === 1) {
           pageParams = Object.assign(pageParams, { pageSize: 10 });
         }
-        this.paginationService.updateRouteWithUrl(this.searchConfigurationService.paginationID, hasValue(searchLinkParts) ? searchLinkParts : [this.getSearchLink()], pageParams, queryParams);
+        this.paginationService.updateRouteWithUrl(this.searchConfigurationService.searchInstanceId, hasValue(searchLinkParts) ? searchLinkParts : [this.getSearchLink()], pageParams, queryParams);
       });
   }
 

--- a/src/app/home-page/recent-item-list/recent-item-list.component.ts
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.ts
@@ -128,7 +128,7 @@ export class RecentItemListComponent implements OnInit, OnDestroy {
   }
 
   onLoadMore(): void {
-    this.paginationService.updateRouteWithUrl(this.searchConfigurationService.paginationID, ['search'], {
+    this.paginationService.updateRouteWithUrl(this.searchConfigurationService.searchInstanceId, ['search'], {
       sortField: environment.homePage.recentSubmissions.sortField,
       sortDirection: 'DESC' as SortDirection,
       page: 1,

--- a/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
+++ b/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
@@ -151,7 +151,7 @@ describe('MyDSpaceConfigurationService', () => {
 
     describe('when subscribeToSearchOptions is called', () => {
       beforeEach(() => {
-        (service as any).subscribeToSearchOptions(defaults);
+        (service as any).subscribeToSearchOptions(defaults.pagination.id, defaults);
       });
       it('should call all getters it needs, but not call any others', () => {
         expect(service.getCurrentPagination).not.toHaveBeenCalled();
@@ -168,14 +168,14 @@ describe('MyDSpaceConfigurationService', () => {
       beforeEach(() => {
         (service as any).subscribeToPaginatedSearchOptions('id', defaults);
       });
-      it('should call all getters it needs', () => {
+      it('should call the pagination-specific getters it needs', () => {
         expect(service.getCurrentPagination).toHaveBeenCalled();
         expect(service.getCurrentSort).toHaveBeenCalled();
-        expect(service.getCurrentScope).toHaveBeenCalled();
-        expect(service.getCurrentConfiguration).toHaveBeenCalled();
-        expect(service.getCurrentQuery).toHaveBeenCalled();
-        expect(service.getCurrentDSOType).toHaveBeenCalled();
-        expect(service.getCurrentFilters).toHaveBeenCalled();
+        expect(service.getCurrentScope).not.toHaveBeenCalled();
+        expect(service.getCurrentConfiguration).not.toHaveBeenCalled();
+        expect(service.getCurrentQuery).not.toHaveBeenCalled();
+        expect(service.getCurrentDSOType).not.toHaveBeenCalled();
+        expect(service.getCurrentFilters).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/app/my-dspace-page/my-dspace-configuration.service.ts
+++ b/src/app/my-dspace-page/my-dspace-configuration.service.ts
@@ -48,6 +48,11 @@ export const SEARCH_CONFIG_SERVICE: InjectionToken<SearchConfigurationService> =
 @Injectable({ providedIn: 'root' })
 export class MyDSpaceConfigurationService extends SearchConfigurationService {
   /**
+   * Search instance id used for the MyDSpace search component.
+   */
+  public searchInstanceId = 'mydspace-page';
+
+  /**
    * Default pagination settings
    */
   protected defaultPagination = Object.assign(new PaginationComponentOptions(), {

--- a/src/app/my-dspace-page/my-dspace.guard.ts
+++ b/src/app/my-dspace-page/my-dspace.guard.ts
@@ -26,9 +26,11 @@ export const myDSpaceGuard: CanActivateFn = (
   configurationService: MyDSpaceConfigurationService = inject(MyDSpaceConfigurationService),
   router: Router = inject(Router),
 ): Observable<boolean> => {
+  const configurationParam = configurationService.getCurrentSearchInstanceParam('configuration');
+  const configuration = route.queryParamMap.get(configurationParam) || route.queryParamMap.get('configuration');
   return configurationService.getAvailableConfigurationTypes().pipe(
     first(),
-    map((configurationList) => validateConfigurationParam(router, route.queryParamMap.get('configuration'), configurationList)));
+    map((configurationList) => validateConfigurationParam(router, configurationService, configuration, configurationList)));
 };
 
 /**
@@ -36,18 +38,22 @@ export const myDSpaceGuard: CanActivateFn = (
  *
  * @param router
  *    the service router
+ * @param configurationService
+ *    the MyDSpace configuration service
  * @param configuration
  *    the configuration to validate
  * @param configurationList
  *    the list of available configuration
  *
  */
-function validateConfigurationParam(router: Router, configuration: string, configurationList: MyDSpaceConfigurationValueType[]): boolean {
+function validateConfigurationParam(router: Router, configurationService: MyDSpaceConfigurationService, configuration: string, configurationList: MyDSpaceConfigurationValueType[]): boolean {
   const configurationDefault: string = configurationList[0];
   if (isEmpty(configuration) || !configurationList.includes(configuration as MyDSpaceConfigurationValueType)) {
     // If configuration param is empty or is not included in available configurations redirect to a default configuration value
     const navigationExtras: NavigationExtras = {
-      queryParams: { configuration: configurationDefault },
+      queryParams: {
+        [configurationService.getCurrentSearchInstanceParam('configuration')]: configurationDefault,
+      },
     };
 
     router.navigate([MYDSPACE_ROUTE], navigationExtras);

--- a/src/app/search-navbar/search-navbar.component.spec.ts
+++ b/src/app/search-navbar/search-navbar.component.spec.ts
@@ -21,7 +21,9 @@ import {
   TranslateModule,
 } from '@ngx-translate/core';
 
+import { PaginationService } from '../core/pagination/pagination.service';
 import { SearchService } from '../core/shared/search/search.service';
+import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
 import { TranslateLoaderMock } from '../shared/mocks/translate-loader.mock';
 import { SearchNavbarComponent } from './search-navbar.component';
 
@@ -54,6 +56,14 @@ describe('SearchNavbarComponent', () => {
       ],
       providers: [
         { provide: SearchService, useValue: mockSearchService },
+        { provide: PaginationService, useValue: { getPageParam: (id: string) => `${id}.page` } },
+        {
+          provide: SearchConfigurationService,
+          useValue: {
+            searchInstanceId: 'spc',
+            getCurrentSearchInstanceParam: (param: string) => `spc.${param}`,
+          },
+        },
       ],
     })
       .compileComponents();
@@ -100,7 +110,7 @@ describe('SearchNavbarComponent', () => {
           fixture.detectChanges();
         }));
         it('to search page with empty query', () => {
-          const extras: NavigationExtras = { queryParams: { query: '' } };
+          const extras: NavigationExtras = { queryParams: { 'spc.query': '', 'spc.page': 1 } };
           expect(component.onSubmit).toHaveBeenCalledWith({ query: '' });
           expect(router.navigate).toHaveBeenCalledWith(['search'], extras);
         });
@@ -125,7 +135,7 @@ describe('SearchNavbarComponent', () => {
           fixture.detectChanges();
         }));
         it('to search page with query', async () => {
-          const extras: NavigationExtras = { queryParams: { query: 'test' } };
+          const extras: NavigationExtras = { queryParams: { 'spc.query': 'test', 'spc.page': 1 } };
           expect(component.onSubmit).toHaveBeenCalledWith({ query: 'test' });
 
           expect(router.navigate).toHaveBeenCalledWith(['search'], extras);

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -11,7 +11,9 @@ import {
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
+import { PaginationService } from '../core/pagination/pagination.service';
 import { SearchService } from '../core/shared/search/search.service';
+import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
 import { expandSearchInput } from '../shared/animations/slide';
 import { BrowserOnlyPipe } from '../shared/utils/browser-only.pipe';
 import { ClickOutsideDirective } from '../shared/utils/click-outside.directive';
@@ -44,7 +46,11 @@ export class SearchNavbarComponent {
   // Search input field
   @ViewChild('searchInput') searchField: ElementRef;
 
-  constructor(private formBuilder: UntypedFormBuilder, private router: Router, private searchService: SearchService) {
+  constructor(private formBuilder: UntypedFormBuilder,
+              private router: Router,
+              private searchService: SearchService,
+              private searchConfigurationService: SearchConfigurationService,
+              private paginationService: PaginationService) {
     this.searchForm = this.formBuilder.group(({
       query: '',
     }));
@@ -81,7 +87,10 @@ export class SearchNavbarComponent {
    */
   onSubmit(data: any) {
     this.collapse();
-    const queryParams = Object.assign({}, data);
+    const queryParams = {
+      [this.searchConfigurationService.getCurrentSearchInstanceParam('query')]: data.query,
+      [this.paginationService.getPageParam(this.searchConfigurationService.searchInstanceId)]: 1,
+    };
     const linkToNavigateTo = [this.searchService.getSearchLink().replace('/', '')];
     this.searchForm.reset();
 

--- a/src/app/search-page/configuration-search-page.component.spec.ts
+++ b/src/app/search-page/configuration-search-page.component.spec.ts
@@ -65,8 +65,8 @@ describe('ConfigurationSearchPageComponent', () => {
     expect(comp.configuration).toBe(CONFIGURATION);
     expect(comp.fixedFilterQuery).toBe(QUERY);
 
-    expect(routeService.setParameter).toHaveBeenCalledWith('configuration', CONFIGURATION);
-    expect(routeService.setParameter).toHaveBeenCalledWith('fixedFilterQuery', QUERY);
+    expect(routeService.setParameter).toHaveBeenCalledWith('search-test-page-id.configuration', CONFIGURATION);
+    expect(routeService.setParameter).toHaveBeenCalledWith('search-test-page-id.fixedFilterQuery', QUERY);
   });
 
 });

--- a/src/app/search-page/configuration-search-page.component.ts
+++ b/src/app/search-page/configuration-search-page.component.ts
@@ -44,6 +44,11 @@ import { ViewModeSwitchComponent } from '../shared/view-mode-switch/view-mode-sw
       provide: SEARCH_CONFIG_SERVICE,
       useClass: SearchConfigurationService,
     },
+    {
+      provide: SearchConfigurationService,
+      useExisting: SEARCH_CONFIG_SERVICE,
+    },
+    SearchService,
   ],
   standalone: true,
   imports: [

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 
+import { SearchService } from '../core/shared/search/search.service';
 import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
 import { SEARCH_CONFIG_SERVICE } from '../my-dspace-page/my-dspace-configuration.service';
 import { ThemedSearchComponent } from '../shared/search/themed-search.component';
@@ -12,6 +13,11 @@ import { ThemedSearchComponent } from '../shared/search/themed-search.component'
       provide: SEARCH_CONFIG_SERVICE,
       useClass: SearchConfigurationService,
     },
+    {
+      provide: SearchConfigurationService,
+      useExisting: SEARCH_CONFIG_SERVICE,
+    },
+    SearchService,
   ],
   standalone: true,
   imports: [

--- a/src/app/search-page/themed-configuration-search-page.component.ts
+++ b/src/app/search-page/themed-configuration-search-page.component.ts
@@ -63,9 +63,9 @@ export class ThemedConfigurationSearchPageComponent extends ThemedComponent<Conf
   @Input() linkType: CollectionElementLinkType;
 
   /**
-   * The pagination id used in the search
+   * The search instance id used in the search
    */
-  @Input() paginationId: string;
+  @Input() searchInstanceId: string;
 
   /**
    * Whether or not the search bar should be visible
@@ -155,7 +155,7 @@ export class ThemedConfigurationSearchPageComponent extends ThemedComponent<Conf
     'useCachedVersionIfAvailable',
     'inPlaceSearch',
     'linkType',
-    'paginationId',
+    'searchInstanceId',
     'searchEnabled',
     'sideBarWidth',
     'searchFormPlaceholder',

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/dynamic-lookup-relation-external-source-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/external-source-tab/dynamic-lookup-relation-external-source-tab.component.ts
@@ -206,7 +206,7 @@ export class DsDynamicLookupRelationExternalSourceTabComponent implements OnInit
         return this.externalSourceService.getExternalSourceEntries(this.externalSource.id, searchOptions).pipe(startWith(undefined));
       }),
     );
-    this.currentPagination$ = this.paginationService.getCurrentPagination(this.searchConfigService.paginationID, this.initialPagination);
+    this.currentPagination$ = this.paginationService.getCurrentPagination(this.searchConfigService.searchInstanceId, this.initialPagination);
     this.importConfig = {
       buttonLabel: 'submission.sections.describe.relationship-lookup.external-source.import-button-title.' + this.label,
     };
@@ -257,7 +257,7 @@ export class DsDynamicLookupRelationExternalSourceTabComponent implements OnInit
    * Method to reset the route when the tab is opened to make sure no strange pagination issues appears
    */
   resetRoute() {
-    this.paginationService.updateRoute(this.searchConfigService.paginationID, {
+    this.paginationService.updateRoute(this.searchConfigService.searchInstanceId, {
       page: 1,
       pageSize: 5,
     });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/search-tab/dynamic-lookup-relation-search-tab.component.ts
@@ -197,7 +197,7 @@ export class DsDynamicLookupRelationSearchTabComponent implements OnInit, OnDest
    * Method to reset the route when the window is opened to make sure no strange pagination issues appears
    */
   resetRoute() {
-    this.paginationService.updateRoute(this.searchConfigService.paginationID, this.initialPagination);
+    this.paginationService.updateRoute(this.searchConfigService.searchInstanceId, this.initialPagination);
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/selection-tab/dynamic-lookup-relation-selection-tab.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/relation-lookup-modal/selection-tab/dynamic-lookup-relation-selection-tab.component.ts
@@ -143,14 +143,14 @@ export class DsDynamicLookupRelationSelectionTabComponent implements OnInit {
           );
         }),
       );
-    this.currentPagination$ = this.paginationService.getCurrentPagination(this.searchConfigService.paginationID, this.initialPagination);
+    this.currentPagination$ = this.paginationService.getCurrentPagination(this.searchConfigService.searchInstanceId, this.initialPagination);
   }
 
   /**
    * Method to reset the route when the tab is opened to make sure no strange pagination issues appears
    */
   resetRoute() {
-    this.paginationService.updateRoute(this.searchConfigService.paginationID, {
+    this.paginationService.updateRoute(this.searchConfigService.searchInstanceId, {
       page: 1,
       pageSize: 5,
     });

--- a/src/app/shared/object-collection/object-collection.component.ts
+++ b/src/app/shared/object-collection/object-collection.component.ts
@@ -18,7 +18,11 @@ import {
   ActivatedRoute,
   Router,
 } from '@angular/router';
-import { Observable } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest as observableCombineLatest,
+  Observable,
+} from 'rxjs';
 import {
   distinctUntilChanged,
   map,
@@ -148,6 +152,13 @@ export class ObjectCollectionComponent implements OnInit {
   @Input() showThumbnails;
 
   /**
+   * The view mode to render. When not provided, this component falls back to the legacy `view` URL parameter.
+   */
+  @Input() set viewMode(viewMode: ViewMode) {
+    this.viewMode$.next(viewMode);
+  }
+
+  /**
    * the page info of the list
    */
   pageInfo: Observable<PageInfo>;
@@ -196,6 +207,8 @@ export class ObjectCollectionComponent implements OnInit {
    */
   currentMode$: Observable<ViewMode>;
 
+  private viewMode$: BehaviorSubject<ViewMode> = new BehaviorSubject<ViewMode>(undefined);
+
   /**
    * The available view modes
    */
@@ -228,10 +241,9 @@ export class ObjectCollectionComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.currentMode$ = this.route
-      .queryParams
+    this.currentMode$ = observableCombineLatest([this.route.queryParams, this.viewMode$])
       .pipe(
-        map((params) => isEmpty(params?.view) ? ViewMode.ListElement : params.view),
+        map(([params, viewMode]) => viewMode || (isEmpty(params?.view) ? ViewMode.ListElement : params.view)),
         distinctUntilChanged(),
       );
     if (isPlatformBrowser(this.platformId)) {

--- a/src/app/shared/search-form/search-form.component.spec.ts
+++ b/src/app/shared/search-form/search-form.component.spec.ts
@@ -35,8 +35,10 @@ describe('SearchFormComponent', () => {
   const searchService = new SearchServiceStub();
   let searchFilterService: SearchFilterServiceStub;
   const paginationService = new PaginationServiceStub();
-  const searchConfigService = { paginationID: 'test-id' };
-  const firstPage = { 'spc.page': 1 };
+  const searchConfigService = {
+    searchInstanceId: 'test-id',
+    getCurrentSearchInstanceParam: (param: string) => `test-id.${param}`,
+  };
   const dspaceObjectService = {
     findById: () => createSuccessfulRemoteDataObject$(undefined),
   };
@@ -111,11 +113,17 @@ describe('SearchFormComponent', () => {
     const scope = 'MCU';
     let searchQuery = {};
 
-    it('should navigate to the search first page even when no parameters are provided', () => {
+    beforeEach(() => {
+      searchQuery = {};
+      router.navigate.calls.reset();
+    });
+
+    it('should navigate to the search page even when no parameters are provided', () => {
+      const expectedQueryParams = { 'test-id.page': 1 };
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: { ...searchQuery, ...firstPage },
+        queryParams: expectedQueryParams,
         queryParamsHandling: 'merge',
       });
     });
@@ -124,11 +132,15 @@ describe('SearchFormComponent', () => {
       searchQuery = {
         query: query,
       };
+      const expectedQueryParams = {
+        'test-id.page': 1,
+        'test-id.query': query,
+      };
 
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: { ...searchQuery, ...firstPage },
+        queryParams: expectedQueryParams,
         queryParamsHandling: 'merge',
       });
     });
@@ -137,11 +149,15 @@ describe('SearchFormComponent', () => {
       searchQuery = {
         scope: scope,
       };
+      const expectedQueryParams = {
+        'test-id.page': 1,
+        'test-id.scope': scope,
+      };
 
       comp.updateSearch(searchQuery);
 
       expect(router.navigate).toHaveBeenCalledWith(comp.getSearchLinkParts(), {
-        queryParams: { ...searchQuery, ...firstPage },
+        queryParams: expectedQueryParams,
         queryParamsHandling: 'merge',
       });
     });

--- a/src/app/shared/search-form/search-form.component.ts
+++ b/src/app/shared/search-form/search-form.component.ts
@@ -7,7 +7,10 @@ import {
   Output,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import {
+  Params,
+  Router,
+} from '@angular/router';
 import {
   NgbModal,
   NgbTooltipModule,
@@ -147,17 +150,15 @@ export class SearchFormComponent implements OnChanges {
    * @param data Updated parameters
    */
   updateSearch(data: any) {
-    const goToFirstPage = { 'spc.page': 1 };
-
-    const queryParams = Object.assign(
-      {
-        ...goToFirstPage,
-      },
-      data,
-    );
-    if (hasValue(data.scope) && this.hideScopeInUrl) {
-      delete queryParams.scope;
-    }
+    const queryParams: Params = {
+      [this.paginationService.getPageParam(this.searchConfig.searchInstanceId)]: 1,
+    };
+    Object.keys(data).forEach((key) => {
+      if (key === 'scope' && hasValue(data.scope) && this.hideScopeInUrl) {
+        return;
+      }
+      queryParams[this.searchConfig.getCurrentSearchInstanceParam(key)] = data[key];
+    });
 
     void this.router.navigate(this.getSearchLinkParts(), {
       queryParams: queryParams,

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.spec.ts
@@ -19,8 +19,8 @@ import { of } from 'rxjs';
 
 import { PaginationService } from '../../../../../../core/pagination/pagination.service';
 import { SearchService } from '../../../../../../core/shared/search/search.service';
-import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { ActivatedRouteStub } from '../../../../../../shared/testing/active-router.stub';
 import { LiveRegionService } from '../../../../../live-region/live-region.service';
 import { getLiveRegionServiceStub } from '../../../../../live-region/live-region.service.stub';
@@ -83,7 +83,7 @@ describe('SearchFacetOptionComponent', () => {
         { provide: SearchService, useValue: searchService },
         { provide: Router, useValue: router },
         { provide: PaginationService, useValue: paginationService },
-        { provide: SearchConfigurationService, useValue: searchConfigurationService },
+        { provide: SEARCH_CONFIG_SERVICE, useValue: searchConfigurationService },
         { provide: SearchFilterService, useValue: searchFilterService },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
         { provide: LiveRegionService, useValue: getLiveRegionServiceStub() },

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
@@ -74,7 +74,7 @@ export class SearchFacetOptionComponent implements OnInit {
    */
   searchLink: string;
 
-  paginationId: string;
+  searchInstanceId: string;
 
   constructor(protected searchService: SearchService,
               protected filterService: SearchFilterService,
@@ -90,7 +90,7 @@ export class SearchFacetOptionComponent implements OnInit {
    * Initializes all observable instance variables and starts listening to them
    */
   ngOnInit(): void {
-    this.paginationId = this.searchConfigService.paginationID;
+    this.searchInstanceId = this.searchConfigService.searchInstanceId;
     this.searchLink = this.getSearchLink();
     this.isVisible = this.isChecked().pipe(map((checked: boolean) => !checked));
     this.addQueryParams$ = this.updateAddParams();
@@ -100,7 +100,7 @@ export class SearchFacetOptionComponent implements OnInit {
    * Checks if a value for this filter is currently active
    */
   isChecked(): Observable<boolean> {
-    return this.filterService.isFilterActiveWithValue(this.filterConfig.paramName, this.getFacetValue());
+    return this.filterService.isFilterActiveWithValue(this.filterConfig.paramName, this.getFacetValue(), this.searchInstanceId);
   }
 
   /**

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-option/search-facet-option.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
@@ -20,6 +21,7 @@ import { PaginationService } from '../../../../../../core/pagination/pagination.
 import { SearchService } from '../../../../../../core/shared/search/search.service';
 import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { LiveRegionService } from '../../../../../../shared/live-region/live-region.service';
 import { currentPath } from '../../../../../utils/route.utils';
 import { ShortNumberPipe } from '../../../../../utils/short-number.pipe';
@@ -78,7 +80,7 @@ export class SearchFacetOptionComponent implements OnInit {
 
   constructor(protected searchService: SearchService,
               protected filterService: SearchFilterService,
-              protected searchConfigService: SearchConfigurationService,
+              @Inject(SEARCH_CONFIG_SERVICE) protected searchConfigService: SearchConfigurationService,
               protected router: Router,
               protected paginationService: PaginationService,
               protected liveRegionService: LiveRegionService,

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
@@ -19,8 +19,8 @@ import { of } from 'rxjs';
 
 import { PaginationService } from '../../../../../../core/pagination/pagination.service';
 import { SearchService } from '../../../../../../core/shared/search/search.service';
-import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { PaginationComponentOptions } from '../../../../../pagination/pagination-component-options.model';
 import { PaginationServiceStub } from '../../../../../testing/pagination-service.stub';
 import { RouterStub } from '../../../../../testing/router.stub';
@@ -80,7 +80,7 @@ describe('SearchFacetRangeOptionComponent', () => {
         { provide: Router, useValue: new RouterStub() },
         { provide: PaginationService, useValue: paginationService },
         {
-          provide: SearchConfigurationService, useValue: {
+          provide: SEARCH_CONFIG_SERVICE, useValue: {
             searchOptions: of({}),
             searchInstanceId: 'page-id',
             getCurrentSearchInstanceFilterParam: (param: string) => `page-id.${param}`,

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.spec.ts
@@ -82,7 +82,8 @@ describe('SearchFacetRangeOptionComponent', () => {
         {
           provide: SearchConfigurationService, useValue: {
             searchOptions: of({}),
-            paginationId: 'page-id',
+            searchInstanceId: 'page-id',
+            getCurrentSearchInstanceFilterParam: (param: string) => `page-id.${param}`,
           },
         },
         {
@@ -136,8 +137,10 @@ describe('SearchFacetRangeOptionComponent', () => {
       };
       (comp as any).updateChangeParams();
       expect(comp.changeQueryParams).toEqual({
-        [mockFilterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: [50],
-        [mockFilterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: [60],
+        [`page-id.${mockFilterConfig.paramName}${RANGE_FILTER_MIN_SUFFIX}`]: [50],
+        [`page-id.${mockFilterConfig.paramName}${RANGE_FILTER_MAX_SUFFIX}`]: [60],
+        [mockFilterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: null,
+        [mockFilterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: null,
         ['page-id.page']: 1,
       });
     });

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -20,6 +21,7 @@ import { PaginationService } from '../../../../../../core/pagination/pagination.
 import { SearchService } from '../../../../../../core/shared/search/search.service';
 import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { hasValue } from '../../../../../empty.util';
 import { currentPath } from '../../../../../utils/route.utils';
 import { ShortNumberPipe } from '../../../../../utils/short-number.pipe';
@@ -86,7 +88,7 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
 
   constructor(protected searchService: SearchService,
               protected filterService: SearchFilterService,
-              protected searchConfigService: SearchConfigurationService,
+              @Inject(SEARCH_CONFIG_SERVICE) protected searchConfigService: SearchConfigurationService,
               protected router: Router,
               protected paginationService: PaginationService,
   ) {

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-range-option/search-facet-range-option.component.ts
@@ -107,7 +107,7 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
    * Checks if a value for this filter is currently active
    */
   private isChecked(): Observable<boolean> {
-    return this.filterService.isFilterActiveWithValue(this.filterConfig.paramName, this.filterValue.value);
+    return this.filterService.isFilterActiveWithValue(this.filterConfig.paramName, this.filterValue.value, this.searchConfigService.searchInstanceId);
   }
 
   /**
@@ -127,10 +127,13 @@ export class SearchFacetRangeOptionComponent implements OnInit, OnDestroy {
     const parts = this.filterValue.value.split(rangeDelimiter);
     const min = parts.length > 1 ? Number(parts[0].trim()) : this.filterValue.value;
     const max = parts.length > 1 ? Number(parts[1].trim()) : this.filterValue.value;
-    const page = this.paginationService.getPageParam(this.searchConfigService.paginationID);
+    const page = this.paginationService.getPageParam(this.searchConfigService.searchInstanceId);
+    const filterParamName = this.searchConfigService.getCurrentSearchInstanceFilterParam(this.filterConfig.paramName);
     this.changeQueryParams = {
-      [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: [min],
-      [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: max === new Date().getUTCFullYear() ? null : [max],
+      [filterParamName + RANGE_FILTER_MIN_SUFFIX]: [min],
+      [filterParamName + RANGE_FILTER_MAX_SUFFIX]: max === new Date().getUTCFullYear() ? null : [max],
+      [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: null,
+      [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: null,
       [page]: 1,
     };
   }

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.spec.ts
@@ -13,8 +13,8 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { PaginationService } from '../../../../../../core/pagination/pagination.service';
 import { SearchService } from '../../../../../../core/shared/search/search.service';
-import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { PaginationComponentOptions } from '../../../../../pagination/pagination-component-options.model';
 import { ActivatedRouteStub } from '../../../../../testing/active-router.stub';
 import { PaginationServiceStub } from '../../../../../testing/pagination-service.stub';
@@ -72,7 +72,7 @@ describe('SearchFacetSelectedOptionComponent', () => {
         { provide: SearchService, useValue:searchService },
         { provide: Router, useValue: router },
         { provide: PaginationService, useValue: paginationService },
-        { provide: SearchConfigurationService, useValue: searchConfigurationService },
+        { provide: SEARCH_CONFIG_SERVICE, useValue: searchConfigurationService },
         { provide: SearchFilterService, useValue: searchFilterService },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
       ],

--- a/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-facet-filter-options/search-facet-selected-option/search-facet-selected-option.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
@@ -16,6 +17,7 @@ import { PaginationService } from '../../../../../../core/pagination/pagination.
 import { SearchService } from '../../../../../../core/shared/search/search.service';
 import { SearchConfigurationService } from '../../../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../my-dspace-page/my-dspace-configuration.service';
 import { currentPath } from '../../../../../utils/route.utils';
 import { AppliedFilter } from '../../../../models/applied-filter.model';
 import { SearchFilterConfig } from '../../../../models/search-filter-config.model';
@@ -66,7 +68,7 @@ export class SearchFacetSelectedOptionComponent implements OnInit {
     protected router: Router,
     protected searchFilterService: SearchFilterService,
     protected searchService: SearchService,
-    protected searchConfigService: SearchConfigurationService,
+    @Inject(SEARCH_CONFIG_SERVICE) protected searchConfigService: SearchConfigurationService,
   ) {
   }
 

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.spec.ts
@@ -148,8 +148,11 @@ describe('SearchRangeFilterComponent', () => {
     it('should call navigate on the router with the right searchlink and parameters', () => {
       expect(router.navigate).toHaveBeenCalledWith(searchUrl.split('/'), {
         queryParams: {
-          [mockFilterConfig.paramName + minSuffix]: [1900],
-          [mockFilterConfig.paramName + maxSuffix]: [1950],
+          [`test-id.${mockFilterConfig.paramName}${minSuffix}`]: [1900],
+          [`test-id.${mockFilterConfig.paramName}${maxSuffix}`]: [1950],
+          [mockFilterConfig.paramName + minSuffix]: null,
+          [mockFilterConfig.paramName + maxSuffix]: null,
+          'test-id.page': 1,
         },
         queryParamsHandling: 'merge',
       });

--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
@@ -135,8 +135,15 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
     this.max = yearFromString(this.filterConfig.maxValue) || this.max;
     this.minLabel = this.translateService.instant('search.filters.filter.' + this.filterConfig.name + '.min.placeholder');
     this.maxLabel = this.translateService.instant('search.filters.filter.' + this.filterConfig.name + '.max.placeholder');
-    const iniMin = this.route.getQueryParameterValue(this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX).pipe(startWith(undefined));
-    const iniMax = this.route.getQueryParameterValue(this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX).pipe(startWith(undefined));
+    const filterParamName = this.searchConfigService.getCurrentSearchInstanceFilterParam(this.filterConfig.paramName);
+    const iniMin = observableCombineLatest([
+      this.route.getQueryParameterValue(filterParamName + RANGE_FILTER_MIN_SUFFIX).pipe(startWith(undefined)),
+      this.route.getQueryParameterValue(this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX).pipe(startWith(undefined)),
+    ]).pipe(map(([instanceMin, legacyMin]: [string, string]) => hasValue(instanceMin) ? instanceMin : legacyMin));
+    const iniMax = observableCombineLatest([
+      this.route.getQueryParameterValue(filterParamName + RANGE_FILTER_MAX_SUFFIX).pipe(startWith(undefined)),
+      this.route.getQueryParameterValue(this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX).pipe(startWith(undefined)),
+    ]).pipe(map(([instanceMax, legacyMax]: [string, string]) => hasValue(instanceMax) ? instanceMax : legacyMax));
     this.subs.push(observableCombineLatest([iniMin, iniMax]).pipe(
       map(([min, max]: [string, string]) => {
         const minimum = hasValue(min) ? Number(min) : this.min;
@@ -177,8 +184,11 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
     void this.router.navigate(this.getSearchLinkParts(), {
       queryParams:
         {
-          [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: newMin,
-          [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: newMax,
+          [this.searchConfigService.getCurrentSearchInstanceFilterParam(this.filterConfig.paramName) + RANGE_FILTER_MIN_SUFFIX]: newMin,
+          [this.searchConfigService.getCurrentSearchInstanceFilterParam(this.filterConfig.paramName) + RANGE_FILTER_MAX_SUFFIX]: newMax,
+          [this.filterConfig.paramName + RANGE_FILTER_MIN_SUFFIX]: null,
+          [this.filterConfig.paramName + RANGE_FILTER_MAX_SUFFIX]: null,
+          [this.searchConfigService.getCurrentPageParam()]: 1,
         },
       queryParamsHandling: 'merge',
     });

--- a/src/app/shared/search/search-labels/search-label/search-label.component.spec.ts
+++ b/src/app/shared/search/search-labels/search-label/search-label.component.spec.ts
@@ -17,8 +17,8 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { PaginationService } from '../../../../core/pagination/pagination.service';
 import { SearchService } from '../../../../core/shared/search/search.service';
-import { SearchConfigurationService } from '../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../my-dspace-page/my-dspace-configuration.service';
 import { PaginationComponentOptions } from '../../../pagination/pagination-component-options.model';
 import { ActivatedRouteStub } from '../../../testing/active-router.stub';
 import { PaginationServiceStub } from '../../../testing/pagination-service.stub';
@@ -81,7 +81,7 @@ describe('SearchLabelComponent', () => {
       ],
       providers: [
         { provide: PaginationService, useValue: paginationService },
-        { provide: SearchConfigurationService, useValue: searchConfigurationService },
+        { provide: SEARCH_CONFIG_SERVICE, useValue: searchConfigurationService },
         { provide: SearchFilterService, useValue: searchFilterService },
         { provide: SearchService, useValue: new SearchServiceStub(searchLink) },
         { provide: ActivatedRoute, useValue: route },

--- a/src/app/shared/search/search-labels/search-label/search-label.component.ts
+++ b/src/app/shared/search/search-labels/search-label/search-label.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnInit,
 } from '@angular/core';
@@ -16,6 +17,7 @@ import { PaginationService } from '../../../../core/pagination/pagination.servic
 import { SearchService } from '../../../../core/shared/search/search.service';
 import { SearchConfigurationService } from '../../../../core/shared/search/search-configuration.service';
 import { SearchFilterService } from '../../../../core/shared/search/search-filter.service';
+import { SEARCH_CONFIG_SERVICE } from '../../../../my-dspace-page/my-dspace-configuration.service';
 import { currentPath } from '../../../utils/route.utils';
 import { AppliedFilter } from '../../models/applied-filter.model';
 
@@ -45,7 +47,7 @@ export class SearchLabelComponent implements OnInit {
   constructor(
     protected paginationService: PaginationService,
     protected router: Router,
-    protected searchConfigurationService: SearchConfigurationService,
+    @Inject(SEARCH_CONFIG_SERVICE) protected searchConfigurationService: SearchConfigurationService,
     protected searchService: SearchService,
     protected searchFilterService: SearchFilterService,
   ) {

--- a/src/app/shared/search/search-results/search-results.component.html
+++ b/src/app/shared/search/search-results/search-results.component.html
@@ -30,11 +30,13 @@
       [selectionConfig]="selectionConfig"
       [linkType]="linkType"
       [context]="context"
+      [viewMode]="searchConfig?.view"
       [hidePaginationDetail]="hidePaginationDetail"
       [showThumbnails]="showThumbnails"
       (contentChange)="contentChange.emit($event)"
       (deselectObject)="deselectObject.emit($event)"
       (selectObject)="selectObject.emit($event)">
+
     </ds-viewable-collection>
   </div>
 }
@@ -54,7 +56,7 @@
   <div>
     {{ 'search.results.no-results' | translate }}
     <a [routerLink]="['/search']"
-      [queryParams]="{ query: surroundStringWithQuotes(searchConfig?.query) }"
+      [queryParams]="getExactMatchQueryParams()"
       queryParamsHandling="merge" role="link" tabindex="0">
       {{"search.results.no-results-link" | translate}}
     </a>

--- a/src/app/shared/search/search-results/search-results.component.ts
+++ b/src/app/shared/search/search-results/search-results.component.ts
@@ -5,7 +5,10 @@ import {
   Input,
   Output,
 } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import {
+  Params,
+  RouterLink,
+} from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
@@ -187,5 +190,16 @@ export class SearchResultsComponent {
     }
 
     return result;
+  }
+
+  getExactMatchQueryParams(): Params {
+    if (hasNoValue(this.searchConfig?.pagination?.id)) {
+      return {
+        query: this.surroundStringWithQuotes(this.searchConfig?.query),
+      };
+    }
+    return {
+      [`${this.searchConfig?.pagination?.id}.query`]: this.surroundStringWithQuotes(this.searchConfig?.query),
+    };
   }
 }

--- a/src/app/shared/search/search-settings/search-settings.component.ts
+++ b/src/app/shared/search/search-settings/search-settings.component.ts
@@ -56,7 +56,7 @@ export class SearchSettingsComponent {
    */
   reloadOrder(event: Event) {
     const values = (event.target as HTMLInputElement).value.split(',');
-    this.paginationService.updateRoute(this.searchConfigurationService.paginationID, {
+    this.paginationService.updateRoute(this.searchConfigurationService.searchInstanceId, {
       sortField: values[0],
       sortDirection: values[1] as SortDirection,
       page: 1,

--- a/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.spec.ts
+++ b/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.spec.ts
@@ -111,7 +111,7 @@ describe('SearchSwitchConfigurationComponent', () => {
     spyOn((comp as any).changeConfiguration, 'emit');
     comp.selectedOption = configurationList[1];
     const navigationExtras: NavigationExtras = {
-      queryParams: { configuration: MyDSpaceConfigurationValueType.Workflow },
+      queryParams: { 'test-id.configuration': MyDSpaceConfigurationValueType.Workflow },
     };
 
     fixture.detectChanges();

--- a/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.ts
+++ b/src/app/shared/search/search-switch-configuration/search-switch-configuration.component.ts
@@ -88,7 +88,9 @@ export class SearchSwitchConfigurationComponent implements OnDestroy, OnInit {
    */
   onSelect() {
     const navigationExtras: NavigationExtras = {
-      queryParams: { configuration: this.selectedOption.value },
+      queryParams: {
+        [this.searchConfigService.getCurrentSearchInstanceParam('configuration')]: this.selectedOption.value,
+      },
     };
 
     this.changeConfiguration.emit(this.selectedOption);

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -200,10 +200,11 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
     getCurrentScope: of('test-id'),
     getCurrentSort: of(sortOptionsList[0]),
     updateFixedFilter: jasmine.createSpy('updateFixedFilter'),
-    setPaginationId: jasmine.createSpy('setPaginationId'),
+    setSearchInstanceId: jasmine.createSpy('setSearchInstanceId'),
   });
+  searchConfigurationServiceStub.getCurrentSearchInstanceParam = (param: string) => `${paginationId}.${param}`;
 
-  searchConfigurationServiceStub.setPaginationId.and.callFake((pageId) => {
+  searchConfigurationServiceStub.setSearchInstanceId.and.callFake((pageId) => {
     paginatedSearchOptions$.next(Object.assign(paginatedSearchOptions$.value, {
       pagination: Object.assign(new PaginationComponentOptions(), {
         id: pageId,
@@ -251,13 +252,6 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
     ],
     schemas: [NO_ERRORS_SCHEMA],
   }).overrideComponent(compType, {
-    add: {
-      changeDetection: ChangeDetectionStrategy.Default,
-      providers: [{
-        provide: SearchConfigurationService,
-        useValue: searchConfigurationServiceStub,
-      }],
-    },
     remove: {
       imports: [
         PageWithSidebarComponent,
@@ -268,7 +262,14 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
         SearchLabelsComponent,
       ],
     },
-
+  }).overrideComponent(compType, {
+    set: {
+      changeDetection: ChangeDetectionStrategy.Default,
+      providers: [{
+        provide: SearchConfigurationService,
+        useValue: searchConfigurationServiceStub,
+      }],
+    },
   }).compileComponents();
 }
 
@@ -281,7 +282,7 @@ describe('SearchComponent', () => {
     fixture = TestBed.createComponent(SearchComponent);
     comp = fixture.componentInstance; // SearchComponent test instance
     comp.inPlaceSearch = false;
-    comp.paginationId = paginationId;
+    comp.searchInstanceId = paginationId;
     comp.hiddenQuery = hiddenQuery;
 
     spyOn((comp as any), 'getSearchOptions').and.returnValue(paginatedSearchOptions$.asObservable());

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -12,7 +12,10 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+} from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { Store } from '@ngrx/store';
@@ -184,6 +187,9 @@ const routeServiceStub = {
   getQueryParamsWithPrefix: () => {
     return of(null);
   },
+  getQueryParamMap: () => {
+    return of(convertToParamMap({}));
+  },
   setParameter: (key: any, value: any) => {
     return;
   },
@@ -203,6 +209,7 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
     setSearchInstanceId: jasmine.createSpy('setSearchInstanceId'),
   });
   searchConfigurationServiceStub.getCurrentSearchInstanceParam = (param: string) => `${paginationId}.${param}`;
+  searchConfigurationServiceStub.isLegacySearchParam = (param: string) => ['configuration', 'scope', 'query', 'dsoType', 'view'].includes(param) || param.startsWith('f.');
 
   searchConfigurationServiceStub.setSearchInstanceId.and.callFake((pageId) => {
     paginatedSearchOptions$.next(Object.assign(paginatedSearchOptions$.value, {
@@ -342,6 +349,63 @@ describe('SearchComponent', () => {
     tick(100);
     expect(comp.resultFound.emit).toHaveBeenCalledWith(expectedResults);
   }));
+
+  describe('migrateLegacySearchParams', () => {
+    let navigateSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      comp.platformId = 'browser';
+      comp.searchInstanceId = paginationId;
+      navigateSpy = spyOn((comp as any).router, 'navigate');
+    });
+
+    it('should replace legacy (unprefixed) search params with their prefixed equivalent', () => {
+      spyOn((comp as any).routeService, 'getQueryParamMap').and.returnValue(of(convertToParamMap({
+        query: 'cats',
+        'f.author': 'Smith',
+      })));
+
+      (comp as any).migrateLegacySearchParams();
+
+      expect(navigateSpy).toHaveBeenCalledWith([], {
+        queryParams: {
+          query: null,
+          [`${paginationId}.query`]: 'cats',
+          'f.author': null,
+          [`${paginationId}.f.author`]: 'Smith',
+        },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    });
+
+    it('should not navigate when there are no legacy search params', () => {
+      spyOn((comp as any).routeService, 'getQueryParamMap').and.returnValue(of(convertToParamMap({
+        [`${paginationId}.query`]: 'cats',
+      })));
+
+      (comp as any).migrateLegacySearchParams();
+
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should drop the legacy param without overriding an existing prefixed param', () => {
+      spyOn((comp as any).routeService, 'getQueryParamMap').and.returnValue(of(convertToParamMap({
+        query: 'legacy',
+        [`${paginationId}.query`]: 'prefixed',
+      })));
+
+      (comp as any).migrateLegacySearchParams();
+
+      expect(navigateSpy).toHaveBeenCalledWith([], {
+        queryParams: {
+          query: null,
+        },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    });
+  });
 
   describe('when the open sidebar button is clicked in mobile view', () => {
 

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -153,9 +153,9 @@ export class SearchComponent implements OnDestroy, OnInit {
   @Input() linkType: CollectionElementLinkType;
 
   /**
-   * The pagination id used in the search
+   * The search instance id used in the search
    */
-  @Input() paginationId = 'spc';
+  @Input() searchInstanceId = 'spc';
 
   /**
    * Whether or not the search bar should be visible
@@ -374,17 +374,17 @@ export class SearchComponent implements OnDestroy, OnInit {
     }
 
     if (this.useUniquePageId) {
-      // Create an unique pagination id related to the instance of the SearchComponent
-      this.paginationId = uniqueId(this.paginationId);
+      // Create a unique search instance id related to this SearchComponent.
+      this.searchInstanceId = uniqueId(this.searchInstanceId);
     }
 
-    this.searchConfigService.setPaginationId(this.paginationId);
+    this.searchConfigService.setSearchInstanceId(this.searchInstanceId);
 
     if (hasValue(this.configuration)) {
-      this.routeService.setParameter('configuration', this.configuration);
+      this.routeService.setParameter(this.searchConfigService.getCurrentSearchInstanceParam('configuration'), this.configuration);
     }
     if (hasValue(this.fixedFilterQuery)) {
-      this.routeService.setParameter('fixedFilterQuery', this.fixedFilterQuery);
+      this.routeService.setParameter(this.searchConfigService.getCurrentSearchInstanceParam('fixedFilterQuery'), this.fixedFilterQuery);
     }
 
     this.currentScope$ = this.routeService.getQueryParameterValue('scope').pipe(
@@ -406,7 +406,7 @@ export class SearchComponent implements OnDestroy, OnInit {
     const sortOption$: Observable<SortOptions> = searchSortOptions$.pipe(
       switchMap((searchSortOptions: SortOptions[]) => {
         const defaultSort: SortOptions = searchSortOptions[0];
-        return this.searchConfigService.getCurrentSort(this.paginationId, defaultSort);
+        return this.searchConfigService.getCurrentSort(this.searchInstanceId, defaultSort);
       }),
       distinctUntilChanged(),
     );
@@ -414,8 +414,8 @@ export class SearchComponent implements OnDestroy, OnInit {
 
     this.subs.push(combineLatest([configuration$, searchSortOptions$, searchOptions$, sortOption$, this.currentScope$]).pipe(
       filter(([configuration, searchSortOptions, searchOptions, sortOption, scope]: [string, SortOptions[], PaginatedSearchOptions, SortOptions, string]) => {
-        // filter for search options related to instanced paginated id
-        return searchOptions.pagination.id === this.paginationId;
+        // filter for search options related to this search instance id
+        return searchOptions.pagination.id === this.searchInstanceId;
       }),
       debounceTime(100),
     ).subscribe(([configuration, searchSortOptions, searchOptions, sortOption, scope]: [string, SortOptions[], PaginatedSearchOptions, SortOptions, string]) => {

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -1,5 +1,6 @@
 import {
   AsyncPipe,
+  isPlatformBrowser,
   isPlatformServer,
   NgTemplateOutlet,
 } from '@angular/common';
@@ -16,6 +17,7 @@ import {
 } from '@angular/core';
 import {
   NavigationStart,
+  Params,
   Router,
 } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -32,6 +34,7 @@ import {
   filter,
   map,
   switchMap,
+  take,
 } from 'rxjs/operators';
 
 import {
@@ -380,6 +383,10 @@ export class SearchComponent implements OnDestroy, OnInit {
 
     this.searchConfigService.setSearchInstanceId(this.searchInstanceId);
 
+    if (isPlatformBrowser(this.platformId)) {
+      this.migrateLegacySearchParams();
+    }
+
     if (hasValue(this.configuration)) {
       this.routeService.setParameter(this.searchConfigService.getCurrentSearchInstanceParam('configuration'), this.configuration);
     }
@@ -584,6 +591,45 @@ export class SearchComponent implements OnDestroy, OnInit {
         }),
       );
     }
+  }
+
+  /**
+   * Detect legacy (unprefixed) search parameters in the current URL and replace them with their
+   * search-instance-prefixed equivalents (e.g. `query` becomes `spc.query`, `f.author` becomes
+   * `spc.f.author`). This keeps backwards compatibility with old search URLs while making sure that
+   * subsequent search interactions (entering a new query, adding a filter, ...) operate on the
+   * prefixed parameters only, instead of mixing or dropping the legacy ones.
+   * @private
+   */
+  private migrateLegacySearchParams(): void {
+    this.subs.push(this.routeService.getQueryParamMap().pipe(take(1)).subscribe((queryParamMap) => {
+      const prefix = `${this.searchInstanceId}.`;
+      const updatedParams: Params = {};
+      let hasLegacyParams = false;
+
+      queryParamMap.keys
+        .filter((key: string) => this.searchConfigService.isLegacySearchParam(key))
+        .forEach((key: string) => {
+          hasLegacyParams = true;
+          // Remove the legacy parameter from the URL
+          updatedParams[key] = null;
+          // Only move its value(s) to the prefixed parameter when no prefixed value is set yet,
+          // so an existing prefixed parameter always takes precedence over the legacy one.
+          const prefixedKey = `${prefix}${key}`;
+          if (!queryParamMap.has(prefixedKey)) {
+            const values: string[] = queryParamMap.getAll(key);
+            updatedParams[prefixedKey] = values.length > 1 ? values : values[0];
+          }
+        });
+
+      if (hasLegacyParams) {
+        void this.router.navigate([], {
+          queryParams: updatedParams,
+          queryParamsHandling: 'merge',
+          replaceUrl: true,
+        });
+      }
+    }));
   }
 
   /**

--- a/src/app/shared/search/themed-search.component.ts
+++ b/src/app/shared/search/themed-search.component.ts
@@ -38,7 +38,7 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
     'useCachedVersionIfAvailable',
     'inPlaceSearch',
     'linkType',
-    'paginationId',
+    'searchInstanceId',
     'searchEnabled',
     'sideBarWidth',
     'searchFormPlaceholder',
@@ -76,7 +76,7 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
 
   @Input() linkType: CollectionElementLinkType;
 
-  @Input() paginationId: string;
+  @Input() searchInstanceId: string;
 
   @Input() searchEnabled: boolean;
 

--- a/src/app/shared/testing/pagination-service.stub.ts
+++ b/src/app/shared/testing/pagination-service.stub.ts
@@ -24,6 +24,6 @@ export class PaginationServiceStub {
   updateRouteWithUrl = jasmine.createSpy('updateRouteWithUrl');
   clearPagination = jasmine.createSpy('clearPagination');
   getRouteParameterValue = jasmine.createSpy('getRouteParameterValue').and.returnValue(of(''));
-  getPageParam = jasmine.createSpy('getPageParam').and.returnValue(`${this.pagination.id}.page`);
+  getPageParam = jasmine.createSpy('getPageParam').and.callFake((paginationId: string) => `${paginationId}.page`);
 
 }

--- a/src/app/shared/testing/search-configuration-service.stub.ts
+++ b/src/app/shared/testing/search-configuration-service.stub.ts
@@ -17,7 +17,7 @@ import { SearchOptions } from '../search/models/search-options.model';
  */
 export class SearchConfigurationServiceStub {
 
-  public paginationID = 'test-id';
+  public searchInstanceId = 'test-id';
 
   public searchOptions: BehaviorSubject<SearchOptions> = new BehaviorSubject(new SearchOptions({}));
   public paginatedSearchOptions: BehaviorSubject<PaginatedSearchOptions> = new BehaviorSubject(new PaginatedSearchOptions({}));
@@ -28,6 +28,18 @@ export class SearchConfigurationServiceStub {
 
   getCurrentFilters() {
     return of([]);
+  }
+
+  getCurrentSearchInstanceParam(param: string) {
+    return `${this.searchInstanceId}.${param}`;
+  }
+
+  getCurrentSearchInstanceFilterParam(param: string) {
+    return `${this.searchInstanceId}.${param}`;
+  }
+
+  getCurrentPageParam() {
+    return `${this.searchInstanceId}.page`;
   }
 
   getCurrentScope(a) {


### PR DESCRIPTION
## References
* Fixes #5738
* Related backports:
  * 9.x: https://github.com/DSpace/dspace-angular/pull/5739
  * 10.x: https://github.com/DSpace/dspace-angular/pull/5740

## Description
Extends the per-search-instance prefixing (currently only applied to `sort` and `pagination`) to all remaining search route and query parameters, so multiple search components can coexist on a single page without interfering with each other.

## Instructions for Reviewers
This builds on the existing mechanism that prefixes `sort`/`pagination` params with a unique search-instance identifier, and applies the same approach to every other search parameter.

List of changes in this PR:
* Added a `searchInstanceId` to `SearchConfigurationService` and helper methods to build/read instance-scoped parameters: `getSearchInstanceParam`, `getCurrentSearchInstanceParam`, `getCurrentSearchInstanceQueryParam`, `getSearchInstanceFilterParam`, `getCurrentSearchInstanceFilterParam`, and `getSearchInstanceFilterParamPrefix`.
* Updated `getCurrentConfiguration`, `getCurrentScope`, `getCurrentQuery`, and `getCurrentDSOType` to resolve their values from instance-prefixed route/query parameters (with a fallback to the legacy unprefixed parameter for backwards compatibility).
* Updated `SearchFilterService` and `SearchService` to read/write the `f.xxx` filter parameters and `view` using the instance prefix.
* Updated the search UI components that emit search params — `search.component`, `search-form.component`, `search-results.component`, `search-settings.component`, `search-switch-configuration.component`, `search-navbar.component`, `search-page.component`, `configuration-search-page.component`, `themed(-configuration)-search.component`, the facet/range filter option components, and `object-collection.component` — to use the instance-prefixed parameter names.
* Updated the relation-lookup-modal search/selection/external-source tabs, `recent-item-list`, `my-dspace-configuration.service`, and `my-dspace.guard` to use the new instance-scoped params.
* Updated specs and the `search-configuration-service`/`pagination-service` test stubs accordingly.


**How to test (multiple search instances):**
1. Build and run the UI (`yarn start` / `npm start`).
2. Render a page containing **two independent search instances**. Each instance needs its **own `SearchConfigurationService` injection**, so use two separate `ConfigurationSearchPageComponent`/`SearchPageComponent` instances — **not** two `SearchComponent` instances sharing a single `SearchConfigurationService`. Because `searchInstanceId` is stored as an instance variable on the service, two `SearchComponent`s backed by the same service would overwrite each other's id.
3. Give each instance a **unique `searchInstanceId`** by explicitly passing it in (e.g. `[searchInstanceId]="'first'"` and `[searchInstanceId]="'second'"`), since the components default to the same id otherwise.
4. In one instance, change the query, scope, configuration, view mode, `dsoType`, and apply facet/range filters.
5. Verify the URL params for that instance are prefixed with its id (e.g. `first.query`, `first.f.author`, `first.configuration`) and that the second instance is unaffected, and vice versa.
6. Confirm a single-search page (default instance id) still behaves as before.

**How to test (backwards compatibility of legacy URLs):**
1. With a single search page, open a URL that uses the old **unprefixed** parameters (e.g. `/search?query=cats&f.author=Smith,equals&view=list`), as produced by older versions / external links / bookmarks.
2. Verify that on load the legacy params are migrated to their instance-prefixed equivalents (e.g. the URL is rewritten to `spc.query=cats&spc.f.author=Smith,equals&spc.view=list`) and the search results, active filters, and view mode reflect those values.
3. Verify that when both a legacy and an already-prefixed param are present, the prefixed one takes precedence and the legacy one is dropped without overriding it.
4. Confirm that subsequent search interactions (new query, adding/removing a filter, paging) operate only on the prefixed params and don't reintroduce the legacy ones.

## Checklist
- [ ] My PR is **created against the `main` branch** of code — _N/A: this is a version-specific PR targeting `dspace-10_x` (the bug is being fixed on the 7.6/9.x/10.x lines)._
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
