### PR TITLE
Add ESLint rule to prevent Observable-returning method calls in the async pipe (#5933)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -341,6 +341,7 @@
         // Custom DSpace Angular rules
         "dspace-angular-html/themed-component-usages": "error",
         "dspace-angular-html/no-disabled-attribute-on-button": "error",
+        "dspace-angular-html/no-method-call-with-async-pipe": "error",
         "@angular-eslint/template/prefer-control-flow": "error"
       }
     },

--- a/docs/lint/html/index.md
+++ b/docs/lint/html/index.md
@@ -3,3 +3,4 @@ _______
 
 - [`dspace-angular-html/themed-component-usages`](./rules/themed-component-usages.md): Themeable components should be used via the selector of their `ThemedComponent` wrapper class
 - [`dspace-angular-html/no-disabled-attribute-on-button`](./rules/no-disabled-attribute-on-button.md): Buttons should use the `dsBtnDisabled` directive instead of the HTML `disabled` attribute.
+- [`dspace-angular-html/no-method-call-with-async-pipe`](./rules/no-method-call-with-async-pipe.md): Don&#39;t call a method directly as the input of the `async` pipe (e.g. `getFoo$() | async`).

--- a/docs/lint/html/rules/no-method-call-with-async-pipe.md
+++ b/docs/lint/html/rules/no-method-call-with-async-pipe.md
@@ -1,0 +1,161 @@
+[DSpace ESLint plugins](../../../../lint/README.md) > [HTML rules](../index.md) > `dspace-angular-html/no-method-call-with-async-pipe`
+_______
+
+Don't call a method directly as the input of the `async` pipe (e.g. `getFoo$() | async`).
+
+This re-executes the method - and the RxJS pipeline it returns - on every change detection cycle, which often leads to performance issues.
+
+Instead:
+- Subscribe to the Observable in `ngOnInit()`
+- Push emitted values into a `BehaviorSubject`
+- Bind `| async` to that `BehaviorSubject` in the template
+- Unsubscribe in `ngOnDestroy()`
+      
+
+_______
+
+[Source code](../../../../lint/src/rules/html/no-method-call-with-async-pipe.ts)
+
+
+
+### Examples
+
+
+#### Valid code
+    
+##### binding the async pipe to a property is still valid
+        
+```html
+<span>{{ foo$ | async }}</span>
+```
+        
+    
+##### calling a method without piping the result through async is still valid
+        
+```html
+<span>{{ getFoo() }}</span>
+```
+        
+    
+##### piping a property through an unrelated pipe is still valid
+        
+```html
+<span>{{ foo$ | someOtherPipe }}</span>
+```
+        
+    
+##### binding the async pipe to a property accessed through a member expression is still valid
+        
+```html
+<span>{{ (foo$ | async)?.length }}</span>
+```
+        
+    
+
+
+
+#### Invalid code 
+    
+##### should not call a method as the direct input of the async pipe
+        
+```html
+<span>{{ getFoo$() | async }}</span>
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not call a method with arguments as the direct input of the async pipe
+        
+```html
+<span>{{ getFoo$(id) | async }}</span>
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not use the safe-call variant as the direct input of the async pipe
+        
+```html
+<span>{{ getFoo$?.() | async }}</span>
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not call a method as the direct input of the async pipe in the *ngIf microsyntax
+        
+```html
+<div *ngIf="getFoo$() | async as foo">{{ foo }}</div>
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not call a method as the direct input of the async pipe in an @if condition, even when wrapped in a member access
+        
+```html
+@if ((getFoo$() | async)?.length > 0) {
+  <span>hi</span>
+}
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not call a method as the direct input of the async pipe in an @for expression
+        
+```html
+@for (item of getFoo$() | async; track item) {
+  <span>{{ item }}</span>
+}
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+##### should not call a method as the direct input of the async pipe inside an object literal binding
+        
+```html
+<div [ngClass]="{'active': (getFoo$() | async)?.length > 0}"></div>
+
+        
+
+```
+Will produce the following error(s):
+```
+Don't call '{{ methodName }}' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.
+```
+        
+    
+

--- a/lint/src/rules/html/index.ts
+++ b/lint/src/rules/html/index.ts
@@ -11,11 +11,13 @@ import {
   RuleExports,
 } from '../../util/structure';
 import * as noDisabledAttributeOnButton from './no-disabled-attribute-on-button';
+import * as noMethodCallWithAsyncPipe from './no-method-call-with-async-pipe';
 import * as themedComponentUsages from './themed-component-usages';
 
 const index = [
   themedComponentUsages,
   noDisabledAttributeOnButton,
+  noMethodCallWithAsyncPipe,
 
 ] as unknown as RuleExports[];
 

