### PR TITLE
Fix #5879: Selecting processes for deletion doesn't highlight all

### DIFF
--- a/src/app/process-page/overview/table/process-overview-table.component.scss
+++ b/src/app/process-page/overview/table/process-overview-table.component.scss
@@ -26,3 +26,7 @@
 .actions-header {
   width: var(--ds-process-overview-table-actions-column-width);
 }
+
+tr.table-danger > * {
+  --bs-table-bg-type: var(--bs-table-bg);
+}


### PR DESCRIPTION
## References
Fixes #5879 

## Description
Forces all selected processes for deletion to be have the table-danger color applied instead of just the odd ones on the process overview page.

## Instructions for Reviewers
Go to {ui}/processes
Select the first an second process in the overview
Notice both processes are highlighted in red

List of changes in this PR:
- Added a css rule to force the red color on table rows marked with `.table-danger` on the process overview page.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
