### PR TITLE
[DURACOM-506] added spellcheck support

### DIFF
--- a/src/app/core/data/search-response-parsing.service.ts
+++ b/src/app/core/data/search-response-parsing.service.ts
@@ -26,6 +26,7 @@ export class SearchResponseParsingService extends DspaceRestResponseParsingServi
     payload.sort = data.payload.sort;
     payload.scope = data.payload.scope;
     payload.configuration = data.payload.configuration;
+    payload.spellCheckSuggestions = data.payload.spellCheckSuggestions;
     const hitHighlights: MetadataMap[] = payload._embedded.objects
       .map((object) => object.hitHighlights)
       .map((hhObject) => {

--- a/src/app/core/shared/search/models/search-query-response.model.ts
+++ b/src/app/core/shared/search/models/search-query-response.model.ts
@@ -56,4 +56,10 @@ export abstract class SearchQueryResponse<T> extends PaginatedList<T> {
 
   @autoserialize
   facets: any; // TODO
+
+  /**
+   * Spellcheck suggestions from the search backend
+   */
+  @autoserialize
+  spellCheckSuggestions: string[];
 }

--- a/src/app/shared/search/search-results/search-results.component.html
+++ b/src/app/shared/search/search-results/search-results.component.html
@@ -18,6 +18,20 @@
     <ds-search-export-csv [searchConfig]="searchConfig" [total]="searchResults?.payload?.totalElements"></ds-search-export-csv>
   }
 </div>
+@if (spellCheckSuggestions?.length > 0) {
+  <div class="spellcheck-suggestion mb-2 h3 mt-3">
+    {{ 'search.results.did-you-mean' | translate }}
+    @for (suggestion of spellCheckSuggestions; track suggestion; let last = $last) {
+      <a [routerLink]="['/search']"
+         [queryParams]="{ query: suggestion }"
+         queryParamsHandling="merge"
+         role="link"
+         tabindex="0">
+        {{ suggestion }}
+      </a>{{ last ? '' : ', ' }}
+    }
+  </div>
+}
 @if (searchResults && searchResults?.hasSucceeded && !searchResults?.isLoading && searchResults?.payload?.page.length > 0) {
   <div @fadeIn>
     <ds-viewable-collection

--- a/src/app/shared/search/search-results/search-results.component.spec.ts
+++ b/src/app/shared/search/search-results/search-results.component.spec.ts
@@ -133,6 +133,31 @@ describe('SearchResultsComponent', () => {
     expect(routerLinkQuery[0].queryParams.query).toBe('"foobar"', 'query params should be "foobar"');
   });
 
+  it('should display link based on spellcheck', () => {
+    (comp as any).searchResults = { payload: { page: { length: 0 } } };
+    (comp as any).spellCheckSuggestions = ['test'];
+    (comp as any).searchConfig = { query: 'testi' };
+    fixture.detectChanges();
+
+    const linkDes = fixture.debugElement.queryAll(By.directive(QueryParamsDirectiveStub));
+
+    // get attached link directive instances
+    // using each DebugElement's injector
+    const routerLinkQuery = linkDes.map((de) => de.injector.get(QueryParamsDirectiveStub)).filter(
+      (val) => val.queryParams.query === 'test');
+
+    expect(routerLinkQuery.length).toBe(1, 'should have 1 router link with query params "test"');
+  });
+
+  it('should not display spellcheck link when there are no suggestions', () => {
+    (comp as any).searchResults = { payload: { page: { length: 0 } } };
+    (comp as any).spellCheckSuggestions = [];
+    (comp as any).searchConfig = { query: 'testi' };
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.spellcheck-suggestion'))).toBeNull();
+  });
+
   it('should add quotes around the given string', () => {
     expect(comp.surroundStringWithQuotes('teststring')).toEqual('"teststring"');
   });

--- a/src/app/shared/search/search-results/search-results.component.ts
+++ b/src/app/shared/search/search-results/search-results.component.ts
@@ -121,6 +121,11 @@ export class SearchResultsComponent {
   @Input() configuration: string;
 
   /**
+   * Spellcheck suggestions from the search backend
+   */
+  @Input() spellCheckSuggestions: string[];
+
+  /**
    * Whether or not to hide the header of the results
    * Defaults to a visible header
    */

--- a/src/app/shared/search/search-results/themed-search-results.component.ts
+++ b/src/app/shared/search/search-results/themed-search-results.component.ts
@@ -30,7 +30,7 @@ import {
 })
 export class ThemedSearchResultsComponent extends ThemedComponent<SearchResultsComponent> {
 
-  protected inAndOutputNames: (keyof SearchResultsComponent & keyof this)[] = ['linkType', 'searchResults', 'searchConfig', 'showCsvExport', 'showThumbnails', 'sortConfig', 'viewMode', 'configuration', 'disableHeader', 'selectable', 'context', 'hidePaginationDetail', 'selectionConfig', 'contentChange', 'deselectObject', 'selectObject'];
+  protected inAndOutputNames: (keyof SearchResultsComponent & keyof this)[] = ['linkType', 'searchResults', 'searchConfig', 'showCsvExport', 'showThumbnails', 'sortConfig', 'viewMode', 'configuration', 'disableHeader', 'selectable', 'context', 'hidePaginationDetail', 'selectionConfig', 'contentChange', 'deselectObject', 'selectObject', 'spellCheckSuggestions'];
 
   @Input() linkType: CollectionElementLinkType;
 
@@ -41,6 +41,8 @@ export class ThemedSearchResultsComponent extends ThemedComponent<SearchResultsC
   @Input() showCsvExport: boolean;
 
   @Input() showThumbnails: boolean;
+
+  @Input() spellCheckSuggestions: string[];
 
   @Input() sortConfig: SortOptions;
 

--- a/src/app/shared/search/search.component.html
+++ b/src/app/shared/search/search.component.html
@@ -47,6 +47,7 @@
     @if (inPlaceSearch) {
       <ds-search-results
         [searchResults]="resultsRD$ | async"
+        [spellCheckSuggestions]="(resultsRD$ | async)?.payload?.spellCheckSuggestions"
         [searchConfig]="searchOptions$ | async"
         [configuration]="(currentConfiguration$ | async)"
         [disableHeader]="!searchEnabled"

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5158,6 +5158,8 @@
 
   "search.results.head": "Search Results",
 
+  "search.results.did-you-mean": "Did you mean?",
+
   "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
 
   "search.results.no-results-link": "quotes around it",

--- a/src/assets/i18n/it.json5
+++ b/src/assets/i18n/it.json5
@@ -8524,7 +8524,9 @@
   // "search.results.head": "Search Results",
   "search.results.head": "Risultati della ricerca",
 
-  // "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
+  // "search.results.did-you-mean": "Did you mean?",
+  "search.results.did-you-mean": "Intendevi?",
+
   "search.results.no-results": "La ricerca non ha prodotto alcun risultato. Hai problemi a trovare quello che cerchi? Prova a inserire",
 
   // "search.results.no-results-link": "quotes around it",


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1480

## Relates to
https://github.com/DSpace/RestContract/pull/359
https://github.com/DSpace/DSpace/pull/12792 

## Description
Added support for Spellcheck "did you mean?" feature whose porting from version 6 was not completed

## Instructions for reviewers
- Create items with dc.title set to test
- Run the following script `./dspace index-discovery --spellchecker` to rebuild the spellchecker index
- Type in the search box testi
- You'll get displayed the correct suggested query in the search page
Alternatively this test could be run using any other item in the repository trying to use a misspelled query.
The result strictly depends on the on the content indexed on Solr as already defined in the Solr configuration

<img width="1389" height="532" alt="Screenshot from 2026-07-07 11-12-32" src="https://github.com/user-attachments/assets/481c8dad-cf58-42e5-84a3-7003d495d1ac" />



## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