--- a/lint/src/rules/html/no-method-call-with-async-pipe.ts
+++ b/lint/src/rules/html/no-method-call-with-async-pipe.ts
@@ -1,0 +1,233 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import {
+  AST,
+  BindingPipe,
+  Call,
+  PropertyRead,
+  RecursiveAstVisitor,
+  SafeCall,
+  TmplAstBoundAttribute,
+  TmplAstBoundDeferredTrigger,
+  TmplAstBoundEvent,
+  TmplAstBoundText,
+  TmplAstForLoopBlock,
+  TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+} from '@angular-eslint/bundled-angular-compiler';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import {
+  RuleContext,
+  RuleListener,
+} from '@typescript-eslint/utils/ts-eslint';
+
+import {
+  DSpaceESLintRuleInfo,
+  NamedTests,
+} from '../../util/structure';
+import { getSourceCode } from '../../util/typescript';
+
+export enum Message {
+  NO_METHOD_CALL_WITH_ASYNC_PIPE = 'noMethodCallWithAsyncPipe',
+}
+
+export const info = {
+  name: 'no-method-call-with-async-pipe',
+  meta: {
+    docs: {
+      description: `Don't call a method directly as the input of the \`async\` pipe (e.g. \`getFoo$() | async\`).
+
+This re-executes the method - and the RxJS pipeline it returns - on every change detection cycle, which often leads to performance issues.
+
+Instead:
+- Subscribe to the Observable in \`ngOnInit()\`
+- Push emitted values into a \`BehaviorSubject\`
+- Bind \`| async\` to that \`BehaviorSubject\` in the template
+- Unsubscribe in \`ngOnDestroy()\`
+      `,
+    },
+    type: 'problem',
+    schema: [],
+    messages: {
+      [Message.NO_METHOD_CALL_WITH_ASYNC_PIPE]: 'Don\'t call \'{{ methodName }}\' directly in the template as the input of the async pipe; subscribe in ngOnInit(), push values into a BehaviorSubject, and bind `| async` to that instead.',
+    },
+  },
+  optionDocs: [],
+  defaultOptions: [],
+} as DSpaceESLintRuleInfo;
+
+/**
+ * @angular-eslint/template-parser's own visitor keys (used to drive ESLint's node traversal)
+ * don't cover every expression AST node type (e.g. SafePropertyRead, LiteralMap, KeyedRead, ...),
+ * so selectors like `BindingPipe[name="async"] > Call` silently miss anything wrapped in one of
+ * those unsupported node types (e.g. `(getFoo$() | async)?.length`, or `[ngClass]="{x: getFoo$() | async}"`).
+ * We work around this by walking each expression ourselves with the Angular compiler's own
+ * RecursiveAstVisitor, which correctly covers the full expression AST regardless of what
+ * @angular-eslint/template-parser exposes to ESLint's selector engine.
+ */
+class AsyncPipedCallVisitor extends RecursiveAstVisitor {
+  constructor(private readonly onFound: (call: Call | SafeCall) => void) {
+    super();
+  }
+
+  override visitPipe(ast: BindingPipe, context: unknown) {
+    if (ast.name === 'async' && (ast.exp instanceof Call || ast.exp instanceof SafeCall)) {
+      this.onFound(ast.exp);
+    }
+    super.visitPipe(ast, context);
+  }
+}
+
+export const rule = ESLintUtils.RuleCreator.withoutDocs({
+  meta: info.meta,
+  defaultOptions: info.defaultOptions,
+  create(context: RuleContext<Message, unknown[]>): RuleListener {
+    const sourceCode = getSourceCode(context);
+
+    const visitor = new AsyncPipedCallVisitor((node) => {
+      const methodName = node.receiver instanceof PropertyRead ? node.receiver.name : 'this method';
+
+      context.report({
+        messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE,
+        loc: {
+          start: sourceCode.getLocFromIndex(node.sourceSpan.start),
+          end: sourceCode.getLocFromIndex(node.sourceSpan.end),
+        },
+        data: {
+          methodName,
+        },
+      });
+    });
+
+    function checkExpression(expression: AST | null | undefined) {
+      if (expression != null) {
+        visitor.visit(expression);
+      }
+    }
+
+    return {
+      BoundAttribute(node: TmplAstBoundAttribute) {
+        checkExpression(node.value);
+      },
+      BoundEvent(node: TmplAstBoundEvent) {
+        checkExpression(node.handler);
+      },
+      BoundText(node: TmplAstBoundText) {
+        checkExpression(node.value);
+      },
+      IfBlockBranch(node: TmplAstIfBlockBranch) {
+        checkExpression(node.expression);
+      },
+      ForLoopBlock(node: TmplAstForLoopBlock) {
+        checkExpression(node.expression);
+        checkExpression(node.trackBy);
+      },
+      SwitchBlock(node: TmplAstSwitchBlock) {
+        checkExpression(node.expression);
+      },
+      SwitchBlockCase(node: TmplAstSwitchBlockCase) {
+        checkExpression(node.expression);
+      },
+      LetDeclaration(node: TmplAstLetDeclaration) {
+        checkExpression(node.value);
+      },
+      BoundDeferredTrigger(node: TmplAstBoundDeferredTrigger) {
+        checkExpression(node.value);
+      },
+    };
+  },
+});
+
+export const tests = {
+  plugin: info.name,
+  valid: [
+    {
+      name: 'binding the async pipe to a property is still valid',
+      code: `
+<span>{{ foo$ | async }}</span>
+      `,
+    },
+    {
+      name: 'calling a method without piping the result through async is still valid',
+      code: `
+<span>{{ getFoo() }}</span>
+      `,
+    },
+    {
+      name: 'piping a property through an unrelated pipe is still valid',
+      code: `
+<span>{{ foo$ | someOtherPipe }}</span>
+      `,
+    },
+    {
+      name: 'binding the async pipe to a property accessed through a member expression is still valid',
+      code: `
+<span>{{ (foo$ | async)?.length }}</span>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'should not call a method as the direct input of the async pipe',
+      code: `
+<span>{{ getFoo$() | async }}</span>
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not call a method with arguments as the direct input of the async pipe',
+      code: `
+<span>{{ getFoo$(id) | async }}</span>
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not use the safe-call variant as the direct input of the async pipe',
+      code: `
+<span>{{ getFoo$?.() | async }}</span>
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not call a method as the direct input of the async pipe in the *ngIf microsyntax',
+      code: `
+<div *ngIf="getFoo$() | async as foo">{{ foo }}</div>
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not call a method as the direct input of the async pipe in an @if condition, even when wrapped in a member access',
+      code: `
+@if ((getFoo$() | async)?.length > 0) {
+  <span>hi</span>
+}
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not call a method as the direct input of the async pipe in an @for expression',
+      code: `
+@for (item of getFoo$() | async; track item) {
+  <span>{{ item }}</span>
+}
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+    {
+      name: 'should not call a method as the direct input of the async pipe inside an object literal binding',
+      code: `
+<div [ngClass]="{'active': (getFoo$() | async)?.length > 0}"></div>
+      `,
+      errors: [{ messageId: Message.NO_METHOD_CALL_WITH_ASYNC_PIPE }],
+    },
+  ],
+} as NamedTests;
+
+export default rule;

--- a/src/app/audit-page/audit-table/audit-table.component.html
+++ b/src/app/audit-page/audit-table/audit-table.component.html
@@ -24,7 +24,8 @@
         </tr>
         </thead>
         <tbody>
-          @for (audit of audits?.page; track audit) {
+          @for (row of auditRows; track row.audit) {
+            @let audit = row.audit;
             <tr>
               <td>
                 @if (audit.hasDetails) {
@@ -51,7 +52,7 @@
               @if (isOverviewPage) {
                 <td>
                   @if (audit.objectUUID) {
-                    <ng-container *ngVar="(getObjectRoute$(audit.objectUUID) | async) as objectRoute">
+                    <ng-container *ngVar="(row.objectRoute$ | async) as objectRoute">
                       @if (objectRoute !== ('/' + auditPath)) {
                         <a [routerLink]="[objectRoute]">{{audit.objectUUID}}</a>
                       } @else {
@@ -63,7 +64,7 @@
                 <td>{{ audit.objectType }}</td>
                 <td>
                   @if (audit.subjectUUID) {
-                    <ng-container *ngVar="(getObjectRoute$(audit.subjectUUID) | async) as subjectRoute">
+                    <ng-container *ngVar="(row.subjectRoute$ | async) as subjectRoute">
                       @if (subjectRoute !== ('/' + auditPath)) {
                         <a [routerLink]="[subjectRoute]">{{audit.subjectUUID}}</a>
                       } @else {

--- a/src/app/audit-page/audit-table/audit-table.component.spec.ts
+++ b/src/app/audit-page/audit-table/audit-table.component.spec.ts
@@ -1,4 +1,7 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  NO_ERRORS_SCHEMA,
+  SimpleChange,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -53,6 +56,9 @@ describe('AuditTableComponent', () => {
     component = fixture.componentInstance;
     component.audits = audits;
     component.isOverviewPage = true;
+    component.ngOnChanges({
+      audits: new SimpleChange(null, audits, true),
+    });
     fixture.detectChanges();
   });
 

--- a/src/app/audit-page/audit-table/audit-table.component.ts
+++ b/src/app/audit-page/audit-table/audit-table.component.ts
@@ -8,6 +8,8 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DSpaceObjectDataService } from '@dspace/core/data/dspace-object-data.service';
@@ -18,7 +20,10 @@ import { URLCombiner } from '@dspace/core/url-combiner/url-combiner';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  shareReplay,
+} from 'rxjs/operators';
 
 import { Audit } from '../../core/audit/model/audit.model';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
@@ -27,6 +32,15 @@ import { DSpaceObject } from '../../core/shared/dspace-object.model';
 import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { StringReplacePipe } from '../../shared/utils/string-replace.pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
+
+/**
+ * An audit record paired with its (memoized) resolved object/subject routes.
+ */
+export interface AuditRow {
+  audit: Audit;
+  objectRoute$: Observable<string>;
+  subjectRoute$: Observable<string>;
+}
 
 /**
  * Renders a paginated table of audit records, either in overview mode for all the environemnt or tied to a specific DSpaceObject.
@@ -49,11 +63,16 @@ import { VarDirective } from '../../shared/utils/var.directive';
     VarDirective,
   ],
 })
-export class AuditTableComponent {
+export class AuditTableComponent implements OnChanges {
   /**
    * The Audit items to be shown
    */
   @Input() audits: PaginatedList<Audit>;
+
+  /**
+   * The current page's audit items, paired with their (memoized) resolved object/subject routes.
+   */
+  auditRows: AuditRow[] = [];
 
   /**
    * Config for pagination
@@ -81,11 +100,28 @@ export class AuditTableComponent {
    */
   protected readonly dateFormat = 'yyyy-MM-dd HH:mm:ss';
 
+  /**
+   * Memoized object/subject route observables, keyed by DSpaceObject id.
+   * Ensures repeated ids (across rows, or across change detection cycles) resolve to the exact
+   * same Observable instance, rather than triggering a new lookup every time.
+   */
+  private readonly objectRoutesById = new Map<string, Observable<string>>();
+
   constructor(
     private dsoNameService: DSONameService,
     private changeDetectorRef: ChangeDetectorRef,
     private dsoDataService: DSpaceObjectDataService,
   ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.audits) {
+      this.auditRows = (this.audits?.page ?? []).map((audit: Audit) => ({
+        audit,
+        objectRoute$: audit.objectUUID ? this.getObjectRoute$(audit.objectUUID) : undefined,
+        subjectRoute$: audit.subjectUUID ? this.getObjectRoute$(audit.subjectUUID) : undefined,
+      }));
+    }
+  }
 
 
   toggleCollapse(audit: Audit) {
@@ -93,11 +129,15 @@ export class AuditTableComponent {
     this.changeDetectorRef.detectChanges();
   }
 
-  getObjectRoute$(id: string): Observable<string> {
-    return this.dsoDataService.findById(id).pipe(
-      getFirstSucceededRemoteDataPayload(),
-      map(resolvedDso =>  new URLCombiner(getDSORoute(resolvedDso), this.auditPath).toString()),
-    );
+  private getObjectRoute$(id: string): Observable<string> {
+    if (!this.objectRoutesById.has(id)) {
+      this.objectRoutesById.set(id, this.dsoDataService.findById(id).pipe(
+        getFirstSucceededRemoteDataPayload(),
+        map(resolvedDso => new URLCombiner(getDSORoute(resolvedDso), this.auditPath).toString()),
+        shareReplay({ bufferSize: 1, refCount: false }),
+      ));
+    }
+    return this.objectRoutesById.get(id);
   }
 
   getDsoName(dso: DSpaceObject): string {

--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -30,7 +30,7 @@
   <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
     class="example-tree-node expandable-node">
     <div class="btn-group">
-      @if (hasChild(null, node) | async) {
+      @if (node.isExpandable$ | async) {
         <button type="button" class="btn btn-default btn-transparent" cdkTreeNodeToggle
           [attr.aria-label]="(node.isExpanded ? 'communityList.collapse' : 'communityList.expand') | translate:{ name: dsoNameService.getName(node.payload) }"
           (click)="toggleExpanded(node)"
@@ -45,7 +45,7 @@
         </button>
       }
       <!--Don't render the button when non-expandable otherwise it's still accessible, instead render this placeholder-->
-      @if ((hasChild(null, node) | async) !== true) {
+      @if ((node.isExpandable$ | async) !== true) {
         <span aria-hidden="true" class="btn btn-default invisible">
           <span class="fa fa-chevron-right"></span>
         </span>

--- a/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-search-result-list-submission-element.component.spec.ts
+++ b/src/app/entity-groups/research-entities/submission/item-list-elements/person/person-search-result-list-submission-element.component.spec.ts
@@ -26,6 +26,7 @@ import { HALEndpointService } from '@dspace/core/shared/hal-endpoint.service';
 import { Item } from '@dspace/core/shared/item.model';
 import { ItemSearchResult } from '@dspace/core/shared/object-collection/item-search-result.model';
 import { UUIDService } from '@dspace/core/shared/uuid.service';
+import { mockTruncatableService } from '@dspace/core/testing/mock-trucatable.service';
 import { createSuccessfulRemoteDataObject$ } from '@dspace/core/utilities/remote-data.utils';
 import { XSRFService } from '@dspace/core/xsrf/xsrf.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -140,7 +141,7 @@ describe('PersonSearchResultListElementSubmissionComponent', () => {
     TestBed.configureTestingModule({
       imports: [TruncatePipe, PersonSearchResultListSubmissionElementComponent],
       providers: [
-        { provide: TruncatableService, useValue: {} },
+        { provide: TruncatableService, useValue: mockTruncatableService },
         { provide: NameVariantService, useValue: mockNameVariantService },
         { provide: TranslateService, useValue: translateServiceStub },
         { provide: NgbModal, useValue: {} },
@@ -241,7 +242,7 @@ describe('PersonSearchResultListElementSubmissionComponent', () => {
     TestBed.configureTestingModule({
       imports: [TruncatePipe, PersonSearchResultListSubmissionElementComponent],
       providers: [
-        { provide: TruncatableService, useValue: {} },
+        { provide: TruncatableService, useValue: mockTruncatableService },
         { provide: NameVariantService, useValue: mockNameVariantService },
         { provide: TranslateService, useValue: translateServiceStub },
         { provide: NgbModal, useValue: {} },

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
@@ -109,7 +109,7 @@
                           title="{{'item.edit.bitstreams.edit.buttons.edit' | translate}}">
                           <i class="fas fa-edit fa-fw"></i>
                         </button>
-                        @if ((canReplaceBitstream(entry.bitstream.self) | async)) {
+                        @if ((entry.canReplace$ | async)) {
                           <button [routerLink]="['/bitstreams/', entry.id, 'replace']" class="btn btn-outline-primary btn-sm"
                                   title="{{'item.edit.bitstreams.edit.buttons.replace' | translate}}">
                             <i class="fas fa-retweet fa-fw"></i>

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.spec.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.spec.ts
@@ -39,7 +39,10 @@ import {
   getItemBitstreamsServiceStub,
   ItemBitstreamsServiceStub,
 } from '../item-bitstreams.service.stub';
-import { ItemEditBitstreamBundleComponent } from './item-edit-bitstream-bundle.component';
+import {
+  BitstreamTableEntryWithReplace,
+  ItemEditBitstreamBundleComponent,
+} from './item-edit-bitstream-bundle.component';
 
 describe('ItemEditBitstreamBundleComponent', () => {
   let comp: ItemEditBitstreamBundleComponent;
@@ -324,7 +327,7 @@ describe('ItemEditBitstreamBundleComponent', () => {
       const event = new KeyboardEvent('keydown');
       spyOnProperty(event, 'repeat', 'get').and.returnValue(false);
 
-      const entry = { } as BitstreamTableEntry;
+      const entry = { } as BitstreamTableEntryWithReplace;
       comp.tableEntries$.next([entry]);
 
       comp.select(event, entry);
@@ -335,7 +338,7 @@ describe('ItemEditBitstreamBundleComponent', () => {
       const event = new KeyboardEvent('keydown');
       spyOnProperty(event, 'repeat', 'get').and.returnValue(false);
 
-      const entry = { } as BitstreamTableEntry;
+      const entry = { } as BitstreamTableEntryWithReplace;
       comp.tableEntries$.next([entry]);
 
       itemBitstreamsService.getSelectedBitstream.and.returnValue({ bitstream: entry });
@@ -349,7 +352,7 @@ describe('ItemEditBitstreamBundleComponent', () => {
       const event = new KeyboardEvent('keydown');
       spyOnProperty(event, 'repeat', 'get').and.returnValue(true);
 
-      const entry = { } as BitstreamTableEntry;
+      const entry = { } as BitstreamTableEntryWithReplace;
       comp.tableEntries$.next([entry]);
 
       itemBitstreamsService.getSelectedBitstream.and.returnValue({ bitstream: entry });

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.ts
@@ -72,6 +72,14 @@ import {
   SelectionAction,
 } from '../item-bitstreams.service';
 
+/**
+ * A {@link BitstreamTableEntry} paired with a (memoized) observable indicating whether the current
+ * user is allowed to replace this bitstream.
+ */
+export interface BitstreamTableEntryWithReplace extends BitstreamTableEntry {
+  canReplace$: Observable<boolean>;
+}
+
 @Component({
   selector: 'ds-item-edit-bitstream-bundle',
   styleUrls: ['../item-bitstreams.component.scss', './item-edit-bitstream-bundle.component.scss'],
@@ -161,7 +169,7 @@ export class ItemEditBitstreamBundleComponent implements OnInit, OnDestroy {
   /**
    * The data to show in the table
    */
-  tableEntries$: BehaviorSubject<BitstreamTableEntry[]> = new BehaviorSubject([]);
+  tableEntries$: BehaviorSubject<BitstreamTableEntryWithReplace[]> = new BehaviorSubject([]);
 
   /**
    * The initial page options to use for fetching the bitstreams
@@ -230,7 +238,7 @@ export class ItemEditBitstreamBundleComponent implements OnInit, OnDestroy {
     this.canReplaceBitstreamCache.clear();
   }
 
-  canReplaceBitstream(bitstreamUrl: string): Observable<boolean> {
+  private canReplaceBitstream(bitstreamUrl: string): Observable<boolean> {
     if (!this.canReplaceBitstreamCache.has(bitstreamUrl)) {
       this.canReplaceBitstreamCache.set(
         bitstreamUrl,
@@ -292,6 +300,10 @@ export class ItemEditBitstreamBundleComponent implements OnInit, OnDestroy {
       this.bitstreamsRD$.pipe(
         paginatedListToArray(),
         map((bitstreams) => this.itemBitstreamsService.mapBitstreamsToTableEntries(bitstreams)),
+        map((tableEntries) => tableEntries.map((entry) => ({
+          ...entry,
+          canReplace$: this.canReplaceBitstream(entry.bitstream.self),
+        }))),
       ).subscribe((tableEntries) => this.tableEntries$.next(tableEntries)),
     );
   }

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -11,7 +11,7 @@
           hasLink(mdValue) ? (hasValue(img) ? linkImg : link) :
           hasSearchFilter() ? searchlink :
           hasBrowseDefinition() ? browselink : simple;
-          context: { value: (isVocabulary ? mdValue : mdValue.value), img: img, lang: mdValue.language }
+          context: { value: (isVocabulary ? mdValue : mdValue.value), img: img, lang: mdValue.language, vocabularyValue$: isVocabulary ? getVocabularyValue$(mdValue) : null }
         ">
       </ng-container>
     @if (!last) {
@@ -72,8 +72,8 @@
 
 
 <!-- Render translated valueof vocabulary entry -->
-<ng-template #controlledVocabulary let-value="value">
-  @let label = getVocabularyValue(value) | async;
+<ng-template #controlledVocabulary let-vocabularyValue$="vocabularyValue$">
+  @let label = vocabularyValue$ | async;
   @if (hasBrowseDefinition()) {
     <ng-container *ngTemplateOutlet="browselink; context: {value: label}"></ng-container>
   } @else {

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.spec.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   NO_ERRORS_SCHEMA,
+  SimpleChange,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -132,7 +133,11 @@ describe('MetadataValuesComponent', () => {
         buildPaginatedList(new PageInfo(), [{ display: 'Translated Value' }]),
       )),
     );
-    comp.getVocabularyValue(controlledMetadata).subscribe((value) => {
+    comp.mdValues = [controlledMetadata];
+    comp.ngOnChanges({
+      mdValues: new SimpleChange(null, comp.mdValues, false),
+    });
+    comp.getVocabularyValue$(controlledMetadata).subscribe((value) => {
       expect(value).toBe('Translated Value');
       done();
     });

--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.ts
@@ -111,8 +111,31 @@ export class MetadataValuesComponent implements OnChanges {
    */
   @Input() searchFilter?: string;
 
+  /**
+   * Memoized vocabulary-value lookups for the current {@link mdValues}, keyed by metadata value.
+   * Ensures each controlled-vocabulary metadata value resolves to the exact same Observable
+   * instance, rather than triggering a new lookup every change detection cycle.
+   */
+  private vocabularyValueCache = new Map<MetadataValue, Observable<string>>();
+
   ngOnChanges(changes: SimpleChanges): void {
     this.renderMarkdown = !!this.appConfig.markdown.enabled && this.enableMarkdown;
+
+    if (changes.mdValues) {
+      this.vocabularyValueCache = new Map(
+        (this.mdValues ?? [])
+          .filter((mdValue: MetadataValue) => this.isControlledVocabulary(mdValue))
+          .map((mdValue: MetadataValue) => [mdValue, this.getVocabularyValue(mdValue)] as const),
+      );
+    }
+  }
+
+  /**
+   * Returns the memoized vocabulary translated value Observable for this metadata value, previously
+   * computed in {@link ngOnChanges}.
+   */
+  getVocabularyValue$(metadataValue: MetadataValue): Observable<string> {
+    return this.vocabularyValueCache.get(metadataValue);
   }
 
   /**
@@ -217,7 +240,7 @@ export class MetadataValuesComponent implements OnChanges {
   /**
    * Get vocabulary translated value from metadata value
    */
-  getVocabularyValue(metadataValue: MetadataValue): Observable<string> {
+  private getVocabularyValue(metadataValue: MetadataValue): Observable<string> {
     const vocabularyId = this.getVocabularyIdFromAuthorityValue(metadataValue);
     const vocabularyName = this.getVocabularyName(vocabularyId);
 

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.html
@@ -32,7 +32,7 @@
                     <span [innerHTML]="dsoNameService.getName(file)"></span>
                   </div>
                   <div class="col-3">
-                    <span>{{ (bitstreamFormatDataService.findByBitstream(file) | async).payload?.shortDescription }}</span>
+                    <span>{{ (file.format | async)?.payload?.shortDescription }}</span>
                   </div>
                    <div class="col-2">
                     <span> {{ (file?.sizeBytes) | dsFileSize }}</span>

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.spec.ts
@@ -9,7 +9,6 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
-import { BitstreamFormatDataService } from '@dspace/core/data/bitstream-format-data.service';
 import { LocaleService } from '@dspace/core/locale/locale.service';
 import { NotificationsService } from '@dspace/core/notification-system/notifications.service';
 import { PaginationService } from '@dspace/core/pagination/pagination.service';
@@ -60,6 +59,13 @@ describe('ExtendedFileSectionComponent', () => {
     },
   });
 
+  const mockBitstreamFormat = Object.assign(new BitstreamFormat(), {
+    resourceType: 'testResourceType',
+    shortDescription: 'testShortDescription',
+    description: 'testDescription',
+    mimetype: 'test/mimeType',
+  });
+
   const mockBitstream = Object.assign(new Bitstream(), {
     id: 'test-bitstream-id',
     uuid: 'test-bitstream-id',
@@ -68,13 +74,7 @@ describe('ExtendedFileSectionComponent', () => {
     _links: {
       self: { href: 'test-bitstream-selflink' },
     },
-  });
-
-  const mockBitstreamFormat = Object.assign(new BitstreamFormat(), {
-    resourceType: 'testResourceType',
-    shortDescription: 'testShortDescription',
-    description: 'testDescription',
-    mimetype: 'test/mimeType',
+    format: createSuccessfulRemoteDataObject$(mockBitstreamFormat),
   });
 
   const paginatedList = createPaginatedList([mockBitstream]);
@@ -83,10 +83,6 @@ describe('ExtendedFileSectionComponent', () => {
 
   const bitstreamDataService = jasmine.createSpyObj('bitstreamDataService', {
     findAllByItemAndBundleName: createSuccessfulRemoteDataObject$(paginatedList),
-  });
-
-  const bitstreamFormatDataService = jasmine.createSpyObj('bitstreamFormatDataService', {
-    findByBitstream: createSuccessfulRemoteDataObject$(mockBitstreamFormat),
   });
 
   beforeEach(waitForAsync(() => {
@@ -109,7 +105,6 @@ describe('ExtendedFileSectionComponent', () => {
         { provide: XSRFService, useValue: {} },
         { provide: BitstreamDataService, useValue: bitstreamDataService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
-        { provide: BitstreamFormatDataService, useValue: bitstreamFormatDataService },
         { provide: ThemeService, useValue: getMockThemeService() },
         { provide: SearchConfigurationService, useValue: jasmine.createSpyObj(['getCurrentConfiguration']) },
         { provide: PaginationService, useValue: paginationServiceStub },

--- a/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
+++ b/src/app/item-page/simple/field-components/extended-file-section/extended-file-section.component.ts
@@ -11,7 +11,6 @@ import {
 } from '@dspace/config/app-config.interface';
 import { DSONameService } from '@dspace/core/breadcrumbs/dso-name.service';
 import { BitstreamDataService } from '@dspace/core/data/bitstream-data.service';
-import { BitstreamFormatDataService } from '@dspace/core/data/bitstream-format-data.service';
 import { PaginatedList } from '@dspace/core/data/paginated-list.model';
 import { RemoteData } from '@dspace/core/data/remote-data';
 import { PaginationService } from '@dspace/core/pagination/pagination.service';
@@ -69,7 +68,6 @@ export class ExtendedFileSectionComponent implements OnInit {
 
   constructor(
     protected bitstreamDataService: BitstreamDataService,
-    protected bitstreamFormatDataService: BitstreamFormatDataService,
     public dsoNameService: DSONameService,
     @Inject(APP_CONFIG) protected appConfig: AppConfig,
     private paginationService: PaginationService,

--- a/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.html
+++ b/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.html
@@ -1,5 +1,5 @@
 @if (ePersonId) {
-  @if (getEPersonData$() | async; as ePersonData) {
+  @if (ePersonData$ | async; as ePersonData) {
     @for (property of properties; track property) {
       @if (ePersonData[property]) {
         <span>

--- a/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.spec.ts
+++ b/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.spec.ts
@@ -1,4 +1,5 @@
 /* tslint:disable:no-unused-variable */
+import { SimpleChange } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -55,7 +56,9 @@ describe('EPersonDataComponent', () => {
     const ePersonDataRD$ = createSuccessfulRemoteDataObject$(ePersonData);
     ePersonDataService.findById.and.returnValue(ePersonDataRD$);
     component.ePersonId = ePersonId;
-    component.getEPersonData$();
+    component.ngOnChanges({
+      ePersonId: new SimpleChange(null, ePersonId, true),
+    });
     fixture.detectChanges();
     expect(ePersonDataService.findById).toHaveBeenCalledWith(ePersonId, true);
   });

--- a/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.ts
+++ b/src/app/notifications/qa/events/ePerson-data/ePerson-data.component.ts
@@ -2,6 +2,9 @@ import { AsyncPipe } from '@angular/common';
 import {
   Component,
   Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
 } from '@angular/core';
 import { EPersonDataService } from '@dspace/core/eperson/eperson-data.service';
 import { EPerson } from '@dspace/core/eperson/models/eperson.model';
@@ -9,7 +12,11 @@ import {
   getFirstCompletedRemoteData,
   getRemoteDataPayload,
 } from '@dspace/core/shared/operators';
-import { Observable } from 'rxjs';
+import { hasValue } from '@dspace/shared/utils/empty.util';
+import {
+  BehaviorSubject,
+  Subscription,
+} from 'rxjs';
 
 @Component({
   selector: 'ds-eperson-data',
@@ -22,7 +29,7 @@ import { Observable } from 'rxjs';
 /**
  * Represents the component for displaying ePerson data.
  */
-export class EPersonDataComponent {
+export class EPersonDataComponent implements OnChanges, OnDestroy {
 
   /**
    * The ID of the ePerson.
@@ -35,21 +42,30 @@ export class EPersonDataComponent {
   @Input() properties: string[];
 
   /**
+   * The EPerson data based on the provided ePersonId.
+   */
+  ePersonData$: BehaviorSubject<EPerson> = new BehaviorSubject<EPerson>(null);
+
+  private subs: Subscription[] = [];
+
+  /**
    * Creates an instance of the EPersonDataComponent.
    * @param ePersonDataService The service for retrieving ePerson data.
    */
   constructor(private ePersonDataService: EPersonDataService) { }
 
-  /**
-   * Retrieves the EPerson data based on the provided ePersonId.
-   * @returns An Observable that emits the EPerson data.
-   */
-  getEPersonData$(): Observable<EPerson> {
-    if (this.ePersonId) {
-      return this.ePersonDataService.findById(this.ePersonId, true).pipe(
-        getFirstCompletedRemoteData(),
-        getRemoteDataPayload(),
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.ePersonId && hasValue(this.ePersonId)) {
+      this.subs.push(
+        this.ePersonDataService.findById(this.ePersonId, true).pipe(
+          getFirstCompletedRemoteData(),
+          getRemoteDataPayload(),
+        ).subscribe((ePerson: EPerson) => this.ePersonData$.next(ePerson)),
       );
     }
+  }
+
+  ngOnDestroy(): void {
+    this.subs.filter((sub) => hasValue(sub)).forEach((sub) => sub.unsubscribe());
   }
 }

--- a/src/app/notifications/qa/events/quality-assurance-events.component.html
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.html
@@ -14,7 +14,7 @@
       @if (targetId) {
         <ds-alert [type]="'alert-info'">
           <span [innerHTML]="'quality-assurance.events.description-with-topic-and-target' | translate : {topic: selectedTopicName, source: sourceId}"></span>
-          <a [routerLink]="itemPageUrl" target="_blank">{{(getTargetItemTitle() | async)}}</a>
+          <a [routerLink]="itemPageUrl" target="_blank">{{(targetItemTitle$ | async)}}</a>
         </ds-alert>
       }
     </div>

--- a/src/app/notifications/qa/events/quality-assurance-events.component.ts
+++ b/src/app/notifications/qa/events/quality-assurance-events.component.ts
@@ -190,6 +190,11 @@ export class QualityAssuranceEventsComponent implements OnInit, OnDestroy {
   isAdmin$: Observable<boolean>;
 
   /**
+   * The title of the target item, when a targetId is present.
+   */
+  public targetItemTitle$: Observable<string>;
+
+  /**
    * Initialize the component variables.
    * @param {ActivatedRoute} activatedRoute
    * @param {NgbModal} modalService
@@ -233,6 +238,9 @@ export class QualityAssuranceEventsComponent implements OnInit, OnDestroy {
         this.targetId = splitList.length > 2 ? splitList.pop() : null;
         this.selectedTopicName = splitList[1];
         this.sourceId = splitList[0];
+        if (this.targetId) {
+          this.targetItemTitle$ = this.getTargetItemTitle();
+        }
         return this.getQualityAssuranceEvents();
       }),
     ).subscribe(

--- a/src/app/notifications/qa/source/quality-assurance-source.component.html
+++ b/src/app/notifications/qa/source/quality-assurance-source.component.html
@@ -5,7 +5,7 @@
       <ds-alert [type]="'alert-info'" [content]="'quality-assurance.source.description'"></ds-alert>
     </div>
   </div>
-  <ds-source-list [loading]="(isSourceLoading() | async) === true || (isSourceProcessing() | async) === true"
+  <ds-source-list [loading]="(isSourceLoading$ | async) === true || (isSourceProcessing$ | async) === true"
                   [paginationConfig]="paginationConfig"
                   [showLastEvent]="true"
                   [sources]="sources$ | async"

--- a/src/app/notifications/qa/source/quality-assurance-source.component.spec.ts
+++ b/src/app/notifications/qa/source/quality-assurance-source.component.spec.ts
@@ -148,14 +148,16 @@ describe('QualityAssuranceSourceComponent test suite', () => {
       expect(compAsAny.getQualityAssuranceSource).toHaveBeenCalled();
     });
 
-    it(('isSourceLoading should return FALSE'), () => {
-      expect(comp.isSourceLoading()).toBeObservable(cold('(a|)', {
+    it(('isSourceLoading$ should return FALSE'), () => {
+      comp.ngOnInit();
+      expect(comp.isSourceLoading$).toBeObservable(cold('(a|)', {
         a: false,
       }));
     });
 
-    it(('isSourceProcessing should return FALSE'), () => {
-      expect(comp.isSourceProcessing()).toBeObservable(cold('(a|)', {
+    it(('isSourceProcessing$ should return FALSE'), () => {
+      comp.ngOnInit();
+      expect(comp.isSourceProcessing$).toBeObservable(cold('(a|)', {
         a: false,
       }));
     });

--- a/src/app/notifications/qa/source/quality-assurance-source.component.ts
+++ b/src/app/notifications/qa/source/quality-assurance-source.component.ts
@@ -72,6 +72,14 @@ export class QualityAssuranceSourceComponent implements OnDestroy, OnInit, After
    */
   public totalElements$: Observable<number>;
   /**
+   * The loading status of the Quality Assurance source (if it's running or not).
+   */
+  public isSourceLoading$: Observable<boolean>;
+  /**
+   * The processing status of the Quality Assurance source (if it's running or not).
+   */
+  public isSourceProcessing$: Observable<boolean>;
+  /**
    * Array to track all the component subscriptions. Useful to unsubscribe them with 'onDestroy'.
    * @type {Array}
    */
@@ -106,6 +114,8 @@ export class QualityAssuranceSourceComponent implements OnDestroy, OnInit, After
       }),
     );
     this.totalElements$ = this.notificationsStateService.getQualityAssuranceSourceTotals();
+    this.isSourceLoading$ = this.notificationsStateService.isQualityAssuranceSourceLoading();
+    this.isSourceProcessing$ = this.notificationsStateService.isQualityAssuranceSourceProcessing();
   }
 
   /**
@@ -127,26 +137,6 @@ export class QualityAssuranceSourceComponent implements OnDestroy, OnInit, After
    */
   onSelect(sourceId: string) {
     this.router.navigate([sourceId], { relativeTo: this.route });
-  }
-
-  /**
-   * Returns the information about the loading status of the Quality Assurance source (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if the source are loading, 'false' otherwise.
-   */
-  public isSourceLoading(): Observable<boolean> {
-    return this.notificationsStateService.isQualityAssuranceSourceLoading();
-  }
-
-  /**
-   * Returns the information about the processing status of the Quality Assurance source (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if there are operations running on the source (ex.: a REST call), 'false' otherwise.
-   */
-  public isSourceProcessing(): Observable<boolean> {
-    return this.notificationsStateService.isQualityAssuranceSourceProcessing();
   }
 
   /**

--- a/src/app/notifications/qa/topics/quality-assurance-topics.component.html
+++ b/src/app/notifications/qa/topics/quality-assurance-topics.component.html
@@ -8,7 +8,7 @@
       @if (targetId) {
         <ds-alert [type]="'alert-info'">
           {{'quality-assurance.topics.description-with-target'| translate:{source: sourceId} }}
-          <a [routerLink]="itemPageUrl">{{(getTargetItemTitle() | async)}}</a>
+          <a [routerLink]="itemPageUrl">{{(targetItemTitle$ | async)}}</a>
         </ds-alert>
       }
     </div>
@@ -17,20 +17,20 @@
     <div class="col-12">
       <h2 class="border-bottom pb-2">{{'quality-assurance.topics'| translate}}</h2>
 
-      @if ((isTopicsLoading() | async)) {
+      @if ((isTopicsLoading$ | async)) {
         <ds-loading class="container" message="{{'quality-assurance.loading' | translate}}"></ds-loading>
       }
-      @if ((isTopicsLoading() | async) !== true) {
+      @if ((isTopicsLoading$ | async) !== true) {
         <ds-pagination
           [paginationOptions]="paginationConfig"
           [collectionSize]="(totalElements$ | async)"
           [hideGear]="false"
           [hideSortOptions]="true"
           (paginationChange)="getQualityAssuranceTopics(sourceId, targetId)">
-          @if ((isTopicsProcessing() | async)) {
+          @if ((isTopicsProcessing$ | async)) {
             <ds-loading class="container" message="'quality-assurance.loading' | translate"></ds-loading>
           }
-          @if ((isTopicsProcessing() | async) !== true) {
+          @if ((isTopicsProcessing$ | async) !== true) {
             @if ((topics$ | async)?.length === 0) {
               <div class="alert alert-info w-100 mb-2 mt-2" role="alert">
                 {{'quality-assurance.noTopics' | translate}}

--- a/src/app/notifications/qa/topics/quality-assurance-topics.component.spec.ts
+++ b/src/app/notifications/qa/topics/quality-assurance-topics.component.spec.ts
@@ -148,14 +148,16 @@ describe('QualityAssuranceTopicsComponent test suite', () => {
       expect(compAsAny.getQualityAssuranceTopics).toHaveBeenCalled();
     });
 
-    it(('isTopicsLoading should return FALSE'), () => {
-      expect(comp.isTopicsLoading()).toBeObservable(cold('(a|)', {
+    it(('isTopicsLoading$ should return FALSE'), () => {
+      comp.ngOnInit();
+      expect(comp.isTopicsLoading$).toBeObservable(cold('(a|)', {
         a: false,
       }));
     });
 
-    it(('isTopicsProcessing should return FALSE'), () => {
-      expect(comp.isTopicsProcessing()).toBeObservable(cold('(a|)', {
+    it(('isTopicsProcessing$ should return FALSE'), () => {
+      comp.ngOnInit();
+      expect(comp.isTopicsProcessing$).toBeObservable(cold('(a|)', {
         a: false,
       }));
     });

--- a/src/app/notifications/qa/topics/quality-assurance-topics.component.ts
+++ b/src/app/notifications/qa/topics/quality-assurance-topics.component.ts
@@ -85,6 +85,18 @@ export class QualityAssuranceTopicsComponent implements OnInit, OnDestroy, After
    */
   public totalElements$: Observable<number>;
   /**
+   * The loading status of the Quality Assurance topics (if it's running or not).
+   */
+  public isTopicsLoading$: Observable<boolean>;
+  /**
+   * The processing status of the Quality Assurance topics (if it's running or not).
+   */
+  public isTopicsProcessing$: Observable<boolean>;
+  /**
+   * The title of the target item, when a targetId is present.
+   */
+  public targetItemTitle$: Observable<string>;
+  /**
    * Array to track all the component subscriptions. Useful to unsubscribe them with 'onDestroy'.
    * @type {Array}
    */
@@ -140,6 +152,11 @@ export class QualityAssuranceTopicsComponent implements OnInit, OnDestroy, After
       }),
     );
     this.totalElements$ = this.notificationsStateService.getQualityAssuranceTopicsTotals();
+    this.isTopicsLoading$ = this.notificationsStateService.isQualityAssuranceTopicsLoading();
+    this.isTopicsProcessing$ = this.notificationsStateService.isQualityAssuranceTopicsProcessing();
+    if (this.targetId) {
+      this.targetItemTitle$ = this.getTargetItemTitle();
+    }
   }
 
   /**
@@ -153,26 +170,6 @@ export class QualityAssuranceTopicsComponent implements OnInit, OnDestroy, After
         this.getQualityAssuranceTopics(this.sourceId, this.targetId);
       }),
     );
-  }
-
-  /**
-   * Returns the information about the loading status of the Quality Assurance topics (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if the topics are loading, 'false' otherwise.
-   */
-  public isTopicsLoading(): Observable<boolean> {
-    return this.notificationsStateService.isQualityAssuranceTopicsLoading();
-  }
-
-  /**
-   * Returns the information about the processing status of the Quality Assurance topics (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if there are operations running on the topics (ex.: a REST call), 'false' otherwise.
-   */
-  public isTopicsProcessing(): Observable<boolean> {
-    return this.notificationsStateService.isQualityAssuranceTopicsProcessing();
   }
 
   /**

--- a/src/app/notifications/suggestions/targets/publication-claim/publication-claim.component.html
+++ b/src/app/notifications/suggestions/targets/publication-claim/publication-claim.component.html
@@ -3,20 +3,20 @@
     <div class="col-12">
       <h1 id="header" class="border-bottom pb-2">{{'suggestion.title'| translate}}</h1>
 
-      @if ((isTargetsLoading() | async)) {
+      @if ((isTargetsLoading$ | async)) {
         <ds-loading class="container" message="{{'suggestion.loading' | translate}}"></ds-loading>
       }
-      @if ((isTargetsLoading() | async) !== true) {
+      @if ((isTargetsLoading$ | async) !== true) {
         <ds-pagination
           [paginationOptions]="paginationConfig"
           [collectionSize]="(totalElements$ | async)"
           [hideGear]="false"
           [retainScrollPosition]="false"
           (paginationChange)="getSuggestionTargets()">
-          @if ((isTargetsProcessing() | async)) {
+          @if ((isTargetsProcessing$ | async)) {
             <ds-loading class="container" message="'suggestion.loading' | translate"></ds-loading>
           }
-          @if ((isTargetsProcessing() | async) !== true) {
+          @if ((isTargetsProcessing$ | async) !== true) {
             @if ((targets$ | async)?.length === 0) {
               <div class="alert alert-info w-100 mb-2 mt-2" role="alert">
                 {{'suggestion.noTargets' | translate}}

--- a/src/app/notifications/suggestions/targets/publication-claim/publication-claim.component.ts
+++ b/src/app/notifications/suggestions/targets/publication-claim/publication-claim.component.ts
@@ -70,6 +70,14 @@ export class PublicationClaimComponent implements AfterViewInit, OnDestroy, OnIn
    */
   public totalElements$: Observable<number>;
   /**
+   * The loading status of the Suggestion Targets (if it's running or not).
+   */
+  public isTargetsLoading$: Observable<boolean>;
+  /**
+   * The processing status of the Suggestion Targets (if it's running or not).
+   */
+  public isTargetsProcessing$: Observable<boolean>;
+  /**
    * Array to track all the component subscriptions. Useful to unsubscribe them with 'onDestroy'.
    * @type {Array}
    */
@@ -96,6 +104,8 @@ export class PublicationClaimComponent implements AfterViewInit, OnDestroy, OnIn
   ngOnInit(): void {
     this.targets$ = this.suggestionTargetsStateService.getSuggestionTargets(this.sourceId());
     this.totalElements$ = this.suggestionTargetsStateService.getSuggestionTargetsTotals(this.sourceId());
+    this.isTargetsLoading$ = this.suggestionTargetsStateService.isSuggestionTargetsLoading(this.sourceId());
+    this.isTargetsProcessing$ = this.suggestionTargetsStateService.isSuggestionTargetsProcessing(this.sourceId());
   }
 
   /**
@@ -109,26 +119,6 @@ export class PublicationClaimComponent implements AfterViewInit, OnDestroy, OnIn
         this.getSuggestionTargets();
       }),
     );
-  }
-
-  /**
-   * Returns the information about the loading status of the Suggestion Targets (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if the targets are loading, 'false' otherwise.
-   */
-  public isTargetsLoading(): Observable<boolean> {
-    return this.suggestionTargetsStateService.isSuggestionTargetsLoading(this.sourceId());
-  }
-
-  /**
-   * Returns the information about the processing status of the Suggestion Targets (if it's running or not).
-   *
-   * @return Observable<boolean>
-   *    'true' if there are operations running on the targets (ex.: a REST call), 'false' otherwise.
-   */
-  public isTargetsProcessing(): Observable<boolean> {
-    return this.suggestionTargetsStateService.isSuggestionTargetsProcessing(this.sourceId());
   }
 
   /**

--- a/src/app/root/root.component.html
+++ b/src/app/root/root.component.html
@@ -2,7 +2,7 @@
   {{ 'root.skip-to-content' | translate }}
 </button>
 
-<div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [ngClass]="browserOsClasses.asObservable() | async" [@slideSidebarPadding]="{
+<div class="outer-wrapper" [class.d-none]="shouldShowFullscreenLoader" [ngClass]="browserOsClasses | async" [@slideSidebarPadding]="{
      value: ((isSidebarVisible$ | async) !== true ? 'hidden' : (slideSidebarOver$ | async) ? 'unpinned' : 'pinned'),
      params: { collapsedWidth: (collapsedSidebarWidth$ | async), expandedWidth: (expandedSidebarWidth$ | async) }
     }">

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.html
@@ -37,7 +37,7 @@
   </ul>
 </ng-template>
 
-@if ((isHierarchicalVocabulary() | async) !== true) {
+@if ((isHierarchicalVocabulary$ | async) !== true) {
   <div class="form-row position-relative align-items-center">
 
     <div class="position-relative right-addon">
@@ -88,7 +88,7 @@
   </div>
 }
 
-@if ((isHierarchicalVocabulary() | async)) {
+@if ((isHierarchicalVocabulary$ | async)) {
   <div class="position-relative right-addon">
     <i class="dropdown-toggle position-absolute tree-toggle" (click)="openTree($event)"
        aria-hidden="true"></i>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
@@ -121,7 +121,7 @@ export class DsDynamicOneboxComponent extends DsDynamicVocabularyComponent imple
   authorithyIcons = environment.submission.icons.authority.sourceIcons;
 
 
-  private isHierarchicalVocabulary$: Observable<boolean>;
+  isHierarchicalVocabulary$: Observable<boolean>;
   private subs: Subscription[] = [];
 
   constructor(protected vocabularyService: VocabularyService,
@@ -217,13 +217,6 @@ export class DsDynamicOneboxComponent extends DsDynamicVocabularyComponent imple
   changeLoadingInitialValueStatus(status: boolean) {
     this.loadingInitialValue = status;
     this.cdr.detectChanges();
-  }
-
-  /**
-   * Checks if configured vocabulary is Hierarchical or not
-   */
-  isHierarchicalVocabulary(): Observable<boolean> {
-    return this.isHierarchicalVocabulary$;
   }
 
   /**

--- a/src/app/shared/form/form.component.html
+++ b/src/app/shared/form/form.component.html
@@ -100,7 +100,7 @@
               <ng-content select="[between]"></ng-content>
               @if (displaySubmit) {
                 <button type="submit" class="btn btn-primary" (click)="onSubmit()"
-                  [dsBtnDisabled]="(isValid() | async) !== true">
+                  [dsBtnDisabled]="(isValid$ | async) !== true">
                   <i class="fas fa-save" aria-hidden="true"></i> {{submitLabel | translate}}
                 </button>
               }

--- a/src/app/shared/form/form.component.spec.ts
+++ b/src/app/shared/form/form.component.spec.ts
@@ -355,7 +355,7 @@ describe('FormComponent', () => {
       valid.next(true);
       formFixture.detectChanges();
 
-      formComp.isValid().subscribe((v) => {
+      formComp.isValid$.subscribe((v) => {
         expect(v).toBe(true);
       });
     });

--- a/src/app/shared/form/form.component.ts
+++ b/src/app/shared/form/form.component.ts
@@ -164,6 +164,11 @@ export class FormComponent implements OnDestroy, OnInit {
   enableInlineGroupCopy: boolean;
 
   /**
+   * Whether the form is valid.
+   */
+  public isValid$: Observable<boolean>;
+
+  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    * @type {Array}
    */
@@ -233,6 +238,7 @@ export class FormComponent implements OnDestroy, OnInit {
     }
 
     this.formService.initForm(this.formId, this.formModel, this.getFormGroupValidStatus());
+    this.isValid$ = this.formService.isValid(this.formId);
 
     this.keepSync();
 
@@ -311,13 +317,6 @@ export class FormComponent implements OnDestroy, OnInit {
       .forEach((sub) => sub.unsubscribe());
     this.formService.removeForm(this.formId);
     this.formBuilderService.removeFormGroup(this.formId);
-  }
-
-  /**
-   * Method to check if the form status is valid or not
-   */
-  public isValid(): Observable<boolean> {
-    return this.formService.isValid(this.formId);
   }
 
   /**

--- a/src/app/shared/object-collection/shared/selectable-list-item-control/selectable-list-item-control.component.html
+++ b/src/app/shared/object-collection/shared/selectable-list-item-control/selectable-list-item-control.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngVar="selectionService?.isObjectSelected(selectionConfig?.listId, object) | async as checked">
+<ng-container *ngVar="selected$ | async as checked">
   <span class="form-check">
     @if (selectionConfig.repeatable) {
       <input #selectListItemCheckbox class="form-check-input" type="checkbox"

--- a/src/app/shared/object-list/my-dspace-result-list-element/pool-search-result/pool-search-result-list-element.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/pool-search-result/pool-search-result-list-element.component.spec.ts
@@ -26,6 +26,7 @@ import { SubmissionDuplicateDataService } from '@dspace/core/submission/submissi
 import { PoolTask } from '@dspace/core/tasks/models/pool-task-object.model';
 import { DSONameServiceMock } from '@dspace/core/testing/dso-name.service.mock';
 import { getMockLinkService } from '@dspace/core/testing/link-service.mock';
+import { mockTruncatableService } from '@dspace/core/testing/mock-trucatable.service';
 import { createPaginatedList } from '@dspace/core/testing/utils.test';
 import {
   createSuccessfulRemoteDataObject,
@@ -113,7 +114,7 @@ describe('PoolSearchResultListElementComponent', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, VarDirective, PoolSearchResultListElementComponent],
       providers: [
-        { provide: TruncatableService, useValue: {} },
+        { provide: TruncatableService, useValue: mockTruncatableService },
         { provide: LinkService, useValue: linkService },
         { provide: DSONameService, useClass: DSONameServiceMock },
         { provide: APP_CONFIG, useValue: environmentUseThumbs },

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
@@ -49,7 +49,7 @@
               }
               @if (dso.allMetadataValues(authorMetadata, placeholderFilter).length > 0) {
                 <span class="item-list-authors">
-                  @let collapsed = isCollapsed() | async;
+                  @let collapsed = isCollapsed$ | async;
                   <ng-container>
                     @if (collapsed) {
                       @for (author of dso.limitedMetadata(authorMetadata, additionalMetadataLimit, placeholderFilter); track author; let last = $last) {

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.spec.ts
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.spec.ts
@@ -292,7 +292,7 @@ describe('ItemSearchResultListElementComponent', () => {
 
   describe('When the item has authors and isCollapsed is true', () => {
     beforeEach(() => {
-      spyOn(publicationListElementComponent, 'isCollapsed').and.returnValue(of(true));
+      spyOn(mockTruncatableService, 'isCollapsed').and.returnValue(of(true));
       publicationListElementComponent.object = mockItemWithMetadata;
       fixture.detectChanges();
     });
@@ -305,7 +305,7 @@ describe('ItemSearchResultListElementComponent', () => {
 
   describe('When the item has authors and isCollapsed is false', () => {
     beforeEach(() => {
-      spyOn(publicationListElementComponent, 'isCollapsed').and.returnValue(of(false));
+      spyOn(mockTruncatableService, 'isCollapsed').and.returnValue(of(false));
       publicationListElementComponent.object = mockItemWithMetadata;
       fixture.detectChanges();
     });

--- a/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
@@ -57,6 +57,8 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
     if (hasValue(this.object)) {
       this.dso = this.object.indexableObject;
       this.dsoTitle = this.dsoNameService.getHitHighlights(this.object, this.dso, true);
+    }
+    if (hasValue(this.dso)) {
       this.isCollapsed$ = this.truncatableService.isCollapsed(this.dso.id);
     }
   }

--- a/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
+++ b/src/app/shared/object-list/search-result-list-element/search-result-list-element.component.ts
@@ -38,6 +38,11 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
    */
   additionalMetadataLimit: number;
 
+  /**
+   * Emits if the list element is currently collapsed or not
+   */
+  isCollapsed$: Observable<boolean>;
+
   public constructor(protected truncatableService: TruncatableService,
                      public dsoNameService: DSONameService,
                      @Inject(APP_CONFIG) protected appConfig?: AppConfig) {
@@ -52,6 +57,7 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
     if (hasValue(this.object)) {
       this.dso = this.object.indexableObject;
       this.dsoTitle = this.dsoNameService.getHitHighlights(this.object, this.dso, true);
+      this.isCollapsed$ = this.truncatableService.isCollapsed(this.dso.id);
     }
   }
 
@@ -106,13 +112,6 @@ export class SearchResultListElementComponent<T extends SearchResult<K>, K exten
    */
   firstMetadataValue(keyOrKeys: string | string[], escapeHTML = true): string {
     return Metadata.firstValue(this.dso.metadata, keyOrKeys, this.object.hitHighlights, undefined, escapeHTML);
-  }
-
-  /**
-   * Emits if the list element is currently collapsed or not
-   */
-  isCollapsed(): Observable<boolean> {
-    return this.truncatableService.isCollapsed(this.dso.id);
   }
 
 }

--- a/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
+++ b/src/app/shared/object-list/sidebar-search-list-element/sidebar-search-list-element.component.spec.ts
@@ -176,7 +176,7 @@ export function createHierarchicalParentTitleTests(
       TestBed.configureTestingModule({
         imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([]), VarDirective],
         providers: [
-          { provide: TruncatableService, useValue: {} },
+          { provide: TruncatableService, useValue: mockTruncatableService },
           { provide: LinkService, useValue: linkService },
           { provide: DSOBreadcrumbsService, useValue: dsoBreadcrumbsService },
           DSONameService,

--- a/src/app/shared/resource-policies/form/resource-policy-form.component.html
+++ b/src/app/shared/resource-policies/form/resource-policy-form.component.html
@@ -37,7 +37,7 @@
             (click)="onReset()">{{'form.cancel' | translate}}</button>
             <button type="button"
               class="btn btn-primary"
-              [dsBtnDisabled]="(isFormValid() | async) !== true || (isProcessing | async)"
+              [dsBtnDisabled]="(isFormValid$ | async) !== true || (isProcessing | async)"
               (click)="onSubmit()">
               @if ((isProcessing | async)) {
                 <span>

--- a/src/app/shared/resource-policies/form/resource-policy-form.component.spec.ts
+++ b/src/app/shared/resource-policies/form/resource-policy-form.component.spec.ts
@@ -313,7 +313,7 @@ describe('ResourcePolicyFormComponent test suite', () => {
     it('should init form model properly', () => {
       epersonService.findByHref.and.returnValue(of(undefined));
       groupService.findByHref.and.returnValue(of(undefined));
-      spyOn(compAsAny, 'isFormValid').and.returnValue(of(false));
+      compAsAny.formService.isValid.and.returnValue(of(false));
       spyOn(compAsAny, 'initModelsValue').and.callThrough();
       spyOn(compAsAny, 'buildResourcePolicyForm').and.callThrough();
       fixture.detectChanges();
@@ -377,7 +377,7 @@ describe('ResourcePolicyFormComponent test suite', () => {
     });
 
     it('should init form model properly', () => {
-      spyOn(compAsAny, 'isFormValid').and.returnValue(of(false));
+      compAsAny.formService.isValid.and.returnValue(of(false));
       spyOn(compAsAny, 'initModelsValue').and.callThrough();
       spyOn(compAsAny, 'buildResourcePolicyForm').and.callThrough();
       fixture.detectChanges();
@@ -395,6 +395,7 @@ describe('ResourcePolicyFormComponent test suite', () => {
 
     it('should init resourcePolicyGrant properly', (done) => {
       compAsAny.isActive = true;
+      compAsAny.formService.isValid.and.returnValue(of(false));
       comp.ngOnInit();
       comp.resourcePolicyTargetName$.pipe(
         isNotEmptyOperator(),

--- a/src/app/shared/resource-policies/form/resource-policy-form.component.ts
+++ b/src/app/shared/resource-policies/form/resource-policy-form.component.ts
@@ -145,6 +145,12 @@ export class ResourcePolicyFormComponent implements OnInit, OnDestroy {
   public formModel: DynamicFormControlModel[];
 
   /**
+   * Whether the form status is valid or not
+   * @type {Observable<boolean>}
+   */
+  public isFormValid$: Observable<boolean>;
+
+  /**
    * The eperson or group that will be granted the permission
    * @type {DSpaceObject}
    */
@@ -205,6 +211,9 @@ export class ResourcePolicyFormComponent implements OnInit, OnDestroy {
     this.isActive = true;
     this.formId = this.formService.getUniqueId('resource-policy-form');
     this.formModel = this.buildResourcePolicyForm();
+    this.isFormValid$ = this.formService.isValid(this.formId).pipe(
+      map((isValid: boolean) => isValid && isNotEmpty(this.resourcePolicyGrant)),
+    );
 
     if (this.isBeingEdited()) {
       const epersonRD$ = this.ePersonService.findByHref(this.resourcePolicy._links.eperson.href, false).pipe(
@@ -231,16 +240,6 @@ export class ResourcePolicyFormComponent implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * Method to check if the form status is valid or not
-   *
-   * @return Observable that emits the form status
-   */
-  isFormValid(): Observable<boolean> {
-    return this.formService.isValid(this.formId).pipe(
-      map((isValid: boolean) => isValid && isNotEmpty(this.resourcePolicyGrant)),
-    );
-  }
 
   /**
    * Initialize the form model

--- a/src/app/shared/resource-policies/resource-policies.component.html
+++ b/src/app/shared/resource-policies/resource-policies.component.html
@@ -13,15 +13,15 @@
             </span>
             <div class="space-children-mr flex-shrink-0">
               <button class="btn btn-danger p-1"
-                [dsBtnDisabled]="((canDelete() | async) !== true) || (isProcessingDelete() | async)"
+                [dsBtnDisabled]="((canDelete$ | async) !== true) || (isProcessingDelete$ | async)"
                 [title]="'resource-policies.delete.btn.title' | translate"
                 (click)="deleteSelectedResourcePolicies()">
-                @if ((isProcessingDelete() | async)) {
+                @if ((isProcessingDelete$ | async)) {
                   <span>
                     <i class='fas fa-circle-notch fa-spin' aria-hidden="true"></i> {{'submission.workflow.tasks.generic.processing' | translate}}
                   </span>
                 }
-                @if ((isProcessingDelete() | async) !== true) {
+                @if ((isProcessingDelete$ | async) !== true) {
                   <span>
                     <i class='fas fa-trash-alt fa-fw' aria-hidden="true"></i>
                     {{'resource-policies.delete.btn' | translate}}
@@ -29,7 +29,7 @@
                 }
               </button>
               <button class="btn btn-success p-1"
-                [dsBtnDisabled]="(isProcessingDelete() | async)"
+                [dsBtnDisabled]="(isProcessingDelete$ | async)"
                 [title]="'resource-policies.add.for.' + resourceType | translate"
                 (click)="redirectToResourcePolicyCreatePage()">
                 <i class='fas fa-plus' aria-hidden="true"></i>
@@ -39,7 +39,7 @@
           </div>
         </th>
       </tr>
-      @if ((getResourcePolicies() | async)?.length > 0) {
+      @if ((resourcePolicies$ | async)?.length > 0) {
         <tr class="text-center">
           <th>
             <div>
@@ -64,9 +64,9 @@
         </tr>
       }
     </thead>
-    @if ((getResourcePolicies() | async)?.length > 0) {
+    @if ((resourcePolicies$ | async)?.length > 0) {
       <tbody>
-        @for (entry of (getResourcePolicies() | async); track entry) {
+        @for (entry of (resourcePolicies$ | async); track entry) {
           <tr ds-resource-policy-entry
             [entry]="entry"
             (toggleCheckbox)="selectCheckbox(entry, $event)"

--- a/src/app/shared/resource-policies/resource-policies.component.spec.ts
+++ b/src/app/shared/resource-policies/resource-policies.component.spec.ts
@@ -349,7 +349,7 @@ describe('ResourcePoliciesComponent test suite', () => {
       });
 
       it('should return false when no row is selected', () => {
-        expect(comp.canDelete()).toBeObservable(cold('(a|)', {
+        expect(comp.canDelete$).toBeObservable(cold('a', {
           a: false,
         }));
       });
@@ -358,7 +358,7 @@ describe('ResourcePoliciesComponent test suite', () => {
         const checkbox = fixture.debugElement.query(By.css('table > tbody > tr:nth-child(1) input'));
         const event = { target: { checked: true } };
         checkbox.triggerEventHandler('change', event);
-        expect(comp.canDelete()).toBeObservable(cold('(a|)', {
+        expect(comp.canDelete$).toBeObservable(cold('a', {
           a: true,
         }));
       });
@@ -410,7 +410,7 @@ describe('ResourcePoliciesComponent test suite', () => {
 
     it('should get the resource\'s policy list', () => {
       const initResourcePolicyEntries = getInitEntries();
-      expect(comp.getResourcePolicies()).toBeObservable(cold('a', {
+      expect(comp.resourcePolicies$).toBeObservable(cold('a', {
         a: initResourcePolicyEntries,
       }));
 

--- a/src/app/shared/resource-policies/resource-policies.component.ts
+++ b/src/app/shared/resource-policies/resource-policies.component.ts
@@ -22,7 +22,6 @@ import { getAllSucceededRemoteData } from '@dspace/core/shared/operators';
 import {
   hasValue,
   isEmpty,
-  isNotEmpty,
 } from '@dspace/shared/utils/empty.util';
 import {
   TranslateModule,
@@ -39,7 +38,6 @@ import {
   distinctUntilChanged,
   filter,
   map,
-  reduce,
   scan,
   take,
 } from 'rxjs/operators';
@@ -104,6 +102,27 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
     new BehaviorSubject<ResourcePolicyCheckboxEntry[]>([]);
 
   /**
+   * Whether there are any selected resource's policies to be deleted
+   * @type {Observable<boolean>}
+   */
+  public canDelete$: Observable<boolean> = this.resourcePoliciesEntries$.pipe(
+    map((entries: ResourcePolicyCheckboxEntry[]) => entries.some((entry) => entry.checked)),
+    distinctUntilChanged(),
+  );
+
+  /**
+   * Whether a delete operation is pending
+   * @type {Observable<boolean>}
+   */
+  public isProcessingDelete$: Observable<boolean> = this.processingDelete$.asObservable();
+
+  /**
+   * All resource's policies
+   * @type {Observable<ResourcePolicyCheckboxEntry[]>}
+   */
+  public resourcePolicies$: Observable<ResourcePolicyCheckboxEntry[]> = this.resourcePoliciesEntries$.asObservable();
+
+  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    * @type {Array}
    */
@@ -146,20 +165,6 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Check if there are any selected resource's policies to be deleted
-   *
-   * @return {Observable<boolean>}
-   */
-  canDelete(): Observable<boolean> {
-    return observableFrom(this.resourcePoliciesEntries$.value).pipe(
-      filter((entry: ResourcePolicyCheckboxEntry) => entry.checked),
-      reduce((acc: any, value: any) => [...acc, value], []),
-      map((entries: ResourcePolicyCheckboxEntry[]) => isNotEmpty(entries)),
-      distinctUntilChanged(),
-    );
-  }
-
-  /**
    * Delete the selected resource's policies
    */
   deleteSelectedResourcePolicies(): void {
@@ -185,15 +190,6 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Return all resource's policies
-   *
-   * @return an observable that emits all resource's policies
-   */
-  getResourcePolicies(): Observable<ResourcePolicyCheckboxEntry[]> {
-    return this.resourcePoliciesEntries$.asObservable();
-  }
-
-  /**
    * Initialize the resource's policies list
    */
   initResourcePolicyList() {
@@ -216,15 +212,6 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Return a boolean representing if a delete operation is pending
-   *
-   * @return {Observable<boolean>}
-   */
-  isProcessingDelete(): Observable<boolean> {
-    return this.processingDelete$.asObservable();
-  }
-
-  /**
    * Redirect to resource policy creation page
    */
   redirectToResourcePolicyCreatePage(): void {
@@ -242,7 +229,9 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
    */
   selectAllCheckbox(event: any): void {
     const checked = event.target.checked;
-    this.resourcePoliciesEntries$.value.forEach((entry: ResourcePolicyCheckboxEntry) => entry.checked = checked);
+    const entries = this.resourcePoliciesEntries$.value;
+    entries.forEach((entry: ResourcePolicyCheckboxEntry) => entry.checked = checked);
+    this.resourcePoliciesEntries$.next(entries);
   }
 
   /**
@@ -250,6 +239,7 @@ export class ResourcePoliciesComponent implements OnInit, OnDestroy {
    */
   selectCheckbox(policyEntry: ResourcePolicyCheckboxEntry, checked: boolean) {
     policyEntry.checked = checked;
+    this.resourcePoliciesEntries$.next(this.resourcePoliciesEntries$.value);
   }
 
   /**

--- a/src/app/submission/sections/container/section-container.component.html
+++ b/src/app/submission/sections/container/section-container.component.html
@@ -2,7 +2,7 @@
   class="mb-2"
   [ngClass]="{ 'section-focus' : sectionRef.isSectionActive() }" [mandatory]="sectionData.mandatory"
   [submissionId]="submissionId" [sectionType]="sectionData.sectionType" [sectionId]="sectionData.id">
-  @if ((sectionRef.isEnabled() | async)) {
+  @if ((sectionRef.enabled | async)) {
     <ngb-accordion #acc="ngbAccordion"
       (panelChange)="sectionRef.sectionChange($event)" activeIds="{{ sectionData.id }}" [destroyOnHide]="false">
       <ngb-panel id="{{ sectionData.id }}" [type]="sectionRef.isInfo() ? 'info' : ''">
@@ -11,7 +11,7 @@
             'submission.sections.'+sectionData.header | translate
           }}</span>
           <div class="d-inline-block">
-            @if ((sectionRef.isValid() | async) !== true && !(sectionRef.hasErrors()) && !(sectionRef.isInfo())) {
+            @if ((sectionRef.valid | async) !== true && !(sectionRef.hasErrors()) && !(sectionRef.isInfo())) {
               <i
                 class="fas fa-exclamation-circle text-warning me-3"
                 title="{{'submission.sections.status.warnings.title' | translate}}" role="img"
@@ -23,7 +23,7 @@
                 title="{{'submission.sections.status.errors.title' | translate}}" role="img"
               [attr.aria-label]="'submission.sections.status.errors.aria' | translate"></i>
             }
-            @if ((sectionRef.isValid() | async) && !(sectionRef.hasErrors()) && !(sectionRef.isInfo())) {
+            @if ((sectionRef.valid | async) && !(sectionRef.hasErrors()) && !(sectionRef.isInfo())) {
               <i
                 class="fas fa-check-circle text-success me-3"
                 title="{{'submission.sections.status.valid.title' | translate}}" role="img"

--- a/src/app/submission/sections/container/section-container.component.spec.ts
+++ b/src/app/submission/sections/container/section-container.component.spec.ts
@@ -145,7 +145,7 @@ describe('SubmissionSectionContainerComponent test suite', () => {
     });
 
     it('should inject section properly', () => {
-      spyOn(comp.sectionRef, 'isEnabled').and.returnValue(of(true));
+      comp.sectionRef.enabled = of(true);
       spyOn(comp.sectionRef, 'hasGenericErrors').and.returnValue(false);
 
       comp.ngOnInit();
@@ -174,7 +174,7 @@ describe('SubmissionSectionContainerComponent test suite', () => {
       let sectionErrorsDiv = fixture.debugElement.query(By.css('[id^=\'sectionGenericError_\']'));
       expect(sectionErrorsDiv).toBeNull();
 
-      spyOn(comp.sectionRef, 'isEnabled').and.returnValue(of(true));
+      comp.sectionRef.enabled = of(true);
       spyOn(comp.sectionRef, 'hasGenericErrors').and.returnValue(true);
 
       comp.ngOnInit();
@@ -186,8 +186,8 @@ describe('SubmissionSectionContainerComponent test suite', () => {
 
     it('should display warning icon', () => {
 
-      spyOn(comp.sectionRef, 'isEnabled').and.returnValue(of(true));
-      spyOn(comp.sectionRef, 'isValid').and.returnValue(of(false));
+      comp.sectionRef.enabled = of(true);
+      comp.sectionRef.valid = of(false);
       spyOn(comp.sectionRef, 'hasErrors').and.returnValue(false);
 
       comp.ngOnInit();
@@ -203,8 +203,8 @@ describe('SubmissionSectionContainerComponent test suite', () => {
 
     it('should display error icon', () => {
 
-      spyOn(comp.sectionRef, 'isEnabled').and.returnValue(of(true));
-      spyOn(comp.sectionRef, 'isValid').and.returnValue(of(false));
+      comp.sectionRef.enabled = of(true);
+      comp.sectionRef.valid = of(false);
       spyOn(comp.sectionRef, 'hasErrors').and.returnValue(true);
 
       comp.ngOnInit();
@@ -220,8 +220,8 @@ describe('SubmissionSectionContainerComponent test suite', () => {
 
     it('should display success icon', () => {
 
-      spyOn(comp.sectionRef, 'isEnabled').and.returnValue(of(true));
-      spyOn(comp.sectionRef, 'isValid').and.returnValue(of(true));
+      comp.sectionRef.enabled = of(true);
+      comp.sectionRef.valid = of(true);
       spyOn(comp.sectionRef, 'hasErrors').and.returnValue(false);
 
       comp.ngOnInit();

--- a/src/app/submission/sections/duplicates/section-duplicates.component.html
+++ b/src/app/submission/sections/duplicates/section-duplicates.component.html
@@ -2,7 +2,7 @@
 Template for the detect duplicates submission section component
 @author Kim Shepherd
 -->
-<div class="text-sm-start" *ngVar="(this.getDuplicateData() | async) as data">
+<div class="text-sm-start" *ngVar="(duplicateData$ | async) as data">
   @if (data?.potentialDuplicates.length === 0) {
     <div class="alert alert-success w-100">{{ 'submission.sections.duplicates.none' | translate }}</div>
   }

--- a/src/app/submission/sections/duplicates/section-duplicates.component.ts
+++ b/src/app/submission/sections/duplicates/section-duplicates.component.ts
@@ -57,6 +57,11 @@ export class SubmissionSectionDuplicatesComponent extends SectionModelComponent 
   public isLoading = true;
 
   /**
+   * The duplicate data as observable from the section data
+   */
+  public duplicateData$: Observable<WorkspaceitemSectionDuplicatesObject>;
+
+  /**
    * Array to track all subscriptions and unsubscribe them onDestroy
    * @type {Array}
    */
@@ -83,6 +88,7 @@ export class SubmissionSectionDuplicatesComponent extends SectionModelComponent 
 
   ngOnInit() {
     super.ngOnInit();
+    this.duplicateData$ = this.getDuplicateData();
   }
 
   /**

--- a/src/app/submission/sections/section-coar-notify/section-coar-notify.component.html
+++ b/src/app/submission/sections/section-coar-notify/section-coar-notify.component.html
@@ -1,8 +1,9 @@
 <div class="container-fluid">
   @if (patterns?.length > 0 ) {
     @for (ldnPattern of patterns; track ldnPattern; let i = $index) {
+      @let filteredServices$ = filterServices(ldnPattern.pattern);
       <div class="col">
-        @if ((filterServices(ldnPattern.pattern ) | async)?.length > 0) {
+        @if ((filteredServices$ | async)?.length > 0) {
           <div>
             <label class="row col-form-label">
               {{'submission.section.section-coar-notify.control.' + ldnPattern.pattern + '.label' | translate }}
@@ -13,6 +14,7 @@
                   @for (
                     service of ldnServiceByPattern[ldnPattern.pattern].services; track
                     service; let serviceIndex = $index) {
+                    @let shownErrors$ = getShownSectionErrors$(ldnPattern.pattern, serviceIndex);
                     <div
                       >
                       <div class="row">
@@ -25,7 +27,7 @@
                               [attr.aria-label]="ldnPattern.pattern+'.dropdownanchor'"
                               type="text"
                               [readonly]="true"
-                              [ngClass]="{'border-danger': (getShownSectionErrors$(ldnPattern.pattern, serviceIndex) | async)?.length > 0}"
+                              [ngClass]="{'border-danger': (shownErrors$ | async)?.length > 0}"
                               class="form-control w-100 scrollable-dropdown-input"
                               [value]="ldnServiceByPattern[ldnPattern.pattern].services[serviceIndex]?.name"
                               (click)="myDropdown.open()"
@@ -45,14 +47,14 @@
                               [infiniteScrollThrottle]="50"
                               [scrollWindow]="false"
                               >
-                              @if ((filterServices(ldnPattern.pattern) | async)?.length === 0) {
+                              @if ((filteredServices$ | async)?.length === 0) {
                                 <button
                                   class="dropdown-item collection-item text-truncate w-100"
                                   >
                                   {{'submission.section.section-coar-notify.dropdown.no-data' | translate}}
                                 </button>
                               }
-                              @if ((filterServices(ldnPattern.pattern ) | async)?.length > 0) {
+                              @if ((filteredServices$ | async)?.length > 0) {
                                 <button
                                   class="dropdown-item collection-item text-truncate w-100"
                                   (click)="onChange(ldnPattern.pattern, serviceIndex, null)"
@@ -60,7 +62,7 @@
                                   {{'submission.section.section-coar-notify.dropdown.select-none' | translate}}
                                 </button>
                               }
-                              @for (serviceOption of filterServices(ldnPattern.pattern ) | async; track serviceOption) {
+                              @for (serviceOption of filteredServices$ | async; track serviceOption) {
                                 <button
                                   [ngClass]="{'bg-light': ldnServiceByPattern[ldnPattern.pattern ].services[serviceIndex]?.id === serviceOption.id}"
                                   class="dropdown-item collection-item text-truncate w-100"
@@ -97,8 +99,8 @@
                           {{'submission.section.section-coar-notify.small.notification' | translate : {pattern : ldnPattern.pattern} }}
                         </small>
                       }
-                      @if ((getShownSectionErrors$(ldnPattern.pattern , serviceIndex) | async)?.length > 0) {
-                        @for (error of (getShownSectionErrors$(ldnPattern.pattern , serviceIndex) | async); track error) {
+                      @if ((shownErrors$ | async)?.length > 0) {
+                        @for (error of (shownErrors$ | async); track error) {
                           <small class="row text-danger">
                             {{ error.message | translate}}
                           </small>
@@ -127,7 +129,7 @@
                           </div>
                         </div>
                       }
-                      @if ((getShownSectionErrors$(ldnPattern.pattern, serviceIndex) | async)?.length > 0) {
+                      @if ((shownErrors$ | async)?.length > 0) {
                         <div class="row">
                           <div
                             class="alert alert-danger w-100 d-flex align-items-center flex-row"

--- a/src/app/submission/sections/section-coar-notify/section-coar-notify.component.ts
+++ b/src/app/submission/sections/section-coar-notify/section-coar-notify.component.ts
@@ -40,6 +40,7 @@ import {
 import {
   filter,
   map,
+  shareReplay,
   take,
   tap,
 } from 'rxjs/operators';
@@ -106,6 +107,19 @@ export class SubmissionSectionCoarNotifyComponent extends SectionModelComponent 
   protected subs: Subscription[] = [];
 
   private filteredServicesByPattern = {};
+
+  /**
+   * Memoized per-pattern list of available LDN services, so repeated template lookups for the
+   * same pattern resolve to the exact same Observable instance instead of re-fetching every time.
+   */
+  private filterServicesCache = new Map<string, Observable<LdnService[]>>();
+
+  /**
+   * Memoized per-(pattern, index) stream of shown section errors, so repeated template lookups
+   * resolve to the exact same (continuously updating) Observable instance instead of taking a
+   * fresh one-off snapshot every change detection cycle.
+   */
+  private shownSectionErrorsCache = new Map<string, Observable<SubmissionSectionError[]>>();
 
   constructor(protected ldnServicesService: LdnServicesService,
               // protected formOperationsService: SectionFormOperationsService,
@@ -266,31 +280,35 @@ export class SubmissionSectionCoarNotifyComponent extends SectionModelComponent 
    * Retrieve services with corresponding patterns to the dropdowns.
    */
   filterServices(pattern: string): Observable<LdnService[]> {
-    return this.ldnServicesService.findByInboundPattern(pattern).pipe(
-      getFirstCompletedRemoteData(),
-      tap((rd) => {
-        if (rd.hasFailed) {
-          throw new Error(`Failed to retrieve services for pattern ${pattern}`);
-        }
-      }),
-      filter((rd) => rd.hasSucceeded),
-      getRemoteDataPayload(),
-      getPaginatedListPayload(),
-      tap(res => {
-        if (!this.filteredServicesByPattern[pattern]){
-          this.filteredServicesByPattern[pattern] = [];
-        }
-        if (this.filteredServicesByPattern[pattern].length === 0) {
-          this.filteredServicesByPattern[pattern].push(...res);
-        }
-      }),
-      map((res: LdnService[]) => res.filter((service) => {
-        if (!this.hasSectionData){
-          this.hasSectionData = this.hasInboundPattern(service, pattern);
-        }
-        return this.hasInboundPattern(service, pattern);
-      })),
-    );
+    if (!this.filterServicesCache.has(pattern)) {
+      this.filterServicesCache.set(pattern, this.ldnServicesService.findByInboundPattern(pattern).pipe(
+        getFirstCompletedRemoteData(),
+        tap((rd) => {
+          if (rd.hasFailed) {
+            throw new Error(`Failed to retrieve services for pattern ${pattern}`);
+          }
+        }),
+        filter((rd) => rd.hasSucceeded),
+        getRemoteDataPayload(),
+        getPaginatedListPayload(),
+        tap(res => {
+          if (!this.filteredServicesByPattern[pattern]){
+            this.filteredServicesByPattern[pattern] = [];
+          }
+          if (this.filteredServicesByPattern[pattern].length === 0) {
+            this.filteredServicesByPattern[pattern].push(...res);
+          }
+        }),
+        map((res: LdnService[]) => res.filter((service) => {
+          if (!this.hasSectionData){
+            this.hasSectionData = this.hasInboundPattern(service, pattern);
+          }
+          return this.hasInboundPattern(service, pattern);
+        })),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      ));
+    }
+    return this.filterServicesCache.get(pattern);
   }
 
   /**
@@ -330,17 +348,17 @@ export class SubmissionSectionCoarNotifyComponent extends SectionModelComponent 
    * @returns An observable of the errors for the current section that match the given pattern and index.
    */
   public getShownSectionErrors$(pattern: string, index: number): Observable<SubmissionSectionError[]> {
-    return this.sectionService.getShownSectionErrors(this.submissionId, this.sectionData.id, this.sectionData.sectionType)
-      .pipe(
-        take(1),
-        filter((validationErrors) => isNotEmpty(validationErrors)),
-        map((validationErrors: SubmissionSectionError[]) => {
-          return validationErrors.filter((error) => {
-            const path = `${pattern}/${index}`;
-            return error.path.includes(path);
-          });
-        }),
-      );
+    const key = `${pattern}/${index}`;
+    if (!this.shownSectionErrorsCache.has(key)) {
+      this.shownSectionErrorsCache.set(key, this.sectionService.getShownSectionErrors(this.submissionId, this.sectionData.id, this.sectionData.sectionType)
+        .pipe(
+          map((validationErrors: SubmissionSectionError[]) => {
+            return validationErrors.filter((error) => error.path.includes(key));
+          }),
+          shareReplay({ bufferSize: 1, refCount: true }),
+        ));
+    }
+    return this.shownSectionErrorsCache.get(key);
   }
 
   /**

--- a/src/app/submission/sections/sections.directive.ts
+++ b/src/app/submission/sections/sections.directive.ts
@@ -78,7 +78,7 @@ export class SectionsDirective implements OnDestroy, OnInit {
    * A boolean representing if section is enabled
    * @type {boolean}
    */
-  private enabled: Observable<boolean>;
+  public enabled: Observable<boolean>;
 
   /**
    * A boolean representing the panel collapsible state: opened (true) or closed (false)
@@ -96,7 +96,7 @@ export class SectionsDirective implements OnDestroy, OnInit {
    * A boolean representing if section is valid
    * @type {boolean}
    */
-  private valid: Observable<boolean>;
+  public valid: Observable<boolean>;
 
   /**
    * Initialize instance variables
@@ -205,26 +205,6 @@ export class SectionsDirective implements OnDestroy, OnInit {
    */
   public isSectionActive(): boolean {
     return this.active;
-  }
-
-  /**
-   * Check if section is enabled
-   *
-   * @returns {Observable<boolean>}
-   *    Emits true whenever section is enabled
-   */
-  public isEnabled(): Observable<boolean> {
-    return this.enabled;
-  }
-
-  /**
-   * Check if section is valid
-   *
-   * @returns {Observable<boolean>}
-   *    Emits true whenever section is valid
-   */
-  public isValid(): Observable<boolean> {
-    return this.valid;
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #5933 

We commonly call a component method directly as the input of the `async` pipe in templates, e.g. `{{ getFoo$() | async }}`. Because the method runs as part of template evaluation, Angular re-executes the whole RxJS pipeline (subscribe + unsubscribe) on every change-detection cycle instead of once — a real, recurring perf issue in this codebase (confirmed instances in `audit-table`, `ePerson-data`, and `section-coar-notify` components).

This PR adds a new `dspace-angular-html` ESLint rule, `no-method-call-with-async-pipe`, that flags this pattern anywhere it appears in a template — interpolations, bound attributes/events, `@if`/`@for`/`@switch` blocks, `@defer` triggers, `@let`, and object/array literals or optional-chaining wrapped around the pipe.

- New rule: `lint/src/rules/html/no-method-call-with-async-pipe.ts`
- Registered in `lint/src/rules/html/index.ts` and enabled in `.eslintrc.json`
- Docs auto-generated via `npm run docs:lint` (`docs/lint/html/index.md`, `docs/lint/html/rules/no-method-call-with-async-pipe.md`)

### Implementation note

The straightforward approach — an ESLint selector like `` BindingPipe[name="async"] > Call `` — turned out to miss common real-world cases, because `@angular-eslint/template-parser`'s own visitor-keys map doesn't cover every expression AST node type (e.g. `SafePropertyRead`, `LiteralMap`), so ESLint's traversal silently stops before reaching calls wrapped in things like `(getFoo$() | async)?.length` or `[ngClass]="{x: getFoo$() | async}"`. To get full, correct coverage, the rule instead walks each template expression with `@angular/compiler`'s own `RecursiveAstVisitor`, which handles every AST node type regardless of that gap.

This rule does not attempt to fix existing offending call sites — per the issue, migrating those (subscribe in `ngOnInit()`, push into a `BehaviorSubject`, `| async` on that, unsubscribe in `ngOnDestroy()`) is a separate follow-up. The rule is not auto-fixable, since that migration can't be done mechanically.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
