### PR TITLE
Fix/5109 debounce metadata field keystroke

### DIFF
--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-field.service.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value-field/dso-edit-metadata-field.service.ts
@@ -23,6 +23,9 @@ import { switchMap } from 'rxjs/operators';
 })
 export class DsoEditMetadataFieldService {
 
+  private static readonly VALID_METADATA_FIELD_PATTERN =
+    /^[a-zA-Z][a-zA-Z0-9_-]*\.[a-zA-Z]{2,}[a-zA-Z0-9_-]*(\.[a-zA-Z]{2,}[a-zA-Z0-9_-]*)?$/;
+
   constructor(
     protected itemService: ItemDataService,
     protected vocabularyService: VocabularyService,
@@ -36,7 +39,7 @@ export class DsoEditMetadataFieldService {
    * @param mdField The metadata field
    */
   findDsoFieldVocabulary(dso: DSpaceObject, mdField: string): Observable<Vocabulary> {
-    if (isNotEmpty(mdField)) {
+    if (isNotEmpty(mdField) && DsoEditMetadataFieldService.VALID_METADATA_FIELD_PATTERN.test(mdField)) {
       const owningCollection$: Observable<Collection> = this.itemService.findByHref(dso._links.self.href, true, true, followLink('owningCollection')).pipe(
         getFirstSucceededRemoteDataPayload(),
         switchMap((item: Item) => item.owningCollection),

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -24,6 +24,7 @@ import {
   VIRTUAL_METADATA_PREFIX,
 } from '@dspace/core/shared/metadata.models';
 import { ItemMetadataRepresentation } from '@dspace/core/shared/metadata-representation/item/item-metadata-representation.model';
+import { Vocabulary } from '@dspace/core/submission/vocabularies/models/vocabulary.model';
 import { DsoEditMetadataFieldServiceStub } from '@dspace/core/testing/dso-edit-metadata-field.service.stub';
 import { createPaginatedList } from '@dspace/core/testing/utils.test';
 import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
@@ -39,12 +40,10 @@ import {
   DsoEditMetadataChangeType,
   DsoEditMetadataValue,
 } from '../dso-edit-metadata-form';
+import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
 import { DsoEditMetadataFieldService } from '../dso-edit-metadata-value-field/dso-edit-metadata-field.service';
 import { DsoEditMetadataValueFieldLoaderComponent } from '../dso-edit-metadata-value-field/dso-edit-metadata-value-field-loader/dso-edit-metadata-value-field-loader.component';
 import { DsoEditMetadataValueComponent } from './dso-edit-metadata-value.component';
-
-import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
-import { Vocabulary } from '@dspace/core/submission/vocabularies/models/vocabulary.model';
 
 const EDIT_BTN = 'edit';
 const CONFIRM_BTN = 'confirm';
@@ -248,18 +247,18 @@ describe('DsoEditMetadataValueComponent', () => {
 
   describe('fieldType$', () => {
 
-    let metadataSchema: MetadataSchema;
+    let dcMetadataSchema: MetadataSchema;
     let metadataFieldDcTitle: MetadataField;
 
     beforeEach(() => {
-      metadataSchema = Object.assign(new MetadataSchema(), {
+      dcMetadataSchema = Object.assign(new MetadataSchema(), {
         prefix: 'dc',
       });
 
       metadataFieldDcTitle = Object.assign(new MetadataField(), {
         element: 'title',
         qualifier: null,
-        schema: createSuccessfulRemoteDataObject$(metadataSchema),
+        schema: createSuccessfulRemoteDataObject$(dcMetadataSchema),
       });
     });
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -40,8 +40,8 @@ import {
   DsoEditMetadataChangeType,
   DsoEditMetadataValue,
 } from '../dso-edit-metadata-form';
-import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
 import { DsoEditMetadataFieldService } from '../dso-edit-metadata-value-field/dso-edit-metadata-field.service';
+import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
 import { DsoEditMetadataValueFieldLoaderComponent } from '../dso-edit-metadata-value-field/dso-edit-metadata-value-field-loader/dso-edit-metadata-value-field-loader.component';
 import { DsoEditMetadataValueComponent } from './dso-edit-metadata-value.component';
 

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.spec.ts
@@ -4,7 +4,9 @@ import {
 } from '@angular/core';
 import {
   ComponentFixture,
+  fakeAsync,
   TestBed,
+  tick,
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -41,6 +43,9 @@ import { DsoEditMetadataFieldService } from '../dso-edit-metadata-value-field/ds
 import { DsoEditMetadataValueFieldLoaderComponent } from '../dso-edit-metadata-value-field/dso-edit-metadata-value-field-loader/dso-edit-metadata-value-field-loader.component';
 import { DsoEditMetadataValueComponent } from './dso-edit-metadata-value.component';
 
+import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
+import { Vocabulary } from '@dspace/core/submission/vocabularies/models/vocabulary.model';
+
 const EDIT_BTN = 'edit';
 const CONFIRM_BTN = 'confirm';
 const REMOVE_BTN = 'remove';
@@ -60,7 +65,7 @@ describe('DsoEditMetadataValueComponent', () => {
   let metadataValue: MetadataValue;
   let dso: DSpaceObject;
 
-  const collection =  Object.assign(new Collection(), {
+  const collection = Object.assign(new Collection(), {
     uuid: 'fake-uuid',
   });
 
@@ -239,6 +244,147 @@ describe('DsoEditMetadataValueComponent', () => {
     assertButton(REMOVE_BTN, true, true);
     assertButton(UNDO_BTN, true, true);
     assertButton(DRAG_BTN, true, false);
+  });
+
+  describe('fieldType$', () => {
+
+    let metadataSchema: MetadataSchema;
+    let metadataFieldDcTitle: MetadataField;
+
+    beforeEach(() => {
+      metadataSchema = Object.assign(new MetadataSchema(), {
+        prefix: 'dc',
+      });
+
+      metadataFieldDcTitle = Object.assign(new MetadataField(), {
+        element: 'title',
+        qualifier: null,
+        schema: createSuccessfulRemoteDataObject$(metadataSchema),
+      });
+    });
+
+    describe('when the metadata field is incomplete or invalid', () => {
+      const invalidFields = ['dc', 'dc.', 'dc.c', 'dc.re'];
+
+      invalidFields.forEach((field) => {
+        it(`should not call findDsoFieldVocabulary for incomplete field "${field}"`, fakeAsync(() => {
+          spyOn(dsoEditMetadataFieldService, 'findDsoFieldVocabulary').and.callThrough();
+          component.mdField = field;
+          tick(300);
+          expect(dsoEditMetadataFieldService.findDsoFieldVocabulary).not.toHaveBeenCalled();
+        }));
+      });
+    });
+
+    describe('when the metadata field does not exist on the server', () => {
+      beforeEach(() => {
+        (registryService.queryMetadataFields as jasmine.Spy).and.returnValue(
+          createSuccessfulRemoteDataObject$(createPaginatedList([])),
+        );
+      });
+
+      it('should not call findDsoFieldVocabulary if field does not exist', fakeAsync(() => {
+        spyOn(dsoEditMetadataFieldService, 'findDsoFieldVocabulary').and.callThrough();
+        component.mdField = 'dc.nonexistent';
+        tick(300);
+        expect(dsoEditMetadataFieldService.findDsoFieldVocabulary).not.toHaveBeenCalled();
+      }));
+
+      it('should emit PLAIN_TEXT if field does not exist on server', fakeAsync(() => {
+        let result: EditMetadataValueFieldType;
+        component.fieldType$.subscribe((fieldType) => result = fieldType);
+        component.mdField = 'dc.nonexistent';
+        tick(300);
+        expect(result).toBe(EditMetadataValueFieldType.PLAIN_TEXT);
+      }));
+    });
+
+    describe('when the metadata field is valid and exists on the server', () => {
+      beforeEach(() => {
+        (registryService.queryMetadataFields as jasmine.Spy).and.returnValue(
+          createSuccessfulRemoteDataObject$(createPaginatedList([metadataFieldDcTitle])),
+        );
+      });
+
+      it('should emit a field type when field is valid and exists', fakeAsync(() => {
+        let result: EditMetadataValueFieldType;
+        const freshFixture = TestBed.createComponent(DsoEditMetadataValueComponent);
+        const freshComponent = freshFixture.componentInstance;
+        freshComponent.mdValue = editMetadataValue;
+        freshComponent.dso = dso;
+        freshComponent.metadataSecurityConfiguration = mockSecurityConfig;
+        freshComponent.saving$ = of(false);
+        spyOn(freshComponent, 'validateMetadataField').and.returnValue(of(true));
+        freshFixture.detectChanges();
+        freshComponent.fieldType$.subscribe((fieldType) => result = fieldType);
+        freshComponent.mdField = 'dc.title';
+        tick(300);
+        expect([
+          EditMetadataValueFieldType.PLAIN_TEXT,
+          EditMetadataValueFieldType.AUTHORITY,
+          EditMetadataValueFieldType.ENTITY_TYPE,
+        ]).toContain(result);
+      }));
+
+      it('should emit PLAIN_TEXT when no vocabulary is associated', fakeAsync(() => {
+        let result: EditMetadataValueFieldType;
+        const freshFixture = TestBed.createComponent(DsoEditMetadataValueComponent);
+        const freshComponent = freshFixture.componentInstance;
+        freshComponent.mdValue = editMetadataValue;
+        freshComponent.dso = dso;
+        freshComponent.metadataSecurityConfiguration = mockSecurityConfig;
+        freshComponent.saving$ = of(false);
+        spyOn(freshComponent, 'validateMetadataField').and.returnValue(of(true));
+        freshFixture.detectChanges();
+        freshComponent.fieldType$.subscribe((fieldType) => result = fieldType);
+        freshComponent.mdField = 'dc.title';
+        tick(300);
+        expect(result).toBe(EditMetadataValueFieldType.PLAIN_TEXT);
+      }));
+
+      it('should emit AUTHORITY when a vocabulary is associated', fakeAsync(() => {
+        let result: EditMetadataValueFieldType;
+        spyOn(dsoEditMetadataFieldService, 'findDsoFieldVocabulary').and.returnValue(of(new Vocabulary()));
+        const freshFixture = TestBed.createComponent(DsoEditMetadataValueComponent);
+        const freshComponent = freshFixture.componentInstance;
+        freshComponent.mdValue = editMetadataValue;
+        freshComponent.dso = dso;
+        freshComponent.metadataSecurityConfiguration = mockSecurityConfig;
+        freshComponent.saving$ = of(false);
+        spyOn(freshComponent, 'validateMetadataField').and.returnValue(of(true));
+        freshFixture.detectChanges();
+        freshComponent.fieldType$.subscribe((fieldType) => result = fieldType);
+        freshComponent.mdField = 'dc.title';
+        tick(300);
+        expect(result).toBe(EditMetadataValueFieldType.AUTHORITY);
+      }));
+
+      it('should emit ENTITY_TYPE for dspace.entity.type field', fakeAsync(() => {
+        let result: EditMetadataValueFieldType;
+        const dspaceSchema = Object.assign(new MetadataSchema(), { prefix: 'dspace' });
+        const entityTypeField = Object.assign(new MetadataField(), {
+          element: 'entity',
+          qualifier: 'type',
+          schema: createSuccessfulRemoteDataObject$(dspaceSchema),
+        });
+        (registryService.queryMetadataFields as jasmine.Spy).and.returnValue(
+          createSuccessfulRemoteDataObject$(createPaginatedList([entityTypeField])),
+        );
+        const freshFixture = TestBed.createComponent(DsoEditMetadataValueComponent);
+        const freshComponent = freshFixture.componentInstance;
+        freshComponent.mdValue = editMetadataValue;
+        freshComponent.dso = dso;
+        freshComponent.metadataSecurityConfiguration = mockSecurityConfig;
+        freshComponent.saving$ = of(false);
+        spyOn(freshComponent, 'validateMetadataField').and.returnValue(of(true));
+        freshFixture.detectChanges();
+        freshComponent.fieldType$.subscribe((fieldType) => result = fieldType);
+        freshComponent.mdField = 'dspace.entity.type';
+        tick(300);
+        expect(result).toBe(EditMetadataValueFieldType.ENTITY_TYPE);
+      }));
+    });
+
   });
 
   function assertButton(name: string, exists: boolean, disabled: boolean = false): void {

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
@@ -38,6 +38,7 @@ import {
   MetadataRepresentationType,
 } from '@dspace/core/shared/metadata-representation/metadata-representation.model';
 import {
+  debounceTimeWorkaround as debounceTime,
   getFirstCompletedRemoteData,
   metadataFieldsToString,
 } from '@dspace/core/shared/operators';
@@ -82,7 +83,6 @@ import {
 import { DsoEditMetadataFieldService } from '../dso-edit-metadata-value-field/dso-edit-metadata-field.service';
 import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
 import { DsoEditMetadataValueFieldLoaderComponent } from '../dso-edit-metadata-value-field/dso-edit-metadata-value-field-loader/dso-edit-metadata-value-field-loader.component';
-import { debounceTimeWorkaround as debounceTime } from '../../../core/shared/operators';
 
 @Component({
   selector: 'ds-dso-edit-metadata-value',
@@ -109,6 +109,15 @@ import { debounceTimeWorkaround as debounceTime } from '../../../core/shared/ope
  * Component displaying a single editable row for a metadata value
  */
 export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestroy {
+
+
+  /**
+   * Minimum valid metadata field pattern: schema.element or schema.element.qualifier.
+   * Used to skip vocabulary and field-type lookups for incomplete inputs, preventing
+   * unnecessary backend requests that would result in 422 errors.
+   */
+  private static readonly VALID_METADATA_FIELD_PATTERN =
+    /^[a-zA-Z][a-zA-Z0-9_-]*\.[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)?$/;
 
   @Input() context: Context;
 
@@ -151,14 +160,6 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
   }
 
   protected readonly _mdField$ = new BehaviorSubject<string | null>(null);
-
-  /**
-   * Minimum valid metadata field pattern: schema.element or schema.element.qualifier.
-   * Used to skip vocabulary and field-type lookups for incomplete inputs, preventing
-   * unnecessary backend requests that would result in 422 errors.
-   */
-  private static readonly VALID_METADATA_FIELD_PATTERN =
-    /^[a-zA-Z][a-zA-Z0-9_-]*\.[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)?$/;
 
   /**
    * Flag whether this is a new metadata field or exists already

--- a/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
+++ b/src/app/dso-shared/dso-edit-metadata/dso-edit-metadata-value/dso-edit-metadata-value.component.ts
@@ -82,6 +82,7 @@ import {
 import { DsoEditMetadataFieldService } from '../dso-edit-metadata-value-field/dso-edit-metadata-field.service';
 import { EditMetadataValueFieldType } from '../dso-edit-metadata-value-field/dso-edit-metadata-field-type.enum';
 import { DsoEditMetadataValueFieldLoaderComponent } from '../dso-edit-metadata-value-field/dso-edit-metadata-value-field-loader/dso-edit-metadata-value-field-loader.component';
+import { debounceTimeWorkaround as debounceTime } from '../../../core/shared/operators';
 
 @Component({
   selector: 'ds-dso-edit-metadata-value',
@@ -116,6 +117,7 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
    * Also used to determine metadata-representations in case of virtual metadata
    */
   @Input() dso: DSpaceObject;
+
   /**
    * Editable metadata value to show
    */
@@ -149,6 +151,14 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
   }
 
   protected readonly _mdField$ = new BehaviorSubject<string | null>(null);
+
+  /**
+   * Minimum valid metadata field pattern: schema.element or schema.element.qualifier.
+   * Used to skip vocabulary and field-type lookups for incomplete inputs, preventing
+   * unnecessary backend requests that would result in 422 errors.
+   */
+  private static readonly VALID_METADATA_FIELD_PATTERN =
+    /^[a-zA-Z][a-zA-Z0-9_-]*\.[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)?$/;
 
   /**
    * Flag whether this is a new metadata field or exists already
@@ -228,6 +238,7 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
    * The name of the item represented by this virtual metadata value (otherwise null)
    */
   mdRepresentationName$: Observable<string | null>;
+
   readonly mdSecurityConfigLevel$: BehaviorSubject<number[]> = new BehaviorSubject<number[]>([]);
 
   canShowMetadataSecurity$: Observable<boolean>;
@@ -239,7 +250,6 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
    */
   public editingAuthority = false;
 
-
   /**
    * Whether or not the free-text editing is enabled when scrollable dropdown or hierarchical vocabulary is used
    */
@@ -249,7 +259,7 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
    * Field group used by authority field
    * @type {UntypedFormGroup}
    */
-  group = new UntypedFormGroup({ authorityField : new UntypedFormControl() });
+  group = new UntypedFormGroup({ authorityField: new UntypedFormControl() });
 
   /**
    * The type of edit field that should be displayed
@@ -273,19 +283,60 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
   ngOnInit(): void {
     this.initVirtualProperties();
 
+    /**
+     * Reactively determine the field type as the user types, with debouncing to avoid
+     * unnecessary backend requests on every keystroke.
+     *
+     * The pipeline:
+     * 1. debounceTime: waits 300ms after the last keystroke before proceeding.
+     * 2. distinctUntilChanged: skips if the value hasn't changed.
+     * 3. VALID_METADATA_FIELD_PATTERN: early exit for inputs that don't match the
+     *    minimum schema.element format, avoiding requests with partial inputs.
+     * 4. validateMetadataField: confirms the field exists on the server via byFieldName
+     *    before calling byMetadataAndCollection, preventing 422 errors from incomplete inputs.
+     * 5. findDsoFieldVocabulary: only called once the field is confirmed valid.
+     */
+    this.fieldType$ = this._mdField$.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap((field: string) => {
+        if (!field || !DsoEditMetadataValueComponent.VALID_METADATA_FIELD_PATTERN.test(field)) {
+          return of(EditMetadataValueFieldType.PLAIN_TEXT);
+        }
+        return this.validateMetadataField().pipe(
+          switchMap((isValid: boolean) => {
+            if (!isValid) {
+              return of(EditMetadataValueFieldType.PLAIN_TEXT);
+            }
+            return this.dsoEditMetadataFieldService.findDsoFieldVocabulary(this.dso, field).pipe(
+              map((vocabulary: Vocabulary) => {
+                if (hasValue(vocabulary)) {
+                  return EditMetadataValueFieldType.AUTHORITY;
+                }
+                if (field === 'dspace.entity.type') {
+                  return EditMetadataValueFieldType.ENTITY_TYPE;
+                }
+                return EditMetadataValueFieldType.PLAIN_TEXT;
+              }),
+            );
+          }),
+        );
+      }),
+    );
+
     this.sub = combineLatest([
       this._mdField$,
       this._metadataSecurityConfiguration$.pipe(filter(config => !!config)),
     ]).subscribe(([mdField, metadataSecurityConfig]) => this.initSecurityLevel(mdField, metadataSecurityConfig));
 
     this.canShowMetadataSecurity$ =
-        combineLatest([
-          this._mdField$.pipe(distinctUntilChanged()),
-          this.mdSecurityConfigLevel$,
-        ]).pipe(
-          map(([mdField, securityConfigLevel]) => hasValue(mdField) && this.hasSecurityChoice(securityConfigLevel)),
-          shareReplay({ refCount: false, bufferSize: 1 }),
-        );
+      combineLatest([
+        this._mdField$.pipe(distinctUntilChanged()),
+        this.mdSecurityConfigLevel$,
+      ]).pipe(
+        map(([mdField, securityConfigLevel]) => hasValue(mdField) && this.hasSecurityChoice(securityConfigLevel)),
+        shareReplay({ refCount: false, bufferSize: 1 }),
+      );
   }
 
   /**
@@ -338,37 +389,15 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
     return securityConfigLevel?.length > 1;
   }
 
-
-  /**
-   * Retrieves the {@link EditMetadataValueFieldType} to be displayed for the current field while in edit mode.
-   */
-  getFieldType(): Observable<EditMetadataValueFieldType> {
-    return this.dsoEditMetadataFieldService.findDsoFieldVocabulary(this.dso, this.mdField).pipe(
-      map((vocabulary: Vocabulary) => {
-        if (hasValue(vocabulary)) {
-          return EditMetadataValueFieldType.AUTHORITY;
-        }
-        if (this.mdField === 'dspace.entity.type') {
-          return EditMetadataValueFieldType.ENTITY_TYPE;
-        }
-        return EditMetadataValueFieldType.PLAIN_TEXT;
-      }),
-    );
-  }
-
   /**
    * Change callback for the component. Check if the mdField has changed to retrieve whether it is metadata
-   * that uses a controlled vocabulary and update the related properties
+   * that uses a controlled vocabulary and update the related properties.
    *
    * @param {SimpleChanges} changes
    */
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.mdField) {
-      this.fieldType$ = this.getFieldType();
-    }
-
     if (isNotEmpty(changes.mdField) && !changes.mdField.firstChange) {
-      if (isNotEmpty(changes.mdField.currentValue) ) {
+      if (isNotEmpty(changes.mdField.currentValue)) {
         if (isNotEmpty(changes.mdField.previousValue) &&
           changes.mdField.previousValue !== changes.mdField.currentValue) {
           // Clear authority value in case it has been assigned with the previous metadataField used
@@ -376,8 +405,8 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
           this.mdValue.newValue.confidence = ConfidenceType.CF_UNSET;
         }
 
-        // Only ask if the current mdField have a period character to reduce request
-        if (changes.mdField.currentValue.includes('.')) {
+        // Only validate if the field matches the minimum valid format to reduce unnecessary requests
+        if (DsoEditMetadataValueComponent.VALID_METADATA_FIELD_PATTERN.test(changes.mdField.currentValue)) {
           this.validateMetadataField().subscribe((isValid: boolean) => {
             if (isValid) {
               this.cdr.detectChanges();
@@ -408,7 +437,6 @@ export class DsoEditMetadataValueComponent implements OnInit, OnChanges, OnDestr
       }),
     );
   }
-
 
   ngOnDestroy(): void {
     if (hasValue(this.sub)) {


### PR DESCRIPTION
## References
* Fixes #5109

## Description
Debounces metadata field name input and gates `findDsoFieldVocabulary()` behind `validateMetadataField()` to prevent 422 errors being triggered on every keystroke when editing item metadata.

## Instructions for Reviewers

### Root Cause
`DsoEditMetadataValueComponent#ngOnChanges` reassigned `fieldType$` on every input change, immediately invoking `findDsoFieldVocabulary()` with no debounce. The `isNotEmpty()` guard in `DsoEditMetadataFieldService` passed for any non-empty string including partial inputs like `dc.re`, causing `byMetadataAndCollection` requests that resulted in 422 errors. Since the 422 propagates through the full Spring Security filter chain before reaching the controller layer, no `@ExceptionHandler` catches it — which is why the stack traces are so verbose.

Reproduced and confirmed on **DSpace 9.1**, **DSpace 10.0** and **DSpace 11.0-SNAPSHOT**.

### List of changes

* **`dso-edit-metadata-value.component.ts`**: Moved `fieldType$` initialization to `ngOnInit` using the existing `_mdField$` BehaviorSubject with a reactive pipeline: `debounceTimeWorkaround(300)` + `distinctUntilChanged()` + regex guard + `validateMetadataField()` before calling `findDsoFieldVocabulary()`. Replaced `includes('.')` with the same regex guard in `ngOnChanges`. Removed unused `getFieldType()` method.
* **`dso-edit-metadata-field.service.ts`**: Added `VALID_METADATA_FIELD_PATTERN` regex as a defensive guard in `findDsoFieldVocabulary()`, rejecting inputs that don't match `schema.element` or `schema.element.qualifier` format before making any HTTP request.
* **`dso-edit-metadata-value.component.spec.ts`**: Added 10 new unit tests for the `fieldType$` pipeline using `fakeAsync/tick(300)`, consistent with the project's `debounceTimeWorkaround` testing approach.

### Before
Typing `dc.contributor.author` (20 chars) generated ~40 requests and thousands of log lines per session, e.g.:

    [422] dc.c is not a valid metadata
    [422] dc.co is not a valid metadata
    [422] dc.con is not a valid metadata
    [422] dc.cont is not a valid metadata
    ... (stack trace repeating for each keystroke)

### After
Typing `dc.contributor.author` generates exactly 1 request to `byMetadataAndCollection`, fired only after the field is confirmed valid:

    GET /server/api/core/metadatafields/search/byFieldName  ← field confirmed valid
    GET /server/api/submission/vocabularies/search/byMetadataAndCollection  ← 200 OK

### How to Test
1. Start DSpace backend and frontend
2. Navigate to an item's edit metadata page: `/items/{uuid}/edit/metadata`
3. Click **"+ Add"**
4. Slowly type `dc.contributor.author` in the metadata field name input, pausing between keystrokes
5. Monitor backend logs: `docker logs -f dspace | grep -E "422|byMetadataAndCollection"`

**Expected result:** No 422 errors appear in the logs during typing. A single `byMetadataAndCollection` request fires only after the complete field name has been confirmed as valid.

## Checklist
- [x] My PR is **created against the `main` branch**
- [x] My PR is **small in size** (3 files modified)
- [ ] My PR **passes ESLint** — `npm run lint` fails with a pre-existing error unrelated to this fix (`src/themes/custom/eager-theme-components.ts`). ESLint was run directly on the 3 modified files and passes without errors.
- [x] My PR **doesn't introduce circular dependencies** (verified via `npx madge --circular` on the affected directory)
- [x] My PR **includes TypeDoc comments** for modified methods
- [x] My PR **passes all specs/tests and includes new/updated specs**
- [x] My PR **aligns with Accessibility guidelines** (no UI changes)
- [x] My PR **uses i18n keys** (no hardcoded English text added)
- [x] My PR **includes details on how to test it**
