### PR TITLE
Fix ORCID redirect URI double slash

### DIFF
--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -343,6 +343,8 @@ describe('AuthService test', () => {
     });
 
     it('should return a token object', () => {
+      mockStore.overrideSelector(getAuthenticationToken, token);
+      mockStore.refreshState();
       const result = authService.getToken();
       expect(result).toEqual(token);
     });

--- a/src/app/core/orcid/orcid-auth.service.spec.ts
+++ b/src/app/core/orcid/orcid-auth.service.spec.ts
@@ -298,7 +298,7 @@ describe('OrcidAuthService', () => {
 
     it('should build the url properly', () => {
       const result = service.getOrcidAuthorizeUrl(mockItemUnlinkedToOrcid);
-      const redirectUri: string = new URLCombiner(nativeWindowService.nativeWindow.origin, encodeURIComponent(routerStub.url.split('?')[0])).toString();
+      const redirectUri: string = new URLCombiner(nativeWindowService.nativeWindow.origin, routerStub.url.split('?')[0]).toString();
       const url = 'orcid.authorize-url?client_id=orcid.application-client-id&redirect_uri=' + redirectUri + '&response_type=code&scope=/authenticate /read-limited';
 
       const expected = cold('(a|)', {

--- a/src/app/core/orcid/orcid-auth.service.ts
+++ b/src/app/core/orcid/orcid-auth.service.ts
@@ -127,7 +127,7 @@ export class OrcidAuthService {
       this.configurationService.findByPropertyName('orcid.scope').pipe(getFirstSucceededRemoteDataPayload())],
     ).pipe(
       map(([authorizeUrl, clientId, scopes]) => {
-        const redirectUri = new URLCombiner(this._window.nativeWindow.origin, encodeURIComponent(this.router.url.split('?')[0]));
+        const redirectUri = new URLCombiner(this._window.nativeWindow.origin, this.router.url.split('?')[0]);
         return authorizeUrl.values[0] + '?client_id=' + clientId.values[0]   + '&redirect_uri=' + redirectUri + '&response_type=code&scope='
           + scopes.values.join(' ');
       }));


### PR DESCRIPTION
## References

* Fixes #5720

## Description

This PR fixes the ORCID authorization URL generation to avoid adding an extra slash before the entity route in the `redirect_uri` parameter.

## Instructions for Reviewers

This PR keeps the fix intentionally small and limited to the ORCID authorization URL generation.

List of changes in this PR:

* Updates `OrcidAuthService#getOrcidAuthorizeUrl()` to pass the raw Angular router path to `URLCombiner`, instead of encoding the route before combining it with the application origin.
* Updates the existing unit test to verify that the generated `redirect_uri` does not contain an encoded leading slash before the `/entities/...` route.

How to test or review this PR:

1. Configure ORCID authentication locally or use an environment where ORCID is enabled.
2. Log in and open the ORCID settings page for a Person entity, for example:
   `/entities/person/{uuid}/orcid`
3. Click **Connect to ORCID ID**.
4. Verify that the generated ORCID authorization URL contains a `redirect_uri` with a single slash after the domain before `/entities/...`.

Expected result:

`redirect_uri=https://demo.dspace.org/entities/person/{uuid}/orcid`

Instead of:

`redirect_uri=https://demo.dspace.org/%2Fentities/person/{uuid}/orcid`

The updated spec can be run with:

`npm test`

## Checklist

* [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
* [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
* [x] My PR **passes [[ESLint](https://eslint.org/)](https://eslint.org/)** validation using `npm run lint`
* [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
* [x] My PR **includes [[TypeDoc](https://typedoc.org/)](https://typedoc.org/) comments** for *all new (or modified) public methods and classes*. It also includes TypeDoc for large or complex private methods.
* [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [[Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide)](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
* [x] My PR **aligns with [[Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
* [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
* [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
* [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [[DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE)](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [[Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
* [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
* [x] If my PR fixes an issue ticket, I've [[linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).