### PR TITLE
Fix unused standalone imports warnings

### DIFF
--- a/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.ts
+++ b/src/app/shared/orcid-badge-and-tooltip/orcid-badge-and-tooltip.component.ts
@@ -1,7 +1,4 @@
-import {
-  AsyncPipe,
-  NgClass,
-} from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import {
   Component,
   Input,
@@ -28,7 +25,6 @@ import { getFirstSucceededRemoteDataPayload } from '../../core/shared/operators'
   imports: [
     AsyncPipe,
     NgbTooltip,
-    NgClass,
   ],
   templateUrl: './orcid-badge-and-tooltip.component.html',
   styleUrl: './orcid-badge-and-tooltip.component.scss',

--- a/src/themes/custom/app/submission/sections/upload/file/section-upload-file.component.ts
+++ b/src/themes/custom/app/submission/sections/upload/file/section-upload-file.component.ts
@@ -4,7 +4,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SubmissionSectionUploadFileComponent as BaseComponent } from 'src/app/submission/sections/upload/file/section-upload-file.component';
 
 import { BtnDisabledDirective } from '../../../../../../../app/shared/btn-disabled.directive';
-import { ThemedFileDownloadLinkComponent } from '../../../../../../../app/shared/file-download-link/themed-file-download-link.component';
 import { SubmissionSectionUploadFileViewComponent } from '../../../../../../../app/submission/sections/upload/file/view/section-upload-file-view.component';
 
 @Component({
@@ -17,7 +16,6 @@ import { SubmissionSectionUploadFileViewComponent } from '../../../../../../../a
     AsyncPipe,
     BtnDisabledDirective,
     SubmissionSectionUploadFileViewComponent,
-    ThemedFileDownloadLinkComponent,
     TranslateModule,
   ],
 })


### PR DESCRIPTION
## References

* Fixes #5866

## Description

This PR removes unused standalone imports that were causing Angular NG8113 warnings during the build.

## Instructions for Reviewers

List of changes in this PR:

* Removed the unused `NgClass` import from `OrcidBadgeAndTooltipComponent`.
* Removed the unused `ThemedFileDownloadLinkComponent` import from `SubmissionSectionUploadFileComponent`.
* No functional changes were made.

How to test:

1. Run the Angular build using `yarn build` or `npm run build`.
2. Verify that the NG8113 warnings reported in #5866 are no longer shown.

## Checklist

* [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
* [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
* [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
* [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
* [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for *all new (or modified) public methods and classes*. It also includes TypeDoc for large or complex private methods.
* [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
* [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
* [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
* [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
* [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
* [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
* [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
