### PR TITLE
Fix #5923: To be deleted bitstreams should be highlighted

### DIFF
--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.scss
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.component.scss
@@ -53,3 +53,7 @@
   top: 50%;
   left: 50%;
 }
+
+tr.table-danger > * {
+  --bs-table-bg-type: var(--bs-table-bg);
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/5923
* Related to https://github.com/DSpace/dspace-angular/pull/5880 and https://github.com/DSpace/dspace-angular/issues/5879

## Description
This PR adds red highlighting to bitstreams marked for deletion, so the user sees clearly which bitstreams they have selected.

## Instructions for Reviewers
I reviewed the PR https://github.com/DSpace/dspace-angular/pull/5880 and encountered the bug this PR here adresses. The solution for both problems seem to be the same. The issue seems to stem from a bootstrap bug (not sure though, could also be a bug we introduced in our code somehow), so we need to add an explicit extra coloring to `tr.table-danger` rows. 

List of changes in this PR:
Introduce a css rule to add an explicit red coloring to `tr.table-danger` children. 

1. Login as administrator
2. Go to an item -> Administer Item -> Bitstreams tab
3. Mark one or more bitstreams for deletion and notice that they are all highlighted in red.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
