### PR TITLE
Improve selected state and keyboard navigation in DSO selector

### DIFF
--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.html
@@ -22,15 +22,17 @@
           {{'dso-selector.no-results' | translate: { type: typesString } }}
         </button>
       }
-      @for (listEntry of (listEntries$ | async); track listEntry) {
+      @for (listEntry of (listEntries$ | async); track listEntry; let i = $index) {
         <button
+          tabindex="0"
           class="list-group-item list-group-item-action border-0 list-entry"
-          [ngClass]="{'bg-primary': listEntry['id'] === currentDSOId}"
+          [ngClass]="{ 'active': isCurrentDso(listEntry) }"
+          [attr.aria-current]="isCurrentDso(listEntry) ? 'true' : null"
           title="{{ getName(listEntry) }}"
           dsHoverClass="ds-hover"
-          (click)="onClick(listEntry)" #listEntryElement>
+          (click)="onClick(listEntry)" (keydown)="onListEntryKeydown($event, i)" #listEntryElement>
           <ds-listable-object-component-loader [object]="listEntry" [viewMode]="viewMode"
-          [linkType]=linkTypes.None [context]="getContext(listEntry['id'])"></ds-listable-object-component-loader>
+          [linkType]=linkTypes.None [context]="getContext(getDsoId(listEntry))"></ds-listable-object-component-loader>
         </button>
       }
     }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -1,6 +1,8 @@
 import {
   DebugElement,
+  ElementRef,
   NO_ERRORS_SCHEMA,
+  QueryList,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -108,6 +110,66 @@ describe('DSOSelectorComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('getDsoId', () => {
+    it('should return the id of the indexable object', () => {
+      expect(component.getDsoId(searchResult)).toEqual(searchResult.indexableObject.id);
+    });
+  });
+
+  describe('isCurrentDso', () => {
+    it('should return true when the list entry represents the current DSO', () => {
+      component.currentDSOId = searchResult.indexableObject.id;
+
+      expect(component.isCurrentDso(searchResult)).toBeTrue();
+    });
+
+    it('should return false when the list entry does not represent the current DSO', () => {
+      component.currentDSOId = 'another-id';
+
+      expect(component.isCurrentDso(searchResult)).toBeFalse();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    let firstElement: HTMLButtonElement;
+    let secondElement: HTMLButtonElement;
+
+    beforeEach(() => {
+      firstElement = document.createElement('button');
+      secondElement = document.createElement('button');
+
+      const listElements = new QueryList<ElementRef>();
+      listElements.reset([
+        new ElementRef(firstElement),
+        new ElementRef(secondElement),
+      ]);
+
+      component.listElements = listElements;
+    });
+
+    it('should move focus to the next list entry when pressing ArrowDown', () => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+      spyOn(event, 'preventDefault');
+      spyOn(secondElement, 'focus');
+
+      component.onListEntryKeydown(event, 0);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(secondElement.focus).toHaveBeenCalled();
+    });
+
+    it('should move focus to the previous list entry when pressing ArrowUp', () => {
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+      spyOn(event, 'preventDefault');
+      spyOn(firstElement, 'focus');
+
+      component.onListEntryKeydown(event, 1);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(firstElement.focus).toHaveBeenCalled();
+    });
   });
 
   describe('populating listEntries', () => {

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -1,6 +1,6 @@
 import {
   AsyncPipe,
-  NgClass,
+  NgClass
 } from '@angular/common';
 import {
   Component,
@@ -332,6 +332,56 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       return Context.SideBarSearchModalCurrent;
     } else {
       return Context.SideBarSearchModal;
+    }
+  }
+
+  /**
+   * Get the DSO id from the given listable object
+   * @param listableObject The {@link ListableObject} to evaluate
+   */
+  getDsoId(listableObject: ListableObject): string {
+    const searchResult = listableObject as SearchResult<DSpaceObject>;
+    return hasValue(searchResult.indexableObject) ? searchResult.indexableObject.id : null;
+  }
+
+  /**
+   * Check if the given list entry represents the currently selected DSO
+   * @param listableObject The {@link ListableObject} to evaluate
+   */
+  isCurrentDso(listableObject: ListableObject): boolean {
+    return this.getDsoId(listableObject) === this.currentDSOId;
+  }
+
+  /**
+   * Handles keyboard navigation between list entries
+   * @param event The keyboard event
+   * @param index The index of the current list entry
+   */
+  onListEntryKeydown(event: KeyboardEvent, index: number): void {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusListEntry(index + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusListEntry(index - 1);
+        break;
+    }
+  }
+
+  /**
+   * Set focus on the list entry at the given index
+   * @param index The index of the list entry to focus
+   */
+  private focusListEntry(index: number): void {
+    if (this.listElements.length > 0) {
+      const boundedIndex = Math.max(0, Math.min(index, this.listElements.length - 1));
+      const element = this.listElements.get(boundedIndex);
+
+      if (hasValue(element)) {
+        element.nativeElement.focus();
+      }
     }
   }
 


### PR DESCRIPTION
## References

* Fixes #5529

## Description

This PR fixes the visual state of the selected collection in the selector, when moving an item from one collection to another, and also fixes keyboard navigation in Safari.

## Instructions for Reviewers

List of changes in this PR:

* Fixed the selected collection state by resolving the actual DSO id from `listEntry.indexableObject.id` instead of using `listEntry['id']`.
* Replaced the previous conditional class logic with Bootstrap’s `active` state, so the selected collection is clearly marked.
* Added helper methods to keep the selected-state logic out of the template.
* Added `tabindex="0"` to the list entries to fix a Safari issue where focus skipped the collection list and moved directly from the search input to the final action buttons.
* Used the `@for` `$index` to support keyboard navigation with `ArrowDown` and `ArrowUp` between collection entries in Safari.
* Added unit tests for selected DSO detection and keyboard focus navigation.

How to test:

1. Go to Admin Search.
2. Select an item and choose Move Item.
3. In the collection selector, select a collection.
4. Verify that the selected collection is clearly marked.
5. Select another collection and verify that the active state updates.
6. In Safari, use `Tab` from the search input and verify that focus enters the collection list instead of skipping to the final action buttons.
7. Use `ArrowDown` and `ArrowUp` to move through the collection entries.
8. Use `Enter` or `Space` to select the focused collection.

Note: I was not able to reproduce the keyboard navigation issue in Chrome, but I was able to reproduce and validate the fix in Safari.

## Checklist

* [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
* [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
* [x] My PR **passes [[ESLint](https://eslint.org/)](https://eslint.org/)** validation using `npm run lint`
* [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
* [x] My PR **includes [[TypeDoc](https://typedoc.org/)](https://typedoc.org/)** comments for *all new (or modified) public methods and classes*. It also includes TypeDoc for large or complex private methods.
* [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [[Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide)](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
* [x] My PR **aligns with [[Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
* [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
* [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
* [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [[DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE)](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [[Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
* [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
* [x] If my PR fixes an issue ticket, I've [[linked them together](https://docs.github.com/en/issues/tracking-your-work/issues/linking-a-pull-request-to-an-issue)](https://docs.github.com/en/issues/tracking-your-work/issues/linking-a-pull-request-to-an-issue).