### PR TITLE
Fix infinite route-loader spinner from per-navigation root cache inva…

### DIFF
--- a/src/modules/app/browser-init.service.spec.ts
+++ b/src/modules/app/browser-init.service.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+import { NavigationStart } from '@angular/router';
+import { Subject } from 'rxjs';
+
+import { BrowserInitService } from './browser-init.service';
+
+describe('BrowserInitService', () => {
+  describe('listenForRouteChanges', () => {
+    let service: BrowserInitService;
+    let rootDataServiceSpy;
+    let routerEvents$: Subject<any>;
+
+    beforeEach(() => {
+      rootDataServiceSpy = jasmine.createSpyObj('rootDataService', ['invalidateRootCache']);
+      routerEvents$ = new Subject();
+
+      service = new BrowserInitService(
+        null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        rootDataServiceSpy,
+        { events: routerEvents$.asObservable() } as any,
+        null, null, null, null,
+      );
+
+      (service as any).listenForRouteChanges();
+    });
+
+    it('should invalidate the root endpoint cache once, at init', () => {
+      expect(rootDataServiceSpy.invalidateRootCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not invalidate the root endpoint cache again on subsequent NavigationStart events', () => {
+      routerEvents$.next(new NavigationStart(1, '/some-route'));
+      routerEvents$.next(new NavigationStart(2, '/another-route'));
+
+      expect(rootDataServiceSpy.invalidateRootCache).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -10,10 +10,7 @@ import {
   Injectable,
   TransferState,
 } from '@angular/core';
-import {
-  NavigationStart,
-  Router,
-} from '@angular/router';
+import { Router } from '@angular/router';
 import {
   APP_CONFIG,
   APP_CONFIG_STATE,
@@ -226,21 +223,18 @@ export class BrowserInitService extends InitService {
   }
 
   /**
-   * Listen to all router events. Every time a new navigation starts, invalidate the cache
-   * for the root endpoint. That way we retrieve it once per routing operation to ensure the
-   * backend is not down. But if the guard is called multiple times during the same routing
-   * operation, the cached version is used.
+   * Invalidate the cache for the root endpoint once, at startup, so the first request for it
+   * is guaranteed to hit the backend rather than serve a value cached before the app booted.
+   *
+   * This used to also run on every `NavigationStart`, but the root endpoint map does not change
+   * between navigations, so that repeated invalidation was unnecessary. Worse, it could mark the
+   * root request stale while {@link HALEndpointService} was still resolving it for an in-flight
+   * data request; the stale value is filtered out of the endpoint map and the retry for it can
+   * lose the race with the next invalidation, so `getEndpoint()` never resolves and the route
+   * that depends on it never finishes loading.
    */
   protected listenForRouteChanges(): void {
-    // we'll always be too late for the first NavigationStart event with the router subscribe below,
-    // so this statement is for the very first route operation.
     this.rootDataService.invalidateRootCache();
-
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationStart),
-    ).subscribe(() => {
-      this.rootDataService.invalidateRootCache();
-    });
   }
 
 }


### PR DESCRIPTION
# PR: Fix infinite route-loader spinner on navigation (stale root-endpoint cache deadlock)

**Target branch:** `DSpace/dspace-angular:main`
**Relates to:** #3584, #3697
Fixes https://github.com/DSpace/dspace-angular/issues/5855

## Description

`BrowserInitService` invalidates the root API endpoint cache on **every**
`NavigationStart`. On a subsequent request, `HALEndpointService.getEndpointMapAt`
(hit on essentially every request via `getEndpoint()`) discards the now-stale
root `/server/api` entry and triggers a re-fetch that can **deadlock** — the
route resolver never completes, `NavigationEnd` never fires, and the
`ds-base-root` route-loader spinner hangs indefinitely on a frozen store.

The root endpoint map is effectively static between navigations, so
re-invalidating it on each `NavigationStart` is unnecessary. Backend-down
detection still happens at init and through normal request-failure handling.

## Root cause

- `BrowserInitService` → `invalidateRootCache()` on every `NavigationStart`.
- Marks the root `/server/api` endpoint cache stale.
- Next `getEndpoint()` → `getEndpointMapAt` discards the stale root → re-fetch
  deadlocks → resolver never resolves → `NavigationEnd` never fires → spinner
  hangs forever.
- Higher REST latency makes it fire on nearly every revisit (why it looks
  intermittent).

## Steps to reproduce

1. Open any listing (collection items, MyDSpace, Browse, Search — even
   Communities & Collections).
2. Navigate listing → listing → listing.
3. The UI hangs on the route-loader spinner; a full page reload clears it.

Reproducible on a small instance (~7k items) — **not** load- or scale-dependent.
Higher REST/proxy latency increases the frequency.

## Fix

Remove the per-`NavigationStart` `invalidateRootCache()` call in
`browser-init.service.ts`; keep the one-time invalidation at init. No behavior
change to backend-down detection.

## How to test

1. Before the fix: reproduce the hang via the steps above.
2. After the fix: the same navigation sequence no longer hangs; the spinner
   always resolves.
3. Backend-down handling still works: stop the REST backend and confirm the
   app still detects/handles it (init-time + request-failure paths).

## Tests

Added a spec asserting the root endpoint cache is invalidated **once at init**
and **not** on subsequent `NavigationStart` events.

## Checklist notes

- One-file logic fix; no new dependencies; no user-facing strings (i18n N/A).
- Passes `yarn lint` and `yarn check-circ-deps`.
- TypeDoc added/updated on any modified public method.