### PR TITLE
Slovak (sk) translation added

### DIFF
--- a/src/assets/i18n/sk.json5
+++ b/src/assets/i18n/sk.json5
@@ -1,0 +1,11835 @@
+{
+  // "401.help": "You're not authorized to access this page. You can use the button below to get back to the home page.",
+  "401.help": "Nemáte oprávnenie na prístup k tejto stránke. Na návrat na domovskú stránku môžete použiť tlačidlo nižšie.",
+
+  // "401.link.home-page": "Take me to the home page",
+  "401.link.home-page": "Návrat na domovskú stránku",
+
+  // "401.unauthorized": "Unauthorized",
+  "401.unauthorized": "Neautorizovaný prístup",
+
+  // "403.help": "You don't have permission to access this page. You can use the button below to get back to the home page.",
+  "403.help": "Nemáte povolenie na prístup k tejto stránke. Na návrat na domovskú stránku môžete použiť tlačidlo nižšie.",
+
+  // "403.link.home-page": "Take me to the home page",
+  "403.link.home-page": "Návrat na domovskú stránku",
+
+  // "403.forbidden": "Forbidden",
+  "403.forbidden": "Prístup zakázaný",
+
+  // "500.page-internal-server-error": "Service unavailable",
+  "500.page-internal-server-error": "Služba je nedostupná",
+
+  // "500.help": "The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.",
+  "500.help": "Server dočasne nedokáže obslúžiť vašu požiadavku z dôvodu odstávky na údržbu alebo kapacitných problémov. Skúste to prosím neskôr.",
+
+  // "500.link.home-page": "Take me to the home page",
+  "500.link.home-page": "Návrat na domovskú stránku",
+
+  // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page.",
+  "404.help": "Nedokážeme nájsť stránku, ktorú hľadáte. Stránka mohla byť presunutá alebo odstránená. Na návrat na domovskú stránku môžete použiť tlačidlo nižšie.",
+
+  // "404.link.home-page": "Take me to the home page",
+  "404.link.home-page": "Návrat na domovskú stránku",
+
+  // "404.page-not-found": "Page not found",
+  "404.page-not-found": "Stránka nebola nájdená",
+
+  // "error-page.description.401": "Unauthorized",
+  "error-page.description.401": "Neautorizovaný prístup",
+
+  // "error-page.description.403": "Forbidden",
+  "error-page.description.403": "Prístup zakázaný",
+
+  // "error-page.description.500": "Service unavailable",
+  "error-page.description.500": "Služba je nedostupná",
+
+  // "error-page.description.404": "Page not found",
+  "error-page.description.404": "Stránka nebola nájdená",
+
+  // "error-page.orcid.generic-error": "An error occurred during login via ORCID. Make sure you have shared your ORCID account email address with DSpace. If the error persists, contact the administrator",
+  "error-page.orcid.generic-error": "Pri prihlasovaní cez ORCID došlo k chybe. Uistite sa, že ste s DSpace zdieľali e-mailovú adresu priradenú k vášmu účtu ORCID. Ak chyba pretrváva, kontaktujte správcu",
+
+  // "listelement.badge.access-status": "Access status:",
+  "listelement.badge.access-status": "Stav prístupu:",
+
+  // "access-status.embargo.listelement.badge": "Embargo",
+  "access-status.embargo.listelement.badge": "Embargo",
+
+  // "access-status.metadata.only.listelement.badge": "Metadata only",
+  "access-status.metadata.only.listelement.badge": "Iba metadáta",
+
+  // "access-status.open.access.listelement.badge": "Open Access",
+  "access-status.open.access.listelement.badge": "Otvorený prístup",
+
+  // "access-status.restricted.listelement.badge": "Restricted",
+  "access-status.restricted.listelement.badge": "Obmedzený prístup",
+
+  // "access-status.unknown.listelement.badge": "Unknown",
+  "access-status.unknown.listelement.badge": "Neznámy stav",
+
+  // "admin.curation-tasks.breadcrumbs": "System curation tasks",
+  "admin.curation-tasks.breadcrumbs": "Systémové kurátorské úlohy",
+
+  // "admin.curation-tasks.title": "System curation tasks",
+  "admin.curation-tasks.title": "Systémové kurátorské úlohy",
+
+  // "admin.curation-tasks.header": "System curation tasks",
+  "admin.curation-tasks.header": "Systémové kurátorské úlohy",
+
+  // "admin.registries.bitstream-formats.breadcrumbs": "Format registry",
+  "admin.registries.bitstream-formats.breadcrumbs": "Register formátov",
+
+  // "admin.registries.bitstream-formats.create.breadcrumbs": "Bitstream format",
+  "admin.registries.bitstream-formats.create.breadcrumbs": "Formát súboru",
+
+  // "admin.registries.bitstream-formats.create.failure.content": "An error occurred while creating the new bitstream format.",
+  "admin.registries.bitstream-formats.create.failure.content": "Pri vytváraní nového formátu súboru došlo k chybe.",
+
+  // "admin.registries.bitstream-formats.create.failure.head": "Failure",
+  "admin.registries.bitstream-formats.create.failure.head": "Vytvorenie nového formátu súboru zlyhalo",
+
+  // "admin.registries.bitstream-formats.create.head": "Create bitstream format",
+  "admin.registries.bitstream-formats.create.head": "Vytvoriť formát súboru",
+
+  // "admin.registries.bitstream-formats.create.new": "Add a new bitstream format",
+  "admin.registries.bitstream-formats.create.new": "Pridať nový formát súboru",
+
+  // "admin.registries.bitstream-formats.create.success.content": "The new bitstream format was successfully created.",
+  "admin.registries.bitstream-formats.create.success.content": "Nový formát súboru bol úspešne vytvorený.",
+
+  // "admin.registries.bitstream-formats.create.success.head": "Success",
+  "admin.registries.bitstream-formats.create.success.head": "Úspešne vytvorené",
+
+  // "admin.registries.bitstream-formats.delete.failure.amount": "Failed to remove {{ amount }} format(s)",
+  "admin.registries.bitstream-formats.delete.failure.amount": "Nepodarilo sa odstrániť {{ amount }} formát(ov)",
+
+  // "admin.registries.bitstream-formats.delete.failure.head": "Failure",
+  "admin.registries.bitstream-formats.delete.failure.head": "Odstránenie formátu súboru zlyhalo",
+
+  // "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
+  "admin.registries.bitstream-formats.delete.success.amount": "Úspešne odstránených {{ amount }} formátov",
+
+  // "admin.registries.bitstream-formats.delete.success.head": "Success",
+  "admin.registries.bitstream-formats.delete.success.head": "Úspešne odstránené",
+
+  // "admin.registries.bitstream-formats.description": "This list of bitstream formats provides information about known formats and their support level.",
+  "admin.registries.bitstream-formats.description": "Tento zoznam formátov súboru poskytuje informácie o známych formátoch a úrovni ich podpory.",
+
+  // "admin.registries.bitstream-formats.edit.breadcrumbs": "Bitstream format",
+  "admin.registries.bitstream-formats.edit.breadcrumbs": "Formát súboru",
+
+  // "admin.registries.bitstream-formats.edit.description.hint": "",
+  "admin.registries.bitstream-formats.edit.description.hint": "",
+
+  // "admin.registries.bitstream-formats.edit.description.label": "Description",
+  "admin.registries.bitstream-formats.edit.description.label": "Popis",
+
+  // "admin.registries.bitstream-formats.edit.extensions.hint": "Extensions are file extensions that are used to automatically identify the format of uploaded files. You can enter several extensions for each format.",
+  "admin.registries.bitstream-formats.edit.extensions.hint": "Prípony sú prípony súborov, ktoré sa používajú na automatickú identifikáciu formátu nahraných súborov. Pre každý formát môžete zadať viacero prípon.",
+
+  // "admin.registries.bitstream-formats.edit.extensions.label": "File extensions",
+  "admin.registries.bitstream-formats.edit.extensions.label": "Prípony súborov",
+
+  // "admin.registries.bitstream-formats.edit.extensions.placeholder": "Enter a file extension without the dot",
+  "admin.registries.bitstream-formats.edit.extensions.placeholder": "Zadajte príponu súboru bez bodky",
+
+  // "admin.registries.bitstream-formats.edit.failure.content": "An error occurred while editing the bitstream format.",
+  "admin.registries.bitstream-formats.edit.failure.content": "Pri úprave formátu súboru došlo k chybe.",
+
+  // "admin.registries.bitstream-formats.edit.failure.head": "Failure",
+  "admin.registries.bitstream-formats.edit.failure.head": "Úprava formátu súboru zlyhala",
+
+  // "admin.registries.bitstream-formats.edit.head": "Bitstream format: {{ format }}",
+  "admin.registries.bitstream-formats.edit.head": "Formát súboru: {{ format }}",
+
+  // "admin.registries.bitstream-formats.edit.internal.hint": "Formats marked as internal are hidden from the user, and used for administrative purposes.",
+  "admin.registries.bitstream-formats.edit.internal.hint": "Formáty označené ako interné sú pre používateľa skryté a používajú sa na účely správy.",
+
+  // "admin.registries.bitstream-formats.edit.internal.label": "Internal",
+  "admin.registries.bitstream-formats.edit.internal.label": "Interný",
+
+  // "admin.registries.bitstream-formats.edit.mimetype.hint": "The MIME type associated with this format, does not have to be unique.",
+  "admin.registries.bitstream-formats.edit.mimetype.hint": "Typ MIME priradený k tomuto formátu nemusí byť jedinečný.",
+
+  // "admin.registries.bitstream-formats.edit.mimetype.label": "MIME Type",
+  "admin.registries.bitstream-formats.edit.mimetype.label": "Typ MIME",
+
+  // "admin.registries.bitstream-formats.edit.shortDescription.hint": "A unique name for this format, (e.g. Microsoft Word XP or Microsoft Word 2000)",
+  "admin.registries.bitstream-formats.edit.shortDescription.hint": "Jedinečný názov pre tento formát (napr. Microsoft Word XP alebo Microsoft Word 2000)",
+
+  // "admin.registries.bitstream-formats.edit.shortDescription.label": "Name",
+  "admin.registries.bitstream-formats.edit.shortDescription.label": "Názov",
+
+  // "admin.registries.bitstream-formats.edit.success.content": "The bitstream format was successfully edited.",
+  "admin.registries.bitstream-formats.edit.success.content": "Formát súboru bol úspešne upravený.",
+
+  // "admin.registries.bitstream-formats.edit.success.head": "Success",
+  "admin.registries.bitstream-formats.edit.success.head": "Úspešne upravené",
+
+  // "admin.registries.bitstream-formats.edit.supportLevel.hint": "The level of support your institution pledges for this format.",
+  "admin.registries.bitstream-formats.edit.supportLevel.hint": "Úroveň podpory, ktorú vaša inštitúcia prisľubuje pre tento formát.",
+
+  // "admin.registries.bitstream-formats.edit.supportLevel.label": "Support level",
+  "admin.registries.bitstream-formats.edit.supportLevel.label": "Úroveň podpory",
+
+  // "admin.registries.bitstream-formats.head": "Bitstream Format Registry",
+  "admin.registries.bitstream-formats.head": "Register formátov súboru",
+
+  // "admin.registries.bitstream-formats.no-items": "No bitstream formats to show.",
+  "admin.registries.bitstream-formats.no-items": "Žiadne formáty súboru na zobrazenie.",
+
+  // "admin.registries.bitstream-formats.table.delete": "Delete selected",
+  "admin.registries.bitstream-formats.table.delete": "Odstrániť vybrané",
+
+  // "admin.registries.bitstream-formats.table.deselect-all": "Deselect all",
+  "admin.registries.bitstream-formats.table.deselect-all": "Zrušiť výber všetkých",
+
+  // "admin.registries.bitstream-formats.table.internal": "internal",
+  "admin.registries.bitstream-formats.table.internal": "interný",
+
+  // "admin.registries.bitstream-formats.table.mimetype": "MIME Type",
+  "admin.registries.bitstream-formats.table.mimetype": "Typ MIME",
+
+  // "admin.registries.bitstream-formats.table.name": "Name",
+  "admin.registries.bitstream-formats.table.name": "Názov",
+
+  // "admin.registries.bitstream-formats.table.selected": "Selected bitstream formats",
+  "admin.registries.bitstream-formats.table.selected": "Vybrané formáty súborov",
+
+  // "admin.registries.bitstream-formats.table.id": "ID",
+  "admin.registries.bitstream-formats.table.id": "ID",
+
+  // "admin.registries.bitstream-formats.table.return": "Back",
+  "admin.registries.bitstream-formats.table.return": "Späť",
+
+  // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Známe",
+
+  // "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Podporované",
+
+  // "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Neznáme",
+
+  // "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
+  "admin.registries.bitstream-formats.table.supportLevel.head": "Úroveň podpory",
+
+  // "admin.registries.bitstream-formats.title": "Bitstream Format Registry",
+  "admin.registries.bitstream-formats.title": "Register formátov súboru",
+
+  // "admin.registries.bitstream-formats.select": "Select",
+  "admin.registries.bitstream-formats.select": "Vybrať",
+
+  // "admin.registries.bitstream-formats.deselect": "Deselect",
+  "admin.registries.bitstream-formats.deselect": "Zrušiť výber",
+
+  // "admin.registries.metadata.breadcrumbs": "Metadata registry",
+  "admin.registries.metadata.breadcrumbs": "Register metadát",
+
+  // "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DSpace requires the qualified Dublin Core schema.",
+  "admin.registries.metadata.description": "Register metadát udržiava zoznam všetkých polí metadát dostupných v repozitári. Tieto polia môžu byť rozdelené medzi viacero schém. DSpace však vyžaduje kvalifikované schéma Dublin Core.",
+
+  // "admin.registries.metadata.form.create": "Create metadata schema",
+  "admin.registries.metadata.form.create": "Vytvoriť metadátové schéma",
+
+  // "admin.registries.metadata.form.edit": "Edit metadata schema",
+  "admin.registries.metadata.form.edit": "Upraviť metadátové schéma",
+
+  // "admin.registries.metadata.form.name": "Name",
+  "admin.registries.metadata.form.name": "Názov",
+
+  // "admin.registries.metadata.form.namespace": "Namespace",
+  "admin.registries.metadata.form.namespace": "Menný priestor",
+
+  // "admin.registries.metadata.head": "Metadata Registry",
+  "admin.registries.metadata.head": "Register metadát",
+
+  // "admin.registries.metadata.schemas.no-items": "No metadata schemas to show.",
+  "admin.registries.metadata.schemas.no-items": "Žiadne schémy metadát na zobrazenie.",
+
+  // "admin.registries.metadata.schemas.select": "Select",
+  "admin.registries.metadata.schemas.select": "Vybrať",
+
+  // "admin.registries.metadata.schemas.deselect": "Deselect",
+  "admin.registries.metadata.schemas.deselect": "Zrušiť výber",
+
+  // "admin.registries.metadata.schemas.table.delete": "Delete selected",
+  "admin.registries.metadata.schemas.table.delete": "Odstrániť vybrané",
+
+  // "admin.registries.metadata.schemas.table.selected": "Selected schemas",
+  "admin.registries.metadata.schemas.table.selected": "Vybrané schémy",
+
+  // "admin.registries.metadata.schemas.table.id": "ID",
+  "admin.registries.metadata.schemas.table.id": "ID",
+
+  // "admin.registries.metadata.schemas.table.name": "Name",
+  "admin.registries.metadata.schemas.table.name": "Názov",
+
+  // "admin.registries.metadata.schemas.table.namespace": "Namespace",
+  "admin.registries.metadata.schemas.table.namespace": "Menný priestor",
+
+  // "admin.registries.metadata.title": "Metadata Registry",
+  "admin.registries.metadata.title": "Register metadát",
+
+  // "admin.registries.schema.breadcrumbs": "Metadata schema",
+  "admin.registries.schema.breadcrumbs": "Metadátové schéma",
+
+  // "admin.registries.schema.description": "This is the metadata schema for \"{{namespace}}\".",
+  "admin.registries.schema.description": "Toto je metadátové schéma pre \"{{namespace}}\".",
+
+  // "admin.registries.schema.fields.select": "Select",
+  "admin.registries.schema.fields.select": "Vybrať",
+
+  // "admin.registries.schema.fields.deselect": "Deselect",
+  "admin.registries.schema.fields.deselect": "Zrušiť výber",
+
+  // "admin.registries.schema.fields.head": "Schema metadata fields",
+  "admin.registries.schema.fields.head": "Metadátové polia schémy",
+
+  // "admin.registries.schema.fields.no-items": "No metadata fields to show.",
+  "admin.registries.schema.fields.no-items": "Žiadne metadátové polia na zobrazenie.",
+
+  // "admin.registries.schema.fields.table.delete": "Delete selected",
+  "admin.registries.schema.fields.table.delete": "Odstrániť vybrané",
+
+  // "admin.registries.schema.fields.table.field": "Field",
+  "admin.registries.schema.fields.table.field": "Pole",
+
+  // "admin.registries.schema.fields.table.selected": "Selected metadata fields",
+  "admin.registries.schema.fields.table.selected": "Vybrané metadátové polia",
+
+  // "admin.registries.schema.fields.table.id": "ID",
+  "admin.registries.schema.fields.table.id": "ID",
+
+  // "admin.registries.schema.fields.table.scopenote": "Scope Note",
+  "admin.registries.schema.fields.table.scopenote": "Poznámka k rozsahu",
+
+  // "admin.registries.schema.form.create": "Create metadata field",
+  "admin.registries.schema.form.create": "Vytvoriť metadátové pole",
+
+  // "admin.registries.schema.form.edit": "Edit metadata field",
+  "admin.registries.schema.form.edit": "Upraviť metadátové pole",
+
+  // "admin.registries.schema.form.element": "Element",
+  "admin.registries.schema.form.element": "Prvok",
+
+  // "admin.registries.schema.form.qualifier": "Qualifier",
+  "admin.registries.schema.form.qualifier": "Kvalifikátor",
+
+  // "admin.registries.schema.form.scopenote": "Scope Note",
+  "admin.registries.schema.form.scopenote": "Poznámka k rozsahu",
+
+  // "admin.registries.schema.head": "Metadata Schema",
+  "admin.registries.schema.head": "Metadátové schéma",
+
+  // "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
+  "admin.registries.schema.notification.created": "Metadátové schéma \"{{prefix}}\" bolo úspešne vytvorené",
+
+  // "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
+  "admin.registries.schema.notification.deleted.failure": "Nepodarilo sa odstrániť {{amount}} metadátových schém",
+
+  // "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
+  "admin.registries.schema.notification.deleted.success": "Úspešne odstránených {{amount}} metadátových schém",
+
+  // "admin.registries.schema.notification.edited": "Successfully edited metadata schema \"{{prefix}}\"",
+  "admin.registries.schema.notification.edited": "Úspešne upravené metadátové schéma \"{{prefix}}\"",
+
+  // "admin.registries.schema.notification.failure": "Error",
+  "admin.registries.schema.notification.failure": "Chyba",
+
+  // "admin.registries.schema.notification.field.created": "Successfully created metadata field \"{{field}}\"",
+  "admin.registries.schema.notification.field.created": "Úspešne vytvorené metadátové pole \"{{field}}\"",
+
+  // "admin.registries.schema.notification.field.deleted.failure": "Failed to delete {{amount}} metadata fields",
+  "admin.registries.schema.notification.field.deleted.failure": "Nepodarilo sa odstrániť {{amount}} metadátových polí",
+
+  // "admin.registries.schema.notification.field.deleted.success": "Successfully deleted {{amount}} metadata fields",
+  "admin.registries.schema.notification.field.deleted.success": "Úspešne odstránených {{amount}} metadátových polí",
+
+  // "admin.registries.schema.notification.field.edited": "Successfully edited metadata field \"{{field}}\"",
+  "admin.registries.schema.notification.field.edited": "Úspešne upravené metadátové pole \"{{field}}\"",
+
+  // "admin.registries.schema.notification.success": "Success",
+  "admin.registries.schema.notification.success": "Úspešné",
+
+  // "admin.registries.schema.return": "Back",
+  "admin.registries.schema.return": "Späť",
+
+  // "admin.registries.schema.title": "Metadata Schema Registry",
+  "admin.registries.schema.title": "Register metadátových schém",
+
+  // "admin.access-control.bulk-access.breadcrumbs": "Bulk Access Management",
+  "admin.access-control.bulk-access.breadcrumbs": "Hromadná správa prístupu",
+
+  // "administrativeBulkAccess.search.results.head": "Search Results",
+  "administrativeBulkAccess.search.results.head": "Výsledky vyhľadávania",
+
+  // "admin.access-control.bulk-access": "Bulk Access Management",
+  "admin.access-control.bulk-access": "Hromadná správa prístupu",
+
+  // "admin.access-control.bulk-access.title": "Bulk Access Management",
+  "admin.access-control.bulk-access.title": "Hromadná správa prístupu",
+
+  // "admin.access-control.bulk-access-browse.header": "Step 1: Select Objects",
+  "admin.access-control.bulk-access-browse.header": "Krok 1: Vyberte objekty",
+
+  // "admin.access-control.bulk-access-browse.search.header": "Search",
+  "admin.access-control.bulk-access-browse.search.header": "Hľadať",
+
+  // "admin.access-control.bulk-access-browse.selected.header": "Current selection({{number}})",
+  "admin.access-control.bulk-access-browse.selected.header": "Aktuálny výber({{number}})",
+
+  // "admin.access-control.bulk-access-settings.header": "Step 2: Operation to Perform",
+  "admin.access-control.bulk-access-settings.header": "Krok 2: Operácia, ktorá sa má vykonať",
+
+  // "admin.access-control.epeople.actions.delete": "Delete EPerson",
+  "admin.access-control.epeople.actions.delete": "Odstrániť používateľa",
+
+  // "admin.access-control.epeople.actions.impersonate": "Impersonate EPerson",
+  "admin.access-control.epeople.actions.impersonate": "Vystupovať ako iný používateľ",
+
+  // "admin.access-control.epeople.actions.reset": "Reset password",
+  "admin.access-control.epeople.actions.reset": "Resetovať heslo",
+
+  // "admin.access-control.epeople.actions.stop-impersonating": "Stop impersonating EPerson",
+  "admin.access-control.epeople.actions.stop-impersonating": "Prestať vystupovať ako iný používateľ",
+
+  // "admin.access-control.epeople.breadcrumbs": "EPeople",
+  "admin.access-control.epeople.breadcrumbs": "Používatelia",
+
+  // "admin.access-control.epeople.title": "EPeople",
+  "admin.access-control.epeople.title": "Používatelia",
+
+  // "admin.access-control.epeople.edit.breadcrumbs": "New EPerson",
+  "admin.access-control.epeople.edit.breadcrumbs": "Nový používateľ",
+
+  // "admin.access-control.epeople.edit.title": "New EPerson",
+  "admin.access-control.epeople.edit.title": "Nový používateľ",
+
+  // "admin.access-control.epeople.add.breadcrumbs": "Add EPerson",
+  "admin.access-control.epeople.add.breadcrumbs": "Pridať používateľa",
+
+  // "admin.access-control.epeople.add.title": "Add EPerson",
+  "admin.access-control.epeople.add.title": "Pridať používateľa",
+
+  // "admin.access-control.epeople.head": "EPeople",
+  "admin.access-control.epeople.head": "Používatelia",
+
+  // "admin.access-control.epeople.search.head": "Search",
+  "admin.access-control.epeople.search.head": "Hľadať",
+
+  // "admin.access-control.epeople.button.see-all": "Browse All",
+  "admin.access-control.epeople.button.see-all": "Prehliadať všetko",
+
+  // "admin.access-control.epeople.search.scope.metadata": "Metadata",
+  "admin.access-control.epeople.search.scope.metadata": "Metadáta",
+
+  // "admin.access-control.epeople.search.scope.email": "Email (exact)",
+  "admin.access-control.epeople.search.scope.email": "E-mail (presný)",
+
+  // "admin.access-control.epeople.search.button": "Search",
+  "admin.access-control.epeople.search.button": "Hľadať",
+
+  // "admin.access-control.epeople.search.placeholder": "Search people...",
+  "admin.access-control.epeople.search.placeholder": "Hľadať používateľov...",
+
+  // "admin.access-control.epeople.button.add": "Add EPerson",
+  "admin.access-control.epeople.button.add": "Pridať používateľa",
+
+  // "admin.access-control.epeople.table.id": "ID",
+  "admin.access-control.epeople.table.id": "ID",
+
+  // "admin.access-control.epeople.table.name": "Name",
+  "admin.access-control.epeople.table.name": "Meno",
+
+  // "admin.access-control.epeople.table.email": "Email (exact)",
+  "admin.access-control.epeople.table.email": "E-mail (presný)",
+
+  // "admin.access-control.epeople.table.edit": "Edit",
+  "admin.access-control.epeople.table.edit": "Upraviť",
+
+  // "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",
+  "admin.access-control.epeople.table.edit.buttons.edit": "Upraviť \"{{name}}\"",
+
+  // "admin.access-control.epeople.table.edit.buttons.edit-disabled": "You are not authorized to edit this group",
+  "admin.access-control.epeople.table.edit.buttons.edit-disabled": "Nie ste oprávnení upravovať túto skupinu",
+
+  // "admin.access-control.epeople.table.edit.buttons.remove": "Delete \"{{name}}\"",
+  "admin.access-control.epeople.table.edit.buttons.remove": "Odstrániť \"{{name}}\"",
+
+  // "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Odstrániť skupinu \"{{ dsoName }}\"",
+
+  // "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Naozaj chcete odstrániť skupinu \"{{ dsoName }}\" a všetky súvisiace pravidlá?",
+
+  // "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Cancel",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Zrušiť",
+
+  // "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Delete",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Odstrániť",
+
+  // "admin.access-control.epeople.no-items": "No EPeople to show.",
+  "admin.access-control.epeople.no-items": "Žiadni používatelia na zobrazenie.",
+
+  // "admin.access-control.epeople.form.create": "Create EPerson",
+  "admin.access-control.epeople.form.create": "Vytvoriť používateľa",
+
+  // "admin.access-control.epeople.form.edit": "Edit EPerson",
+  "admin.access-control.epeople.form.edit": "Upraviť používateľa",
+
+  // "admin.access-control.epeople.form.firstName": "First name",
+  "admin.access-control.epeople.form.firstName": "Krstné meno",
+
+  // "admin.access-control.epeople.form.lastName": "Last name",
+  "admin.access-control.epeople.form.lastName": "Priezvisko",
+
+  // "admin.access-control.epeople.form.email": "Email",
+  "admin.access-control.epeople.form.email": "E-mail",
+
+  // "admin.access-control.epeople.form.emailHint": "Must be a valid email address",
+  "admin.access-control.epeople.form.emailHint": "Musí to byť platná e-mailová adresa",
+
+  // "admin.access-control.epeople.form.canLogIn": "Can log in",
+  "admin.access-control.epeople.form.canLogIn": "Môže sa prihlásiť",
+
+  // "admin.access-control.epeople.form.requireCertificate": "Requires certificate",
+  "admin.access-control.epeople.form.requireCertificate": "Vyžaduje certifikát",
+
+  // "admin.access-control.epeople.form.return": "Back",
+  "admin.access-control.epeople.form.return": "Späť",
+
+  // "admin.access-control.epeople.form.notification.created.success": "Successfully created EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.created.success": "Úspešne vytvorený používateľ \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.notification.created.failure": "Failed to create EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.created.failure": "Nepodarilo sa vytvoriť používateľa \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Failed to create EPerson \"{{name}}\", email \"{{email}}\" already in use.",
+  "admin.access-control.epeople.form.notification.created.failure.emailInUse": "Nepodarilo sa vytvoriť používateľa \"{{name}}\", e-mail \"{{email}}\" sa už používa.",
+
+  // "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Failed to edit EPerson \"{{name}}\", email \"{{email}}\" already in use.",
+  "admin.access-control.epeople.form.notification.edited.failure.emailInUse": "Nepodarilo sa upraviť používateľa \"{{name}}\", e-mail \"{{email}}\" sa už používa.",
+
+  // "admin.access-control.epeople.form.notification.edited.success": "Successfully edited EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.edited.success": "Úspešne upravený používateľ \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.notification.edited.failure": "Failed to edit EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.edited.failure": "Nepodarilo sa upraviť používateľa \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.notification.deleted.success": "Successfully deleted EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.deleted.success": "Úspešne odstránený používateľ \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
+  "admin.access-control.epeople.form.notification.deleted.failure": "Nepodarilo sa odstrániť používateľa \"{{name}}\"",
+
+  // "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
+  "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Člen týchto skupín:",
+
+  // "admin.access-control.epeople.form.table.id": "ID",
+  "admin.access-control.epeople.form.table.id": "ID",
+
+  // "admin.access-control.epeople.form.table.name": "Name",
+  "admin.access-control.epeople.form.table.name": "Meno",
+
+  // "admin.access-control.epeople.form.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.epeople.form.table.collectionOrCommunity": "Kolekcia/Komunita",
+
+  // "admin.access-control.epeople.form.memberOfNoGroups": "This EPerson is not a member of any groups",
+  "admin.access-control.epeople.form.memberOfNoGroups": "Tento používateľ nie je členom žiadnej skupiny",
+
+  // "admin.access-control.epeople.form.goToGroups": "Add to groups",
+  "admin.access-control.epeople.form.goToGroups": "Pridať do skupín",
+
+  // "admin.access-control.epeople.notification.deleted.failure": "Error occurred when trying to delete EPerson with id \"{{id}}\" with code: \"{{statusCode}}\" and message: \"{{restResponse.errorMessage}}\"",
+  "admin.access-control.epeople.notification.deleted.failure": "Pri pokuse o odstránenie používateľa s id \"{{id}}\" došlo k chybe s kódom: \"{{statusCode}}\" a správou: \"{{restResponse.errorMessage}}\"",
+
+  // "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
+  "admin.access-control.epeople.notification.deleted.success": "Úspešne odstránený používateľ: \"{{name}}\"",
+
+  // "admin.access-control.groups.title": "Groups",
+  "admin.access-control.groups.title": "Skupiny",
+
+  // "admin.access-control.groups.breadcrumbs": "Groups",
+  "admin.access-control.groups.breadcrumbs": "Skupiny",
+
+  // "admin.access-control.groups.singleGroup.breadcrumbs": "Edit Group",
+  "admin.access-control.groups.singleGroup.breadcrumbs": "Upraviť skupinu",
+
+  // "admin.access-control.groups.title.singleGroup": "Edit Group",
+  "admin.access-control.groups.title.singleGroup": "Upraviť skupinu",
+
+  // "admin.access-control.groups.title.addGroup": "New Group",
+  "admin.access-control.groups.title.addGroup": "Nová skupina",
+
+  // "admin.access-control.groups.addGroup.breadcrumbs": "New Group",
+  "admin.access-control.groups.addGroup.breadcrumbs": "Nová skupina",
+
+  // "admin.access-control.groups.head": "Groups",
+  "admin.access-control.groups.head": "Skupiny",
+
+  // "admin.access-control.groups.button.add": "Add group",
+  "admin.access-control.groups.button.add": "Pridať skupinu",
+
+  // "admin.access-control.groups.search.head": "Search groups",
+  "admin.access-control.groups.search.head": "Hľadať skupiny",
+
+  // "admin.access-control.groups.button.see-all": "Browse all",
+  "admin.access-control.groups.button.see-all": "Prehliadať všetko",
+
+  // "admin.access-control.groups.search.button": "Search",
+  "admin.access-control.groups.search.button": "Hľadať",
+
+  // "admin.access-control.groups.search.placeholder": "Search groups...",
+  "admin.access-control.groups.search.placeholder": "Hľadať skupiny...",
+
+  // "admin.access-control.groups.table.id": "ID",
+  "admin.access-control.groups.table.id": "ID",
+
+  // "admin.access-control.groups.table.name": "Name",
+  "admin.access-control.groups.table.name": "Názov",
+
+  // "admin.access-control.groups.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.groups.table.collectionOrCommunity": "Kolekcia/Komunita",
+
+  // "admin.access-control.groups.table.members": "Members",
+  "admin.access-control.groups.table.members": "Členovia",
+
+  // "admin.access-control.groups.table.edit": "Edit",
+  "admin.access-control.groups.table.edit": "Upraviť",
+
+  // "admin.access-control.groups.table.edit.buttons.edit": "Edit \"{{name}}\"",
+  "admin.access-control.groups.table.edit.buttons.edit": "Upraviť \"{{name}}\"",
+
+  // "admin.access-control.groups.table.edit.buttons.remove": "Delete \"{{name}}\"",
+  "admin.access-control.groups.table.edit.buttons.remove": "Odstrániť \"{{name}}\"",
+
+  // "admin.access-control.groups.no-items": "No groups found with this in their name or this as UUID",
+  "admin.access-control.groups.no-items": "Nenašla sa žiadna skupina s týmto textom v názve alebo s týmto UUID",
+
+  // "admin.access-control.groups.notification.deleted.success": "Successfully deleted group \"{{name}}\"",
+  "admin.access-control.groups.notification.deleted.success": "Úspešne odstránená skupina \"{{name}}\"",
+
+  // "admin.access-control.groups.notification.deleted.failure.title": "Failed to delete group \"{{name}}\"",
+  "admin.access-control.groups.notification.deleted.failure.title": "Nepodarilo sa odstrániť skupinu \"{{name}}\"",
+
+  // "admin.access-control.groups.notification.deleted.failure.content": "Cause: \"{{cause}}\"",
+  "admin.access-control.groups.notification.deleted.failure.content": "Príčina: \"{{cause}}\"",
+
+  // "admin.access-control.groups.form.alert.permanent": "This group is permanent, so it can't be edited or deleted. You can still add and remove group members using this page.",
+  "admin.access-control.groups.form.alert.permanent": "Táto skupina je trvalá, preto ju nemožno upraviť ani odstrániť. Členov skupiny však môžete na tejto stránke naďalej pridávať a odoberať.",
+
+  // "admin.access-control.groups.form.alert.workflowGroup": "This group can’t be modified or deleted because it corresponds to a role in the submission and workflow process in the \"{{name}}\" {{comcol}}. You can delete it from the <a href='{{comcolEditRolesRoute}}'>\"assign roles\"</a> tab on the edit {{comcol}} page. You can still add and remove group members using this page.",
+  "admin.access-control.groups.form.alert.workflowGroup": "Túto skupinu nemožno zmeniť ani odstrániť, pretože zodpovedá role v procese zadávania a workflow v \"{{name}}\" {{comcol}}. Môžete ju odstrániť na karte <a href='{{comcolEditRolesRoute}}'>„priradiť role“</a> na stránke úpravy {{comcol}}. Členov skupiny však môžete na tejto stránke naďalej pridávať a odoberať.",
+
+  // "admin.access-control.groups.form.head.create": "Create group",
+  "admin.access-control.groups.form.head.create": "Vytvoriť skupinu",
+
+  // "admin.access-control.groups.form.head.edit": "Edit group",
+  "admin.access-control.groups.form.head.edit": "Upraviť skupinu",
+
+  // "admin.access-control.groups.form.groupName": "Group name",
+  "admin.access-control.groups.form.groupName": "Názov skupiny",
+
+  // "admin.access-control.groups.form.groupCommunity": "Community or Collection",
+  "admin.access-control.groups.form.groupCommunity": "Komunita alebo kolekcia",
+
+  // "admin.access-control.groups.form.groupDescription": "Description",
+  "admin.access-control.groups.form.groupDescription": "Popis",
+
+  // "admin.access-control.groups.form.notification.created.success": "Successfully created Group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.created.success": "Úspešne vytvorená skupina \"{{name}}\"",
+
+  // "admin.access-control.groups.form.notification.created.failure": "Failed to create Group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.created.failure": "Nepodarilo sa vytvoriť skupinu \"{{name}}\"",
+
+  // "admin.access-control.groups.form.notification.created.failure.groupNameInUse": "Failed to create Group with name: \"{{name}}\", make sure the name is not already in use.",
+  "admin.access-control.groups.form.notification.created.failure.groupNameInUse": "Nepodarilo sa vytvoriť skupinu s názvom: \"{{name}}\", uistite sa, že názov sa ešte nepoužíva.",
+
+  // "admin.access-control.groups.form.notification.edited.failure": "Failed to edit Group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.edited.failure": "Nepodarilo sa upraviť skupinu \"{{name}}\"",
+
+  // "admin.access-control.groups.form.notification.edited.failure.groupNameInUse": "Name \"{{name}}\" already in use!",
+  "admin.access-control.groups.form.notification.edited.failure.groupNameInUse": "Názov \"{{name}}\" sa už používa!",
+
+  // "admin.access-control.groups.form.notification.edited.success": "Successfully edited Group \"{{name}}\"",
+  "admin.access-control.groups.form.notification.edited.success": "Úspešne upravená skupina \"{{name}}\"",
+
+  // "admin.access-control.groups.form.actions.delete": "Delete Group",
+  "admin.access-control.groups.form.actions.delete": "Odstrániť skupinu",
+
+  // "admin.access-control.groups.form.delete-group.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "admin.access-control.groups.form.delete-group.modal.header": "Odstrániť skupinu \"{{ dsoName }}\"",
+
+  // "admin.access-control.groups.form.delete-group.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "admin.access-control.groups.form.delete-group.modal.info": "Naozaj chcete odstrániť skupinu \"{{ dsoName }}\" a všetky súvisiace pravidlá?",
+
+  // "admin.access-control.groups.form.delete-group.modal.cancel": "Cancel",
+  "admin.access-control.groups.form.delete-group.modal.cancel": "Zrušiť",
+
+  // "admin.access-control.groups.form.delete-group.modal.confirm": "Delete",
+  "admin.access-control.groups.form.delete-group.modal.confirm": "Odstrániť",
+
+  // "admin.access-control.groups.form.notification.deleted.success": "Successfully deleted group \"{{ name }}\"",
+  "admin.access-control.groups.form.notification.deleted.success": "Úspešne odstránená skupina \"{{ name }}\"",
+
+  // "admin.access-control.groups.form.notification.deleted.failure.title": "Failed to delete group \"{{ name }}\"",
+  "admin.access-control.groups.form.notification.deleted.failure.title": "Nepodarilo sa odstrániť skupinu \"{{ name }}\"",
+
+  // "admin.access-control.groups.form.notification.deleted.failure.content": "Cause: \"{{ cause }}\"",
+  "admin.access-control.groups.form.notification.deleted.failure.content": "Príčina: \"{{ cause }}\"",
+
+  // "admin.access-control.groups.form.members-list.head": "EPeople",
+  "admin.access-control.groups.form.members-list.head": "Používatelia",
+
+  // "admin.access-control.groups.form.members-list.search.head": "Add EPeople",
+  "admin.access-control.groups.form.members-list.search.head": "Pridať používateľov",
+
+  // "admin.access-control.groups.form.members-list.button.see-all": "Browse All",
+  "admin.access-control.groups.form.members-list.button.see-all": "Prehliadať všetko",
+
+  // "admin.access-control.groups.form.members-list.headMembers": "Current Members",
+  "admin.access-control.groups.form.members-list.headMembers": "Súčasní členovia",
+
+  // "admin.access-control.groups.form.members-list.search.button": "Search",
+  "admin.access-control.groups.form.members-list.search.button": "Hľadať",
+
+  // "admin.access-control.groups.form.members-list.table.id": "ID",
+  "admin.access-control.groups.form.members-list.table.id": "ID",
+
+  // "admin.access-control.groups.form.members-list.table.name": "Name",
+  "admin.access-control.groups.form.members-list.table.name": "Názov",
+
+  // "admin.access-control.groups.form.members-list.table.identity": "Identity",
+  "admin.access-control.groups.form.members-list.table.identity": "Identita",
+
+  // "admin.access-control.groups.form.members-list.table.email": "Email",
+  "admin.access-control.groups.form.members-list.table.email": "E-mail",
+
+  // "admin.access-control.groups.form.members-list.table.netid": "NetID",
+  "admin.access-control.groups.form.members-list.table.netid": "NetID",
+
+  // "admin.access-control.groups.form.members-list.table.edit": "Remove / Add",
+  "admin.access-control.groups.form.members-list.table.edit": "Odobrať / Pridať",
+
+  // "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Remove member with name \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.table.edit.buttons.remove": "Odobrať člena s menom \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.notification.success.addMember": "Successfully added member: \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.notification.success.addMember": "Úspešne pridaný člen: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.notification.failure.addMember": "Failed to add member: \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.notification.failure.addMember": "Nepodarilo sa pridať člena: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.notification.success.deleteMember": "Successfully deleted member: \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.notification.success.deleteMember": "Úspešne odstránený člen: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.notification.failure.deleteMember": "Failed to delete member: \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.notification.failure.deleteMember": "Nepodarilo sa odstrániť člena: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
+  "admin.access-control.groups.form.members-list.table.edit.buttons.add": "Pridať člena s menom \"{{name}}\"",
+
+  // "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
+  "admin.access-control.groups.form.members-list.notification.failure.noActiveGroup": "Žiadna aktuálne aktívna skupina, najprv zadajte názov.",
+
+  // "admin.access-control.groups.form.members-list.no-members-yet": "No members in group yet, search and add.",
+  "admin.access-control.groups.form.members-list.no-members-yet": "V skupine zatiaľ nie sú žiadni členovia, vyhľadajte ich a pridajte.",
+
+  // "admin.access-control.groups.form.members-list.no-items": "No EPeople found in that search",
+  "admin.access-control.groups.form.members-list.no-items": "V tomto vyhľadávaní neboli nájdení žiadni používatelia",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.failure": "Something went wrong: \"{{cause}}\"",
+  "admin.access-control.groups.form.subgroups-list.notification.failure": "Niečo sa pokazilo: \"{{cause}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.head": "Groups",
+  "admin.access-control.groups.form.subgroups-list.head": "Skupiny",
+
+  // "admin.access-control.groups.form.subgroups-list.search.head": "Add Subgroup",
+  "admin.access-control.groups.form.subgroups-list.search.head": "Pridať podskupinu",
+
+  // "admin.access-control.groups.form.subgroups-list.button.see-all": "Browse All",
+  "admin.access-control.groups.form.subgroups-list.button.see-all": "Prehliadať všetko",
+
+  // "admin.access-control.groups.form.subgroups-list.headSubgroups": "Current Subgroups",
+  "admin.access-control.groups.form.subgroups-list.headSubgroups": "Aktuálne podskupiny",
+
+  // "admin.access-control.groups.form.subgroups-list.search.button": "Search",
+  "admin.access-control.groups.form.subgroups-list.search.button": "Hľadať",
+
+  // "admin.access-control.groups.form.subgroups-list.table.id": "ID",
+  "admin.access-control.groups.form.subgroups-list.table.id": "ID",
+
+  // "admin.access-control.groups.form.subgroups-list.table.name": "Name",
+  "admin.access-control.groups.form.subgroups-list.table.name": "Názov",
+
+  // "admin.access-control.groups.form.subgroups-list.table.collectionOrCommunity": "Collection/Community",
+  "admin.access-control.groups.form.subgroups-list.table.collectionOrCommunity": "Kolekcia/Komunita",
+
+  // "admin.access-control.groups.form.subgroups-list.table.edit": "Remove / Add",
+  "admin.access-control.groups.form.subgroups-list.table.edit": "Odobrať / Pridať",
+
+  // "admin.access-control.groups.form.subgroups-list.table.edit.buttons.remove": "Remove subgroup with name \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.table.edit.buttons.remove": "Odobrať podskupinu s názvom \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Add subgroup with name \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.table.edit.buttons.add": "Pridať podskupinu s názvom \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.success.addSubgroup": "Successfully added subgroup: \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.notification.success.addSubgroup": "Úspešne pridaná podskupina: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.failure.addSubgroup": "Failed to add subgroup: \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.notification.failure.addSubgroup": "Nepodarilo sa pridať podskupinu: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.success.deleteSubgroup": "Successfully deleted subgroup: \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.notification.success.deleteSubgroup": "Úspešne odstránená podskupina: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.failure.deleteSubgroup": "Failed to delete subgroup: \"{{name}}\"",
+  "admin.access-control.groups.form.subgroups-list.notification.failure.deleteSubgroup": "Nepodarilo sa odstrániť podskupinu: \"{{name}}\"",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
+  "admin.access-control.groups.form.subgroups-list.notification.failure.noActiveGroup": "Žiadna aktuálne aktívna skupina, najprv zadajte názov.",
+
+  // "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "This is the current group, can't be added.",
+  "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "Toto je aktuálna skupina, nemožno ju pridať.",
+
+  // "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
+  "admin.access-control.groups.form.subgroups-list.no-items": "Nenašla sa žiadna skupina s týmto názvom alebo s týmto UUID",
+
+  // "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet.",
+  "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "V skupine zatiaľ nie sú žiadne podskupiny.",
+
+  // "admin.access-control.groups.form.return": "Back",
+  "admin.access-control.groups.form.return": "Späť",
+
+  // "admin.quality-assurance.breadcrumbs": "Quality Assurance",
+  "admin.quality-assurance.breadcrumbs": "Zabezpečenie kvality",
+
+  // "admin.notifications.event.breadcrumbs": "Quality Assurance Suggestions",
+  "admin.notifications.event.breadcrumbs": "Odporúčania na zabezpečenie kvality",
+
+  // "admin.notifications.event.page.title": "Quality Assurance Suggestions",
+  "admin.notifications.event.page.title": "Odporúčania na zabezpečenie kvality",
+
+  // "admin.quality-assurance.page.title": "Quality Assurance",
+  "admin.quality-assurance.page.title": "Zabezpečenie kvality",
+
+  // "admin.notifications.source.breadcrumbs": "Quality Assurance",
+  "admin.notifications.source.breadcrumbs": "Zabezpečenie kvality",
+
+  // "admin.access-control.groups.form.tooltip.editGroupPage": "On this page, you can modify the properties and members of a group. In the top section, you can edit the group name and description, unless this is an admin group for a collection or community, in which case the group name and description are auto-generated and cannot be edited. In the following sections, you can edit group membership. See [the wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group) for more details.",
+  "admin.access-control.groups.form.tooltip.editGroupPage": "Na tejto stránke môžete upraviť vlastnosti a členov skupiny. V hornej časti môžete upraviť názov a popis skupiny, pokiaľ nejde o skupinu správcov pre kolekciu alebo komunitu. V takom prípade sú názov a popis skupiny vygenerované automaticky a nemožno ich upravovať. V nasledujúcich častiach môžete upravovať členstvo v skupine. Ďalšie podrobnosti nájdete na [wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group).",
+
+  // "admin.access-control.groups.form.tooltip.editGroup.addEpeople": "To add or remove an EPerson to/from this group, either click the 'Browse All' button or use the search bar below to search for users (use the dropdown to the left of the search bar to choose whether to search by metadata or by email). Then click the plus icon for each user you wish to add in the list below, or the trash can icon for each user you wish to remove. The list below may have several pages: use the page controls below the list to navigate to the next pages.",
+  "admin.access-control.groups.form.tooltip.editGroup.addEpeople": "Ak chcete pridať alebo odobrať používateľa do/z tejto skupiny, buď kliknite na tlačidlo „Prehliadať všetko“, alebo použite vyhľadávacie pole nižšie na vyhľadanie používateľov (pomocou rozbaľovacieho zoznamu naľavo od vyhľadávacieho poľa zvoľte, či chcete vyhľadávať podľa metadát alebo e-mailu). Potom kliknite na ikonu plus pri každom používateľovi, ktorého chcete pridať v zozname nižšie, alebo na ikonu odpadkového koša pri každom používateľovi, ktorého chcete odobrať. Zoznam nižšie môže obsahovať niekoľko strán: na prechod na ďalšie strany použite ovládacie prvky pod zoznamom.",
+
+  // "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "To add or remove a Subgroup to/from this group, either click the 'Browse All' button or use the search bar below to search for groups. Then click the plus icon for each group you wish to add in the list below, or the trash can icon for each group you wish to remove. The list below may have several pages: use the page controls below the list to navigate to the next pages.",
+  "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "Ak chcete pridať alebo odobrať podskupinu do/z tejto skupiny, buď kliknite na tlačidlo „Prehliadať všetko“, alebo použite vyhľadávacie pole nižšie na vyhľadanie skupín. Potom kliknite na ikonu plus pri každej skupine, ktorú chcete pridať v zozname nižšie, alebo na ikonu odpadkového koša pri každej skupine, ktorú chcete odobrať. Zoznam nižšie môže obsahovať niekoľko strán: na prechod na ďalšie strany použite ovládacie prvky pod zoznamom.",
+
+  // "admin.reports.collections.title": "Collection Filter Report",
+  "admin.reports.collections.title": "Zostava filtra kolekcií",
+
+  // "admin.reports.collections.breadcrumbs": "Collection Filter Report",
+  "admin.reports.collections.breadcrumbs": "Zostava filtra kolekcií",
+
+  // "admin.reports.collections.head": "Collection Filter Report",
+  "admin.reports.collections.head": "Zostava filtra kolekcií",
+
+  // "admin.reports.button.show-collections": "Show Collections",
+  "admin.reports.button.show-collections": "Zobraziť kolekcie",
+
+  // "admin.reports.collections.collections-report": "Collection Report",
+  "admin.reports.collections.collections-report": "Zostava o kolekciách",
+
+  // "admin.reports.collections.item-results": "Item Results",
+  "admin.reports.collections.item-results": "Výsledky záznamov",
+
+  // "admin.reports.collections.community": "Community",
+  "admin.reports.collections.community": "Komunita",
+
+  // "admin.reports.collections.collection": "Collection",
+  "admin.reports.collections.collection": "Kolekcia",
+
+  // "admin.reports.collections.nb_items": "Nb. Items",
+  "admin.reports.collections.nb_items": "Počet záznamov",
+
+  // "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
+  "admin.reports.collections.match_all_selected_filters": "Zodpovedá všetkým vybraným filtrom",
+
+  // "admin.reports.items.breadcrumbs": "Metadata Query Report",
+  "admin.reports.items.breadcrumbs": "Zostava dopytu na metadáta",
+
+  // "admin.reports.items.head": "Metadata Query Report",
+  "admin.reports.items.head": "Zostava dopytu na metadáta",
+
+  // "admin.reports.items.run": "Run Item Query",
+  "admin.reports.items.run": "Spustiť dopyt na záznamy",
+
+  // "admin.reports.items.section.collectionSelector": "Collection Selector",
+  "admin.reports.items.section.collectionSelector": "Výber kolekcie",
+
+  // "admin.reports.items.section.metadataFieldQueries": "Metadata Field Queries",
+  "admin.reports.items.section.metadataFieldQueries": "Dopyty na metadátové polia",
+
+  // "admin.reports.items.predefinedQueries": "Predefined Queries",
+  "admin.reports.items.predefinedQueries": "Preddefinované dopyty",
+
+  // "admin.reports.items.section.limitPaginateQueries": "Limit/Paginate Queries",
+  "admin.reports.items.section.limitPaginateQueries": "Obmedzenie/stránkovanie dopytov",
+
+  // "admin.reports.items.limit": "Limit/",
+  "admin.reports.items.limit": "Limit/",
+
+  // "admin.reports.items.offset": "Offset",
+  "admin.reports.items.offset": "Posun",
+
+  // "admin.reports.items.wholeRepo": "Whole Repository",
+  "admin.reports.items.wholeRepo": "Celý repozitár",
+
+  // "admin.reports.items.anyField": "Any field",
+  "admin.reports.items.anyField": "Ľubovoľné pole",
+
+  // "admin.reports.items.predicate.exists": "exists",
+  "admin.reports.items.predicate.exists": "existuje",
+
+  // "admin.reports.items.predicate.doesNotExist": "does not exist",
+  "admin.reports.items.predicate.doesNotExist": "neexistuje",
+
+  // "admin.reports.items.predicate.equals": "equals",
+  "admin.reports.items.predicate.equals": "rovná sa",
+
+  // "admin.reports.items.predicate.doesNotEqual": "does not equal",
+  "admin.reports.items.predicate.doesNotEqual": "nerovná sa",
+
+  // "admin.reports.items.predicate.like": "like",
+  "admin.reports.items.predicate.like": "je ako",
+
+  // "admin.reports.items.predicate.notLike": "not like",
+  "admin.reports.items.predicate.notLike": "nie je ako",
+
+  // "admin.reports.items.predicate.contains": "contains",
+  "admin.reports.items.predicate.contains": "obsahuje",
+
+  // "admin.reports.items.predicate.doesNotContain": "does not contain",
+  "admin.reports.items.predicate.doesNotContain": "neobsahuje",
+
+  // "admin.reports.items.predicate.matches": "matches",
+  "admin.reports.items.predicate.matches": "zodpovedá",
+
+  // "admin.reports.items.predicate.doesNotMatch": "does not match",
+  "admin.reports.items.predicate.doesNotMatch": "nezodpovedá",
+
+  // "admin.reports.items.preset.new": "New Query",
+  "admin.reports.items.preset.new": "Nový dopyt",
+
+  // "admin.reports.items.preset.hasNoTitle": "Has No Title",
+  "admin.reports.items.preset.hasNoTitle": "Nemá názov",
+
+  // "admin.reports.items.preset.hasNoIdentifierUri": "Has No dc.identifier.uri",
+  "admin.reports.items.preset.hasNoIdentifierUri": "Nemá dc.identifier.uri",
+
+  // "admin.reports.items.preset.hasCompoundSubject": "Has compound subject",
+  "admin.reports.items.preset.hasCompoundSubject": "Má zložený predmet",
+
+  // "admin.reports.items.preset.hasCompoundAuthor": "Has compound dc.contributor.author",
+  "admin.reports.items.preset.hasCompoundAuthor": "Má zložené dc.contributor.author",
+
+  // "admin.reports.items.preset.hasCompoundCreator": "Has compound dc.creator",
+  "admin.reports.items.preset.hasCompoundCreator": "Má zložené dc.creator",
+
+  // "admin.reports.items.preset.hasUrlInDescription": "Has URL in dc.description",
+  "admin.reports.items.preset.hasUrlInDescription": "Obsahuje URL v dc.description",
+
+  // "admin.reports.items.preset.hasFullTextInProvenance": "Has full text in dc.description.provenance",
+  "admin.reports.items.preset.hasFullTextInProvenance": "Obsahuje plný text v dc.description.provenance",
+
+  // "admin.reports.items.preset.hasNonFullTextInProvenance": "Has non-full text in dc.description.provenance",
+  "admin.reports.items.preset.hasNonFullTextInProvenance": "Obsahuje neúplný text v dc.description.provenance",
+
+  // "admin.reports.items.preset.hasEmptyMetadata": "Has empty metadata",
+  "admin.reports.items.preset.hasEmptyMetadata": "Má prázdne metadáta",
+
+  // "admin.reports.items.preset.hasUnbreakingDataInDescription": "Has unbreaking metadata in description",
+  "admin.reports.items.preset.hasUnbreakingDataInDescription": "Obsahuje nezalomiteľné metadáta v popise",
+
+  // "admin.reports.items.preset.hasXmlEntityInMetadata": "Has XML entity in metadata",
+  "admin.reports.items.preset.hasXmlEntityInMetadata": "Obsahuje XML entitu v metadátach",
+
+  // "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Has non-ascii character in metadata",
+  "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Obsahuje ne-ASCII znak v metadátach",
+
+  // "admin.reports.items.number": "No.",
+  "admin.reports.items.number": "Č.",
+
+  // "admin.reports.items.id": "UUID",
+  "admin.reports.items.id": "UUID",
+
+  // "admin.reports.items.collection": "Collection",
+  "admin.reports.items.collection": "Kolekcia",
+
+  // "admin.reports.items.handle": "URI",
+  "admin.reports.items.handle": "URI",
+
+  // "admin.reports.items.title": "Title",
+  "admin.reports.items.title": "Názov",
+
+  // "admin.reports.commons.filters": "Filters",
+  "admin.reports.commons.filters": "Filtre",
+
+  // "admin.reports.commons.additional-data": "Additional data to return",
+  "admin.reports.commons.additional-data": "Ďalšie údaje na vrátenie",
+
+  // "admin.reports.commons.previous-page": "Prev Page",
+  "admin.reports.commons.previous-page": "Predchádzajúca strana",
+
+  // "admin.reports.commons.next-page": "Next Page",
+  "admin.reports.commons.next-page": "Ďalšia strana",
+
+  // "admin.reports.commons.page": "Page",
+  "admin.reports.commons.page": "Strana",
+
+  // "admin.reports.commons.of": "of",
+  "admin.reports.commons.of": "z",
+
+  // "admin.reports.commons.export": "Export for Metadata Update",
+  "admin.reports.commons.export": "Export na aktualizáciu metadát",
+
+  // "admin.reports.commons.filters.deselect_all": "Deselect all filters",
+  "admin.reports.commons.filters.deselect_all": "Zrušiť výber všetkých filtrov",
+
+  // "admin.reports.commons.filters.select_all": "Select all filters",
+  "admin.reports.commons.filters.select_all": "Vybrať všetky filtre",
+
+  // "admin.reports.commons.filters.matches_all": "Matches all specified filters",
+  "admin.reports.commons.filters.matches_all": "Zodpovedá všetkým zadaným filtrom",
+
+  // "admin.reports.commons.filters.property": "Item Property Filters",
+  "admin.reports.commons.filters.property": "Filtre vlastností záznamu",
+
+  // "admin.reports.commons.filters.property.is_item": "Is Item - always true",
+  "admin.reports.commons.filters.property.is_item": "Je záznam – vždy pravda",
+
+  // "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
+  "admin.reports.commons.filters.property.is_withdrawn": "Stiahnuté záznamy",
+
+  // "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
+  "admin.reports.commons.filters.property.is_not_withdrawn": "Dostupné záznamy – nestiahnuté",
+
+  // "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
+  "admin.reports.commons.filters.property.is_discoverable": "Vyhľadateľné záznamy – nie sú súkromné",
+
+  // "admin.reports.commons.filters.property.is_not_discoverable": "Not Discoverable - Private Item",
+  "admin.reports.commons.filters.property.is_not_discoverable": "Nevyhľadateľné – súkromný záznam",
+
+  // "admin.reports.commons.filters.bitstream": "Basic Bitstream Filters",
+  "admin.reports.commons.filters.bitstream": "Základné filtre súborov",
+
+  // "admin.reports.commons.filters.bitstream.has_multiple_originals": "Item has Multiple Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_multiple_originals": "Záznam má viacero pôvodných súborov",
+
+  // "admin.reports.commons.filters.bitstream.has_no_originals": "Item has No Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_no_originals": "Záznam nemá žiadne pôvodné súbory",
+
+  // "admin.reports.commons.filters.bitstream.has_one_original": "Item has One Original Bitstream",
+  "admin.reports.commons.filters.bitstream.has_one_original": "Záznam má jeden pôvodný súbor",
+
+  // "admin.reports.commons.filters.bitstream_mime": "Bitstream Filters by MIME Type",
+  "admin.reports.commons.filters.bitstream_mime": "Filtre súborov podľa typu MIME",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Item has a Doc Original Bitstream (PDF, Office, Text, HTML, XML, etc)",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Záznam má pôvodný súbor typu dokument (PDF, Office, text, HTML, XML atď.)",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_image_original": "Item has an Image Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_image_original": "Záznam má pôvodný súbor typu obrázok",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Has Other Bitstream Types (not Doc or Image)",
+  "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Má iné typy súborov (nie dokument ani obrázok)",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Item has multiple types of Original Bitstreams (Doc, Image, Other)",
+  "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Záznam má viacero typov pôvodných súborov (dokument, obrázok, iné)",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Item has a PDF Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Záznam má pôvodný súbor PDF",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Item has JPG Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Záznam má pôvodný súbor JPG",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Has unusually small PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Má neobvykle malý súbor PDF",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Has unusually large PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Má neobvykle veľký súbor PDF",
+
+  // "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Has document bitstream without TEXT item",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Má dokumentový súbor bez položky TEXT",
+
+  // "admin.reports.commons.filters.mime": "Supported MIME Type Filters",
+  "admin.reports.commons.filters.mime": "Filtre podporovaných typov MIME",
+
+  // "admin.reports.commons.filters.mime.has_only_supp_image_type": "Item Image Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_image_type": "Obrázkové súbory záznamu sú podporované",
+
+  // "admin.reports.commons.filters.mime.has_unsupp_image_type": "Item has Image Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_image_type": "Záznam má obrázkový súbor, ktorý nie je podporovaný",
+
+  // "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Item Document Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Dokumentové súbory záznamu sú podporované",
+
+  // "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Item has Document Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Záznam má dokumentový súbor, ktorý nie je podporovaný",
+
+  // "admin.reports.commons.filters.bundle": "Bitstream Bundle Filters",
+  "admin.reports.commons.filters.bundle": "Filtre zväzkov súborov",
+
+  // "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Has bitstream in an unsupported bundle",
+  "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Má súbor v nepodporovanom zväzku",
+
+  // "admin.reports.commons.filters.bundle.has_small_thumbnail": "Has unusually small thumbnail",
+  "admin.reports.commons.filters.bundle.has_small_thumbnail": "Má neobvykle malý náhľad",
+
+  // "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Has original bitstream without thumbnail",
+  "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Má pôvodný súbor bez náhľadu",
+
+  // "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Has invalid thumbnail name (assumes one thumbnail for each original)",
+  "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Má neplatný názov náhľadu (predpokladá sa jeden náhľad pre každý pôvodný súbor)",
+
+  // "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Has non-generated thumbnail",
+  "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Má negenerovaný náhľad",
+
+  // "admin.reports.commons.filters.bundle.no_license": "Doesn't have a license",
+  "admin.reports.commons.filters.bundle.no_license": "Nemá licenciu",
+
+  // "admin.reports.commons.filters.bundle.has_license_documentation": "Has documentation in the license bundle",
+  "admin.reports.commons.filters.bundle.has_license_documentation": "Má dokumentáciu v zväzku licencie",
+
+  // "admin.reports.commons.filters.permission": "Permission Filters",
+  "admin.reports.commons.filters.permission": "Filtre oprávnení",
+
+  // "admin.reports.commons.filters.permission.has_restricted_original": "Item has Restricted Original Bitstream",
+  "admin.reports.commons.filters.permission.has_restricted_original": "Záznam má obmedzený pôvodný súbor",
+
+  // "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Item has at least one original bitstream that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Záznam má aspoň jeden pôvodný súbor, ktorý nie je prístupný anonymnému používateľovi",
+
+  // "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Item has Restricted Thumbnail",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Záznam má obmedzený náhľad",
+
+  // "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Item has at least one thumbnail that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Záznam má aspoň jeden náhľad, ktorý nie je prístupný anonymnému používateľovi",
+
+  // "admin.reports.commons.filters.permission.has_restricted_metadata": "Item has Restricted Metadata",
+  "admin.reports.commons.filters.permission.has_restricted_metadata": "Záznam má obmedzené metadáta",
+
+  // "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Item has metadata that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Záznam má metadáta, ktoré nie sú prístupné anonymnému používateľovi",
+
+  // "admin.search.breadcrumbs": "Administrative Search",
+  "admin.search.breadcrumbs": "Administrátorské vyhľadávanie",
+
+  // "admin.search.collection.edit": "Edit",
+  "admin.search.collection.edit": "Upraviť",
+
+  // "admin.search.community.edit": "Edit",
+  "admin.search.community.edit": "Upraviť",
+
+  // "admin.search.item.delete": "Delete",
+  "admin.search.item.delete": "Odstrániť",
+
+  // "admin.search.item.edit": "Edit",
+  "admin.search.item.edit": "Upraviť",
+
+  // "admin.search.item.make-private": "Make non-discoverable",
+  "admin.search.item.make-private": "Skryť z vyhľadávania",
+
+  // "admin.search.item.make-public": "Make discoverable",
+  "admin.search.item.make-public": "Sprístupniť vo vyhľadávaní",
+
+  // "admin.search.item.move": "Move",
+  "admin.search.item.move": "Presunúť",
+
+  // "admin.search.item.reinstate": "Reinstate",
+  "admin.search.item.reinstate": "Obnoviť",
+
+  // "admin.search.item.withdraw": "Withdraw",
+  "admin.search.item.withdraw": "Stiahnuť",
+
+  // "admin.search.title": "Administrative Search",
+  "admin.search.title": "Administrátorské vyhľadávanie",
+
+  // "administrativeView.search.results.head": "Administrative Search",
+  "administrativeView.search.results.head": "Administrátorské vyhľadávanie",
+
+  // "admin.workflow.breadcrumbs": "Administer Workflow",
+  "admin.workflow.breadcrumbs": "Spravovať workflow",
+
+  // "admin.workflow.title": "Administer Workflow",
+  "admin.workflow.title": "Spravovať workflow",
+
+  // "admin.workflow.item.workflow": "Workflow",
+  "admin.workflow.item.workflow": "Workflow",
+
+  // "admin.workflow.item.workspace": "Workspace",
+  "admin.workflow.item.workspace": "Pracovný priestor",
+
+  // "admin.workflow.item.delete": "Delete",
+  "admin.workflow.item.delete": "Odstrániť",
+
+  // "admin.workflow.item.send-back": "Send back",
+  "admin.workflow.item.send-back": "Odoslať späť",
+
+  // "admin.workflow.item.policies": "Policies",
+  "admin.workflow.item.policies": "Pravidlá pre záznam",
+
+  // "admin.workflow.item.supervision": "Supervision",
+  "admin.workflow.item.supervision": "Dohľad",
+
+  // "admin.metadata-import.breadcrumbs": "Import Metadata",
+  "admin.metadata-import.breadcrumbs": "Importovať metadáta",
+
+  // "admin.batch-import.breadcrumbs": "Import Batch",
+  "admin.batch-import.breadcrumbs": "Importovať dávku",
+
+  // "admin.metadata-import.title": "Import Metadata",
+  "admin.metadata-import.title": "Importovať metadáta",
+
+  // "admin.batch-import.title": "Import Batch",
+  "admin.batch-import.title": "Importovať dávku",
+
+  // "admin.metadata-import.page.header": "Import Metadata",
+  "admin.metadata-import.page.header": "Importovať metadáta",
+
+  // "admin.batch-import.page.header": "Import Batch",
+  "admin.batch-import.page.header": "Importovať dávku",
+
+  // "admin.metadata-import.page.help": "You can drop or browse CSV files that contain batch metadata operations on files here",
+  "admin.metadata-import.page.help": "Sem môžete presunúť alebo vybrať súbory CSV, ktoré obsahujú dávkové operácie s metadátami súborov",
+
+  // "admin.batch-import.page.help": "Select the collection to import into. Then, drop or browse to a Simple Archive Format (SAF) zip file that includes the items to import",
+  "admin.batch-import.page.help": "Vyberte kolekciu, do ktorej sa má importovať. Potom presuňte alebo vyberte súbor ZIP vo formáte Simple Archive Format (SAF), ktorý obsahuje záznamy na import",
+
+  // "admin.batch-import.page.toggle.help": "It is possible to perform import either with file upload or via URL, use above toggle to set the input source",
+  "admin.batch-import.page.toggle.help": "Import je možné vykonať buď nahraním súboru, alebo prostredníctvom URL adresy. Zdroj vstupu nastavte prepínačom vyššie",
+
+  // "admin.metadata-import.page.dropMsg": "Drop a metadata CSV to import",
+  "admin.metadata-import.page.dropMsg": "Presuňte sem súbor CSV s metadátami na import",
+
+  // "admin.batch-import.page.dropMsg": "Drop a batch ZIP to import",
+  "admin.batch-import.page.dropMsg": "Presuňte sem súbor ZIP na import",
+
+  // "admin.metadata-import.page.dropMsgReplace": "Drop to replace the metadata CSV to import",
+  "admin.metadata-import.page.dropMsgReplace": "Presunutím nahradíte súbor CSV s metadátami na import",
+
+  // "admin.batch-import.page.dropMsgReplace": "Drop to replace the batch ZIP to import",
+  "admin.batch-import.page.dropMsgReplace": "Presunutím nahradíte súbor ZIP na import",
+
+  // "admin.metadata-import.page.button.return": "Back",
+  "admin.metadata-import.page.button.return": "Späť",
+
+  // "admin.metadata-import.page.button.proceed": "Proceed",
+  "admin.metadata-import.page.button.proceed": "Pokračovať",
+
+  // "admin.metadata-import.page.button.select-collection": "Select Collection",
+  "admin.metadata-import.page.button.select-collection": "Vybrať kolekciu",
+
+  // "admin.metadata-import.page.error.addFile": "Select file first!",
+  "admin.metadata-import.page.error.addFile": "Najprv vyberte súbor!",
+
+  // "admin.metadata-import.page.error.addFileUrl": "Insert file URL first!",
+  "admin.metadata-import.page.error.addFileUrl": "Najprv vložte URL adresu súboru!",
+
+  // "admin.batch-import.page.error.addFile": "Select ZIP file first!",
+  "admin.batch-import.page.error.addFile": "Najprv vyberte súbor ZIP!",
+
+  // "admin.metadata-import.page.toggle.upload": "Upload",
+  "admin.metadata-import.page.toggle.upload": "Nahrať",
+
+  // "admin.metadata-import.page.toggle.url": "URL",
+  "admin.metadata-import.page.toggle.url": "URL",
+
+  // "admin.metadata-import.page.urlMsg": "Insert the batch ZIP url to import",
+  "admin.metadata-import.page.urlMsg": "Vložte URL súboru ZIP na import",
+
+  // "admin.metadata-import.page.validateOnly": "Validate Only",
+  "admin.metadata-import.page.validateOnly": "Iba overiť",
+
+  // "admin.metadata-import.page.validateOnly.hint": "When selected, the uploaded CSV will be validated. You will receive a report of detected changes, but no changes will be saved.",
+  "admin.metadata-import.page.validateOnly.hint": "Po zvolení sa nahraný súbor CSV overí. Dostanete správu o zistených zmenách, ale žiadne zmeny sa neuložia.",
+
+  // "advanced-workflow-action.rating.form.rating.label": "Rating",
+  "advanced-workflow-action.rating.form.rating.label": "Hodnotenie",
+
+  // "advanced-workflow-action.rating.form.rating.error": "You must rate the item",
+  "advanced-workflow-action.rating.form.rating.error": "Musíte ohodnotiť záznam",
+
+  // "advanced-workflow-action.rating.form.review.label": "Review",
+  "advanced-workflow-action.rating.form.review.label": "Recenzia",
+
+  // "advanced-workflow-action.rating.form.review.error": "You must enter a review to submit this rating",
+  "advanced-workflow-action.rating.form.review.error": "Na odoslanie tohto hodnotenia musíte zadať recenziu",
+
+  // "advanced-workflow-action.rating.description": "Please select a rating below",
+  "advanced-workflow-action.rating.description": "Nižšie vyberte hodnotenie",
+
+  // "advanced-workflow-action.rating.description-requiredDescription": "Please select a rating below and also add a review",
+  "advanced-workflow-action.rating.description-requiredDescription": "Nižšie vyberte hodnotenie a pridajte aj recenziu",
+
+  // "advanced-workflow-action.select-reviewer.description-single": "Please select a single reviewer below before submitting",
+  "advanced-workflow-action.select-reviewer.description-single": "Pred odoslaním si nižšie vyberte jedného recenzenta.",
+
+  // "advanced-workflow-action.select-reviewer.description-multiple": "Please select one or more reviewers below before submitting",
+  "advanced-workflow-action.select-reviewer.description-multiple": "Pred odoslaním si nižšie vyberte jedného alebo viacerých recenzentov.",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.head": "EPeople",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.head": "Používatelia",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.search.head": "Add EPeople",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.search.head": "Pridať používateľov",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.button.see-all": "Browse All",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.button.see-all": "Prehliadať všetko",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.headMembers": "Current Members",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.headMembers": "Súčasní členovia",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.search.button": "Search",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.search.button": "Hľadať",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.id": "ID",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.id": "ID",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.name": "Name",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.name": "Meno",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.identity": "Identity",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.identity": "Identita",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.email": "Email",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.email": "E-mail",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.netid": "NetID",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.netid": "NetID",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit": "Remove / Add",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit": "Odobrať / Pridať",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit.buttons.remove": "Remove member with name \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit.buttons.remove": "Odobrať člena s menom \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.success.addMember": "Successfully added member: \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.success.addMember": "Úspešne pridaný člen: \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.addMember": "Failed to add member: \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.addMember": "Nepodarilo sa pridať člena: \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.success.deleteMember": "Successfully deleted member: \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.success.deleteMember": "Úspešne odstránený člen: \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.deleteMember": "Failed to delete member: \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.deleteMember": "Nepodarilo sa odstrániť člena: \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit.buttons.add": "Add member with name \"{{name}}\"",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.table.edit.buttons.add": "Pridať člena s menom \"{{name}}\"",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.noActiveGroup": "No current active group, submit a name first.",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.notification.failure.noActiveGroup": "Žiadna aktuálne aktívna skupina, najprv zadajte názov.",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.no-members-yet": "No members in group yet, search and add.",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.no-members-yet": "V skupine zatiaľ nie sú žiadni členovia, najprv vyhľadajte a pridajte.",
+
+  // "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.no-items": "No EPeople found in that search",
+  "advanced-workflow-action-select-reviewer.groups.form.reviewers-list.no-items": "V tomto vyhľadávaní neboli nájdení žiadni používatelia",
+
+  // "advanced-workflow-action.select-reviewer.no-reviewer-selected.error": "No reviewer selected.",
+  "advanced-workflow-action.select-reviewer.no-reviewer-selected.error": "Nebol vybraný žiadny recenzent.",
+
+  // "admin.batch-import.page.validateOnly.hint": "When selected, the uploaded ZIP will be validated. You will receive a report of detected changes, but no changes will be saved.",
+  "admin.batch-import.page.validateOnly.hint": "Po zvolení sa nahraný súbor ZIP overí. Dostanete správu o zistených zmenách, ale žiadne zmeny sa neuložia.",
+
+  // "admin.batch-import.page.remove": "remove",
+  "admin.batch-import.page.remove": "Odstrániť",
+
+  // "audit.data.not-found": "No audits found.",
+  "audit.data.not-found": "Nenašli sa žiadne audity.",
+
+  // "audit.data.self": "self",
+  "audit.data.self": "vlastný",
+
+  // "audit.detail.metadata.field": "Metadata field:",
+  "audit.detail.metadata.field": "Metadátové pole:",
+
+  // "audit.detail.metadata.value": "Value:",
+  "audit.detail.metadata.value": "Hodnota:",
+
+  // "audit.detail.metadata.authority": "Authority:",
+  "audit.detail.metadata.authority": "Autorita:",
+
+  // "audit.detail.metadata.confidence": "Confidence:",
+  "audit.detail.metadata.confidence": "Spoľahlivosť:",
+
+  // "audit.detail.metadata.place": "Place:",
+  "audit.detail.metadata.place": "Pozícia:",
+
+  // "audit.detail.metadata.action": "Action:",
+  "audit.detail.metadata.action": "Akcia:",
+
+  // "audit.detail.metadata.checksum": "Checksum:",
+  "audit.detail.metadata.checksum": "Kontrolný súčet:",
+
+  // "audit.overview.title": "All Audit Logs",
+  "audit.overview.title": "Všetky auditné záznamy",
+
+  // "audit.overview.table.id": "Audit ID",
+  "audit.overview.table.id": "ID auditu",
+
+  // "audit.overview.table.objectUUID": "Object ID",
+  "audit.overview.table.objectUUID": "ID objektu",
+
+  // "audit.overview.table.objectType": "Object Type",
+  "audit.overview.table.objectType": "Typ objektu",
+
+  // "audit.overview.table.subjectUUID": "Subject ID",
+  "audit.overview.table.subjectUUID": "ID subjektu",
+
+  // "audit.overview.table.subjectType": "Subject Type",
+  "audit.overview.table.subjectType": "Typ subjektu",
+
+  // "audit.overview.table.entityType": "Audit Type",
+  "audit.overview.table.entityType": "Typ auditu",
+
+  // "audit.overview.table.eperson": "EPerson",
+  "audit.overview.table.eperson": "Používateľ",
+
+  // "audit.overview.table.other": "Object",
+  "audit.overview.table.other": "Objekt",
+
+  // "audit.overview.table.timestamp": "Time (UTC)",
+  "audit.overview.table.timestamp": "Čas (UTC)",
+
+  // "audit.overview.breadcrumbs": "Audit Logs",
+  "audit.overview.breadcrumbs": "Auditné záznamy",
+
+  // "audit.object.back": "Back",
+  "audit.object.back": "Späť",
+
+  // "audit.object.breadcrumbs": "Object Audit Logs",
+  "audit.object.breadcrumbs": "Auditné záznamy objektu",
+
+  // "audit.object.overview.title": "Object Audit Logs",
+  "audit.object.overview.title": "Auditné záznamy objektu",
+
+  // "audit.object.logs.label": "Logs for object: ",
+  "audit.object.logs.label": "Záznamy pre objekt: ",
+
+  // "audit.object.overview.disabled.message": "Audit feature is currently disabled",
+  "audit.object.overview.disabled.message": "Funkcia auditu je momentálne vypnutá",
+
+  // "auth.errors.invalid-user": "Invalid email address or password.",
+  "auth.errors.invalid-user": "Neplatná e-mailová adresa alebo heslo.",
+
+  // "auth.messages.expired": "Your session has expired. Please log in again.",
+  "auth.messages.expired": "Vaša relácia vypršala. Prihláste sa prosím znova.",
+
+  // "auth.messages.token-refresh-failed": "Refreshing your session token failed. Please log in again.",
+  "auth.messages.token-refresh-failed": "Obnovenie vášho prístupového tokenu zlyhalo. Prihláste sa prosím znova.",
+
+  // "bitstream.download.page": "Now downloading {{bitstream}}...",
+  "bitstream.download.page": "Teraz sa sťahuje {{bitstream}}...",
+
+  // "bitstream.download.page.back": "Back",
+  "bitstream.download.page.back": "Späť",
+
+  // "bitstream.edit.authorizations.link": "Edit bitstream's Policies",
+  "bitstream.edit.authorizations.link": "Upraviť pravidlá súboru",
+
+  // "bitstream.edit.authorizations.title": "Edit bitstream's Policies",
+  "bitstream.edit.authorizations.title": "Upraviť pravidlá súboru",
+
+  // "bitstream.edit.return": "Back",
+  "bitstream.edit.return": "Späť",
+
+  // "bitstream.edit.bitstream": "Bitstream: ",
+  "bitstream.edit.bitstream": "Súbor: ",
+
+  // "bitstream.edit.form.description.hint": "Optionally, provide a brief description of the file, for example \"<i>Main article</i>\" or \"<i>Experiment data readings</i>\".",
+  "bitstream.edit.form.description.hint": "Voliteľne zadajte stručný popis súboru, napríklad \"<i>Hlavný článok</i>\" alebo \"<i>Experimentálne dáta</i>\".",
+
+  // "bitstream.edit.form.description.label": "Description",
+  "bitstream.edit.form.description.label": "Popis",
+
+  // "bitstream.edit.form.embargo.hint": "The first day from which access is allowed. <b>This date cannot be modified on this form.</b> To set an embargo date for a bitstream, go to the <i>Item Status</i> tab, click <i>Authorizations...</i>, create or edit the bitstream's <i>READ</i> policy, and set the <i>Start Date</i> as desired.",
+  "bitstream.edit.form.embargo.hint": "Prvý deň, od ktorého je prístup povolený. <b>Tento dátum nemožno na tomto formulári zmeniť.</b> Na nastavenie dátumu embarga pre súbor prejdite na kartu <i>Stav záznamu</i>, kliknite na <i>Oprávnenia...</i>, vytvorte alebo upravte pravidlo <i>READ</i> súboru a nastavte <i>Dátum začiatku</i> podľa potreby.",
+
+  // "bitstream.edit.form.embargo.label": "Embargo until specific date",
+  "bitstream.edit.form.embargo.label": "Embargo do určitého dátumu",
+
+  // "bitstream.edit.form.fileName.hint": "Change the filename for the bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.",
+  "bitstream.edit.form.fileName.hint": "Zmeňte názov súboru. Upozorňujeme, že sa tým zmení zobrazovaná URL adresa súboru, ale pôvodné odkazy budú naďalej fungovať, pokiaľ sa nezmení ID sekvencie.",
+
+  // "bitstream.edit.form.fileName.label": "Filename",
+  "bitstream.edit.form.fileName.label": "Názov súboru",
+
+  // "bitstream.edit.form.newFormat.label": "Describe new format",
+  "bitstream.edit.form.newFormat.label": "Opíšte nový formát",
+
+  // "bitstream.edit.form.newFormat.hint": "The application you used to create the file, and the version number (for example, \"<i>ACMESoft SuperApp version 1.5</i>\").",
+  "bitstream.edit.form.newFormat.hint": "Aplikácia, ktorú ste použili na vytvorenie súboru, a číslo verzie (napríklad \"<i>ACMESoft SuperApp verzia 1.5</i>\").",
+
+  // "bitstream.edit.form.primaryBitstream.label": "Primary File",
+  "bitstream.edit.form.primaryBitstream.label": "Primárny súbor",
+
+  // "bitstream.edit.form.selectedFormat.hint": "If the format is not in the above list, <b>select \"format not in list\" above</b> and describe it under \"Describe new format\".",
+  "bitstream.edit.form.selectedFormat.hint": "Ak formát nie je vo vyššie uvedenom zozname, <b>vyberte vyššie „formát nie je v zozname“</b> a opíšte ho v časti „Opíšte nový formát“.",
+
+  // "bitstream.edit.form.selectedFormat.label": "Selected Format",
+  "bitstream.edit.form.selectedFormat.label": "Vybraný formát",
+
+  // "bitstream.edit.form.selectedFormat.unknown": "Format not in list",
+  "bitstream.edit.form.selectedFormat.unknown": "Formát nie je v zozname",
+
+  // "bitstream.edit.notifications.error.format.title": "An error occurred saving the bitstream's format",
+  "bitstream.edit.notifications.error.format.title": "Pri ukladaní formátu súboru došlo k chybe",
+
+  // "bitstream.edit.notifications.error.primaryBitstream.title": "An error occurred saving the primary bitstream",
+  "bitstream.edit.notifications.error.primaryBitstream.title": "Pri ukladaní primárneho súboru došlo k chybe",
+
+  // "bitstream.edit.form.iiifLabel.label": "IIIF Label",
+  "bitstream.edit.form.iiifLabel.label": "Štítok IIIF",
+
+  // "bitstream.edit.form.iiifLabel.hint": "Canvas label for this image. If not provided default label will be used.",
+  "bitstream.edit.form.iiifLabel.hint": "Štítok plátna pre tento obrázok. Ak nebude zadaný, použije sa predvolený štítok.",
+
+  // "bitstream.edit.form.iiifToc.label": "IIIF Table of Contents",
+  "bitstream.edit.form.iiifToc.label": "Obsah IIIF",
+
+  // "bitstream.edit.form.iiifToc.hint": "Adding text here makes this the start of a new table of contents range.",
+  "bitstream.edit.form.iiifToc.hint": "Pridaním textu na toto miesto sa vytvorí začiatok nového rozsahu obsahu.",
+
+  // "bitstream.edit.form.iiifWidth.label": "IIIF Canvas Width",
+  "bitstream.edit.form.iiifWidth.label": "Šírka plátna IIIF",
+
+  // "bitstream.edit.form.iiifWidth.hint": "The canvas width should usually match the image width.",
+  "bitstream.edit.form.iiifWidth.hint": "Šírka plátna by obvykle mala zodpovedať šírke obrázka.",
+
+  // "bitstream.edit.form.iiifHeight.label": "IIIF Canvas Height",
+  "bitstream.edit.form.iiifHeight.label": "Výška plátna IIIF",
+
+  // "bitstream.edit.form.iiifHeight.hint": "The canvas height should usually match the image height.",
+  "bitstream.edit.form.iiifHeight.hint": "Výška plátna by obvykle mala zodpovedať výške obrázka.",
+
+  // "bitstream.edit.form.mediaType.label": "Audio or video media type",
+  "bitstream.edit.form.mediaType.label": "Typ audio alebo video média",
+
+  // "bitstream.edit.form.mediaType.hint": "Choose how this bitstream should be interpreted.",
+  "bitstream.edit.form.mediaType.hint": "Zvoľte, ako sa má tento súbor interpretovať.",
+
+  // "bitstream.edit.form.mediaType.option.neither": "Neither",
+  "bitstream.edit.form.mediaType.option.neither": "Ani jedno",
+
+  // "bitstream.edit.form.mediaType.option.audio": "Audio",
+  "bitstream.edit.form.mediaType.option.audio": "Audio",
+
+  // "bitstream.edit.form.mediaType.option.video": "Video",
+  "bitstream.edit.form.mediaType.option.video": "Video",
+
+  // "bitstream.edit.form.mediaType.option.audio-video": "Audio and video",
+  "bitstream.edit.form.mediaType.option.audio-video": "Audio a video",
+
+  // "bitstream.edit.form.audioTranscript.label": "Audio transcript",
+  "bitstream.edit.form.audioTranscript.label": "Prepis zvuku",
+
+  // "bitstream.edit.form.audioTranscript.hint": "Provide a transcript for audio content.",
+  "bitstream.edit.form.audioTranscript.hint": "Poskytnite prepis pre zvukový obsah.",
+
+  // "bitstream.edit.form.videoDescription.label": "Video description",
+  "bitstream.edit.form.videoDescription.label": "Popis videa",
+
+  // "bitstream.edit.form.videoDescription.hint": "Provide a description for video content.",
+  "bitstream.edit.form.videoDescription.hint": "Poskytnite popis pre obrazový obsah.",
+
+  // "bitstream.edit.notifications.saved.content": "Your changes to this bitstream were saved.",
+  "bitstream.edit.notifications.saved.content": "Vaše zmeny v tomto súbore boli uložené.",
+
+  // "bitstream.edit.notifications.saved.title": "Bitstream saved",
+  "bitstream.edit.notifications.saved.title": "Súbor uložený",
+
+  // "bitstream.edit.title": "Edit bitstream",
+  "bitstream.edit.title": "Upraviť súbor",
+
+  // "bitstream-request-a-copy.alert.canDownload1": "You already have access to this file. If you want to download the file, click ",
+  "bitstream-request-a-copy.alert.canDownload1": "K tomuto súboru už máte prístup. Ak chcete súbor stiahnuť, kliknite ",
+
+  // "bitstream-request-a-copy.alert.canDownload2": "here",
+  "bitstream-request-a-copy.alert.canDownload2": "sem",
+
+  // "bitstream-request-a-copy.header": "Request a copy of the file",
+  "bitstream-request-a-copy.header": "Vyžiadať si kópiu súboru",
+
+  // "bitstream-request-a-copy.intro": "Enter the following information to request a copy for the following item: ",
+  "bitstream-request-a-copy.intro": "Zadajte nasledujúce informácie, aby ste si vyžiadali kópiu nasledujúceho záznamu: ",
+
+  // "bitstream-request-a-copy.intro.bitstream.one": "Requesting the following file: ",
+  "bitstream-request-a-copy.intro.bitstream.one": "Žiadate o nasledujúci súbor: ",
+
+  // "bitstream-request-a-copy.intro.bitstream.all": "Requesting all files. ",
+  "bitstream-request-a-copy.intro.bitstream.all": "Žiadate o všetky súbory. ",
+
+  // "bitstream-request-a-copy.name.label": "Name *",
+  "bitstream-request-a-copy.name.label": "Meno *",
+
+  // "bitstream-request-a-copy.name.error": "The name is required",
+  "bitstream-request-a-copy.name.error": "Meno je povinné",
+
+  // "bitstream-request-a-copy.email.label": "Your email address *",
+  "bitstream-request-a-copy.email.label": "Vaša e-mailová adresa *",
+
+  // "bitstream-request-a-copy.email.hint": "This email address is used for sending the file.",
+  "bitstream-request-a-copy.email.hint": "Táto e-mailová adresa sa používa na odoslanie súboru.",
+
+  // "bitstream-request-a-copy.email.error": "Please enter a valid email address.",
+  "bitstream-request-a-copy.email.error": "Zadajte prosím platnú e-mailovú adresu.",
+
+  // "bitstream-request-a-copy.allfiles.label": "Files",
+  "bitstream-request-a-copy.allfiles.label": "Súbory",
+
+  // "bitstream-request-a-copy.files-all-false.label": "Only the requested file",
+  "bitstream-request-a-copy.files-all-false.label": "Iba požadovaný súbor",
+
+  // "bitstream-request-a-copy.files-all-true.label": "All files (of this item) in restricted access",
+  "bitstream-request-a-copy.files-all-true.label": "Všetky súbory (tohto záznamu) v obmedzenom prístupe",
+
+  // "bitstream-request-a-copy.message.label": "Message",
+  "bitstream-request-a-copy.message.label": "Správa",
+
+  // "bitstream-request-a-copy.return": "Back",
+  "bitstream-request-a-copy.return": "Späť",
+
+  // "bitstream-request-a-copy.submit": "Request copy",
+  "bitstream-request-a-copy.submit": "Požiadať o kópiu",
+
+  // "bitstream-request-a-copy.submit.success": "The item request was submitted successfully.",
+  "bitstream-request-a-copy.submit.success": "Požiadavka na záznam bola úspešne odoslaná.",
+
+  // "bitstream-request-a-copy.submit.error": "Something went wrong with submitting the item request.",
+  "bitstream-request-a-copy.submit.error": "Pri odosielaní požiadavky na záznam sa niečo pokazilo.",
+
+  // "bitstream-request-a-copy.access-by-token.warning": "You are viewing this item with the secure access link provided to you by the author or repository staff. It is important not to share this link to unauthorised users.",
+  "bitstream-request-a-copy.access-by-token.warning": "Tento záznam si prezeráte pomocou zabezpečeného prístupového odkazu, ktorý vám poskytol autor alebo pracovníci repozitára. Je dôležité nezdieľať tento odkaz s neoprávnenými používateľmi.",
+
+  // "bitstream-request-a-copy.access-by-token.expiry-label": "Access provided by this link will expire on",
+  "bitstream-request-a-copy.access-by-token.expiry-label": "Prístup poskytnutý týmto odkazom vyprší dňa",
+
+  // "bitstream-request-a-copy.access-by-token.expired": "Access provided by this link is no longer possible. Access expired on",
+  "bitstream-request-a-copy.access-by-token.expired": "Prístup poskytnutý týmto odkazom už nie je možný. Prístup vypršal dňa",
+
+  // "bitstream-request-a-copy.access-by-token.not-granted": "Access provided by this link is not possible. Access has either not been granted, or has been revoked.",
+  "bitstream-request-a-copy.access-by-token.not-granted": "Prístup poskytnutý týmto odkazom nie je možný. Prístup buď nebol udelený, alebo bol zrušený.",
+
+  // "bitstream-request-a-copy.access-by-token.re-request": "Follow restricted download links to submit a new request for access.",
+  "bitstream-request-a-copy.access-by-token.re-request": "Nasledujte odkazy na obmedzené sťahovanie a odošlite novú žiadosť o prístup.",
+
+  // "bitstream-request-a-copy.access-by-token.alt-text": "Access to this item is provided by a secure token",
+  "bitstream-request-a-copy.access-by-token.alt-text": "Prístup k tomuto záznamu je poskytnutý pomocou zabezpečeného tokenu",
+
+  // "browse.back.all-results": "All browse results",
+  "browse.back.all-results": "Všetky výsledky prehliadania",
+
+  // "browse.comcol.by.author": "By Author",
+  "browse.comcol.by.author": "Podľa autora",
+
+  // "browse.comcol.by.dateissued": "By Issue Date",
+  "browse.comcol.by.dateissued": "Podľa dátumu vydania",
+
+  // "browse.comcol.by.subject": "By Subject",
+  "browse.comcol.by.subject": "Podľa predmetu",
+
+  // "browse.comcol.by.srsc": "By Subject Category",
+  "browse.comcol.by.srsc": "Podľa predmetovej kategórie",
+
+  // "browse.comcol.by.nsi": "By Norwegian Science Index",
+  "browse.comcol.by.nsi": "Podľa Norwegian Science Index",
+
+  // "browse.comcol.by.title": "By Title",
+  "browse.comcol.by.title": "Podľa názvu",
+
+  // "browse.comcol.head": "Browse",
+  "browse.comcol.head": "Prehliadať",
+
+  // "browse.empty": "No items to show.",
+  "browse.empty": "Žiadne záznamy na zobrazenie.",
+
+  // "browse.metadata.author": "Author",
+  "browse.metadata.author": "Autor",
+
+  // "browse.metadata.dateissued": "Issue Date",
+  "browse.metadata.dateissued": "Dátum vydania",
+
+  // "browse.metadata.subject": "Subject",
+  "browse.metadata.subject": "Predmet",
+
+  // "browse.metadata.title": "Title",
+  "browse.metadata.title": "Názov",
+
+  // "browse.metadata.srsc": "Subject Category",
+  "browse.metadata.srsc": "Predmetová kategória",
+
+  // "browse.metadata.author.breadcrumbs": "Browse by Author",
+  "browse.metadata.author.breadcrumbs": "Prehliadať podľa autora",
+
+  // "browse.metadata.dateissued.breadcrumbs": "Browse by Date",
+  "browse.metadata.dateissued.breadcrumbs": "Prehliadať podľa dátumu vydania",
+
+  // "browse.metadata.subject.breadcrumbs": "Browse by Subject",
+  "browse.metadata.subject.breadcrumbs": "Prehliadať podľa predmetu",
+
+  // "browse.metadata.srsc.breadcrumbs": "Browse by Subject Category",
+  "browse.metadata.srsc.breadcrumbs": "Prehliadať podľa predmetovej kategórie",
+
+  // "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
+  "browse.metadata.srsc.tree.description": "Vyberte predmet, ktorý sa pridá ako filter vyhľadávania",
+
+  // "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
+  "browse.metadata.nsi.breadcrumbs": "Prehliadať podľa Norwegian Science Index",
+
+  // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
+  "browse.metadata.nsi.tree.description": "Vyberte index, ktorý sa pridá ako filter vyhľadávania",
+
+  // "browse.metadata.title.breadcrumbs": "Browse by Title",
+  "browse.metadata.title.breadcrumbs": "Prehliadať podľa názvu",
+
+  // "browse.metadata.map": "Browse by Geolocation",
+  "browse.metadata.map": "Prehliadať podľa geolokácie",
+
+  // "browse.metadata.map.breadcrumbs": "Browse by Geolocation",
+  "browse.metadata.map.breadcrumbs": "Prehliadať podľa geolokácie",
+
+  // "browse.metadata.map.count.items": "items",
+  "browse.metadata.map.count.items": "záznamov",
+
+  // "pagination.next.button": "Next",
+  "pagination.next.button": "Ďalej",
+
+  // "pagination.previous.button": "Previous",
+  "pagination.previous.button": "Predchádzajúce",
+
+  // "pagination.next.button.disabled.tooltip": "No more pages of results",
+  "pagination.next.button.disabled.tooltip": "Žiadne ďalšie stránky výsledkov",
+
+  // "pagination.page-number-bar": "Control bar for page navigation, relative to element with ID: ",
+  "pagination.page-number-bar": "Ovládací panel na navigáciu medzi stránkami, vzhľadom na prvok s ID: ",
+
+  // "browse.startsWith": ", starting with {{ startsWith }}",
+  "browse.startsWith": ", začína na {{ startsWith }}",
+
+  // "browse.startsWith.choose_start": "(Choose start)",
+  "browse.startsWith.choose_start": "(Vyberte začiatok)",
+
+  // "browse.startsWith.choose_year": "(Choose year)",
+  "browse.startsWith.choose_year": "(Vyberte rok)",
+
+  // "browse.startsWith.choose_year.label": "Choose the issue year",
+  "browse.startsWith.choose_year.label": "Vyberte rok vydania",
+
+  // "browse.startsWith.jump": "Filter results by year or month",
+  "browse.startsWith.jump": "Filtrovať výsledky podľa roku alebo mesiaca",
+
+  // "browse.startsWith.months.april": "April",
+  "browse.startsWith.months.april": "Apríl",
+
+  // "browse.startsWith.months.august": "August",
+  "browse.startsWith.months.august": "August",
+
+  // "browse.startsWith.months.december": "December",
+  "browse.startsWith.months.december": "December",
+
+  // "browse.startsWith.months.february": "February",
+  "browse.startsWith.months.february": "Február",
+
+  // "browse.startsWith.months.january": "January",
+  "browse.startsWith.months.january": "Január",
+
+  // "browse.startsWith.months.july": "July",
+  "browse.startsWith.months.july": "Júl",
+
+  // "browse.startsWith.months.june": "June",
+  "browse.startsWith.months.june": "Jún",
+
+  // "browse.startsWith.months.march": "March",
+  "browse.startsWith.months.march": "Marec",
+
+  // "browse.startsWith.months.may": "May",
+  "browse.startsWith.months.may": "Máj",
+
+  // "browse.startsWith.months.none": "(Choose month)",
+  "browse.startsWith.months.none": "(Vyberte mesiac)",
+
+  // "browse.startsWith.months.none.label": "Choose the issue month",
+  "browse.startsWith.months.none.label": "Vyberte mesiac vydania",
+
+  // "browse.startsWith.months.november": "November",
+  "browse.startsWith.months.november": "November",
+
+  // "browse.startsWith.months.october": "October",
+  "browse.startsWith.months.october": "Október",
+
+  // "browse.startsWith.months.september": "September",
+  "browse.startsWith.months.september": "September",
+
+  // "browse.startsWith.submit": "Browse",
+  "browse.startsWith.submit": "Prehliadať",
+
+  // "browse.startsWith.type_date": "Filter results by date",
+  "browse.startsWith.type_date": "Filtrovať výsledky podľa dátumu",
+
+  // "browse.startsWith.type_date.label": "Or type in a date (year-month) and click on the Browse button",
+  "browse.startsWith.type_date.label": "Alebo zadajte dátum (rok-mesiac) a kliknite na tlačidlo Prehliadať",
+
+  // "browse.startsWith.type_text": "Filter results by typing the first few letters",
+  "browse.startsWith.type_text": "Filtrovať výsledky zadaním niekoľkých prvých písmen",
+
+  // "browse.startsWith.input": "Filter",
+  "browse.startsWith.input": "Filtrovať",
+
+  // "browse.taxonomy.button": "Browse",
+  "browse.taxonomy.button": "Prehliadať",
+
+  // "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}",
+  "browse.title": "Prehliadanie podľa {{ field }}{{ startsWith }} {{ value }}",
+
+  // "browse.taxonomy.show_next_results": "Show next results",
+  "browse.taxonomy.show_next_results": "Zobraziť ďalšie výsledky",
+
+  // "browse.taxonomy.show_previous_results": "Show previous results",
+  "browse.taxonomy.show_previous_results": "Zobraziť predchádzajúce výsledky",
+
+  // "browse.title.page": "Browsing by {{ field }} {{ value }}",
+  "browse.title.page": "Prehliadanie podľa {{ field }} {{ value }}",
+
+  // "search.browse.item-back": "Back to Results",
+  "search.browse.item-back": "Späť na zoznam výsledkov",
+
+  // "chips.remove": "Remove chip",
+  "chips.remove": "Odstrániť čip",
+
+  // "claimed-approved-search-result-list-element.title": "Approved",
+  "claimed-approved-search-result-list-element.title": "Schválené",
+
+  // "claimed-declined-search-result-list-element.title": "Rejected, sent back to submitter",
+  "claimed-declined-search-result-list-element.title": "Zamietnuté, poslané späť odosielateľovi",
+
+  // "claimed-declined-task-search-result-list-element.title": "Declined, sent back to Review Manager's workflow",
+  "claimed-declined-task-search-result-list-element.title": "Zamietnuté, poslané späť do workflow správcu posudzovania",
+
+  // "collection.create.breadcrumbs": "Create collection",
+  "collection.create.breadcrumbs": "Vytvoriť kolekciu",
+
+  // "collection.browse.logo": "Browse for a collection logo",
+  "collection.browse.logo": "Vybrať logo kolekcie",
+
+  // "collection.create.head": "Create a Collection",
+  "collection.create.head": "Vytvoriť kolekciu",
+
+  // "collection.create.notifications.success": "Successfully created the collection",
+  "collection.create.notifications.success": "Kolekcia bola úspešne vytvorená",
+
+  // "collection.create.sub-head": "Create a Collection for Community {{ parent }}",
+  "collection.create.sub-head": "Vytvoriť kolekciu pre komunitu {{ parent }}",
+
+  // "collection.curate.header": "Curate Collection: {{collection}}",
+  "collection.curate.header": "Spravovať kolekciu: {{collection}}",
+
+  // "collection.delete.cancel": "Cancel",
+  "collection.delete.cancel": "Zrušiť",
+
+  // "collection.delete.confirm": "Confirm",
+  "collection.delete.confirm": "Potvrdiť",
+
+  // "collection.delete.processing": "Deleting",
+  "collection.delete.processing": "Odstraňuje sa",
+
+  // "collection.delete.head": "Delete Collection",
+  "collection.delete.head": "Odstrániť kolekciu",
+
+  // "collection.delete.notification.fail": "Collection could not be deleted",
+  "collection.delete.notification.fail": "Kolekciu sa nepodarilo odstrániť",
+
+  // "collection.delete.notification.success": "Successfully started a process to delete this collection",
+  "collection.delete.notification.success": "Úspešne spustený proces na odstránenie tejto kolekcie",
+
+  // "collection.delete.text": "Are you sure you want to delete collection \"{{ dso }}\"",
+  "collection.delete.text": "Naozaj chcete odstrániť kolekciu \"{{ dso }}\"",
+
+  // "collection.edit.delete": "Delete this collection",
+  "collection.edit.delete": "Odstrániť túto kolekciu",
+
+  // "collection.edit.head": "Edit Collection",
+  "collection.edit.head": "Upraviť kolekciu",
+
+  // "collection.edit.breadcrumbs": "Edit Collection",
+  "collection.edit.breadcrumbs": "Upraviť kolekciu",
+
+  // "collection.edit.tabs.mapper.head": "Item Mapper",
+  "collection.edit.tabs.mapper.head": "Mapovač záznamov",
+
+  // "collection.edit.tabs.item-mapper.title": "Collection Edit - Item Mapper",
+  "collection.edit.tabs.item-mapper.title": "Úprava kolekcie – Mapovač záznamov",
+
+  // "collection.edit.item-mapper.cancel": "Cancel",
+  "collection.edit.item-mapper.cancel": "Zrušiť",
+
+  // "collection.edit.item-mapper.collection": "Collection: \"<b>{{name}}</b>\"",
+  "collection.edit.item-mapper.collection": "Kolekcia: \"<b>{{name}}</b>\"",
+
+  // "collection.edit.item-mapper.confirm": "Map selected items",
+  "collection.edit.item-mapper.confirm": "Mapovať vybrané záznamy",
+
+  // "collection.edit.item-mapper.description": "This is the item mapper tool that allows collection administrators to map items from other collections into this collection. You can search for items from other collections and map them, or browse the list of currently mapped items.",
+  "collection.edit.item-mapper.description": "Toto je nástroj na mapovanie záznamov, ktorý umožňuje správcom kolekcií mapovať záznamy z iných kolekcií do tejto kolekcie. Môžete vyhľadávať záznamy z iných kolekcií a mapovať ich alebo prehliadať zoznam aktuálne mapovaných záznamov.",
+
+  // "collection.edit.item-mapper.head": "Item Mapper - Map Items from Other Collections",
+  "collection.edit.item-mapper.head": "Mapovač záznamov – Mapovanie záznamov z iných kolekcií",
+
+  // "collection.edit.item-mapper.no-search": "Please enter a query to search",
+  "collection.edit.item-mapper.no-search": "Zadajte prosím dopyt na vyhľadávanie",
+
+  // "collection.edit.item-mapper.notifications.map.error.content": "Errors occurred for mapping of {{amount}} items.",
+  "collection.edit.item-mapper.notifications.map.error.content": "Pri mapovaní {{amount}} záznamov došlo k chybám.",
+
+  // "collection.edit.item-mapper.notifications.map.error.head": "Mapping errors",
+  "collection.edit.item-mapper.notifications.map.error.head": "Chyby pri mapovaní",
+
+  // "collection.edit.item-mapper.notifications.map.success.content": "Successfully mapped {{amount}} items.",
+  "collection.edit.item-mapper.notifications.map.success.content": "Úspešne namapovaných {{amount}} záznamov.",
+
+  // "collection.edit.item-mapper.notifications.map.success.head": "Mapping completed",
+  "collection.edit.item-mapper.notifications.map.success.head": "Mapovanie dokončené",
+
+  // "collection.edit.item-mapper.notifications.unmap.error.content": "Errors occurred for removing the mappings of {{amount}} items.",
+  "collection.edit.item-mapper.notifications.unmap.error.content": "Pri odstraňovaní mapovania {{amount}} záznamov došlo k chybám.",
+
+  // "collection.edit.item-mapper.notifications.unmap.error.head": "Remove mapping errors",
+  "collection.edit.item-mapper.notifications.unmap.error.head": "Chyby pri odstraňovaní mapovania",
+
+  // "collection.edit.item-mapper.notifications.unmap.success.content": "Successfully removed the mappings of {{amount}} items.",
+  "collection.edit.item-mapper.notifications.unmap.success.content": "Úspešne odstránené mapovanie {{amount}} záznamov.",
+
+  // "collection.edit.item-mapper.notifications.unmap.success.head": "Remove mapping completed",
+  "collection.edit.item-mapper.notifications.unmap.success.head": "Odstránenie mapovania dokončené",
+
+  // "collection.edit.item-mapper.remove": "Remove selected item mappings",
+  "collection.edit.item-mapper.remove": "Odstrániť vybrané mapovania záznamov",
+
+  // "collection.edit.item-mapper.search-form.placeholder": "Search items...",
+  "collection.edit.item-mapper.search-form.placeholder": "Hľadať záznamy...",
+
+  // "collection.edit.item-mapper.tabs.browse": "Browse mapped items",
+  "collection.edit.item-mapper.tabs.browse": "Prehliadať mapované záznamy",
+
+  // "collection.edit.item-mapper.tabs.map": "Map new items",
+  "collection.edit.item-mapper.tabs.map": "Mapovať nové záznamy",
+
+  // "collection.edit.logo.delete.title": "Delete logo",
+  "collection.edit.logo.delete.title": "Odstrániť logo",
+
+  // "collection.edit.logo.delete-undo.title": "Undo delete",
+  "collection.edit.logo.delete-undo.title": "Vrátiť odstránenie",
+
+  // "collection.edit.logo.label": "Collection logo",
+  "collection.edit.logo.label": "Logo kolekcie",
+
+  // "collection.edit.logo.notifications.add.error": "Uploading collection logo failed. Please verify the content before retrying.",
+  "collection.edit.logo.notifications.add.error": "Nahranie loga kolekcie zlyhalo. Pred ďalším pokusom overte obsah.",
+
+  // "collection.edit.logo.notifications.add.success": "Uploading collection logo successful.",
+  "collection.edit.logo.notifications.add.success": "Nahranie loga kolekcie prebehlo úspešne.",
+
+  // "collection.edit.logo.notifications.delete.success.title": "Logo deleted",
+  "collection.edit.logo.notifications.delete.success.title": "Logo odstránené",
+
+  // "collection.edit.logo.notifications.delete.success.content": "Successfully deleted the collection's logo",
+  "collection.edit.logo.notifications.delete.success.content": "Logo kolekcie bolo úspešne odstránené",
+
+  // "collection.edit.logo.notifications.delete.error.title": "Error deleting logo",
+  "collection.edit.logo.notifications.delete.error.title": "Chyba pri odstraňovaní loga",
+
+  // "collection.edit.logo.upload": "Drop a collection logo to upload",
+  "collection.edit.logo.upload": "Presuňte sem logo kolekcie na nahranie",
+
+  // "collection.edit.notifications.success": "Successfully edited the collection",
+  "collection.edit.notifications.success": "Kolekcia bola úspešne upravená",
+
+  // "collection.edit.return": "Back",
+  "collection.edit.return": "Späť",
+
+  // "collection.edit.tabs.access-control.head": "Access Control",
+  "collection.edit.tabs.access-control.head": "Riadenie prístupu",
+
+  // "collection.edit.tabs.access-control.title": "Collection Edit - Access Control",
+  "collection.edit.tabs.access-control.title": "Úprava kolekcie – Riadenie prístupu",
+
+  // "collection.edit.tabs.curate.head": "Curate",
+  "collection.edit.tabs.curate.head": "Spravovať",
+
+  // "collection.edit.tabs.curate.title": "Collection Edit - Curate",
+  "collection.edit.tabs.curate.title": "Úprava kolekcie – Spravovať",
+
+  // "collection.edit.tabs.authorizations.head": "Authorizations",
+  "collection.edit.tabs.authorizations.head": "Oprávnenia",
+
+  // "collection.edit.tabs.authorizations.title": "Collection Edit - Authorizations",
+  "collection.edit.tabs.authorizations.title": "Úprava kolekcie – Oprávnenia",
+
+  // "collection.edit.item.authorizations.load-bundle-button": "Load more bundles",
+  "collection.edit.item.authorizations.load-bundle-button": "Načítať ďalšie zväzky",
+
+  // "collection.edit.item.authorizations.load-more-button": "Load more",
+  "collection.edit.item.authorizations.load-more-button": "Načítať ďalšie",
+
+  // "collection.edit.item.authorizations.show-bitstreams-button": "Show bitstream policies for bundle",
+  "collection.edit.item.authorizations.show-bitstreams-button": "Zobraziť pravidlá súborov pre zväzok",
+
+  // "collection.edit.tabs.metadata.head": "Edit Metadata",
+  "collection.edit.tabs.metadata.head": "Upraviť metadáta",
+
+  // "collection.edit.tabs.metadata.title": "Collection Edit - Metadata",
+  "collection.edit.tabs.metadata.title": "Úprava kolekcie – Metadáta",
+
+  // "collection.edit.tabs.roles.head": "Assign Roles",
+  "collection.edit.tabs.roles.head": "Prideliť role",
+
+  // "collection.edit.tabs.roles.title": "Collection Edit - Roles",
+  "collection.edit.tabs.roles.title": "Úprava kolekcie – Role",
+
+  // "collection.edit.tabs.source.external": "This collection harvests its content from an external source",
+  "collection.edit.tabs.source.external": "Táto kolekcia získava svoj obsah z externého zdroja",
+
+  // "collection.edit.tabs.source.form.errors.oaiSource.required": "You must provide a set id of the target collection.",
+  "collection.edit.tabs.source.form.errors.oaiSource.required": "Musíte zadať id cieľovej kolekcie.",
+
+  // "collection.edit.tabs.source.form.harvestType": "Content being harvested",
+  "collection.edit.tabs.source.form.harvestType": "Zbieraný obsah",
+
+  // "collection.edit.tabs.source.form.head": "Configure an external source",
+  "collection.edit.tabs.source.form.head": "Konfigurácia externého zdroja",
+
+  // "collection.edit.tabs.source.form.metadataConfigId": "Metadata Format",
+  "collection.edit.tabs.source.form.metadataConfigId": "Formát metadát",
+
+  // "collection.edit.tabs.source.form.oaiSetId": "OAI specific set id",
+  "collection.edit.tabs.source.form.oaiSetId": "OAI id konkrétnej množiny",
+
+  // "collection.edit.tabs.source.form.oaiSource": "OAI Provider",
+  "collection.edit.tabs.source.form.oaiSource": "Poskytovateľ OAI",
+
+  // "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_BITSTREAMS": "Harvest metadata and bitstreams (requires ORE support)",
+  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_BITSTREAMS": "Zbierať metadáta a súbory (vyžaduje podporu ORE)",
+
+  // "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_REF": "Harvest metadata and references to bitstreams (requires ORE support)",
+  "collection.edit.tabs.source.form.options.harvestType.METADATA_AND_REF": "Zbierať metadáta a odkazy na súbory (vyžaduje podporu ORE)",
+
+  // "collection.edit.tabs.source.form.options.harvestType.METADATA_ONLY": "Harvest metadata only",
+  "collection.edit.tabs.source.form.options.harvestType.METADATA_ONLY": "Zbierať iba metadáta",
+
+  // "collection.edit.tabs.source.head": "Content Source",
+  "collection.edit.tabs.source.head": "Zdroj obsahu",
+
+  // "collection.edit.tabs.source.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  "collection.edit.tabs.source.notifications.discarded.content": "Vaše zmeny boli zahodené. Na obnovenie zmien kliknite na tlačidlo „Vrátiť zmeny“",
+
+  // "collection.edit.tabs.source.notifications.discarded.title": "Changes discarded",
+  "collection.edit.tabs.source.notifications.discarded.title": "Zmeny zahodené",
+
+  // "collection.edit.tabs.source.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  "collection.edit.tabs.source.notifications.invalid.content": "Vaše zmeny neboli uložené. Pred uložením sa prosím uistite, že všetky polia sú platné.",
+
+  // "collection.edit.tabs.source.notifications.invalid.title": "Metadata invalid",
+  "collection.edit.tabs.source.notifications.invalid.title": "Neplatné metadáta",
+
+  // "collection.edit.tabs.source.notifications.saved.content": "Your changes to this collection's content source were saved.",
+  "collection.edit.tabs.source.notifications.saved.content": "Vaše zmeny v zdroji obsahu tejto kolekcie boli uložené.",
+
+  // "collection.edit.tabs.source.notifications.saved.title": "Content Source saved",
+  "collection.edit.tabs.source.notifications.saved.title": "Zdroj obsahu uložený",
+
+  // "collection.edit.tabs.source.title": "Collection Edit - Content Source",
+  "collection.edit.tabs.source.title": "Úprava kolekcie – Zdroj obsahu",
+
+  // "collection.edit.template.add-button": "Add",
+  "collection.edit.template.add-button": "Pridať",
+
+  // "collection.edit.template.breadcrumbs": "Item template",
+  "collection.edit.template.breadcrumbs": "Šablóna záznamu",
+
+  // "collection.edit.template.cancel": "Cancel",
+  "collection.edit.template.cancel": "Zrušiť",
+
+  // "collection.edit.template.delete-button": "Delete",
+  "collection.edit.template.delete-button": "Odstrániť",
+
+  // "collection.edit.template.edit-button": "Edit",
+  "collection.edit.template.edit-button": "Upraviť",
+
+  // "collection.edit.template.error": "An error occurred retrieving the template item",
+  "collection.edit.template.error": "Pri načítaní šablóny záznamu došlo k chybe",
+
+  // "collection.edit.template.head": "Edit Template Item for Collection \"{{ collection }}\"",
+  "collection.edit.template.head": "Upraviť šablónu záznamu pre kolekciu \"{{ collection }}\"",
+
+  // "collection.edit.template.label": "Template item",
+  "collection.edit.template.label": "Šablóna záznamu",
+
+  // "collection.edit.template.loading": "Loading template item...",
+  "collection.edit.template.loading": "Načítava sa šablóna záznamu...",
+
+  // "collection.edit.template.notifications.delete.error": "Failed to delete the item template",
+  "collection.edit.template.notifications.delete.error": "Nepodarilo sa odstrániť šablónu záznamu",
+
+  // "collection.edit.template.notifications.delete.success": "Successfully deleted the item template",
+  "collection.edit.template.notifications.delete.success": "Šablóna záznamu bola úspešne odstránená",
+
+  // "collection.edit.template.title": "Edit Template Item",
+  "collection.edit.template.title": "Upraviť šablónu záznamu",
+
+  // "collection.form.abstract": "Short Description",
+  "collection.form.abstract": "Krátky popis",
+
+  // "collection.form.description": "Introductory text (HTML)",
+  "collection.form.description": "Úvodný text (HTML)",
+
+  // "collection.form.errors.title.required": "Please enter a collection name",
+  "collection.form.errors.title.required": "Zadajte prosím názov kolekcie",
+
+  // "collection.form.errors.submissionDefinition.required": "Please choose a submission definition for this collection",
+  "collection.form.errors.submissionDefinition.required": "Zvoľte prosím definíciu vkladania pre túto kolekciu",
+
+  // "collection.form.errors.entityType.required": "Please choose an entity type for this collection",
+  "collection.form.errors.entityType.required": "Zvoľte prosím typ entity pre túto kolekciu",
+
+  // "collection.form.license": "License",
+  "collection.form.license": "Licencia",
+
+  // "collection.form.provenance": "Provenance",
+  "collection.form.provenance": "Pôvod",
+
+  // "collection.form.rights": "Copyright text (HTML)",
+  "collection.form.rights": "Text autorských práv (HTML)",
+
+  // "collection.form.sharedWorkspace": "Shared workspace",
+  "collection.form.sharedWorkspace": "Zdieľaný pracovný priestor",
+
+  // "collection.form.tableofcontents": "News (HTML)",
+  "collection.form.tableofcontents": "Novinky (HTML)",
+
+  // "collection.form.title": "Name",
+  "collection.form.title": "Názov",
+
+  // "collection.form.entityType": "Entity Type",
+  "collection.form.entityType": "Typ entity",
+
+  // "collection.form.submissionDefinition": "Submission definition",
+  "collection.form.submissionDefinition": "Definícia vkladania",
+
+  // "collection.form.correctionSubmissionDefinition": "Submission definition for correction request",
+  "collection.form.correctionSubmissionDefinition": "Definícia vkladania pre žiadosť o opravu",
+
+
+
+  // "collection.listelement.badge": "Collection",
+  "collection.listelement.badge": "Kolekcia",
+
+  // "collection.logo": "Collection logo",
+  "collection.logo": "Logo kolekcie",
+
+  // "collection.page.browse.search.head": "Search",
+  "collection.page.browse.search.head": "Hľadať",
+
+  // "collection.page.edit": "Edit this collection",
+  "collection.page.edit": "Upraviť túto kolekciu",
+
+  // "collection.page.handle": "Permanent URI for this collection",
+  "collection.page.handle": "Trvalá URI pre túto kolekciu",
+
+  // "collection.page.license": "License",
+  "collection.page.license": "Licencia",
+
+  // "collection.page.news": "News",
+  "collection.page.news": "Novinky",
+
+  // "collection.page.options": "Options",
+  "collection.page.options": "Možnosti",
+
+  // "collection.search.breadcrumbs": "Search",
+  "collection.search.breadcrumbs": "Hľadať",
+
+  // "collection.search.results.head": "Search Results",
+  "collection.search.results.head": "Výsledky vyhľadávania",
+
+  // "collection.select.confirm": "Confirm selected",
+  "collection.select.confirm": "Potvrdiť vybrané",
+
+  // "collection.select.empty": "No collections to show",
+  "collection.select.empty": "Žiadne kolekcie na zobrazenie",
+
+  // "collection.select.table.selected": "Selected collections",
+  "collection.select.table.selected": "Vybrané kolekcie",
+
+  // "collection.select.table.select": "Select collection",
+  "collection.select.table.select": "Vybrať kolekciu",
+
+  // "collection.select.table.deselect": "Deselect collection",
+  "collection.select.table.deselect": "Zrušiť výber kolekcie",
+
+  // "collection.select.table.title": "Title",
+  "collection.select.table.title": "Názov",
+
+  // "collection.source.controls.head": "Harvest Controls",
+  "collection.source.controls.head": "Ovládanie zberu",
+
+  // "collection.source.controls.test.submit.error": "Something went wrong with initiating the testing of the settings",
+  "collection.source.controls.test.submit.error": "Pri spúšťaní testovania nastavení sa niečo pokazilo",
+
+  // "collection.source.controls.test.failed": "The script to test the settings has failed",
+  "collection.source.controls.test.failed": "Skript na testovanie nastavení zlyhal",
+
+  // "collection.source.controls.test.completed": "The script to test the settings has successfully finished",
+  "collection.source.controls.test.completed": "Skript na testovanie nastavení bol úspešne dokončený",
+
+  // "collection.source.controls.test.submit": "Test configuration",
+  "collection.source.controls.test.submit": "Otestovať konfiguráciu",
+
+  // "collection.source.controls.test.running": "Testing configuration...",
+  "collection.source.controls.test.running": "Testuje sa konfigurácia...",
+
+  // "collection.source.controls.import.submit.success": "The import has been successfully initiated",
+  "collection.source.controls.import.submit.success": "Import bol úspešne spustený",
+
+  // "collection.source.controls.import.submit.error": "Something went wrong with initiating the import",
+  "collection.source.controls.import.submit.error": "Pri spúšťaní importu sa niečo pokazilo",
+
+  // "collection.source.controls.import.submit": "Import now",
+  "collection.source.controls.import.submit": "Importovať teraz",
+
+  // "collection.source.controls.import.running": "Importing...",
+  "collection.source.controls.import.running": "Importuje sa...",
+
+  // "collection.source.controls.import.failed": "An error occurred during the import",
+  "collection.source.controls.import.failed": "Počas importu došlo k chybe",
+
+  // "collection.source.controls.import.completed": "The import completed",
+  "collection.source.controls.import.completed": "Import bol dokončený",
+
+  // "collection.source.controls.reset.submit.success": "The reset and reimport has been successfully initiated",
+  "collection.source.controls.reset.submit.success": "Reset a opätovný import boli úspešne spustené",
+
+  // "collection.source.controls.reset.submit.error": "Something went wrong with initiating the reset and reimport",
+  "collection.source.controls.reset.submit.error": "Pri spúšťaní resetu a opätovného importu sa niečo pokazilo",
+
+  // "collection.source.controls.reset.failed": "An error occurred during the reset and reimport",
+  "collection.source.controls.reset.failed": "Počas resetu a opätovného importu došlo k chybe",
+
+  // "collection.source.controls.reset.completed": "The reset and reimport completed",
+  "collection.source.controls.reset.completed": "Reset a opätovný import boli dokončené",
+
+  // "collection.source.controls.reset.submit": "Reset and reimport",
+  "collection.source.controls.reset.submit": "Reset a opätovný import",
+
+  // "collection.source.controls.reset.running": "Resetting and reimporting...",
+  "collection.source.controls.reset.running": "Prebieha reset a opätovný import...",
+
+  // "collection.source.controls.harvest.status": "Harvest status:",
+  "collection.source.controls.harvest.status": "Stav zberu:",
+
+  // "collection.source.controls.harvest.start": "Harvest start time:",
+  "collection.source.controls.harvest.start": "Čas začiatku zberu:",
+
+  // "collection.source.controls.harvest.last": "Last time harvested:",
+  "collection.source.controls.harvest.last": "Naposledy zbierané:",
+
+  // "collection.source.controls.harvest.message": "Harvest info:",
+  "collection.source.controls.harvest.message": "Informácie o zbere:",
+
+  // "collection.source.controls.harvest.no-information": "N/A",
+  "collection.source.controls.harvest.no-information": "Nie je k dispozícii",
+
+  // "collection.source.update.notifications.error.content": "The provided settings have been tested and didn't work.",
+  "collection.source.update.notifications.error.content": "Zadané nastavenia boli otestované a nefungovali.",
+
+  // "collection.source.update.notifications.error.title": "Server Error",
+  "collection.source.update.notifications.error.title": "Chyba servera",
+
+  // "communityList.breadcrumbs": "Community List",
+  "communityList.breadcrumbs": "Zoznam komunít",
+
+  // "communityList.tabTitle": "Community List",
+  "communityList.tabTitle": "Zoznam komunít",
+
+  // "communityList.title": "List of Communities",
+  "communityList.title": "Zoznam komunít",
+
+  // "communityList.showMore": "Show More",
+  "communityList.showMore": "Zobraziť viac",
+
+  // "communityList.expand": "Expand {{ name }}",
+  "communityList.expand": "Rozbaliť {{ name }}",
+
+  // "communityList.collapse": "Collapse {{ name }}",
+  "communityList.collapse": "Zbaliť {{ name }}",
+
+  // "community.browse.logo": "Browse for a community logo",
+  "community.browse.logo": "Vybrať logo komunity",
+
+  // "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
+  "community.subcoms-cols.breadcrumbs": "Podkomunity a kolekcie",
+
+  // "community.create.breadcrumbs": "Create Community",
+  "community.create.breadcrumbs": "Vytvoriť komunitu",
+
+  // "community.create.head": "Create a Community",
+  "community.create.head": "Vytvoriť komunitu",
+
+  // "community.create.notifications.success": "Successfully created the community",
+  "community.create.notifications.success": "Komunita bola úspešne vytvorená",
+
+  // "community.create.sub-head": "Create a Sub-Community for Community {{ parent }}",
+  "community.create.sub-head": "Vytvoriť podkomunitu v komunite {{ parent }}",
+
+  // "community.curate.header": "Curate Community: {{community}}",
+  "community.curate.header": "Spravovať komunitu: {{ community }}",
+
+  // "community.delete.cancel": "Cancel",
+  "community.delete.cancel": "Zrušiť",
+
+  // "community.delete.confirm": "Confirm",
+  "community.delete.confirm": "Potvrdiť",
+
+  // "community.delete.processing": "Deleting...",
+  "community.delete.processing": "Prebieha odstraňovanie...",
+
+  // "community.delete.head": "Delete Community",
+  "community.delete.head": "Odstrániť komunitu",
+
+  // "community.delete.notification.fail": "Community could not be deleted",
+  "community.delete.notification.fail": "Komunitu sa nepodarilo odstrániť",
+
+  // "community.delete.notification.success": "Successfully started a process to delete this community",
+  "community.delete.notification.success": "Úspešne spustený proces na odstránenie tejto komunity",
+
+  // "community.delete.text": "Are you sure you want to delete community \"{{ dso }}\"",
+  "community.delete.text": "Naozaj chcete odstrániť komunitu \"{{ dso }}\"",
+
+  // "community.edit.delete": "Delete this community",
+  "community.edit.delete": "Odstrániť túto komunitu",
+
+  // "community.edit.head": "Edit Community",
+  "community.edit.head": "Upraviť komunitu",
+
+  // "community.edit.breadcrumbs": "Edit Community",
+  "community.edit.breadcrumbs": "Upraviť komunitu",
+
+  // "community.edit.logo.delete.title": "Delete logo",
+  "community.edit.logo.delete.title": "Odstrániť logo",
+
+  // "community-collection.edit.logo.delete.title": "Confirm deletion",
+  "community-collection.edit.logo.delete.title": "Potvrdiť odstránenie",
+
+  // "community.edit.logo.delete-undo.title": "Undo delete",
+  "community.edit.logo.delete-undo.title": "Vrátiť odstránenie",
+
+  // "community-collection.edit.logo.delete-undo.title": "Undo delete",
+  "community-collection.edit.logo.delete-undo.title": "Vrátiť odstránenie",
+
+  // "community.edit.logo.label": "Community logo",
+  "community.edit.logo.label": "Logo komunity",
+
+  // "community.edit.logo.notifications.add.error": "Uploading community logo failed. Please verify the content before retrying.",
+  "community.edit.logo.notifications.add.error": "Nahranie loga komunity zlyhalo. Pred ďalším pokusom overte obsah.",
+
+  // "community.edit.logo.notifications.add.success": "Upload community logo successful.",
+  "community.edit.logo.notifications.add.success": "Nahranie loga komunity prebehlo úspešne.",
+
+  // "community.edit.logo.notifications.delete.success.title": "Logo deleted",
+  "community.edit.logo.notifications.delete.success.title": "Logo odstránené",
+
+  // "community.edit.logo.notifications.delete.success.content": "Successfully deleted the community's logo",
+  "community.edit.logo.notifications.delete.success.content": "Logo komunity bolo úspešne odstránené",
+
+  // "community.edit.logo.notifications.delete.error.title": "Error deleting logo",
+  "community.edit.logo.notifications.delete.error.title": "Chyba pri odstraňovaní loga",
+
+  // "community.edit.logo.upload": "Drop a community logo to upload",
+  "community.edit.logo.upload": "Presuňte sem logo komunity na nahranie",
+
+  // "community.edit.notifications.success": "Successfully edited the community",
+  "community.edit.notifications.success": "Komunita bola úspešne upravená",
+
+  // "community.edit.notifications.unauthorized": "You do not have privileges to make this change",
+  "community.edit.notifications.unauthorized": "Na vykonanie tejto zmeny nemáte oprávnenie",
+
+  // "community.edit.notifications.error": "An error occurred while editing the community",
+  "community.edit.notifications.error": "Pri úprave komunity došlo k chybe",
+
+  // "community.edit.return": "Back",
+  "community.edit.return": "Späť",
+
+  // "community.edit.tabs.curate.head": "Curate",
+  "community.edit.tabs.curate.head": "Spravovať",
+
+  // "community.edit.tabs.curate.title": "Community Edit - Curate",
+  "community.edit.tabs.curate.title": "Úprava komunity – Správa",
+
+  // "community.edit.tabs.access-control.head": "Access Control",
+  "community.edit.tabs.access-control.head": "Riadenie prístupu",
+
+  // "community.edit.tabs.access-control.title": "Community Edit - Access Control",
+  "community.edit.tabs.access-control.title": "Úprava komunity – Riadenie prístupu",
+
+  // "community.edit.tabs.metadata.head": "Edit Metadata",
+  "community.edit.tabs.metadata.head": "Upraviť metadáta",
+
+  // "community.edit.tabs.metadata.title": "Community Edit - Metadata",
+  "community.edit.tabs.metadata.title": "Úprava komunity – Metadáta",
+
+  // "community.edit.tabs.roles.head": "Assign Roles",
+  "community.edit.tabs.roles.head": "Prideliť role",
+
+  // "community.edit.tabs.roles.title": "Community Edit - Roles",
+  "community.edit.tabs.roles.title": "Úprava komunity – Role",
+
+  // "community.edit.tabs.authorizations.head": "Authorizations",
+  "community.edit.tabs.authorizations.head": "Oprávnenia",
+
+  // "community.edit.tabs.authorizations.title": "Community Edit - Authorizations",
+  "community.edit.tabs.authorizations.title": "Úprava komunity – Oprávnenia",
+
+  // "community.listelement.badge": "Community",
+  "community.listelement.badge": "Komunita",
+
+  // "community.logo": "Community logo",
+  "community.logo": "Logo komunity",
+
+  // "comcol-role.edit.no-group": "None",
+  "comcol-role.edit.no-group": "Žiadna skupina",
+
+  // "comcol-role.edit.create": "Create",
+  "comcol-role.edit.create": "Vytvoriť",
+
+  // "comcol-role.edit.create.error.title": "Failed to create a group for the '{{ role }}' role",
+  "comcol-role.edit.create.error.title": "Nepodarilo sa vytvoriť skupinu pre rolu '{{ role }}'",
+
+  // "comcol-role.edit.restrict": "Restrict",
+  "comcol-role.edit.restrict": "Obmedziť",
+
+  // "comcol-role.edit.delete": "Delete",
+  "comcol-role.edit.delete": "Odstrániť",
+
+  // "comcol-role.edit.delete.error.title": "Failed to delete the '{{ role }}' role's group",
+  "comcol-role.edit.delete.error.title": "Nepodarilo sa odstrániť skupinu pre rolu '{{ role }}'",
+
+  // "comcol-role.edit.delete.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "comcol-role.edit.delete.modal.header": "Odstrániť skupinu \"{{ dsoName }}\"",
+
+  // "comcol-role.edit.delete.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "comcol-role.edit.delete.modal.info": "Naozaj chcete odstrániť skupinu \"{{ dsoName }}\" a všetky súvisiace pravidlá?",
+
+  // "comcol-role.edit.delete.modal.cancel": "Cancel",
+  "comcol-role.edit.delete.modal.cancel": "Zrušiť",
+
+  // "comcol-role.edit.delete.modal.confirm": "Delete",
+  "comcol-role.edit.delete.modal.confirm": "Odstrániť",
+
+  // "comcol-role.edit.community-admin.name": "Administrators",
+  "comcol-role.edit.community-admin.name": "Správcovia",
+
+  // "comcol-role.edit.collection-admin.name": "Administrators",
+  "comcol-role.edit.collection-admin.name": "Správcovia",
+
+  // "comcol-role.edit.community-admin.description": "Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections. In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).",
+  "comcol-role.edit.community-admin.description": "Správcovia komunít môžu vytvárať podkomunity alebo kolekcie a spravovať alebo prideľovať správu týmto podkomunitám alebo kolekciám. Okrem toho rozhodujú o tom, kto môže vkladať záznamy do ktorýchkoľvek podkolekcií, upravovať metadáta záznamov (po vložení) a pridávať (mapovať) existujúce záznamy z iných kolekcií (na základe oprávnenia).",
+
+  // "comcol-role.edit.collection-admin.description": "Collection administrators decide who can submit items to the collection, edit item metadata (after submission), and add (map) existing items from other collections to this collection (subject to authorization for that collection).",
+  "comcol-role.edit.collection-admin.description": "Správcovia kolekcií rozhodujú o tom, kto môže vkladať záznamy do kolekcie, upravovať metadáta záznamov (po vložení) a pridávať (mapovať) existujúce záznamy z iných kolekcií do tejto kolekcie (na základe oprávnenia pre danú kolekciu).",
+
+  // "comcol-role.edit.submitters.name": "Submitters",
+  "comcol-role.edit.submitters.name": "Vkladatelia",
+
+  // "comcol-role.edit.submitters.description": "The E-People and Groups that have permission to submit new items to this collection.",
+  "comcol-role.edit.submitters.description": "Používatelia a skupiny, ktoré majú oprávnenie vkladať nové záznamy do tejto kolekcie.",
+
+  // "comcol-role.edit.item_read.name": "Default item read access",
+  "comcol-role.edit.item_read.name": "Predvolený prístup na čítanie záznamov",
+
+  // "comcol-role.edit.item_read.description": "E-People and Groups that can read new items submitted to this collection. Changes to this role are not retroactive. Existing items in the system will still be viewable by those who had read access at the time of their addition.",
+  "comcol-role.edit.item_read.description": "Používatelia a skupiny, ktoré môžu čítať nové záznamy vložené do tejto kolekcie. Zmeny tejto roly nie sú spätné. Existujúce záznamy v systéme budú naďalej viditeľné pre tých, ktorí mali prístup na čítanie v čase ich pridania.",
+
+  // "comcol-role.edit.item_read.anonymous-group": "Default read for incoming items is currently set to Anonymous.",
+  "comcol-role.edit.item_read.anonymous-group": "Predvolené čítanie prichádzajúcich záznamov je momentálne nastavené na Anonymný.",
+
+  // "comcol-role.edit.bitstream_read.name": "Default bitstream read access",
+  "comcol-role.edit.bitstream_read.name": "Predvolený prístup na čítanie súborov",
+
+  // "comcol-role.edit.bitstream_read.description": "E-People and Groups that can read new bitstreams submitted to this collection. Changes to this role are not retroactive. Existing bitstreams in the system will still be viewable by those who had read access at the time of their addition.",
+  "comcol-role.edit.bitstream_read.description": "Používatelia a skupiny, ktoré môžu čítať nové súbory vložené do tejto kolekcie. Zmeny tejto roly nie sú spätné. Existujúce súbory v systéme budú naďalej viditeľné pre tých, ktorí mali prístup na čítanie v čase ich pridania.",
+
+  // "comcol-role.edit.bitstream_read.anonymous-group": "Default read for incoming bitstreams is currently set to Anonymous.",
+  "comcol-role.edit.bitstream_read.anonymous-group": "Predvolené čítanie prichádzajúcich súborov je momentálne nastavené na Anonymný.",
+
+  // "comcol-role.edit.editor.name": "Editors",
+  "comcol-role.edit.editor.name": "Editori",
+
+  // "comcol-role.edit.editor.description": "Editors are able to edit the metadata of incoming submissions, and then accept or reject them.",
+  "comcol-role.edit.editor.description": "Editori môžu upravovať metadáta prichádzajúcich príspevkov a potom ich prijať alebo odmietnuť.",
+
+  // "comcol-role.edit.finaleditor.name": "Final editors",
+  "comcol-role.edit.finaleditor.name": "Finálni editori",
+
+  // "comcol-role.edit.finaleditor.description": "Final editors are able to edit the metadata of incoming submissions, but will not be able to reject them.",
+  "comcol-role.edit.finaleditor.description": "Finálni editori môžu upravovať metadáta prichádzajúcich príspevkov, ale nebudú ich môcť odmietnuť.",
+
+  // "comcol-role.edit.reviewer.name": "Reviewers",
+  "comcol-role.edit.reviewer.name": "Recenzenti",
+
+  // "comcol-role.edit.reviewer.description": "Reviewers are able to accept or reject incoming submissions. However, they are not able to edit the submission's metadata.",
+  "comcol-role.edit.reviewer.description": "Recenzenti môžu prijímať alebo odmietať prichádzajúce príspevky. Nemôžu však upravovať metadáta príspevku.",
+
+  // "comcol-role.edit.scorereviewers.name": "Score Reviewers",
+  "comcol-role.edit.scorereviewers.name": "Bodoví recenzenti",
+
+  // "comcol-role.edit.scorereviewers.description": "Reviewers are able to give a score to incoming submissions, this will define whether the submission will be rejected or not.",
+  "comcol-role.edit.scorereviewers.description": "Recenzenti môžu prideliť skóre prichádzajúcim príspevkom, čo určí, či bude príspevok zamietnutý alebo nie.",
+
+  // "community.form.abstract": "Short Description",
+  "community.form.abstract": "Krátky popis",
+
+  // "community.form.description": "Introductory text (HTML)",
+  "community.form.description": "Úvodný text (HTML)",
+
+  // "community.form.errors.title.required": "Please enter a community name",
+  "community.form.errors.title.required": "Zadajte názov komunity",
+
+  // "community.form.rights": "Copyright text (HTML)",
+  "community.form.rights": "Text autorských práv (HTML)",
+
+  // "community.form.tableofcontents": "News (HTML)",
+  "community.form.tableofcontents": "Novinky (HTML)",
+
+  // "community.form.title": "Name",
+  "community.form.title": "Názov",
+
+  // "community.page.edit": "Edit this community",
+  "community.page.edit": "Upraviť túto komunitu",
+
+  // "community.page.handle": "Permanent URI for this community",
+  "community.page.handle": "Trvalá URI pre túto komunitu",
+
+  // "community.page.license": "License",
+  "community.page.license": "Licencia",
+
+  // "community.page.news": "News",
+  "community.page.news": "Novinky",
+
+  // "community.page.options": "Options",
+  "community.page.options": "Možnosti",
+
+  // "community.all-lists.head": "Subcommunities and Collections",
+  "community.all-lists.head": "Podkomunity a kolekcie",
+
+  // "community.search.breadcrumbs": "Search",
+  "community.search.breadcrumbs": "Hľadať",
+
+  // "community.search.results.head": "Search Results",
+  "community.search.results.head": "Výsledky vyhľadávania",
+
+  // "community.sub-collection-list.head": "Collections in this community",
+  "community.sub-collection-list.head": "Kolekcie v tejto komunite",
+
+  // "community.sub-community-list.head": "Communities in this Community",
+  "community.sub-community-list.head": "Komunity v tejto komunite",
+
+  // "confirmation-modal.pending-changes.header": "Unsaved changes",
+  "confirmation-modal.pending-changes.header": "Neuložené zmeny",
+
+  // "confirmation-modal.pending-changes.info": "There are unsaved changes. Do you want to leave the page?",
+  "confirmation-modal.pending-changes.info": "Existujú neuložené zmeny. Chcete opustiť stránku?",
+
+  // "confirmation-modal.pending-changes.cancel": "Cancel",
+  "confirmation-modal.pending-changes.cancel": "Zrušiť",
+
+  // "confirmation-modal.pending-changes.confirm": "Leave",
+  "confirmation-modal.pending-changes.confirm": "Opustiť",
+
+  // "context-menu.actions.audit-item.btn": "Audit",
+  "context-menu.actions.audit-item.btn": "Audit",
+
+  // "context-menu.actions.subscription.frequency.required": "Please select a frequency",
+  "context-menu.actions.subscription.frequency.required": "Vyberte prosím frekvenciu",
+
+  // "cookies.consent.accept-all": "Accept all",
+  "cookies.consent.accept-all": "Prijať všetko",
+
+  // "cookies.consent.accept-selected": "Accept selected",
+  "cookies.consent.accept-selected": "Prijať vybrané",
+
+  // "cookies.consent.app.opt-out.description": "This app is loaded by default (but you can opt out)",
+  "cookies.consent.app.opt-out.description": "Táto aplikácia sa načíta v predvolenom nastavení (ale môžete sa odhlásiť)",
+
+  // "cookies.consent.app.opt-out.title": "(opt-out)",
+  "cookies.consent.app.opt-out.title": "(odhlásiť sa)",
+
+  // "cookies.consent.app.purpose": "purpose",
+  "cookies.consent.app.purpose": "účel",
+
+  // "cookies.consent.app.required.description": "This application is always required",
+  "cookies.consent.app.required.description": "Táto aplikácia je vždy vyžadovaná",
+
+  // "cookies.consent.app.required.title": "(always required)",
+  "cookies.consent.app.required.title": "(vždy vyžadované)",
+
+  // "cookies.consent.update": "There were changes since your last visit, please update your consent.",
+  "cookies.consent.update": "Od vašej poslednej návštevy došlo k zmenám, aktualizujte prosím svoj súhlas.",
+
+  // "cookies.consent.close": "Close",
+  "cookies.consent.close": "Zavrieť",
+
+  // "cookies.consent.decline": "Decline",
+  "cookies.consent.decline": "Odmietnuť",
+
+  // "cookies.consent.decline-all": "Decline all",
+  "cookies.consent.decline-all": "Odmietnuť všetko",
+
+  // "cookies.consent.ok": "That's ok",
+  "cookies.consent.ok": "V poriadku.",
+
+  // "cookies.consent.save": "Save",
+  "cookies.consent.save": "Uložiť",
+
+  // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
+  "cookies.consent.content-notice.description": "Zhromažďujeme a spracúvame vaše osobné údaje na tieto účely: {purposes}",
+
+  // "cookies.consent.content-notice.learnMore": "Customize",
+  "cookies.consent.content-notice.learnMore": "Prispôsobiť",
+
+  // "cookies.consent.content-modal.description": "Here you can see and customize the information that we collect about you.",
+  "cookies.consent.content-modal.description": "Tu môžete zobraziť a prispôsobiť informácie, ktoré o vás zhromažďujeme.",
+
+  // "cookies.consent.content-modal.privacy-policy.name": "privacy policy",
+  "cookies.consent.content-modal.privacy-policy.name": "zásady ochrany osobných údajov",
+
+  // "cookies.consent.content-modal.privacy-policy.text": "To learn more, please read our {privacyPolicy}.",
+  "cookies.consent.content-modal.privacy-policy.text": "Ak sa chcete dozvedieť viac, prečítajte si prosím naše {privacyPolicy}.",
+
+  // "cookies.consent.content-modal.no-privacy-policy.text": "",
+  "cookies.consent.content-modal.no-privacy-policy.text": "",
+
+  // "cookies.consent.content-modal.title": "Information that we collect",
+  "cookies.consent.content-modal.title": "Informácie, ktoré zhromažďujeme",
+
+  // "cookies.consent.app.title.accessibility": "Accessibility Settings",
+  "cookies.consent.app.title.accessibility": "Nastavenia prístupnosti",
+
+  // "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
+  "cookies.consent.app.description.accessibility": "Vyžadované na lokálne uloženie nastavení prístupnosti",
+
+  // "cookies.consent.app.title.authentication": "Authentication",
+  "cookies.consent.app.title.authentication": "Overovanie",
+
+  // "cookies.consent.app.description.authentication": "Required for signing you in",
+  "cookies.consent.app.description.authentication": "Vyžadované na vaše prihlásenie",
+
+  // "cookies.consent.app.title.correlation-id": "Correlation ID",
+  "cookies.consent.app.title.correlation-id": "ID korelácie",
+
+  // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
+  "cookies.consent.app.description.correlation-id": "Umožňuje nám sledovať vašu reláciu v protokoloch backendu na účely podpory/ladenia",
+
+  // "cookies.consent.app.title.preferences": "Preferences",
+  "cookies.consent.app.title.preferences": "Predvoľby",
+
+  // "cookies.consent.app.description.preferences": "Required for saving your preferences",
+  "cookies.consent.app.description.preferences": "Vyžadované na uloženie vašich predvolieb",
+
+  // "cookies.consent.app.title.acknowledgement": "Acknowledgement",
+  "cookies.consent.app.title.acknowledgement": "Potvrdenie",
+
+  // "cookies.consent.app.description.acknowledgement": "Required for saving your acknowledgements and consents",
+  "cookies.consent.app.description.acknowledgement": "Vyžadované na uloženie vašich potvrdení a súhlasov",
+
+  // "cookies.consent.app.title.google-analytics": "Google Analytics",
+  "cookies.consent.app.title.google-analytics": "Google Analytics",
+
+  // "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
+  "cookies.consent.app.description.google-analytics": "Umožňuje nám sledovať štatistické údaje",
+
+  // "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
+  "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
+
+  // "cookies.consent.app.description.google-recaptcha": "We use google reCAPTCHA service during registration and password recovery",
+  "cookies.consent.app.description.google-recaptcha": "Pri registrácii a obnove hesla používame službu Google reCAPTCHA",
+
+  // "cookies.consent.app.title.matomo": "Matomo",
+  "cookies.consent.app.title.matomo": "Matomo",
+
+  // "cookies.consent.app.description.matomo": "Allows us to track statistical data",
+  "cookies.consent.app.description.matomo": "Umožňuje nám sledovať štatistické údaje",
+
+  // "cookies.consent.purpose.functional": "Functional",
+  "cookies.consent.purpose.functional": "Funkčné",
+
+  // "cookies.consent.purpose.statistical": "Statistical",
+  "cookies.consent.purpose.statistical": "Štatistické",
+
+  // "cookies.consent.purpose.registration-password-recovery": "Registration and Password recovery",
+  "cookies.consent.purpose.registration-password-recovery": "Registrácia a obnova hesla",
+
+  // "cookies.consent.purpose.sharing": "Sharing",
+  "cookies.consent.purpose.sharing": "Zdieľanie",
+
+  // "curation-task.task.citationpage.label": "Generate Citation Page",
+  "curation-task.task.citationpage.label": "Vytvoriť stránku s citáciami",
+
+  // "curation-task.task.checklinks.label": "Check Links in Metadata",
+  "curation-task.task.checklinks.label": "Skontrolovať odkazy v metadátach",
+
+  // "curation-task.task.noop.label": "NOOP",
+  "curation-task.task.noop.label": "NOOP",
+
+  // "curation-task.task.profileformats.label": "Profile Bitstream Formats",
+  "curation-task.task.profileformats.label": "Profilovať formáty súborov",
+
+  // "curation-task.task.requiredmetadata.label": "Check for Required Metadata",
+  "curation-task.task.requiredmetadata.label": "Kontrola povinných metadát",
+
+  // "curation-task.task.translate.label": "Microsoft Translator",
+  "curation-task.task.translate.label": "Prekladač Microsoft",
+
+  // "curation-task.task.vscan.label": "Virus Scan",
+  "curation-task.task.vscan.label": "Antivírusová kontrola",
+
+  // "curation-task.task.registerdoi.label": "Register DOI",
+  "curation-task.task.registerdoi.label": "Zaregistrovať DOI",
+
+  // "curation.form.task-select.label": "Task:",
+  "curation.form.task-select.label": "Úloha:",
+
+  // "curation.form.submit": "Start",
+  "curation.form.submit": "Spustiť",
+
+  // "curation.form.submit.success.head": "The curation task has been started successfully",
+  "curation.form.submit.success.head": "Kurátorská úloha bola úspešne spustená",
+
+  // "curation.form.submit.success.content": "You will be redirected to the corresponding process page.",
+  "curation.form.submit.success.content": "Budete presmerovaní na príslušnú stránku procesu.",
+
+  // "curation.form.submit.error.head": "Running the curation task failed",
+  "curation.form.submit.error.head": "Spustenie kurátorskej úlohy zlyhalo.",
+
+  // "curation.form.submit.error.content": "An error occurred when trying to start the curation task.",
+  "curation.form.submit.error.content": "Pri pokuse o spustenie kurátorskej úlohy došlo k chybe.",
+
+  // "curation.form.submit.error.invalid-handle": "Couldn't determine the handle for this object",
+  "curation.form.submit.error.invalid-handle": "Nepodarilo sa určiť handle pre tento objekt",
+
+  // "curation.form.handle.label": "Handle:",
+  "curation.form.handle.label": "Handle:",
+
+  // "curation.form.handle.hint": "Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)",
+  "curation.form.handle.hint": "Rada: Zadajte [your-handle-prefix]/0 na spustenie úlohy na celom webe (nie všetky úlohy túto možnosť podporujú)",
+
+  // "deny-request-copy.email.message": "Dear {{ recipientName }},\nIn response to your request I regret to inform you that it's not possible to send you a copy of the file(s) you have requested, concerning the document: \"{{ itemUrl }}\" ({{ itemName }}), of which I am an author.\n\nBest regards,\n{{ authorName }} <{{ authorEmail }}>",
+  "deny-request-copy.email.message": "Vážený/á {{ recipientName }},\nv reakcii na Vašu žiadosť Vám, žiaľ, musím oznámiť, že nie je možné zaslať Vám kópiu súboru(ov), o ktorý(é) ste požiadali, týkajúcu(e) sa dokumentu: \"{{ itemUrl }}\" ({{ itemName }}), ktorého som autorom.\n\nS pozdravom,\n{{ authorName }} <{{ authorEmail }}>",
+
+  // "deny-request-copy.email.subject": "Request copy of document",
+  "deny-request-copy.email.subject": "Žiadosť o kópiu dokumentu",
+
+  // "deny-request-copy.error": "An error occurred",
+  "deny-request-copy.error": "Došlo k chybe",
+
+  // "deny-request-copy.header": "Deny document copy request",
+  "deny-request-copy.header": "Zamietnuť žiadosť o kópiu dokumentu",
+
+  // "deny-request-copy.intro": "This message will be sent to the applicant of the request",
+  "deny-request-copy.intro": "Táto správa bude zaslaná žiadateľovi o kópiu",
+
+  // "deny-request-copy.success": "Successfully denied item request",
+  "deny-request-copy.success": "Žiadosť o záznam bola úspešne zamietnutá",
+
+  // "dynamic-list.load-more": "Load more",
+  "dynamic-list.load-more": "Načítať ďalšie",
+
+  // "dropdown.clear": "Clear selection",
+  "dropdown.clear": "Vymazať výber",
+
+  // "dropdown.clear.tooltip": "Clear the selected option",
+  "dropdown.clear.tooltip": "Vymazať vybranú možnosť",
+
+  // "dso.name.untitled": "Untitled",
+  "dso.name.untitled": "Bez názvu",
+
+  // "dso.name.unnamed": "Unnamed",
+  "dso.name.unnamed": "Bez mena",
+
+  // "dso-selector.create.collection.head": "New collection",
+  "dso-selector.create.collection.head": "Nová kolekcia",
+
+  // "dso-selector.create.collection.sub-level": "Create a new collection in",
+  "dso-selector.create.collection.sub-level": "Vytvoriť novú kolekciu v",
+
+  // "dso-selector.create.community.head": "New community",
+  "dso-selector.create.community.head": "Nová komunita",
+
+  // "dso-selector.create.community.or-divider": "or",
+  "dso-selector.create.community.or-divider": "alebo",
+
+  // "dso-selector.create.community.sub-level": "Create a new community in",
+  "dso-selector.create.community.sub-level": "Vytvoriť novú komunitu v",
+
+  // "dso-selector.create.community.top-level": "Create a new top-level community",
+  "dso-selector.create.community.top-level": "Vytvoriť novú komunitu najvyššej úrovne",
+
+  // "dso-selector.create.item.head": "New item",
+  "dso-selector.create.item.head": "Nový záznam",
+
+  // "dso-selector.create.item.sub-level": "Create a new item in",
+  "dso-selector.create.item.sub-level": "Vytvoriť nový záznam v",
+
+  // "dso-selector.create.submission.head": "New submission",
+  "dso-selector.create.submission.head": "Nové vloženie",
+
+  // "dso-selector.edit.collection.head": "Edit collection",
+  "dso-selector.edit.collection.head": "Upraviť kolekciu",
+
+  // "dso-selector.edit.community.head": "Edit community",
+  "dso-selector.edit.community.head": "Upraviť komunitu",
+
+  // "dso-selector.edit.item.head": "Edit item",
+  "dso-selector.edit.item.head": "Upraviť záznam",
+
+  // "dso-selector.error.title": "An error occurred searching for a {{ type }}",
+  "dso-selector.error.title": "Pri hľadaní {{ type }} došlo k chybe",
+
+  // "dso-selector.export-metadata.dspaceobject.head": "Export metadata from",
+  "dso-selector.export-metadata.dspaceobject.head": "Exportovať metadáta z",
+
+  // "dso-selector.export-batch.dspaceobject.head": "Export Batch (ZIP) from",
+  "dso-selector.export-batch.dspaceobject.head": "Exportovať dávku (ZIP) z",
+
+  // "dso-selector.import-batch.dspaceobject.head": "Import batch from",
+  "dso-selector.import-batch.dspaceobject.head": "Importovať dávku z",
+
+  // "dso-selector.no-results": "No {{ type }} found",
+  "dso-selector.no-results": "Nenašiel sa žiadny {{ type }}",
+
+  // "dso-selector.placeholder": "Search for {{ type }}",
+  "dso-selector.placeholder": "Hľadať {{ type }}",
+
+  // "dso-selector.placeholder.type.community": "community",
+  "dso-selector.placeholder.type.community": "komunita",
+
+  // "dso-selector.placeholder.type.collection": "collection",
+  "dso-selector.placeholder.type.collection": "kolekcia",
+
+  // "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.item": "záznam",
+
+  // "dso-selector.select.collection.head": "Select a collection",
+  "dso-selector.select.collection.head": "Vyberte kolekciu",
+
+  // "dso-selector.set-scope.community.head": "Select a search scope",
+  "dso-selector.set-scope.community.head": "Vyberte rozsah vyhľadávania",
+
+  // "dso-selector.set-scope.community.button": "Search all of DSpace",
+  "dso-selector.set-scope.community.button": "Hľadať v celom DSpace",
+
+  // "dso-selector.set-scope.community.or-divider": "or",
+  "dso-selector.set-scope.community.or-divider": "alebo",
+
+  // "dso-selector.set-scope.community.input-header": "Search for a community or collection",
+  "dso-selector.set-scope.community.input-header": "Hľadať komunitu alebo kolekciu",
+
+  // "dso-selector.claim.item.head": "Profile tips",
+  "dso-selector.claim.item.head": "Tipy pre profil",
+
+  // "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
+  "dso-selector.claim.item.body": "Toto sú existujúce profily, ktoré s vami môžu súvisieť. Ak sa v niektorom z týchto profilov spoznávate, vyberte ho a na stránke s podrobnosťami medzi možnosťami zvoľte, že si ho chcete nárokovať. V opačnom prípade si môžete vytvoriť nový profil od začiatku pomocou tlačidla nižšie.",
+
+  // "dso-selector.claim.item.not-mine-label": "None of these are mine",
+  "dso-selector.claim.item.not-mine-label": "Žiadny z týchto záznamov nie je môj",
+
+  // "dso-selector.claim.item.create-from-scratch": "Create a new one",
+  "dso-selector.claim.item.create-from-scratch": "Vytvoriť nový",
+
+  // "dso-selector.results-could-not-be-retrieved": "Something went wrong, please refresh again ↻",
+  "dso-selector.results-could-not-be-retrieved": "Niečo sa pokazilo, skúste prosím načítať znova ↻",
+
+  // "supervision-group-selector.header": "Supervision Group Selector",
+  "supervision-group-selector.header": "Výber skupiny dohľadu",
+
+  // "supervision-group-selector.select.type-of-order.label": "Select a type of Order",
+  "supervision-group-selector.select.type-of-order.label": "Vyberte typ príkazu",
+
+  // "supervision-group-selector.select.type-of-order.option.none": "NONE",
+  "supervision-group-selector.select.type-of-order.option.none": "ŽIADNY",
+
+  // "supervision-group-selector.select.type-of-order.option.editor": "EDITOR",
+  "supervision-group-selector.select.type-of-order.option.editor": "EDITOR",
+
+  // "supervision-group-selector.select.type-of-order.option.observer": "OBSERVER",
+  "supervision-group-selector.select.type-of-order.option.observer": "OBSERVER",
+
+  // "supervision-group-selector.select.group.label": "Select a Group",
+  "supervision-group-selector.select.group.label": "Vyberte skupinu",
+
+  // "supervision-group-selector.button.cancel": "Cancel",
+  "supervision-group-selector.button.cancel": "Zrušiť",
+
+  // "supervision-group-selector.button.save": "Save",
+  "supervision-group-selector.button.save": "Uložiť",
+
+  // "supervision-group-selector.select.type-of-order.error": "Please select a type of order",
+  "supervision-group-selector.select.type-of-order.error": "Vyberte prosím typ príkazu",
+
+  // "supervision-group-selector.select.group.error": "Please select a group",
+  "supervision-group-selector.select.group.error": "Vyberte prosím skupinu",
+
+  // "supervision-group-selector.notification.create.success.title": "Successfully created supervision order for group {{ name }}",
+  "supervision-group-selector.notification.create.success.title": "Úspešne vytvorený príkaz dohľadu pre skupinu {{ name }}",
+
+  // "supervision-group-selector.notification.create.failure.title": "Error",
+  "supervision-group-selector.notification.create.failure.title": "Chyba",
+
+  // "supervision-group-selector.notification.create.already-existing": "A supervision order already exists on this item for selected group",
+  "supervision-group-selector.notification.create.already-existing": "Pre vybranú skupinu už na tomto zázname existuje príkaz dohľadu",
+
+  // "confirmation-modal.export-metadata.header": "Export metadata for {{ dsoName }}",
+  "confirmation-modal.export-metadata.header": "Exportovať metadáta pre {{ dsoName }}",
+
+  // "confirmation-modal.export-metadata.info": "Are you sure you want to export metadata for {{ dsoName }}",
+  "confirmation-modal.export-metadata.info": "Naozaj chcete exportovať metadáta pre {{ dsoName }}",
+
+  // "confirmation-modal.export-metadata.cancel": "Cancel",
+  "confirmation-modal.export-metadata.cancel": "Zrušiť",
+
+  // "confirmation-modal.export-metadata.confirm": "Export",
+  "confirmation-modal.export-metadata.confirm": "Exportovať",
+
+  // "confirmation-modal.export-batch.header": "Export batch (ZIP) for {{ dsoName }}",
+  "confirmation-modal.export-batch.header": "Exportovať dávku (ZIP) pre {{ dsoName }}",
+
+  // "confirmation-modal.export-batch.info": "Are you sure you want to export batch (ZIP) for {{ dsoName }}",
+  "confirmation-modal.export-batch.info": "Naozaj chcete exportovať dávku (ZIP) pre {{ dsoName }}",
+
+  // "confirmation-modal.export-batch.cancel": "Cancel",
+  "confirmation-modal.export-batch.cancel": "Zrušiť",
+
+  // "confirmation-modal.export-batch.confirm": "Export",
+  "confirmation-modal.export-batch.confirm": "Exportovať",
+
+  // "confirmation-modal.delete-eperson.header": "Delete EPerson \"{{ dsoName }}\"",
+  "confirmation-modal.delete-eperson.header": "Odstrániť používateľa \"{{ dsoName }}\"",
+
+  // "confirmation-modal.delete-eperson.info": "Are you sure you want to delete EPerson \"{{ dsoName }}\"",
+  "confirmation-modal.delete-eperson.info": "Naozaj chcete odstrániť používateľa \"{{ dsoName }}\"",
+
+  // "confirmation-modal.delete-eperson.cancel": "Cancel",
+  "confirmation-modal.delete-eperson.cancel": "Zrušiť",
+
+  // "confirmation-modal.delete-eperson.confirm": "Delete",
+  "confirmation-modal.delete-eperson.confirm": "Odstrániť",
+
+  // "confirmation-modal.delete-community-collection-logo.info": "Are you sure you want to delete the logo?",
+  "confirmation-modal.delete-community-collection-logo.info": "Naozaj chcete odstrániť logo?",
+
+  // "confirmation-modal.delete-profile.header": "Delete Profile",
+  "confirmation-modal.delete-profile.header": "Odstrániť profil",
+
+  // "confirmation-modal.delete-profile.info": "Are you sure you want to delete your profile",
+  "confirmation-modal.delete-profile.info": "Naozaj chcete odstrániť svoj profil",
+
+  // "confirmation-modal.delete-profile.cancel": "Cancel",
+  "confirmation-modal.delete-profile.cancel": "Zrušiť",
+
+  // "confirmation-modal.delete-profile.confirm": "Delete",
+  "confirmation-modal.delete-profile.confirm": "Odstrániť",
+
+  // "confirmation-modal.delete-subscription.header": "Delete Subscription",
+  "confirmation-modal.delete-subscription.header": "Zrušiť odber",
+
+  // "confirmation-modal.delete-subscription.info": "Are you sure you want to delete subscription for \"{{ dsoName }}\"",
+  "confirmation-modal.delete-subscription.info": "Naozaj chcete zrušiť odber pre \"{{ dsoName }}\"",
+
+  // "confirmation-modal.delete-subscription.cancel": "Cancel",
+  "confirmation-modal.delete-subscription.cancel": "Zrušiť",
+
+  // "confirmation-modal.delete-subscription.confirm": "Delete",
+  "confirmation-modal.delete-subscription.confirm": "Odstrániť",
+
+  // "confirmation-modal.review-account-info.header": "Save the changes",
+  "confirmation-modal.review-account-info.header": "Uložiť zmeny",
+
+  // "confirmation-modal.review-account-info.info": "Are you sure you want to save the changes to your profile",
+  "confirmation-modal.review-account-info.info": "Naozaj chcete uložiť zmeny svojho profilu",
+
+  // "confirmation-modal.review-account-info.cancel": "Cancel",
+  "confirmation-modal.review-account-info.cancel": "Zrušiť",
+
+  // "confirmation-modal.review-account-info.confirm": "Confirm",
+  "confirmation-modal.review-account-info.confirm": "Potvrdiť",
+
+  // "confirmation-modal.review-account-info.save": "Save",
+  "confirmation-modal.review-account-info.save": "Uložiť",
+
+  // "error.bitstream": "Error fetching bitstream",
+  "error.bitstream": "Chyba pri načítaní súboru",
+
+  // "error.browse-by": "Error fetching items",
+  "error.browse-by": "Chyba pri načítaní záznamov",
+
+  // "error.collection": "Error fetching collection",
+  "error.collection": "Chyba pri načítaní kolekcie",
+
+  // "error.collections": "Error fetching collections",
+  "error.collections": "Chyba pri načítaní kolekcií",
+
+  // "error.community": "Error fetching community",
+  "error.community": "Chyba pri načítaní komunity",
+
+  // "error.identifier": "No item found for the identifier",
+  "error.identifier": "Pre identifikátor sa nenašiel žiadny záznam",
+
+  // "error.default": "Error",
+  "error.default": "Chyba",
+
+  // "error.item": "Error fetching item",
+  "error.item": "Chyba pri načítaní záznamu",
+
+  // "error.custom-url-conflict.title": "Duplicate custom URL detected",
+  "error.custom-url-conflict.title": "Zistená duplicitná vlastná URL",
+
+  // "error.custom-url-conflict.description": "The custom URL \"{{customUrl}}\" is assigned to more than one item. This causes a conflict and the item cannot be displayed.",
+  "error.custom-url-conflict.description": "Vlastná URL \"{{customUrl}}\" je priradená k viac ako jednému záznamu. To spôsobuje konflikt a záznam nemožno zobraziť.",
+
+  // "error.custom-url-conflict.admin-action": "Please contact your repository administrator. The following affected items need their dspace.customurl metadata fixed so each value is unique:",
+  "error.custom-url-conflict.admin-action": "Kontaktujte prosím správcu vášho repozitára. Pri nasledujúcich dotknutých záznamoch je potrebné opraviť metadáta dspace.customurl tak, aby každá hodnota bola jedinečná:",
+
+  // "error.custom-url-conflict.edit-link": "Edit \"{{name}}\" ({{uuid}})",
+  "error.custom-url-conflict.edit-link": "Upraviť \"{{name}}\" ({{uuid}})",
+
+  // "error.custom-url-conflict.no-items-found": "No conflicting items could be retrieved. Please contact your administrator.",
+  "error.custom-url-conflict.no-items-found": "Nepodarilo sa načítať žiadne konfliktné záznamy. Kontaktujte prosím správcu.",
+
+  // "error.items": "Error fetching items",
+  "error.items": "Chyba pri načítaní záznamov",
+
+  // "error.objects": "Error fetching objects",
+  "error.objects": "Chyba pri načítaní objektov",
+
+  // "error.recent-submissions": "Error fetching recent submissions",
+  "error.recent-submissions": "Chyba pri načítaní nedávnych vložení",
+
+  // "error.profile-groups": "Error retrieving profile groups",
+  "error.profile-groups": "Chyba pri načítaní skupín profilov",
+
+  // "error.search-results": "Error fetching search results",
+  "error.search-results": "Chyba pri načítaní výsledkov vyhľadávania",
+
+  // "error.invalid-search-query": "Search query is not valid. Please check <a href=\"https://solr.apache.org/guide/query-syntax-and-parsing.html\" target=\"_blank\">Solr query syntax</a> best practices for further information about this error.",
+  "error.invalid-search-query": "Vyhľadávací dopyt nie je platný. Ďalšie informácie o tejto chybe nájdete v osvedčených postupoch <a href=\"https://solr.apache.org/guide/query-syntax-and-parsing.html\" target=\"_blank\">Solr query syntax</a>.",
+
+  // "error.sub-collections": "Error fetching sub-collections",
+  "error.sub-collections": "Chyba pri načítaní podkolekcií",
+
+  // "error.sub-communities": "Error fetching sub-communities",
+  "error.sub-communities": "Chyba pri načítaní podkomunít",
+
+  // "error.submission.sections.init-form-error": "An error occurred during section initialize, please check your input-form configuration. Details are below : <br> <br>",
+  "error.submission.sections.init-form-error": "Pri inicializácii sekcie došlo k chybe, skontrolujte prosím konfiguráciu vstupného formulára. Podrobnosti sú uvedené nižšie : <br> <br>",
+
+  // "error.top-level-communities": "Error fetching top-level communities",
+  "error.top-level-communities": "Chyba pri načítaní komunít najvyššej úrovne",
+
+  // "error.validation.license.required": "You must grant this license to complete your submission. If you are unable to grant this license at this time you may save your work and return later or remove the submission.",
+  "error.validation.license.required": "Na dokončenie vloženia musíte udeliť túto licenciu. Ak v tejto chvíli licenciu nemôžete udeliť, môžete svoju prácu uložiť a vrátiť sa neskôr alebo vloženie odstrániť.",
+
+  // "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
+  "error.validation.cclicense.required": "Na dokončenie vloženia musíte udeliť túto licenciu CC. Ak v tejto chvíli licenciu CC nemôžete udeliť, môžete svoju prácu uložiť a vrátiť sa neskôr alebo vloženie odstrániť.",
+
+  // "error.validation.custom-url.conflict": "The custom url has been already used, please try with a new one.",
+  "error.validation.custom-url.conflict": "Vlastná URL už bola použitá, skúste prosím inú.",
+
+  // "error.validation.custom-url.empty": "The custom url is required and cannot be empty.",
+  "error.validation.custom-url.empty": "Vlastná URL je povinná a nemôže byť prázdna.",
+
+  // "error.validation.custom-url.invalid-characters": "The custom url contains invalid characters. Only alphanumeric characters, dashes and underscores are supported.",
+  "error.validation.custom-url.invalid-characters": "Vlastná URL obsahuje neplatné znaky. Podporované sú iba alfanumerické znaky, pomlčky a podčiarkovníky.",
+
+  // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
+  "error.validation.pattern": "Toto zadanie je obmedzené aktuálnym vzorom: {{ pattern }}.",
+
+  // "error.validation.filerequired": "The file upload is mandatory",
+  "error.validation.filerequired": "Nahranie súboru je povinné",
+
+  // "error.validation.required": "This field is required",
+  "error.validation.required": "Toto pole je povinné",
+
+  // "error.validation.NotValidEmail": "This is not a valid email",
+  "error.validation.NotValidEmail": "Toto nie je platný e-mail",
+
+  // "error.validation.emailTaken": "This email is already taken",
+  "error.validation.emailTaken": "Tento e-mail je už obsadený",
+
+  // "error.validation.groupExists": "This group already exists",
+  "error.validation.groupExists": "Táto skupina už existuje",
+
+  // "error.validation.metadata.name.invalid-pattern": "This field cannot contain dots, commas or spaces. Please use the Element & Qualifier fields instead",
+  "error.validation.metadata.name.invalid-pattern": "Toto pole nesmie obsahovať bodky, čiarky ani medzery. Namiesto toho použite polia Prvok a Kvalifikátor",
+
+  // "error.validation.metadata.name.max-length": "This field may not contain more than 32 characters",
+  "error.validation.metadata.name.max-length": "Toto pole nesmie obsahovať viac ako 32 znakov",
+
+  // "error.validation.metadata.namespace.max-length": "This field may not contain more than 256 characters",
+  "error.validation.metadata.namespace.max-length": "Toto pole nesmie obsahovať viac ako 256 znakov",
+
+  // "error.validation.metadata.element.invalid-pattern": "This field cannot contain dots, commas or spaces. Please use the Qualifier field instead",
+  "error.validation.metadata.element.invalid-pattern": "Toto pole nesmie obsahovať bodky, čiarky ani medzery. Namiesto toho použite pole Kvalifikátor",
+
+  // "error.validation.metadata.element.max-length": "This field may not contain more than 64 characters",
+  "error.validation.metadata.element.max-length": "Toto pole nesmie obsahovať viac ako 64 znakov",
+
+  // "error.validation.metadata.qualifier.invalid-pattern": "This field cannot contain dots, commas or spaces",
+  "error.validation.metadata.qualifier.invalid-pattern": "Toto pole nesmie obsahovať bodky, čiarky ani medzery",
+
+  // "error.validation.metadata.qualifier.max-length": "This field may not contain more than 64 characters",
+  "error.validation.metadata.qualifier.max-length": "Toto pole nesmie obsahovať viac ako 64 znakov",
+
+  // "feed.description": "Syndication feed",
+  "feed.description": "Syndikačný kanál",
+
+  // "file-download-link.restricted": "Restricted bitstream",
+  "file-download-link.restricted": "Súbor s obmedzeným prístupom",
+
+  // "file-download-link.secure-access": "Restricted bitstream available via secure access token",
+  "file-download-link.secure-access": "Obmedzený súbor dostupný pomocou zabezpečeného prístupového tokenu",
+
+  // "file-section.error.header": "Error obtaining files for this item",
+  "file-section.error.header": "Chyba pri získavaní súborov pre tento záznam",
+
+  // "footer.copyright": "copyright © 2002-{{ year }}",
+  "footer.copyright": "copyright © 2002-{{ year }}",
+
+  // "footer.link.accessibility": "Accessibility settings",
+  "footer.link.accessibility": "Nastavenia prístupnosti",
+
+  // "footer.link.dspace": "DSpace software",
+  "footer.link.dspace": "DSpace software",
+
+  // "footer.link.lyrasis": "LYRASIS",
+  "footer.link.lyrasis": "LYRASIS",
+
+  // "footer.link.cookies": "Cookie settings",
+  "footer.link.cookies": "Nastavenia súborov cookie",
+
+  // "footer.link.privacy-policy": "Privacy policy",
+  "footer.link.privacy-policy": "Zásady ochrany osobných údajov",
+
+  // "footer.link.end-user-agreement": "End User Agreement",
+  "footer.link.end-user-agreement": "Zmluva s koncovým používateľom",
+
+  // "footer.link.feedback": "Send Feedback",
+  "footer.link.feedback": "Odoslať spätnú väzbu",
+
+  // "footer.link.coar-notify-support": "COAR Notify",
+  "footer.link.coar-notify-support": "COAR Notify",
+
+  // "forgot-email.form.header": "Forgot Password",
+  "forgot-email.form.header": "Zabudnuté heslo",
+
+  // "forgot-email.form.info": "Enter the email address associated with the account.",
+  "forgot-email.form.info": "Zadajte e-mailovú adresu priradenú k účtu.",
+
+  // "forgot-email.form.email": "Email Address *",
+  "forgot-email.form.email": "E-mailová adresa *",
+
+  // "forgot-email.form.email.error.required": "Please fill in an email address",
+  "forgot-email.form.email.error.required": "Vyplňte prosím e-mailovú adresu",
+
+  // "forgot-email.form.email.error.not-email-form": "Please fill in a valid email address",
+  "forgot-email.form.email.error.not-email-form": "Zadajte prosím platnú e-mailovú adresu",
+
+  // "forgot-email.form.email.hint": "An email will be sent to this address with a further instructions.",
+  "forgot-email.form.email.hint": "Na túto adresu bude zaslaný e-mail s ďalšími pokynmi.",
+
+  // "forgot-email.form.submit": "Reset password",
+  "forgot-email.form.submit": "Obnoviť heslo",
+
+  // "forgot-email.form.success.head": "Password reset email sent",
+  "forgot-email.form.success.head": "E-mail na obnovenie hesla odoslaný",
+
+  // "forgot-email.form.success.content": "An email has been sent to {{ email }} containing a special URL and further instructions.",
+  "forgot-email.form.success.content": "Na adresu {{ email }} bol odoslaný e-mail obsahujúci špeciálnu URL a ďalšie pokyny.",
+
+  // "forgot-email.form.error.head": "Error when trying to reset password",
+  "forgot-email.form.error.head": "Chyba pri pokuse o obnovenie hesla",
+
+  // "forgot-email.form.error.content": "An error occurred when attempting to reset the password for the account associated with the following email address: {{ email }}",
+  "forgot-email.form.error.content": "Pri pokuse o obnovenie hesla k účtu priradenému k nasledujúcej e-mailovej adrese došlo k chybe: {{ email }}",
+
+  // "forgot-password.title": "Forgot Password",
+  "forgot-password.title": "Zabudnuté heslo",
+
+  // "forgot-password.form.head": "Forgot Password",
+  "forgot-password.form.head": "Zabudnuté heslo",
+
+  // "forgot-password.form.info": "Enter a new password in the box below, and confirm it by typing it again into the second box.",
+  "forgot-password.form.info": "Zadajte nové heslo do poľa nižšie a potvrďte ho opätovným zadaním do druhého poľa.",
+
+  // "forgot-password.form.card.security": "Security",
+  "forgot-password.form.card.security": "Zabezpečenie",
+
+  // "forgot-password.form.identification.header": "Identify",
+  "forgot-password.form.identification.header": "Identifikácia",
+
+  // "forgot-password.form.identification.email": "Email address: ",
+  "forgot-password.form.identification.email": "E-mailová adresa: ",
+
+  // "forgot-password.form.label.password": "Password",
+  "forgot-password.form.label.password": "Heslo",
+
+  // "forgot-password.form.label.passwordrepeat": "Retype to confirm",
+  "forgot-password.form.label.passwordrepeat": "Zadajte znova pre potvrdenie",
+
+  // "forgot-password.form.error.empty-password": "Please enter a password in the boxes above.",
+  "forgot-password.form.error.empty-password": "Zadajte prosím heslo do polí vyššie.",
+
+  // "forgot-password.form.error.matching-passwords": "The passwords do not match.",
+  "forgot-password.form.error.matching-passwords": "Heslá sa nezhodujú.",
+
+  // "forgot-password.form.notification.error.title": "Error when trying to submit new password",
+  "forgot-password.form.notification.error.title": "Chyba pri pokuse o zadanie nového hesla",
+
+  // "forgot-password.form.notification.success.content": "The password reset was successful. You have been logged in as the created user.",
+  "forgot-password.form.notification.success.content": "Zmena hesla bola úspešná. Boli ste prihlásení ako vytvorený používateľ.",
+
+  // "forgot-password.form.notification.success.title": "Password reset completed",
+  "forgot-password.form.notification.success.title": "Obnovenie hesla bolo dokončené",
+
+  // "forgot-password.form.submit": "Submit password",
+  "forgot-password.form.submit": "Odoslať heslo",
+
+  // "form.add": "Add more",
+  "form.add": "Pridať ďalšie",
+
+  // "form.add-help": "Click here to add the current entry and to add another one",
+  "form.add-help": "Kliknutím sem pridáte aktuálny záznam a pridáte ďalší",
+
+  // "form.cancel": "Cancel",
+  "form.cancel": "Zrušiť",
+
+  // "form.clear": "Clear",
+  "form.clear": "Vymazať",
+
+  // "form.clear-help": "Click here to remove the selected value",
+  "form.clear-help": "Kliknutím sem odstránite vybranú hodnotu",
+
+  // "form.copy": "Duplicate",
+  "form.copy": "Duplikovať",
+
+  // "form.discard": "Discard",
+  "form.discard": "Zahodiť",
+
+  // "form.drag": "Drag",
+  "form.drag": "Presunúť",
+
+  // "form.edit": "Edit",
+  "form.edit": "Upraviť",
+
+  // "form.edit-help": "Click here to edit the selected value",
+  "form.edit-help": "Kliknutím sem upravíte vybranú hodnotu",
+
+  // "form.first-name": "First name",
+  "form.first-name": "Krstné meno",
+
+  // "form.group.add": "Add",
+  "form.group.add": "Pridať",
+
+  // "form.group.close": "Close",
+  "form.group.close": "Zavrieť",
+
+  // "form.group.set": "Set",
+  "form.group.set": "Nastaviť",
+
+  // "form.group-collapse": "Collapse",
+  "form.group-collapse": "Zbaliť",
+
+  // "form.group-collapse-help": "Click here to collapse",
+  "form.group-collapse-help": "Kliknutím sem zbalíte",
+
+  // "form.group-expand": "Expand",
+  "form.group-expand": "Rozbaliť",
+
+  // "form.group-expand-help": "Click here to expand and add more elements",
+  "form.group-expand-help": "Kliknutím sem rozbalíte a pridáte ďalšie prvky",
+
+  // "form.last-name": "Last name",
+  "form.last-name": "Priezvisko",
+
+  // "form.loading": "Loading...",
+  "form.loading": "Načítava sa...",
+
+  // "form.lookup": "Lookup",
+  "form.lookup": "Vyhľadať",
+
+  // "form.lookup-help": "Click here to look up an existing relation",
+  "form.lookup-help": "Kliknutím sem vyhľadáte existujúci vzťah",
+
+  // "form.no-results": "No results found",
+  "form.no-results": "Nenašli sa žiadne výsledky",
+
+  // "form.no-value": "No value entered",
+  "form.no-value": "Nebola zadaná žiadna hodnota",
+
+  // "form.other-information.email": "Email",
+  "form.other-information.email": "E-mail",
+
+  // "form.other-information.first-name": "First Name",
+  "form.other-information.first-name": "Meno",
+
+  // "form.other-information.insolr": "In Solr Index",
+  "form.other-information.insolr": "Zaindexované v Solr",
+
+  // "form.other-information.institution": "Institution",
+  "form.other-information.institution": "Inštitúcia",
+
+  // "form.other-information.last-name": "Last Name",
+  "form.other-information.last-name": "Priezvisko",
+
+  // "form.other-information.orcid": "ORCID",
+  "form.other-information.orcid": "ORCID",
+
+  // "form.other-information.oairecerif_author_affiliation": "Affiliation",
+  "form.other-information.oairecerif_author_affiliation": "Afiliácia",
+
+  // "form.other-information.oairecerif_editor_affiliation": "Affiliation",
+  "form.other-information.oairecerif_editor_affiliation": "Afiliácia",
+
+  // "form.other-information.person_identifier_orcid": "ORCID iD",
+  "form.other-information.person_identifier_orcid": "ORCID iD",
+
+  // "form.other-information.institution-affiliation-name": "Affiliation(s)",
+  "form.other-information.institution-affiliation-name": "Afiliácia(e)",
+
+  // "form.other-information.dc_relation_grantno": "Grant Number",
+  "form.other-information.dc_relation_grantno": "Číslo grantu",
+
+  // "form.other-information.not-available": "Not available",
+  "form.other-information.not-available": "Nie je k dispozícii",
+
+  // "form.other-information.ror_orgunit_id": "ROR ID",
+  "form.other-information.ror_orgunit_id": "ROR ID",
+
+  // "form.other-information.ror_orgunit_type": "ROR type",
+  "form.other-information.ror_orgunit_type": "Typ ROR",
+
+  // "form.other-information.ror_orgunit_acronym": "ROR acronym",
+  "form.other-information.ror_orgunit_acronym": "Skratka ROR",
+
+  // "form.other-information.ror_orgunit_countryName": "ROR country",
+  "form.other-information.ror_orgunit_countryName": "Krajina ROR",
+
+  // "form.entry.source.local": "",
+  "form.entry.source.local": "",
+
+  // "form.entry.source.orcid": "",
+  "form.entry.source.orcid": "",
+
+  // "form.entry.source.ror": "",
+  "form.entry.source.ror": "",
+
+  // "form.entry.source.openaire": "",
+  "form.entry.source.openaire": "",
+
+  // "form.entry.source.zdb": "",
+  "form.entry.source.zdb": "",
+
+  // "form.entry.source.jisc": "- Jisc Open policy finder",
+  "form.entry.source.jisc": "- Jisc Open policy finder",
+
+  // "form.remove": "Remove",
+  "form.remove": "Odstrániť",
+
+  // "form.save": "Save",
+  "form.save": "Uložiť",
+
+  // "form.save-help": "Save changes",
+  "form.save-help": "Uložiť zmeny",
+
+  // "form.search": "Search",
+  "form.search": "Hľadať",
+
+  // "form.search-help": "Click here to look for an existing correspondence",
+  "form.search-help": "Kliknutím sem vyhľadáte existujúcu zhodu",
+
+  // "form.submit": "Save",
+  "form.submit": "Uložiť",
+
+  // "form.create": "Create",
+  "form.create": "Vytvoriť",
+
+  // "form.number-picker.decrement": "Decrement {{field}}",
+  "form.number-picker.decrement": "Znížiť {{field}}",
+
+  // "form.number-picker.increment": "Increment {{field}}",
+  "form.number-picker.increment": "Zvýšiť {{field}}",
+
+  // "form.number-picker.label.Year": "Year",
+  "form.number-picker.label.Year": "Rok",
+
+  // "form.number-picker.label.Month": "Month",
+  "form.number-picker.label.Month": "Mesiac",
+
+  // "form.number-picker.label.Day": "Day",
+  "form.number-picker.label.Day": "Deň",
+
+  // "form.repeatable.sort.tip": "Drop the item in the new position",
+  "form.repeatable.sort.tip": "Presuňte záznam na novú pozíciu",
+
+  // "grant-deny-request-copy.deny": "Deny access request",
+  "grant-deny-request-copy.deny": "Zamietnuť žiadosť o prístup",
+
+  // "grant-deny-request-copy.revoke": "Revoke access",
+  "grant-deny-request-copy.revoke": "Zrušiť prístup",
+
+  // "grant-deny-request-copy.email.back": "Back",
+  "grant-deny-request-copy.email.back": "Späť",
+
+  // "grant-deny-request-copy.email.message": "Optional additional message",
+  "grant-deny-request-copy.email.message": "Voliteľná doplňujúca správa",
+
+  // "grant-deny-request-copy.email.message.empty": "Please enter a message",
+  "grant-deny-request-copy.email.message.empty": "Zadajte prosím správu",
+
+  // "grant-deny-request-copy.email.permissions.info": "You may use this occasion to reconsider the access restrictions on the document, to avoid having to respond to these requests. If you’d like to ask the repository administrators to remove these restrictions, please check the box below.",
+  "grant-deny-request-copy.email.permissions.info": "Pri tejto príležitosti môžete prehodnotiť obmedzenia prístupu k dokumentu, aby ste nemuseli na tieto žiadosti odpovedať. Ak chcete požiadať správcov repozitára o zrušenie týchto obmedzení, zaškrtnite prosím políčko nižšie.",
+
+  // "grant-deny-request-copy.email.permissions.label": "Change to open access",
+  "grant-deny-request-copy.email.permissions.label": "Zmeniť na otvorený prístup",
+
+  // "grant-deny-request-copy.email.send": "Send",
+  "grant-deny-request-copy.email.send": "Odoslať",
+
+  // "grant-deny-request-copy.email.subject": "Subject",
+  "grant-deny-request-copy.email.subject": "Predmet",
+
+  // "grant-deny-request-copy.email.subject.empty": "Please enter a subject",
+  "grant-deny-request-copy.email.subject.empty": "Zadajte prosím predmet správy",
+
+  // "grant-deny-request-copy.grant": "Grant access request",
+  "grant-deny-request-copy.grant": "Schváliť žiadosť o prístup",
+
+  // "grant-deny-request-copy.header": "Document copy request",
+  "grant-deny-request-copy.header": "Žiadosť o kópiu dokumentu",
+
+  // "grant-deny-request-copy.home-page": "Take me to the home page",
+  "grant-deny-request-copy.home-page": "Návrat na domovskú stránku",
+
+  // "grant-deny-request-copy.intro1": "If you are one of the authors of the document <a href='{{ url }}'>{{ name }}</a>, then please use one of the options below to respond to the user's request.",
+  "grant-deny-request-copy.intro1": "Ak ste jedným z autorov dokumentu <a href='{{ url }}'>{{ name }}</a>, použite prosím jednu z možností nižšie na odpoveď na žiadosť používateľa.",
+
+  // "grant-deny-request-copy.intro2": "After choosing an option, you will be presented with a suggested email reply which you may edit.",
+  "grant-deny-request-copy.intro2": "Po výbere možnosti sa zobrazí navrhovaná e-mailová odpoveď, ktorú môžete upraviť.",
+
+  // "grant-deny-request-copy.previous-decision": "This request was previously granted with a secure access token. You may revoke this access now to immediately invalidate the access token",
+  "grant-deny-request-copy.previous-decision": "Táto žiadosť bola predtým schválená pomocou zabezpečeného prístupového tokenu. Tento prístup môžete teraz zrušiť a okamžite zneplatniť prístupový token",
+
+  // "grant-deny-request-copy.processed": "This request has already been processed. You can use the button below to get back to the home page.",
+  "grant-deny-request-copy.processed": "Táto žiadosť už bola spracovaná. Na návrat na domovskú stránku môžete použiť tlačidlo nižšie.",
+
+  // "grant-request-copy.email.subject": "Request copy of document",
+  "grant-request-copy.email.subject": "Žiadosť o kópiu dokumentu",
+
+  // "grant-request-copy.error": "An error occurred",
+  "grant-request-copy.error": "Došlo k chybe",
+
+  // "grant-request-copy.header": "Grant document copy request",
+  "grant-request-copy.header": "Schváliť žiadosť o kópiu dokumentu",
+
+  // "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
+  "grant-request-copy.intro.attachment": "Žiadateľovi bude odoslaná správa. Požadované dokumenty budú priložené.",
+
+  // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
+  "grant-request-copy.intro.link": "Žiadateľovi bude odoslaná správa. Bude priložený zabezpečený odkaz poskytujúci prístup k požadovaným dokumentom. Odkaz bude poskytovať prístup po dobu zvolenú v ponuke „Doba prístupu“ nižšie.",
+
+  // "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
+  "grant-request-copy.intro.link.preview": "Nižšie je náhľad odkazu, ktorý bude odoslaný žiadateľovi:",
+
+  // "grant-request-copy.success": "Successfully granted item request",
+  "grant-request-copy.success": "Žiadosť o záznam bola úspešne schválená",
+
+  // "grant-request-copy.access-period.header": "Access period",
+  "grant-request-copy.access-period.header": "Doba prístupu",
+
+  // "grant-request-copy.access-period.+1DAY": "1 day",
+  "grant-request-copy.access-period.+1DAY": "1 deň",
+
+  // "grant-request-copy.access-period.+7DAYS": "1 week",
+  "grant-request-copy.access-period.+7DAYS": "1 týždeň",
+
+  // "grant-request-copy.access-period.+1MONTH": "1 month",
+  "grant-request-copy.access-period.+1MONTH": "1 mesiac",
+
+  // "grant-request-copy.access-period.+3MONTHS": "3 months",
+  "grant-request-copy.access-period.+3MONTHS": "3 mesiace",
+
+  // "grant-request-copy.access-period.FOREVER": "Forever",
+  "grant-request-copy.access-period.FOREVER": "Navždy",
+
+  // "health.breadcrumbs": "Health",
+  "health.breadcrumbs": "Stav systému",
+
+  // "health-page.heading": "Health",
+  "health-page.heading": "Stav systému",
+
+  // "health-page.info-tab": "Info",
+  "health-page.info-tab": "Informácie",
+
+  // "health-page.status-tab": "Status",
+  "health-page.status-tab": "Stav",
+
+  // "health-page.error.msg": "The health check service is temporarily unavailable",
+  "health-page.error.msg": "Služba kontroly stavu systému je momentálne nedostupná.",
+
+  // "health-page.property.status": "Status code",
+  "health-page.property.status": "Stavový kód",
+
+  // "health-page.section.db.title": "Database",
+  "health-page.section.db.title": "Databáza",
+
+  // "health-page.section.geoIp.title": "GeoIp",
+  "health-page.section.geoIp.title": "GeoIP",
+
+  // "health-page.section.solrAuthorityCore.title": "Solr: authority core",
+  "health-page.section.solrAuthorityCore.title": "Solr: authority core",
+
+  // "health-page.section.solrOaiCore.title": "Solr: oai core",
+  "health-page.section.solrOaiCore.title": "Solr: oai core",
+
+  // "health-page.section.solrSearchCore.title": "Solr: search core",
+  "health-page.section.solrSearchCore.title": "Solr: search core",
+
+  // "health-page.section.solrStatisticsCore.title": "Solr: statistics core",
+  "health-page.section.solrStatisticsCore.title": "Solr: statistics core",
+
+  // "health-page.section-info.app.title": "Application Backend",
+  "health-page.section-info.app.title": "Aplikačný server",
+
+  // "health-page.section-info.java.title": "Java",
+  "health-page.section-info.java.title": "Java",
+
+  // "health-page.status": "Status",
+  "health-page.status": "Stav",
+
+  // "health-page.status.ok.info": "Operational",
+  "health-page.status.ok.info": "Funkčné",
+
+  // "health-page.status.error.info": "Problems detected",
+  "health-page.status.error.info": "Zistené problémy",
+
+  // "health-page.status.warning.info": "Possible issues detected",
+  "health-page.status.warning.info": "Zistené možné problémy",
+
+  // "health-page.title": "Health",
+  "health-page.title": "Stav systému",
+
+  // "health-page.section.no-issues": "No issues detected",
+  "health-page.section.no-issues": "Nezistili sa žiadne problémy",
+
+  // "home.description": "",
+  "home.description": "",
+
+  // "home.breadcrumbs": "Home",
+  "home.breadcrumbs": "Domov",
+
+  // "home.search-form.placeholder": "Search the repository ...",
+  "home.search-form.placeholder": "Hľadať v repozitári...",
+
+  // "home.title": "Home",
+  "home.title": "Domov",
+
+  // "home.top-level-communities.head": "Communities in DSpace",
+  "home.top-level-communities.head": "Komunity v DSpace",
+
+  // "home.top-level-communities.help": "Select a community to browse its collections.",
+  "home.top-level-communities.help": "Vyberte komunitu a prehliadajte jej kolekcie.",
+
+  // "info.accessibility-settings.breadcrumbs": "Accessibility settings",
+  "info.accessibility-settings.breadcrumbs": "Nastavenia prístupnosti",
+
+  // "info.accessibility-settings.cookie-warning": "Saving the accessibility settings is currently not possible. Either log in to save the settings in user data, or accept the 'Accessibility Settings' cookie using the 'Cookie Settings' menu at the bottom of the page. Once the cookie has been accepted, you can reload the page to remove this message.",
+  "info.accessibility-settings.cookie-warning": "Uloženie nastavení prístupnosti momentálne nie je možné. Prihláste sa na uloženie nastavení do používateľských údajov alebo prijmite súbor cookie „Nastavenia prístupnosti“ pomocou ponuky „Nastavenia súborov cookie“ v spodnej časti stránky. Po prijatí súboru cookie môžete stránku znova načítať a odstrániť túto správu.",
+
+  // "info.accessibility-settings.disableNotificationTimeOut.label": "Automatically close notifications after time out",
+  "info.accessibility-settings.disableNotificationTimeOut.label": "Automaticky zatvárať upozornenia po uplynutí času",
+
+  // "info.accessibility-settings.disableNotificationTimeOut.hint": "When this toggle is activated, notifications will close automatically after the time out passes. When deactivated, notifications will remain open until manually closed.",
+  "info.accessibility-settings.disableNotificationTimeOut.hint": "Keď je tento prepínač aktivovaný, upozornenia sa po uplynutí času automaticky zatvoria. Keď je deaktivovaný, upozornenia zostanú otvorené, kým ich ručne nezatvoríte.",
+
+  // "info.accessibility-settings.failed-notification": "Failed to save accessibility settings",
+  "info.accessibility-settings.failed-notification": "Nepodarilo sa uložiť nastavenia prístupnosti",
+
+  // "info.accessibility-settings.invalid-form-notification": "Did not save. The form contains invalid values.",
+  "info.accessibility-settings.invalid-form-notification": "Neuložené. Formulár obsahuje neplatné hodnoty.",
+
+  // "info.accessibility-settings.liveRegionTimeOut.label": "ARIA Live region time out (in seconds)",
+  "info.accessibility-settings.liveRegionTimeOut.label": "Časový limit ARIA Live region (v sekundách)",
+
+  // "info.accessibility-settings.liveRegionTimeOut.hint": "The duration after which a message in the ARIA live region disappears. ARIA live regions are not visible on the page, but provide announcements of notifications (or other actions) to screen readers.",
+  "info.accessibility-settings.liveRegionTimeOut.hint": "Doba, po ktorej správa v ARIA live region zmizne. ARIA live regióny nie sú na stránke viditeľné, ale poskytujú oznámenia upozornení (alebo iných akcií) čítačkám obrazovky.",
+
+  // "info.accessibility-settings.liveRegionTimeOut.invalid": "Live region time out must be greater than 0",
+  "info.accessibility-settings.liveRegionTimeOut.invalid": "Časový limit live region musí byť väčší ako 0",
+
+  // "info.accessibility-settings.notificationTimeOut.label": "Notification time out (in seconds)",
+  "info.accessibility-settings.notificationTimeOut.label": "Časový limit upozornenia (v sekundách)",
+
+  // "info.accessibility-settings.notificationTimeOut.hint": "The duration after which a notification disappears.",
+  "info.accessibility-settings.notificationTimeOut.hint": "Doba, po ktorej upozornenie zmizne.",
+
+  // "info.accessibility-settings.notificationTimeOut.invalid": "Notification time out must be greater than 0",
+  "info.accessibility-settings.notificationTimeOut.invalid": "Časový limit upozornenia musí byť väčší ako 0",
+
+  // "info.accessibility-settings.save-notification.cookie": "Successfully saved settings locally.",
+  "info.accessibility-settings.save-notification.cookie": "Nastavenia úspešne uložené lokálne.",
+
+  // "info.accessibility-settings.save-notification.metadata": "Successfully saved settings on the user profile.",
+  "info.accessibility-settings.save-notification.metadata": "Nastavenia úspešne uložené v používateľskom profile.",
+
+  // "info.accessibility-settings.reset-failed": "Failed to reset. Either log in or accept the 'Accessibility Settings' cookie.",
+  "info.accessibility-settings.reset-failed": "Nepodarilo sa resetovať. Prihláste sa alebo prijmite súbor cookie „Nastavenia prístupnosti“.",
+
+  // "info.accessibility-settings.reset-notification": "Successfully reset settings.",
+  "info.accessibility-settings.reset-notification": "Nastavenia boli úspešne resetované.",
+
+  // "info.accessibility-settings.reset": "Reset accessibility settings",
+  "info.accessibility-settings.reset": "Resetovať nastavenia prístupnosti",
+
+  // "info.accessibility-settings.submit": "Save accessibility settings",
+  "info.accessibility-settings.submit": "Uložiť nastavenia prístupnosti",
+
+  // "info.accessibility-settings.title": "Accessibility settings",
+  "info.accessibility-settings.title": "Nastavenia prístupnosti",
+
+  // "info.end-user-agreement.accept": "I have read and I agree to the End User Agreement",
+  "info.end-user-agreement.accept": "Prečítal/a som si a súhlasím so zmluvou s koncovým používateľom",
+
+  // "info.end-user-agreement.accept.error": "An error occurred accepting the End User Agreement",
+  "info.end-user-agreement.accept.error": "Pri prijímaní zmluvy s koncovým používateľom došlo k chybe",
+
+  // "info.end-user-agreement.accept.success": "Successfully updated the End User Agreement",
+  "info.end-user-agreement.accept.success": "Zmluva s koncovým používateľom bola úspešne aktualizovaná",
+
+  // "info.end-user-agreement.breadcrumbs": "End User Agreement",
+  "info.end-user-agreement.breadcrumbs": "Zmluva s koncovým používateľom",
+
+  // "info.end-user-agreement.buttons.cancel": "Cancel",
+  "info.end-user-agreement.buttons.cancel": "Zrušiť",
+
+  // "info.end-user-agreement.buttons.save": "Save",
+  "info.end-user-agreement.buttons.save": "Uložiť",
+
+  // "info.end-user-agreement.head": "End User Agreement",
+  "info.end-user-agreement.head": "Zmluva s koncovým používateľom",
+
+  // "info.end-user-agreement.title": "End User Agreement",
+  "info.end-user-agreement.title": "Zmluva s koncovým používateľom",
+
+  // "info.end-user-agreement.hosting-country": "the United States",
+  "info.end-user-agreement.hosting-country": "Slovenská republika",
+
+  // "info.privacy.breadcrumbs": "Privacy Statement",
+  "info.privacy.breadcrumbs": "Vyhlásenie o ochrane osobných údajov",
+
+  // "info.privacy.head": "Privacy Statement",
+  "info.privacy.head": "Vyhlásenie o ochrane osobných údajov",
+
+  // "info.privacy.title": "Privacy Statement",
+  "info.privacy.title": "Vyhlásenie o ochrane osobných údajov",
+
+  // "info.feedback.breadcrumbs": "Feedback",
+  "info.feedback.breadcrumbs": "Spätná väzba",
+
+  // "info.feedback.head": "Feedback",
+  "info.feedback.head": "Spätná väzba",
+
+  // "info.feedback.title": "Feedback",
+  "info.feedback.title": "Spätná väzba",
+
+  // "info.feedback.info": "Thanks for sharing your feedback about the DSpace system. Your comments are appreciated!",
+  "info.feedback.info": "Ďakujeme za spätnú väzbu k systému DSpace. Vážime si vaše pripomienky!",
+
+  // "info.feedback.email_help": "This address will be used to follow up on your feedback.",
+  "info.feedback.email_help": "Táto adresa bude použitá na následné vybavenie vašej spätnej väzby.",
+
+  // "info.feedback.send": "Send Feedback",
+  "info.feedback.send": "Odoslať spätnú väzbu",
+
+  // "info.feedback.comments": "Comments",
+  "info.feedback.comments": "Komentáre",
+
+  // "info.feedback.email-label": "Your Email",
+  "info.feedback.email-label": "Váš e-mail",
+
+  // "info.feedback.create.success": "Feedback Sent Successfully!",
+  "info.feedback.create.success": "Spätná väzba úspešne odoslaná!",
+
+  // "info.feedback.error.email.required": "A valid email address is required",
+  "info.feedback.error.email.required": "Vyžaduje sa platná e-mailová adresa",
+
+  // "info.feedback.error.message.required": "A comment is required",
+  "info.feedback.error.message.required": "Vyžaduje sa komentár",
+
+  // "info.feedback.page-label": "Page",
+  "info.feedback.page-label": "Stránka",
+
+  // "info.feedback.page_help": "The page related to your feedback",
+  "info.feedback.page_help": "Stránka, ktorá sa týka vašej spätnej väzby",
+
+  // "info.coar-notify-support.title": "COAR Notify Support",
+  "info.coar-notify-support.title": "Podpora COAR Notify",
+
+  // "info.coar-notify-support.breadcrumbs": "COAR Notify Support",
+  "info.coar-notify-support.breadcrumbs": "Podpora COAR Notify",
+
+  // "item.alerts.private": "This item is non-discoverable",
+  "item.alerts.private": "Tento záznam je nevyhľadateľný",
+
+  // "item.alerts.withdrawn": "This item has been withdrawn",
+  "item.alerts.withdrawn": "Tento záznam bol stiahnutý",
+
+  // "item.alerts.reinstate-request": "Request reinstate",
+  "item.alerts.reinstate-request": "Požiadať o obnovenie",
+
+  // "quality-assurance.event.table.person-who-requested": "Requested by",
+  "quality-assurance.event.table.person-who-requested": "Požiadal",
+
+  // "item.edit.authorizations.heading": "With this editor you can view and alter the policies of an item, plus alter policies of individual item components: bundles and bitstreams. Briefly, an item is a container of bundles, and bundles are containers of bitstreams. Containers usually have ADD/REMOVE/READ/WRITE policies, while bitstreams only have READ/WRITE policies.",
+  "item.edit.authorizations.heading": "Pomocou tohto editora môžete zobraziť a meniť pravidlá záznamu, ako aj meniť pravidlá jednotlivých súčastí záznamu: zväzkov a súborov. Stručne povedané, záznam je kontajnerom zväzkov a zväzky sú kontajnermi súborov. Kontajnery majú zvyčajne pravidlá ADD/REMOVE/READ/WRITE, zatiaľ čo súbory majú iba pravidlá READ/WRITE.",
+
+  // "item.edit.authorizations.title": "Edit item's Policies",
+  "item.edit.authorizations.title": "Upraviť pravidlá záznamu",
+
+  // "item.badge.status": "Item status:",
+  "item.badge.status": "Stav záznamu:",
+
+  // "item.badge.private": "Non-discoverable",
+  "item.badge.private": "Nevyhľadateľný",
+
+  // "item.badge.withdrawn": "Withdrawn",
+  "item.badge.withdrawn": "Stiahnutý",
+
+  // "item.bitstreams.upload.bundle": "Bundle",
+  "item.bitstreams.upload.bundle": "Zväzok",
+
+  // "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
+  "item.bitstreams.upload.bundle.placeholder": "Vyberte zväzok alebo zadajte názov nového zväzku",
+
+  // "item.bitstreams.upload.bundle.new": "Create bundle",
+  "item.bitstreams.upload.bundle.new": "Vytvoriť zväzok",
+
+  // "item.bitstreams.upload.bundles.empty": "This item doesn't contain any bundles to upload a bitstream to.",
+  "item.bitstreams.upload.bundles.empty": "Tento záznam neobsahuje žiadne zväzky, do ktorých by bolo možné nahrať súbor.",
+
+  // "item.bitstreams.upload.cancel": "Cancel",
+  "item.bitstreams.upload.cancel": "Zrušiť",
+
+  // "item.bitstreams.upload.drop-message": "Drop a file to upload",
+  "item.bitstreams.upload.drop-message": "Presuňte sem súbor na nahranie",
+
+  // "item.bitstreams.upload.item": "Item: ",
+  "item.bitstreams.upload.item": "Záznam: ",
+
+  // "item.bitstreams.upload.notifications.bundle.created.content": "Successfully created new bundle.",
+  "item.bitstreams.upload.notifications.bundle.created.content": "Nový zväzok bol úspešne vytvorený.",
+
+  // "item.bitstreams.upload.notifications.bundle.created.title": "Created bundle",
+  "item.bitstreams.upload.notifications.bundle.created.title": "Zväzok vytvorený",
+
+  // "item.bitstreams.upload.notifications.upload.failed": "Upload failed. Please verify the content before retrying.",
+  "item.bitstreams.upload.notifications.upload.failed": "Nahrávanie zlyhalo. Pred ďalším pokusom overte obsah.",
+
+  // "item.bitstreams.upload.title": "Upload bitstream",
+  "item.bitstreams.upload.title": "Nahrať súbor",
+
+  // "item.edit.bitstreams.bundle.edit.buttons.upload": "Upload",
+  "item.edit.bitstreams.bundle.edit.buttons.upload": "Nahrať",
+
+  // "item.edit.bitstreams.bundle.displaying": "Currently displaying {{ amount }} bitstreams of {{ total }}.",
+  "item.edit.bitstreams.bundle.displaying": "Aktuálne sa zobrazuje {{ amount }} súborov z {{ total }}.",
+
+  // "item.edit.bitstreams.bundle.load.all": "Load all ({{ total }})",
+  "item.edit.bitstreams.bundle.load.all": "Načítať všetky ({{ total }})",
+
+  // "item.edit.bitstreams.bundle.load.more": "Load more",
+  "item.edit.bitstreams.bundle.load.more": "Načítať ďalšie",
+
+  // "item.edit.bitstreams.bundle.name": "BUNDLE: {{ name }}",
+  "item.edit.bitstreams.bundle.name": "ZVÄZOK: {{ name }}",
+
+  // "item.edit.bitstreams.bundle.table.aria-label": "Bitstreams in the {{ bundle }} Bundle",
+  "item.edit.bitstreams.bundle.table.aria-label": "Súbory vo zväzku {{ bundle }}",
+
+  // "item.edit.bitstreams.bundle.tooltip": "You can move a bitstream to a different page by dropping it on the page number.",
+  "item.edit.bitstreams.bundle.tooltip": "Súbor môžete presunúť na inú stranu tak, že ho pustíte na číslo strany.",
+
+  // "item.edit.bitstreams.discard-button": "Discard",
+  "item.edit.bitstreams.discard-button": "Zahodiť",
+
+  // "item.edit.bitstreams.edit.buttons.download": "Download",
+  "item.edit.bitstreams.edit.buttons.download": "Stiahnuť",
+
+  // "item.edit.bitstreams.edit.buttons.drag": "Drag",
+  "item.edit.bitstreams.edit.buttons.drag": "Presunúť",
+
+  // "item.edit.bitstreams.edit.buttons.edit": "Edit",
+  "item.edit.bitstreams.edit.buttons.edit": "Upraviť",
+
+  // "item.edit.bitstreams.edit.buttons.remove": "Remove",
+  "item.edit.bitstreams.edit.buttons.remove": "Odstrániť",
+
+  // "item.edit.bitstreams.edit.buttons.undo": "Undo changes",
+  "item.edit.bitstreams.edit.buttons.undo": "Vrátiť zmeny",
+
+  // "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} was returned to position {{ toIndex }} and is no longer selected.",
+  "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} bol vrátený na pozíciu {{ toIndex }} a už nie je vybraný.",
+
+  // "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} is no longer selected.",
+  "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} už nie je vybraný.",
+
+  // "item.edit.bitstreams.edit.live.loading": "Waiting for move to complete.",
+  "item.edit.bitstreams.edit.live.loading": "Čaká sa na dokončenie presunu.",
+
+  // "item.edit.bitstreams.edit.live.select": "{{ bitstream }} is selected.",
+  "item.edit.bitstreams.edit.live.select": "{{ bitstream }} je vybraný.",
+
+  // "item.edit.bitstreams.edit.live.move": "{{ bitstream }} is now in position {{ toIndex }}.",
+  "item.edit.bitstreams.edit.live.move": "{{ bitstream }} je teraz na pozícii {{ toIndex }}.",
+
+  // "item.edit.bitstreams.empty": "This item doesn't contain any bitstreams. Click the upload button to create one.",
+  "item.edit.bitstreams.empty": "Tento záznam neobsahuje žiadne súbory. Kliknutím na tlačidlo nahrania nejaký vytvorte.",
+
+  // "item.edit.bitstreams.info-alert": "Bitstreams can be reordered within their bundles by holding the drag handle and moving the mouse. Alternatively, bitstreams can be moved using the keyboard in the following way: Select the bitstream by pressing enter when the bitstream's drag handle is in focus. Move the bitstream up or down using the arrow keys. Press enter again to confirm the current position of the bitstream.",
+  "item.edit.bitstreams.info-alert": "Súbory možno v rámci ich zväzkov preusporiadať podržaním uchopovacieho bodu a pohybom myši. Alternatívne možno súbory presúvať pomocou klávesnice takto: Vyberte súbor stlačením klávesu Enter, keď je uchopovací bod súboru zameraný. Presuňte súbor nahor alebo nadol pomocou klávesov so šípkami. Opätovným stlačením klávesu Enter potvrďte aktuálnu pozíciu súboru.",
+
+  // "item.edit.bitstreams.headers.actions": "Actions",
+  "item.edit.bitstreams.headers.actions": "Akcie",
+
+  // "item.edit.bitstreams.headers.bundle": "Bundle",
+  "item.edit.bitstreams.headers.bundle": "Zväzok",
+
+  // "item.edit.bitstreams.headers.description": "Description",
+  "item.edit.bitstreams.headers.description": "Popis",
+
+  // "item.edit.bitstreams.headers.format": "Format",
+  "item.edit.bitstreams.headers.format": "Formát",
+
+  // "item.edit.bitstreams.headers.name": "Name",
+  "item.edit.bitstreams.headers.name": "Názov",
+
+  // "item.edit.bitstreams.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  "item.edit.bitstreams.notifications.discarded.content": "Vaše zmeny boli zahodené. Na obnovenie zmien kliknite na tlačidlo „Vrátiť zmeny“",
+
+  // "item.edit.bitstreams.notifications.discarded.title": "Changes discarded",
+  "item.edit.bitstreams.notifications.discarded.title": "Zmeny zahodené",
+
+  // "item.edit.bitstreams.notifications.move.failed.title": "Error moving bitstreams",
+  "item.edit.bitstreams.notifications.move.failed.title": "Chyba pri presune súborov",
+
+  // "item.edit.bitstreams.notifications.move.saved.content": "Your move changes to this item's bitstreams and bundles have been saved.",
+  "item.edit.bitstreams.notifications.move.saved.content": "Vaše zmeny presunu v súboroch a zväzkoch tohto záznamu boli uložené.",
+
+  // "item.edit.bitstreams.notifications.move.saved.title": "Move changes saved",
+  "item.edit.bitstreams.notifications.move.saved.title": "Zmeny presunu uložené",
+
+  // "item.edit.bitstreams.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  "item.edit.bitstreams.notifications.outdated.content": "Záznam, na ktorom práve pracujete, zmenil iný používateľ. Vaše aktuálne zmeny boli zahodené, aby sa zabránilo konfliktom",
+
+  // "item.edit.bitstreams.notifications.outdated.title": "Changes outdated",
+  "item.edit.bitstreams.notifications.outdated.title": "Zmeny sú zastarané",
+
+  // "item.edit.bitstreams.notifications.remove.failed.title": "Error deleting bitstream",
+  "item.edit.bitstreams.notifications.remove.failed.title": "Chyba pri odstraňovaní súboru.",
+
+  // "item.edit.bitstreams.notifications.remove.saved.content": "Your removal changes to this item's bitstreams have been saved.",
+  "item.edit.bitstreams.notifications.remove.saved.content": "Vaše zmeny odstránenia súborov tohto záznamu boli uložené.",
+
+  // "item.edit.bitstreams.notifications.remove.saved.title": "Removal changes saved",
+  "item.edit.bitstreams.notifications.remove.saved.title": "Zmeny odstránenia uložené",
+
+  // "item.edit.bitstreams.reinstate-button": "Undo",
+  "item.edit.bitstreams.reinstate-button": "Vrátiť späť",
+
+  // "item.edit.bitstreams.save-button": "Save",
+  "item.edit.bitstreams.save-button": "Uložiť",
+
+  // "item.edit.bitstreams.upload-button": "Upload",
+  "item.edit.bitstreams.upload-button": "Nahrať",
+
+  // "item.edit.bitstreams.load-more.link": "Load more",
+  "item.edit.bitstreams.load-more.link": "Načítať ďalšie",
+
+  // "item.edit.delete.cancel": "Cancel",
+  "item.edit.delete.cancel": "Zrušiť",
+
+  // "item.edit.delete.confirm": "Delete",
+  "item.edit.delete.confirm": "Odstrániť",
+
+  // "item.edit.delete.description": "Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.",
+  "item.edit.delete.description": "Naozaj má byť tento záznam úplne odstránený? Upozornenie: V súčasnosti by nezostala žiadna náhrobná stránka (tombstone).",
+
+  // "item.edit.delete.error": "An error occurred while deleting the item",
+  "item.edit.delete.error": "Pri odstraňovaní záznamu došlo k chybe",
+
+  // "item.edit.delete.header": "Delete item: {{ id }}",
+  "item.edit.delete.header": "Odstrániť záznam: {{ id }}",
+
+  // "item.edit.delete.success": "Successfully started a process to delete this item",
+  "item.edit.delete.success": "Úspešne spustený proces na odstránenie tohto záznamu",
+
+  // "item.edit.delete.confirmation-title": "Confirm deletion",
+  "item.edit.delete.confirmation-title": "Potvrdiť odstránenie",
+
+  // "item.edit.delete.confirmation-message": "Are you sure you want to permanently delete this item?",
+  "item.edit.delete.confirmation-message": "Naozaj chcete tento záznam natrvalo odstrániť?",
+
+  // "item.edit.delete.confirmation-detail": "This item may have been cited, has (or had) a persistent identifier (Handle/DOI), and deleting it may break scholarly references and external links.",
+  "item.edit.delete.confirmation-detail": "Tento záznam mohol byť citovaný, má (alebo mal) trvalý identifikátor (Handle/DOI) a jeho odstránenie môže narušiť vedecké odkazy a externé prepojenia.",
+
+  // "item.edit.head": "Edit Item",
+  "item.edit.head": "Upraviť záznam",
+
+  // "item.edit.breadcrumbs": "Edit Item",
+  "item.edit.breadcrumbs": "Upraviť záznam",
+
+  // "item.edit.tabs.disabled.tooltip": "You're not authorized to access this tab",
+  "item.edit.tabs.disabled.tooltip": "Na túto kartu nemáte oprávnenie",
+
+  // "item.edit.tabs.mapper.head": "Collection Mapper",
+  "item.edit.tabs.mapper.head": "Mapovač kolekcií",
+
+  // "item.edit.tabs.item-mapper.title": "Item Edit - Collection Mapper",
+  "item.edit.tabs.item-mapper.title": "Úprava záznamu – Mapovač kolekcií",
+
+  // "item.edit.identifiers.doi.status.UNKNOWN": "Unknown",
+  "item.edit.identifiers.doi.status.UNKNOWN": "Neznámy",
+
+  // "item.edit.identifiers.doi.status.TO_BE_REGISTERED": "Queued for registration",
+  "item.edit.identifiers.doi.status.TO_BE_REGISTERED": "Zaradené na registráciu",
+
+  // "item.edit.identifiers.doi.status.TO_BE_RESERVED": "Queued for reservation",
+  "item.edit.identifiers.doi.status.TO_BE_RESERVED": "Zaradené na rezerváciu",
+
+  // "item.edit.identifiers.doi.status.IS_REGISTERED": "Registered",
+  "item.edit.identifiers.doi.status.IS_REGISTERED": "Zaregistrované",
+
+  // "item.edit.identifiers.doi.status.IS_RESERVED": "Reserved",
+  "item.edit.identifiers.doi.status.IS_RESERVED": "Rezervované",
+
+  // "item.edit.identifiers.doi.status.UPDATE_RESERVED": "Reserved (update queued)",
+  "item.edit.identifiers.doi.status.UPDATE_RESERVED": "Rezervované (aktualizácia zaradená)",
+
+  // "item.edit.identifiers.doi.status.UPDATE_REGISTERED": "Registered (update queued)",
+  "item.edit.identifiers.doi.status.UPDATE_REGISTERED": "Zaregistrované (aktualizácia zaradená)",
+
+  // "item.edit.identifiers.doi.status.UPDATE_BEFORE_REGISTRATION": "Queued for update and registration",
+  "item.edit.identifiers.doi.status.UPDATE_BEFORE_REGISTRATION": "Zaradené na aktualizáciu a registráciu",
+
+  // "item.edit.identifiers.doi.status.TO_BE_DELETED": "Queued for deletion",
+  "item.edit.identifiers.doi.status.TO_BE_DELETED": "Zaradené na odstránenie",
+
+  // "item.edit.identifiers.doi.status.DELETED": "Deleted",
+  "item.edit.identifiers.doi.status.DELETED": "Odstránené",
+
+  // "item.edit.identifiers.doi.status.PENDING": "Pending (not registered)",
+  "item.edit.identifiers.doi.status.PENDING": "Čaká sa (nezaregistrované)",
+
+  // "item.edit.identifiers.doi.status.MINTED": "Minted (not registered)",
+  "item.edit.identifiers.doi.status.MINTED": "Vygenerované (nezaregistrované)",
+
+  // "item.edit.tabs.status.buttons.register-doi.label": "Register a new or pending DOI",
+  "item.edit.tabs.status.buttons.register-doi.label": "Registrovať nové alebo čakajúce DOI",
+
+  // "item.edit.tabs.status.buttons.register-doi.button": "Register DOI...",
+  "item.edit.tabs.status.buttons.register-doi.button": "Zaregistrovať DOI...",
+
+  // "item.edit.register-doi.header": "Register a new or pending DOI",
+  "item.edit.register-doi.header": "Registrovať nové alebo čakajúce DOI",
+
+  // "item.edit.register-doi.description": "Review any pending identifiers and item metadata below and click Confirm to proceed with DOI registration, or Cancel to back out",
+  "item.edit.register-doi.description": "Nižšie skontrolujte všetky čakajúce identifikátory a metadáta záznamu a kliknutím na „Potvrdiť“ pokračujte v registrácii DOI, alebo „Zrušiť“ na prerušenie",
+
+  // "item.edit.register-doi.confirm": "Confirm",
+  "item.edit.register-doi.confirm": "Potvrdiť",
+
+  // "item.edit.register-doi.cancel": "Cancel",
+  "item.edit.register-doi.cancel": "Zrušiť",
+
+  // "item.edit.register-doi.success": "DOI queued for registration successfully.",
+  "item.edit.register-doi.success": "DOI úspešne zaradené na registráciu.",
+
+  // "item.edit.register-doi.error": "Error registering DOI",
+  "item.edit.register-doi.error": "Chyba pri registrácii DOI",
+
+  // "item.edit.register-doi.to-update": "The following DOI has already been minted and will be queued for registration online",
+  "item.edit.register-doi.to-update": "Nasledujúce DOI už bolo vygenerované a bude zaradené na online registráciu",
+
+  // "item.edit.item-mapper.buttons.add": "Map item to selected collections",
+  "item.edit.item-mapper.buttons.add": "Mapovať záznam do vybraných kolekcií",
+
+  // "item.edit.item-mapper.buttons.remove": "Remove item's mapping for selected collections",
+  "item.edit.item-mapper.buttons.remove": "Odobrať mapovanie záznamu pre vybrané kolekcie",
+
+  // "item.edit.item-mapper.cancel": "Cancel",
+  "item.edit.item-mapper.cancel": "Zrušiť",
+
+  // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
+  "item.edit.item-mapper.description": "Toto je nástroj na mapovanie záznamov, ktorý umožňuje správcom mapovať tento záznam do iných kolekcií. Môžete vyhľadávať kolekcie a mapovať ich alebo prehliadať zoznam kolekcií, do ktorých je záznam aktuálne mapovaný.",
+
+  // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
+  "item.edit.item-mapper.head": "Mapovač záznamov – Mapovanie záznamu do kolekcií",
+
+  // "item.edit.item-mapper.item": "Item: \"<b>{{name}}</b>\"",
+  "item.edit.item-mapper.item": "Záznam: \"<b>{{name}}</b>\"",
+
+  // "item.edit.item-mapper.no-search": "Please enter a query to search",
+  "item.edit.item-mapper.no-search": "Zadajte prosím dopyt na vyhľadávanie",
+
+  // "item.edit.item-mapper.notifications.add.error.content": "Errors occurred for mapping of item to {{amount}} collections.",
+  "item.edit.item-mapper.notifications.add.error.content": "Pri mapovaní záznamu do {{amount}} kolekcií došlo k chybám.",
+
+  // "item.edit.item-mapper.notifications.add.error.forbidden.head": "Permission denied",
+  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Prístup zamietnutý",
+
+  // "item.edit.item-mapper.notifications.add.error.forbidden.content": "You do not have permission to map this item to a collection.",
+  "item.edit.item-mapper.notifications.add.error.forbidden.content": "Nemáte oprávnenie mapovať tento záznam do kolekcie.",
+
+  // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
+  "item.edit.item-mapper.notifications.add.error.head": "Chyby pri mapovaní",
+
+  // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
+  "item.edit.item-mapper.notifications.add.success.content": "Záznam bol úspešne namapovaný do {{amount}} kolekcií.",
+
+  // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
+  "item.edit.item-mapper.notifications.add.success.head": "Mapovanie dokončené",
+
+  // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
+  "item.edit.item-mapper.notifications.remove.error.content": "Pri odstraňovaní mapovania do {{amount}} kolekcií došlo k chybám.",
+
+  // "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Permission denied",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Prístup zamietnutý",
+
+  // "item.edit.item-mapper.notifications.remove.error.forbidden.content": "You do not have permission to remove this item from a collection.",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "Nemáte oprávnenie odobrať tento záznam z kolekcie.",
+
+  // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
+  "item.edit.item-mapper.notifications.remove.error.head": "Chyby pri odstraňovaní mapovania",
+
+  // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
+  "item.edit.item-mapper.notifications.remove.success.content": "Úspešne odstránené mapovanie záznamu do {{amount}} kolekcií.",
+
+  // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
+  "item.edit.item-mapper.notifications.remove.success.head": "Odstránenie mapovania dokončené",
+
+  // "item.edit.item-mapper.search-form.placeholder": "Search collections...",
+  "item.edit.item-mapper.search-form.placeholder": "Hľadať kolekcie...",
+
+  // "item.edit.item-mapper.tabs.browse": "Browse mapped collections",
+  "item.edit.item-mapper.tabs.browse": "Prehliadať mapované kolekcie",
+
+  // "item.edit.item-mapper.tabs.map": "Map new collections",
+  "item.edit.item-mapper.tabs.map": "Mapovať nové kolekcie",
+
+  // "item.edit.metadata.add-button": "Add",
+  "item.edit.metadata.add-button": "Pridať",
+
+  // "item.edit.metadata.discard-button": "Discard",
+  "item.edit.metadata.discard-button": "Zahodiť",
+
+  // "item.edit.metadata.edit.language": "Edit language",
+  "item.edit.metadata.edit.language": "Upraviť jazyk",
+
+  // "item.edit.metadata.edit.authority": "Edit authority",
+  "item.edit.metadata.edit.authority": "Upraviť autoritu",
+
+  // "item.edit.metadata.edit.value": "Edit value",
+  "item.edit.metadata.edit.value": "Upraviť hodnotu",
+
+  // "item.edit.metadata.edit.authority.key": "Edit authority key",
+  "item.edit.metadata.edit.authority.key": "Upraviť autoritný kľúč",
+
+  // "item.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
+  "item.edit.metadata.edit.buttons.enable-free-text-editing": "Povoliť úpravy voľného textu",
+
+  // "item.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
+  "item.edit.metadata.edit.buttons.disable-free-text-editing": "Zakázať úpravy voľného textu",
+
+  // "item.edit.metadata.edit.buttons.confirm": "Confirm",
+  "item.edit.metadata.edit.buttons.confirm": "Potvrdiť",
+
+  // "item.edit.metadata.edit.buttons.drag": "Drag to reorder",
+  "item.edit.metadata.edit.buttons.drag": "Presunutím zmeníte poradie",
+
+  // "item.edit.metadata.edit.buttons.edit": "Edit",
+  "item.edit.metadata.edit.buttons.edit": "Upraviť",
+
+  // "item.edit.metadata.edit.buttons.remove": "Remove",
+  "item.edit.metadata.edit.buttons.remove": "Odstrániť",
+
+  // "item.edit.metadata.edit.buttons.undo": "Undo changes",
+  "item.edit.metadata.edit.buttons.undo": "Vrátiť zmeny",
+
+  // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  "item.edit.metadata.edit.buttons.unedit": "Ukončiť úpravy",
+
+  // "item.edit.metadata.edit.buttons.virtual": "This is a virtual metadata value, i.e. a value inherited from a related entity. It can’t be modified directly. Add or remove the corresponding relationship in the \"Relationships\" tab",
+  "item.edit.metadata.edit.buttons.virtual": "Toto je virtuálna hodnota metadát, t. j. hodnota zdedená z priradenej entity. Nemožno ju upraviť priamo. Pridajte alebo odoberte príslušný vzťah na karte „Vzťahy“.",
+
+  // "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
+  "item.edit.metadata.empty": "Záznam momentálne neobsahuje žiadne metadáta. Kliknutím na Pridať začnete pridávať hodnotu metadát.",
+
+  // "item.edit.metadata.headers.edit": "Edit",
+  "item.edit.metadata.headers.edit": "Upraviť",
+
+  // "item.edit.metadata.headers.field": "Field",
+  "item.edit.metadata.headers.field": "Pole",
+
+  // "item.edit.metadata.headers.language": "Lang",
+  "item.edit.metadata.headers.language": "Jazyk",
+
+  // "item.edit.metadata.headers.security": "Security level",
+  "item.edit.metadata.headers.security": "Úroveň zabezpečenia",
+
+  // "item.edit.metadata.headers.authority": "Authority",
+  "item.edit.metadata.headers.authority": "Autorita",
+
+  // "item.edit.metadata.headers.value": "Value",
+  "item.edit.metadata.headers.value": "Hodnota",
+
+  // "item.edit.metadata.metadatafield": "Edit field",
+  "item.edit.metadata.metadatafield": "Upraviť pole",
+
+  // "item.edit.metadata.metadatafield.error": "An error occurred validating the metadata field",
+  "item.edit.metadata.metadatafield.error": "Pri overovaní metadátového poľa došlo k chybe",
+
+  // "item.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  "item.edit.metadata.metadatafield.invalid": "Vyberte prosím platné metadátové pole",
+
+  // "item.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  "item.edit.metadata.notifications.discarded.content": "Vaše zmeny boli zahodené. Na obnovenie zmien kliknite na tlačidlo „Vrátiť zmeny“",
+
+  // "item.edit.metadata.notifications.discarded.title": "Changes discarded",
+  "item.edit.metadata.notifications.discarded.title": "Zmeny zahodené",
+
+  // "item.edit.metadata.notifications.error.title": "An error occurred",
+  "item.edit.metadata.notifications.error.title": "Došlo k chybe",
+
+  // "item.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  "item.edit.metadata.notifications.invalid.content": "Vaše zmeny neboli uložené. Pred uložením sa prosím uistite, že všetky polia sú platné.",
+
+  // "item.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  "item.edit.metadata.notifications.invalid.title": "Neplatné metadáta",
+
+  // "item.edit.metadata.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  "item.edit.metadata.notifications.outdated.content": "Záznam, na ktorom práve pracujete, zmenil iný používateľ. Vaše aktuálne zmeny boli zahodené, aby sa zabránilo konfliktom",
+
+  // "item.edit.metadata.notifications.outdated.title": "Changes outdated",
+  "item.edit.metadata.notifications.outdated.title": "Zmeny sú zastarané",
+
+  // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
+  "item.edit.metadata.notifications.saved.content": "Vaše zmeny metadát tohto záznamu boli uložené.",
+
+  // "item.edit.metadata.notifications.saved.title": "Metadata saved",
+  "item.edit.metadata.notifications.saved.title": "Metadáta uložené",
+
+  // "item.edit.metadata.reinstate-button": "Undo",
+  "item.edit.metadata.reinstate-button": "Vrátiť späť",
+
+  // "item.edit.metadata.reset-order-button": "Undo reorder",
+  "item.edit.metadata.reset-order-button": "Vrátiť zmenu poradia",
+
+  // "item.edit.metadata.save-button": "Save",
+  "item.edit.metadata.save-button": "Uložiť",
+
+  // "item.edit.metadata.authority.label": "Authority: ",
+  "item.edit.metadata.authority.label": "Autorita: ",
+
+  // "item.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.open-authority-edition": "Odomknúť hodnotu autoritného kľúča na manuálnu úpravu",
+
+  // "item.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.close-authority-edition": "Uzamknúť hodnotu autoritného kľúča na manuálnu úpravu",
+
+  // "item.edit.modify.overview.field": "Field",
+  "item.edit.modify.overview.field": "Pole",
+
+  // "item.edit.modify.overview.language": "Language",
+  "item.edit.modify.overview.language": "Jazyk",
+
+  // "item.edit.modify.overview.value": "Value",
+  "item.edit.modify.overview.value": "Hodnota",
+
+  // "item.edit.move.cancel": "Back",
+  "item.edit.move.cancel": "Späť",
+
+  // "item.edit.move.save-button": "Save",
+  "item.edit.move.save-button": "Uložiť",
+
+  // "item.edit.move.discard-button": "Discard",
+  "item.edit.move.discard-button": "Zahodiť",
+
+  // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  "item.edit.move.description": "Vyberte kolekciu, do ktorej chcete tento záznam presunúť. Na zúženie zoznamu zobrazených kolekcií môžete do poľa zadať vyhľadávací dopyt.",
+
+  // "item.edit.move.error": "An error occurred when attempting to move the item",
+  "item.edit.move.error": "Pri pokuse o presun záznamu došlo k chybe",
+
+  // "item.edit.move.head": "Move item: {{id}}",
+  "item.edit.move.head": "Presunúť záznam: {{id}}",
+
+  // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  "item.edit.move.inheritpolicies.checkbox": "Zdediť pravidlá",
+
+  // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
+  "item.edit.move.inheritpolicies.description": "Zdediť predvolené pravidlá cieľovej kolekcie",
+
+  // "item.edit.move.inheritpolicies.tooltip": "Warning: When enabled, the read access policy for the item and any files associated with the item will be replaced by the default read access policy of the collection. This cannot be undone.",
+  "item.edit.move.inheritpolicies.tooltip": "Upozornenie: Ak je táto možnosť povolená, pravidlo prístupu na čítanie pre záznam a všetky s ním spojené súbory bude nahradené predvoleným pravidlom prístupu na čítanie kolekcie. Túto akciu nemožno vrátiť späť.",
+
+  // "item.edit.move.move": "Move",
+  "item.edit.move.move": "Presunúť",
+
+  // "item.edit.move.processing": "Moving...",
+  "item.edit.move.processing": "Presúva sa...",
+
+  // "item.edit.move.search.placeholder": "Enter a search query to look for collections",
+  "item.edit.move.search.placeholder": "Zadajte vyhľadávací dopyt na hľadanie kolekcií",
+
+  // "item.edit.move.success": "The item has been moved successfully",
+  "item.edit.move.success": "Záznam bol úspešne presunutý",
+
+  // "item.edit.move.title": "Move item",
+  "item.edit.move.title": "Presunúť záznam",
+
+  // "item.edit.private.cancel": "Cancel",
+  "item.edit.private.cancel": "Zrušiť",
+
+  // "item.edit.private.confirm": "Make it non-discoverable",
+  "item.edit.private.confirm": "Nastaviť ako nevyhľadateľný",
+
+  // "item.edit.private.description": "Are you sure this item should be made non-discoverable in the archive?",
+  "item.edit.private.description": "Naozaj má byť tento záznam v archíve nevyhľadateľný?",
+
+  // "item.edit.private.error": "An error occurred while making the item non-discoverable",
+  "item.edit.private.error": "Pri nastavovaní záznamu ako nevyhľadateľného došlo k chybe",
+
+  // "item.edit.private.header": "Make item non-discoverable: {{ id }}",
+  "item.edit.private.header": "Nastaviť záznam ako nevyhľadateľný: {{ id }}",
+
+  // "item.edit.private.success": "The item is now non-discoverable",
+  "item.edit.private.success": "Záznam je teraz nevyhľadateľný",
+
+  // "item.edit.public.cancel": "Cancel",
+  "item.edit.public.cancel": "Zrušiť",
+
+  // "item.edit.public.confirm": "Make it discoverable",
+  "item.edit.public.confirm": "Nastaviť ako vyhľadateľný",
+
+  // "item.edit.public.description": "Are you sure this item should be made discoverable in the archive?",
+  "item.edit.public.description": "Naozaj má byť tento záznam v archíve vyhľadateľný?",
+
+  // "item.edit.public.error": "An error occurred while making the item discoverable",
+  "item.edit.public.error": "Pri nastavovaní záznamu ako vyhľadateľného došlo k chybe",
+
+  // "item.edit.public.header": "Make item discoverable: {{ id }}",
+  "item.edit.public.header": "Nastaviť záznam ako vyhľadateľný: {{ id }}",
+
+  // "item.edit.public.success": "The item is now discoverable",
+  "item.edit.public.success": "Záznam je teraz vyhľadateľný",
+
+  // "item.edit.reinstate.cancel": "Cancel",
+  "item.edit.reinstate.cancel": "Zrušiť",
+
+  // "item.edit.reinstate.confirm": "Reinstate",
+  "item.edit.reinstate.confirm": "Obnoviť",
+
+  // "item.edit.reinstate.description": "Are you sure this item should be reinstated to the archive?",
+  "item.edit.reinstate.description": "Naozaj má byť tento záznam znovu zaradený do archívu?",
+
+  // "item.edit.reinstate.error": "An error occurred while reinstating the item",
+  "item.edit.reinstate.error": "Pri obnovovaní záznamu došlo k chybe",
+
+  // "item.edit.reinstate.header": "Reinstate item: {{ id }}",
+  "item.edit.reinstate.header": "Obnoviť záznam: {{ id }}",
+
+  // "item.edit.reinstate.success": "The item was reinstated successfully",
+  "item.edit.reinstate.success": "Záznam bol úspešne obnovený",
+
+  // "item.edit.relationships.discard-button": "Discard",
+  "item.edit.relationships.discard-button": "Zahodiť",
+
+  // "item.edit.relationships.edit.buttons.add": "Add",
+  "item.edit.relationships.edit.buttons.add": "Pridať",
+
+  // "item.edit.relationships.edit.buttons.remove": "Remove",
+  "item.edit.relationships.edit.buttons.remove": "Odstrániť",
+
+  // "item.edit.relationships.edit.buttons.undo": "Undo changes",
+  "item.edit.relationships.edit.buttons.undo": "Vrátiť zmeny",
+
+  // "item.edit.relationships.no-relationships": "No relationships",
+  "item.edit.relationships.no-relationships": "Žiadne vzťahy",
+
+  // "item.edit.relationships.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  "item.edit.relationships.notifications.discarded.content": "Vaše zmeny boli zahodené. Na obnovenie zmien kliknite na tlačidlo „Vrátiť zmeny“",
+
+  // "item.edit.relationships.notifications.discarded.title": "Changes discarded",
+  "item.edit.relationships.notifications.discarded.title": "Zmeny zahodené",
+
+  // "item.edit.relationships.notifications.failed.title": "Error editing relationships",
+  "item.edit.relationships.notifications.failed.title": "Chyba pri úprave vzťahov",
+
+  // "item.edit.relationships.notifications.outdated.content": "The item you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  "item.edit.relationships.notifications.outdated.content": "Záznam, na ktorom práve pracujete, zmenil iný používateľ. Vaše aktuálne zmeny boli zahodené, aby sa zabránilo konfliktom",
+
+  // "item.edit.relationships.notifications.outdated.title": "Changes outdated",
+  "item.edit.relationships.notifications.outdated.title": "Zmeny sú zastarané",
+
+  // "item.edit.relationships.notifications.saved.content": "Your changes to this item's relationships were saved.",
+  "item.edit.relationships.notifications.saved.content": "Vaše zmeny vzťahov tohto záznamu boli uložené.",
+
+  // "item.edit.relationships.notifications.saved.title": "Relationships saved",
+  "item.edit.relationships.notifications.saved.title": "Vzťahy uložené",
+
+  // "item.edit.relationships.reinstate-button": "Undo",
+  "item.edit.relationships.reinstate-button": "Vrátiť späť",
+
+  // "item.edit.relationships.save-button": "Save",
+  "item.edit.relationships.save-button": "Uložiť",
+
+  // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
+  "item.edit.relationships.no-entity-type": "Pridajte metadáta 'dspace.entity.type' na povolenie vzťahov pre tento záznam",
+
+  // "item.edit.return": "Back",
+  "item.edit.return": "Späť",
+
+  // "item.edit.tabs.bitstreams.head": "Bitstreams",
+  "item.edit.tabs.bitstreams.head": "Súbory",
+
+  // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
+  "item.edit.tabs.bitstreams.title": "Úprava záznamu – Súbory",
+
+  // "item.edit.tabs.curate.head": "Curate",
+  "item.edit.tabs.curate.head": "Spravovať",
+
+  // "item.edit.tabs.curate.title": "Item Edit - Curate",
+  "item.edit.tabs.curate.title": "Úprava záznamu – Spravovať",
+
+  // "item.edit.curate.title": "Curate Item: {{item}}",
+  "item.edit.curate.title": "Spravovať záznam: {{item}}",
+
+  // "item.edit.tabs.access-control.head": "Access Control",
+  "item.edit.tabs.access-control.head": "Riadenie prístupu",
+
+  // "item.edit.tabs.access-control.title": "Item Edit - Access Control",
+  "item.edit.tabs.access-control.title": "Úprava záznamu – Riadenie prístupu",
+
+  // "item.edit.tabs.metadata.head": "Metadata",
+  "item.edit.tabs.metadata.head": "Metadáta",
+
+  // "item.edit.tabs.metadata.title": "Item Edit - Metadata",
+  "item.edit.tabs.metadata.title": "Úprava záznamu – Metadáta",
+
+  // "item.edit.tabs.relationships.head": "Relationships",
+  "item.edit.tabs.relationships.head": "Vzťahy",
+
+  // "item.edit.tabs.relationships.title": "Item Edit - Relationships",
+  "item.edit.tabs.relationships.title": "Úprava záznamu – Vzťahy",
+
+  // "item.edit.tabs.status.buttons.authorizations.button": "Authorizations...",
+  "item.edit.tabs.status.buttons.authorizations.button": "Oprávnenia...",
+
+  // "item.edit.tabs.status.buttons.authorizations.label": "Edit item's authorization policies",
+  "item.edit.tabs.status.buttons.authorizations.label": "Upraviť autorizačné pravidlá záznamu",
+
+  // "item.edit.tabs.status.buttons.delete.button": "Permanently delete",
+  "item.edit.tabs.status.buttons.delete.button": "Natrvalo odstrániť",
+
+  // "item.edit.tabs.status.buttons.delete.label": "Completely expunge item",
+  "item.edit.tabs.status.buttons.delete.label": "Úplne vymazať záznam",
+
+  // "item.edit.tabs.status.buttons.mappedCollections.button": "Mapped collections",
+  "item.edit.tabs.status.buttons.mappedCollections.button": "Mapované kolekcie",
+
+  // "item.edit.tabs.status.buttons.mappedCollections.label": "Manage mapped collections",
+  "item.edit.tabs.status.buttons.mappedCollections.label": "Spravovať mapované kolekcie",
+
+  // "item.edit.tabs.status.buttons.move.button": "Move this item to a different collection",
+  "item.edit.tabs.status.buttons.move.button": "Presunúť...",
+
+  // "item.edit.tabs.status.buttons.move.label": "Move item to another collection",
+  "item.edit.tabs.status.buttons.move.label": "Presunúť záznam do inej kolekcie",
+
+  // "item.edit.tabs.status.buttons.private.button": "Make it non-discoverable...",
+  "item.edit.tabs.status.buttons.private.button": "Nastaviť ako nevyhľadateľný...",
+
+  // "item.edit.tabs.status.buttons.private.label": "Make item non-discoverable",
+  "item.edit.tabs.status.buttons.private.label": "Nastaviť záznam ako nevyhľadateľný",
+
+  // "item.edit.tabs.status.buttons.public.button": "Make it discoverable...",
+  "item.edit.tabs.status.buttons.public.button": "Nastaviť ako vyhľadateľný...",
+
+  // "item.edit.tabs.status.buttons.public.label": "Make item discoverable",
+  "item.edit.tabs.status.buttons.public.label": "Nastaviť záznam ako vyhľadateľný",
+
+  // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
+  "item.edit.tabs.status.buttons.reinstate.button": "Obnoviť...",
+
+  // "item.edit.tabs.status.buttons.reinstate.label": "Reinstate item into the repository",
+  "item.edit.tabs.status.buttons.reinstate.label": "Obnoviť záznam do repozitára",
+
+  // "item.edit.tabs.status.buttons.unauthorized": "You're not authorized to perform this action",
+  "item.edit.tabs.status.buttons.unauthorized": "Nie ste oprávnení vykonať túto akciu",
+
+  // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw this item",
+  "item.edit.tabs.status.buttons.withdraw.button": "Stiahnuť tento záznam",
+
+  // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
+  "item.edit.tabs.status.buttons.withdraw.label": "Stiahnuť záznam z repozitára",
+
+  // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
+  "item.edit.tabs.status.description": "Vitajte na stránke správy záznamu. Odtiaľto môžete záznam stiahnuť, obnoviť, presunúť alebo odstrániť. Na ostatných kartách môžete tiež aktualizovať alebo pridávať nové metadáta / súbory.",
+
+  // "item.edit.tabs.status.head": "Status",
+  "item.edit.tabs.status.head": "Stav",
+
+  // "item.edit.tabs.status.labels.handle": "Handle",
+  "item.edit.tabs.status.labels.handle": "Handle",
+
+  // "item.edit.tabs.status.labels.id": "Item Internal ID",
+  "item.edit.tabs.status.labels.id": "Interné ID záznamu",
+
+  // "item.edit.tabs.status.labels.itemPage": "Item Page",
+  "item.edit.tabs.status.labels.itemPage": "Stránka záznamu",
+
+  // "item.edit.tabs.status.labels.lastModified": "Last Modified",
+  "item.edit.tabs.status.labels.lastModified": "Posledná úprava",
+
+  // "item.edit.tabs.status.title": "Item Edit - Status",
+  "item.edit.tabs.status.title": "Úprava záznamu – Stav",
+
+  // "item.edit.tabs.versionhistory.head": "Version History",
+  "item.edit.tabs.versionhistory.head": "História verzií",
+
+  // "item.edit.tabs.versionhistory.title": "Item Edit - Version History",
+  "item.edit.tabs.versionhistory.title": "Úprava záznamu – História verzií",
+
+  // "item.edit.tabs.versionhistory.under-construction": "Editing or adding new versions is not yet possible in this user interface.",
+  "item.edit.tabs.versionhistory.under-construction": "V tomto používateľskom rozhraní zatiaľ nie je možné upravovať ani pridávať nové verzie.",
+
+  // "item.edit.tabs.view.head": "View Item",
+  "item.edit.tabs.view.head": "Zobraziť záznam",
+
+  // "item.edit.tabs.view.title": "Item Edit - View",
+  "item.edit.tabs.view.title": "Úprava záznamu – Zobrazenie",
+
+  // "item.edit.withdraw.cancel": "Cancel",
+  "item.edit.withdraw.cancel": "Zrušiť",
+
+  // "item.edit.withdraw.confirm": "Withdraw",
+  "item.edit.withdraw.confirm": "Stiahnuť",
+
+  // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
+  "item.edit.withdraw.description": "Naozaj má byť tento záznam stiahnutý z archívu?",
+
+  // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
+  "item.edit.withdraw.error": "Pri sťahovaní záznamu došlo k chybe",
+
+  // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
+  "item.edit.withdraw.header": "Stiahnuť záznam: {{ id }}",
+
+  // "item.edit.withdraw.success": "The item was withdrawn successfully",
+  "item.edit.withdraw.success": "Záznam bol úspešne stiahnutý",
+
+  // "item.orcid.return": "Back",
+  "item.orcid.return": "Späť",
+
+  // "item.listelement.badge": "Item",
+  "item.listelement.badge": "Záznam",
+
+  // "item.page.description": "Description",
+  "item.page.description": "Popis",
+
+  // "item.page.org-unit": "Organizational Unit",
+  "item.page.org-unit": "Organizačná jednotka",
+
+  // "item.page.org-units": "Organizational Units",
+  "item.page.org-units": "Organizačné jednotky",
+
+  // "item.page.project": "Research Project",
+  "item.page.project": "Výskumný projekt",
+
+  // "item.page.projects": "Research Projects",
+  "item.page.projects": "Výskumné projekty",
+
+  // "item.page.publication": "Publications",
+  "item.page.publication": "Publikácie",
+
+  // "item.page.publications": "Publications",
+  "item.page.publications": "Publikácie",
+
+  // "item.page.article": "Article",
+  "item.page.article": "Článok",
+
+  // "item.page.articles": "Articles",
+  "item.page.articles": "Články",
+
+  // "item.page.journal": "Journal",
+  "item.page.journal": "Časopis",
+
+  // "item.page.journals": "Journals",
+  "item.page.journals": "Časopisy",
+
+  // "item.page.journal-issue": "Journal Issue",
+  "item.page.journal-issue": "Číslo časopisu",
+
+  // "item.page.journal-issues": "Journal Issues",
+  "item.page.journal-issues": "Čísla časopisu",
+
+  // "item.page.journal-volume": "Journal Volume",
+  "item.page.journal-volume": "Ročník časopisu",
+
+  // "item.page.journal-volumes": "Journal Volumes",
+  "item.page.journal-volumes": "Ročníky časopisu",
+
+  // "item.page.journal-issn": "Journal ISSN",
+  "item.page.journal-issn": "ISSN časopisu",
+
+  // "item.page.journal-title": "Journal Title",
+  "item.page.journal-title": "Názov časopisu",
+
+  // "item.page.publisher": "Publisher",
+  "item.page.publisher": "Vydavateľ",
+
+  // "item.page.titleprefix": "Item: ",
+  "item.page.titleprefix": "Záznam: ",
+
+  // "item.page.volume-title": "Volume Title",
+  "item.page.volume-title": "Názov zväzku",
+
+  // "item.page.dcterms.spatial": "Geospatial point",
+  "item.page.dcterms.spatial": "Geopriestorový bod",
+
+  // "item.page.doi": "DOI",
+  "item.page.doi": "DOI",
+
+  // "item.search.results.head": "Item Search Results",
+  "item.search.results.head": "Výsledky vyhľadávania záznamov",
+
+  // "item.search.title": "Item Search",
+  "item.search.title": "Vyhľadávanie záznamov",
+
+  // "item.truncatable-part.show-more": "Show more",
+  "item.truncatable-part.show-more": "Zobraziť viac",
+
+  // "item.truncatable-part.show-less": "Collapse",
+  "item.truncatable-part.show-less": "Zbaliť",
+
+  // "item.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+  "item.qa-event-notification.check.notification-info.singular": "S vaším účtom súvisí {{num}} čakajúce odporúčanie",
+
+  // "item.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
+  "item.qa-event-notification.check.notification-info.plural": "S vaším účtom súvisí {{num}} čakajúcich odporúčaní",
+
+  // "item.qa-event-notification-info.check.button": "View",
+  "item.qa-event-notification-info.check.button": "Zobraziť",
+
+  // "mydspace.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+  "mydspace.qa-event-notification.check.notification-info.singular": "S vaším účtom súvisí {{num}} čakajúce odporúčanie",
+
+  // "mydspace.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
+  "mydspace.qa-event-notification.check.notification-info.plural": "S vaším účtom súvisí {{num}} čakajúcich odporúčaní",
+
+  // "mydspace.qa-event-notification-info.check.button": "View",
+  "mydspace.qa-event-notification-info.check.button": "Zobraziť",
+
+  // "workflow-item.search.result.delete-supervision.modal.header": "Delete Supervision Order",
+  "workflow-item.search.result.delete-supervision.modal.header": "Odstrániť príkaz dohľadu",
+
+  // "workflow-item.search.result.delete-supervision.modal.info": "Are you sure you want to delete Supervision Order",
+  "workflow-item.search.result.delete-supervision.modal.info": "Naozaj chcete odstrániť príkaz dohľadu?",
+
+  // "workflow-item.search.result.delete-supervision.modal.cancel": "Cancel",
+  "workflow-item.search.result.delete-supervision.modal.cancel": "Zrušiť",
+
+  // "workflow-item.search.result.delete-supervision.modal.confirm": "Delete",
+  "workflow-item.search.result.delete-supervision.modal.confirm": "Odstrániť",
+
+  // "workflow-item.search.result.notification.deleted.success": "Successfully deleted supervision order \"{{name}}\"",
+  "workflow-item.search.result.notification.deleted.success": "Úspešne odstránený príkaz dohľadu \"{{name}}\"",
+
+  // "workflow-item.search.result.notification.deleted.failure": "Failed to delete supervision order \"{{name}}\"",
+  "workflow-item.search.result.notification.deleted.failure": "Pri odstraňovaní príkazu dohľadu \"{{name}}\" došlo k chybe",
+
+  // "workflow-item.search.result.list.element.supervised-by": "Supervised by:",
+  "workflow-item.search.result.list.element.supervised-by": "Pod dohľadom:",
+
+  // "workflow-item.search.result.list.element.supervised.remove-tooltip": "Remove supervision group",
+  "workflow-item.search.result.list.element.supervised.remove-tooltip": "Odobrať skupinu dohľadu",
+
+  // "confidence.indicator.help-text.accepted": "This authority value has been confirmed as accurate by an interactive user",
+  "confidence.indicator.help-text.accepted": "Túto autoritnú hodnotu potvrdil ako správnu interaktívny používateľ",
+
+  // "confidence.indicator.help-text.uncertain": "Value is singular and valid but has not been seen and accepted by a human so it is still uncertain",
+  "confidence.indicator.help-text.uncertain": "Hodnota je jediná a platná, ale nebola videná a prijatá človekom, preto je stále neistá",
+
+  // "confidence.indicator.help-text.ambiguous": "There are multiple matching authority values of equal validity",
+  "confidence.indicator.help-text.ambiguous": "Existuje viacero zodpovedajúcich autoritných hodnôt s rovnakou platnosťou",
+
+  // "confidence.indicator.help-text.notfound": "There are no matching answers in the authority",
+  "confidence.indicator.help-text.notfound": "V autorite nie sú žiadne zodpovedajúce odpovede",
+
+  // "confidence.indicator.help-text.failed": "The authority encountered an internal failure",
+  "confidence.indicator.help-text.failed": "Autoritná služba narazila na internú chybu",
+
+  // "confidence.indicator.help-text.rejected": "The authority recommends this submission be rejected",
+  "confidence.indicator.help-text.rejected": "Autorita odporúča tento vklad zamietnuť",
+
+  // "confidence.indicator.help-text.novalue": "No reasonable confidence value was returned from the authority",
+  "confidence.indicator.help-text.novalue": "Autorita nevrátila žiadnu rozumnú hodnotu istoty",
+
+  // "confidence.indicator.help-text.unset": "Confidence was never recorded for this value",
+  "confidence.indicator.help-text.unset": "Pre túto hodnotu nebola istota nikdy zaznamenaná",
+
+  // "confidence.indicator.help-text.unknown": "Unknown confidence value",
+  "confidence.indicator.help-text.unknown": "Neznáma hodnota istoty",
+
+  // "item.page.abstract": "Abstract",
+  "item.page.abstract": "Abstrakt",
+
+  // "item.page.author": "Author",
+  "item.page.author": "Autor",
+
+  // "item.page.authors": "Authors",
+  "item.page.authors": "Autori",
+
+  // "item.page.citation": "Citation",
+  "item.page.citation": "Citácia",
+
+  // "item.page.collections": "Collections",
+  "item.page.collections": "Kolekcie",
+
+  // "item.page.collections.loading": "Loading...",
+  "item.page.collections.loading": "Načítava sa...",
+
+  // "item.page.collections.load-more": "Load more",
+  "item.page.collections.load-more": "Načítať ďalšie",
+
+  // "item.page.date": "Date",
+  "item.page.date": "Dátum",
+
+  // "item.page.edit": "Administer",
+  "item.page.edit": "Spravovať",
+
+  // "item.page.files": "Files",
+  "item.page.files": "Súbory",
+
+  // "item.page.filesection.description": "Description:",
+  "item.page.filesection.description": "Popis:",
+
+  // "item.page.filesection.download": "Download",
+  "item.page.filesection.download": "Stiahnuť",
+
+  // "item.page.filesection.format": "Format:",
+  "item.page.filesection.format": "Formát:",
+
+  // "item.page.filesection.name": "Name:",
+  "item.page.filesection.name": "Názov:",
+
+  // "item.page.filesection.size": "Size:",
+  "item.page.filesection.size": "Veľkosť:",
+
+  // "item.page.journal.search.title": "Articles in this journal",
+  "item.page.journal.search.title": "Články v tomto časopise",
+
+  // "item.page.link.full": "Full item page",
+  "item.page.link.full": "Zobraziť úplný záznam",
+
+  // "item.page.link.simple": "Simple item page",
+  "item.page.link.simple": "Zobraziť minimálny záznam",
+
+  // "item.page.options": "Options",
+  "item.page.options": "Možnosti",
+
+  // "item.page.orcid.title": "ORCID",
+  "item.page.orcid.title": "ORCID",
+
+  // "item.page.orcid.tooltip": "Open ORCID setting page",
+  "item.page.orcid.tooltip": "Otvoriť stránku nastavení ORCID",
+
+  // "item.page.orcid-ico": "ORCID icon",
+  "item.page.orcid-ico": "Ikona ORCID",
+
+  // "item.page.orcid-profile": "ORCID Profile",
+  "item.page.orcid-profile": "Profil ORCID",
+
+  // "item.page.person.search.title": "Articles by this author",
+  "item.page.person.search.title": "Články tohto autora",
+
+  // "item.page.related-items.view-more": "Show {{ amount }} more",
+  "item.page.related-items.view-more": "Zobraziť ďalších {{ amount }}",
+
+  // "item.page.related-items.view-less": "Hide last {{ amount }}",
+  "item.page.related-items.view-less": "Skryť posledných {{ amount }}",
+
+  // "item.page.relationships.isAuthorOfPublication": "Publications",
+  "item.page.relationships.isAuthorOfPublication": "Publikácie",
+
+  // "item.page.relationships.isJournalOfPublication": "Publications",
+  "item.page.relationships.isJournalOfPublication": "Publikácie",
+
+  // "item.page.relationships.isOrgUnitOfPerson": "Authors",
+  "item.page.relationships.isOrgUnitOfPerson": "Autori",
+
+  // "item.page.relationships.isOrgUnitOfProject": "Research Projects",
+  "item.page.relationships.isOrgUnitOfProject": "Výskumné projekty",
+
+  // "item.page.relationships.RELATION.Person.researchoutputs": "Publications",
+  "item.page.relationships.RELATION.Person.researchoutputs": "Publikácie",
+
+  // "item.page.relationships.RELATION.Person.projects": "Projects",
+  "item.page.relationships.RELATION.Person.projects": "Projekty",
+
+  // "item.page.relationships.RELATION.OrgUnit.rpprojects": "Researchers Projects",
+  "item.page.relationships.RELATION.OrgUnit.rpprojects": "Projekty výskumníkov",
+
+  // "item.page.relationships.RELATION.OrgUnit.publications": "Publications",
+  "item.page.relationships.RELATION.OrgUnit.publications": "Publikácie",
+
+  // "item.page.relationships.RELATION.OrgUnit.rppublications": "Researchers Publications",
+  "item.page.relationships.RELATION.OrgUnit.rppublications": "Publikácie výskumníkov",
+
+  // "item.page.relationships.RELATION.OrgUnit.people": "People",
+  "item.page.relationships.RELATION.OrgUnit.people": "Ľudia",
+
+  // "item.page.relationships.RELATION.OrgUnit.projects": "Projects",
+  "item.page.relationships.RELATION.OrgUnit.projects": "Projekty",
+
+  // "item.page.relationships.RELATION.OrgUnit.organizations": "Organizations",
+  "item.page.relationships.RELATION.OrgUnit.organizations": "Organizácie",
+
+  // "item.page.relationships.RELATION.Project.projects": "Projects",
+  "item.page.relationships.RELATION.Project.projects": "Projekty",
+
+  // "item.page.relationships.RELATION.Project.fundings": "Fundings",
+  "item.page.relationships.RELATION.Project.fundings": "Financovania",
+
+  // "item.page.relationships.RELATION.Project.researchoutputs": "Publications",
+  "item.page.relationships.RELATION.Project.researchoutputs": "Publikácie",
+
+
+  // "item.page.subject": "Keywords",
+  "item.page.subject": "Kľúčové slová",
+
+  // "item.page.uri": "URI",
+  "item.page.uri": "Trvalý identifikátor",
+
+  // "item.page.bitstreams.view-more": "Show more",
+  "item.page.bitstreams.view-more": "Zobraziť viac",
+
+  // "item.page.bitstreams.collapse": "Collapse",
+  "item.page.bitstreams.collapse": "Zbaliť",
+
+  // "item.page.bitstreams.primary": "Primary",
+  "item.page.bitstreams.primary": "Primárny",
+
+  // "item.page.filesection.original.bundle": "Original bundle",
+  "item.page.filesection.original.bundle": "Pôvodný zväzok",
+
+  // "item.page.filesection.license.bundle": "License bundle",
+  "item.page.filesection.license.bundle": "Licenčný zväzok",
+
+  // "item-page.resolver.invalid-custom-url.title": "Invalid custom URL",
+  "item-page.resolver.invalid-custom-url.title": "Neplatná vlastná URL",
+
+  // "item-page.resolver.invalid-custom-url.message": "The custom URL of this item contains unsupported characters. The item is being displayed using its UUID.",
+  "item-page.resolver.invalid-custom-url.message": "Vlastná URL tohto záznamu obsahuje nepodporované znaky. Záznam sa zobrazuje pomocou svojho UUID.",
+
+  // "item.page.return": "Back",
+  "item.page.return": "Späť",
+
+  // "item.page.version.create": "Create new version",
+  "item.page.version.create": "Vytvoriť novú verziu",
+
+  // "item.page.withdrawn": "Request a withdrawal for this item",
+  "item.page.withdrawn": "Požiadať o stiahnutie tohto záznamu",
+
+  // "item.page.reinstate": "Request reinstatement",
+  "item.page.reinstate": "Požiadať o obnovenie",
+
+  // "item.page.version.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
+  "item.page.version.hasDraft": "Novú verziu nemožno vytvoriť, pretože v histórii verzií už existuje rozpracované vloženie.",
+
+  // "item.page.claim.button": "Claim",
+  "item.page.claim.button": "Prevziať",
+
+  // "item.page.claim.tooltip": "Claim this item as profile",
+  "item.page.claim.tooltip": "Nárokovať si tento záznam ako profil",
+
+  // "item.page.image.alt.ROR": "ROR logo",
+  "item.page.image.alt.ROR": "Logo ROR",
+
+  // "item.preview.dc.identifier.uri": "Identifier:",
+  "item.preview.dc.identifier.uri": "Identifikátor:",
+
+  // "item.preview.dc.contributor.author": "Authors:",
+  "item.preview.dc.contributor.author": "Autori:",
+
+  // "item.preview.dc.date.issued": "Published date:",
+  "item.preview.dc.date.issued": "Dátum vydania:",
+
+  // "item.preview.dc.description": "Description:",
+  "item.preview.dc.description": "Popis:",
+
+  // "item.preview.dc.description.abstract": "Abstract:",
+  "item.preview.dc.description.abstract": "Abstrakt:",
+
+  // "item.preview.dc.identifier.other": "Other identifier:",
+  "item.preview.dc.identifier.other": "Ďalší identifikátor:",
+
+  // "item.preview.dc.language.iso": "Language:",
+  "item.preview.dc.language.iso": "Jazyk:",
+
+  // "item.preview.dc.subject": "Subjects:",
+  "item.preview.dc.subject": "Predmety:",
+
+  // "item.preview.dc.title": "Title:",
+  "item.preview.dc.title": "Názov:",
+
+  // "item.preview.dc.type": "Type:",
+  "item.preview.dc.type": "Typ:",
+
+  // "item.preview.oaire.version": "Version",
+  "item.preview.oaire.version": "Verzia",
+
+  // "item.preview.oaire.citation.issue": "Issue",
+  "item.preview.oaire.citation.issue": "Číslo",
+
+  // "item.preview.oaire.citation.volume": "Volume",
+  "item.preview.oaire.citation.volume": "Ročník",
+
+  // "item.preview.oaire.citation.title": "Citation container",
+  "item.preview.oaire.citation.title": "Zdroj citácie",
+
+  // "item.preview.oaire.citation.startPage": "Citation start page",
+  "item.preview.oaire.citation.startPage": "Začiatočná strana citácie",
+
+  // "item.preview.oaire.citation.endPage": "Citation end page",
+  "item.preview.oaire.citation.endPage": "Koncová strana citácie",
+
+  // "item.preview.dc.relation.hasversion": "Has version",
+  "item.preview.dc.relation.hasversion": "Má verziu",
+
+  // "item.preview.dc.relation.ispartofseries": "Is part of series",
+  "item.preview.dc.relation.ispartofseries": "Je súčasťou série",
+
+  // "item.preview.dc.rights": "Rights",
+  "item.preview.dc.rights": "Práva",
+
+  // "item.preview.dc.relation.issn": "ISSN",
+  "item.preview.dc.relation.issn": "ISSN",
+
+  // "item.preview.dc.identifier.isbn": "ISBN",
+  "item.preview.dc.identifier.isbn": "ISBN",
+
+  // "item.preview.dc.identifier": "Identifier:",
+  "item.preview.dc.identifier": "Identifikátor:",
+
+  // "item.preview.dc.relation.ispartof": "Journal or Series",
+  "item.preview.dc.relation.ispartof": "Časopis alebo edícia",
+
+  // "item.preview.dc.identifier.doi": "DOI",
+  "item.preview.dc.identifier.doi": "DOI",
+
+  // "item.preview.dc.publisher": "Publisher:",
+  "item.preview.dc.publisher": "Vydavateľ:",
+
+  // "item.preview.person.familyName": "Surname:",
+  "item.preview.person.familyName": "Priezvisko:",
+
+  // "item.preview.person.givenName": "Name:",
+  "item.preview.person.givenName": "Meno:",
+
+  // "item.preview.person.identifier.orcid": "ORCID:",
+  "item.preview.person.identifier.orcid": "ORCID:",
+
+  // "item.preview.person.affiliation.name": "Affiliations:",
+  "item.preview.person.affiliation.name": "Afiliácie:",
+
+  // "item.preview.project.funder.name": "Funder:",
+  "item.preview.project.funder.name": "Financujúci subjekt:",
+
+  // "item.preview.project.funder.identifier": "Funder Identifier:",
+  "item.preview.project.funder.identifier": "Identifikátor financujúceho subjektu:",
+
+  // "item.preview.project.investigator": "Project Investigator",
+  "item.preview.project.investigator": "Riešiteľ projektu",
+
+  // "item.preview.oaire.awardNumber": "Funding ID:",
+  "item.preview.oaire.awardNumber": "Identifikátor financovania:",
+
+  // "item.preview.dc.title.alternative": "Acronym:",
+  "item.preview.dc.title.alternative": "Skratka:",
+
+  // "item.preview.dc.coverage.spatial": "Jurisdiction:",
+  "item.preview.dc.coverage.spatial": "Jurisdikcia:",
+
+  // "item.preview.oaire.fundingStream": "Funding Stream:",
+  "item.preview.oaire.fundingStream": "Prúd financovania:",
+
+  // "item.preview.oairecerif.identifier.url": "URL",
+  "item.preview.oairecerif.identifier.url": "URL",
+
+  // "item.preview.organization.address.addressCountry": "Country",
+  "item.preview.organization.address.addressCountry": "Krajina",
+
+  // "item.preview.organization.foundingDate": "Founding Date",
+  "item.preview.organization.foundingDate": "Dátum založenia",
+
+  // "item.preview.organization.identifier.crossrefid": "Crossref ID",
+  "item.preview.organization.identifier.crossrefid": "Crossref ID",
+
+  // "item.preview.organization.identifier.isni": "ISNI",
+  "item.preview.organization.identifier.isni": "ISNI",
+
+  // "item.preview.organization.identifier.ror": "ROR ID",
+  "item.preview.organization.identifier.ror": "ROR ID",
+
+  // "item.preview.organization.legalName": "Legal Name",
+  "item.preview.organization.legalName": "Právny názov",
+
+  // "item.preview.dspace.entity.type": "Entity Type:",
+  "item.preview.dspace.entity.type": "Typ entity:",
+
+  // "item.preview.creativework.publisher": "Publisher",
+  "item.preview.creativework.publisher": "Vydavateľ",
+
+  // "item.preview.creativeworkseries.issn": "ISSN",
+  "item.preview.creativeworkseries.issn": "ISSN",
+
+  // "item.preview.dc.identifier.issn": "ISSN",
+  "item.preview.dc.identifier.issn": "ISSN",
+
+  // "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
+  "item.preview.dc.identifier.openalex": "Identifikátor OpenAlex",
+
+  // "item.select.confirm": "Confirm selected",
+  "item.select.confirm": "Potvrdiť vybrané",
+
+  // "item.select.empty": "No items to show",
+  "item.select.empty": "Žiadne záznamy na zobrazenie",
+
+  // "item.select.table.selected": "Selected items",
+  "item.select.table.selected": "Vybrané záznamy",
+
+  // "item.select.table.select": "Select item",
+  "item.select.table.select": "Vybrať záznam",
+
+  // "item.select.table.deselect": "Deselect item",
+  "item.select.table.deselect": "Zrušiť výber záznamu",
+
+  // "item.select.table.author": "Author",
+  "item.select.table.author": "Autor",
+
+  // "item.select.table.collection": "Collection",
+  "item.select.table.collection": "Kolekcia",
+
+  // "item.select.table.title": "Title",
+  "item.select.table.title": "Názov",
+
+  // "item.version.history.empty": "There are no other versions for this item yet.",
+  "item.version.history.empty": "Pre tento záznam zatiaľ neexistujú žiadne ďalšie verzie.",
+
+  // "item.version.history.head": "Version History",
+  "item.version.history.head": "História verzií",
+
+  // "item.version.history.return": "Back",
+  "item.version.history.return": "Späť",
+
+  // "item.version.history.selected": "Selected version",
+  "item.version.history.selected": "Vybraná verzia",
+
+  // "item.version.history.selected.alert": "You are currently viewing version {{version}} of the item.",
+  "item.version.history.selected.alert": "Práve si prezeráte verziu {{version}} záznamu.",
+
+  // "item.version.history.table.version": "Version",
+  "item.version.history.table.version": "Verzia",
+
+  // "item.version.history.table.item": "Item",
+  "item.version.history.table.item": "Záznam",
+
+  // "item.version.history.table.editor": "Editor",
+  "item.version.history.table.editor": "Editor",
+
+  // "item.version.history.table.date": "Date",
+  "item.version.history.table.date": "Dátum",
+
+  // "item.version.history.table.summary": "Summary",
+  "item.version.history.table.summary": "Súhrn",
+
+  // "item.version.history.table.workspaceItem": "Workspace item",
+  "item.version.history.table.workspaceItem": "Položka pracovného priestoru",
+
+  // "item.version.history.table.workflowItem": "Workflow item",
+  "item.version.history.table.workflowItem": "Záznam vo workflow",
+
+  // "item.version.history.table.actions": "Action",
+  "item.version.history.table.actions": "Akcia",
+
+  // "item.version.history.table.action.editWorkspaceItem": "Edit workspace item",
+  "item.version.history.table.action.editWorkspaceItem": "Upraviť položku pracovného priestoru",
+
+  // "item.version.history.table.action.editSummary": "Edit summary",
+  "item.version.history.table.action.editSummary": "Upraviť súhrn",
+
+  // "item.version.history.table.action.saveSummary": "Save summary edits",
+  "item.version.history.table.action.saveSummary": "Uložiť úpravy súhrnu",
+
+  // "item.version.history.table.action.discardSummary": "Discard summary edits",
+  "item.version.history.table.action.discardSummary": "Zahodiť úpravy súhrnu",
+
+  // "item.version.history.table.action.newVersion": "Create new version from this one",
+  "item.version.history.table.action.newVersion": "Vytvoriť novú verziu z tejto verzie",
+
+  // "item.version.history.table.action.deleteVersion": "Delete version",
+  "item.version.history.table.action.deleteVersion": "Odstrániť verziu",
+
+  // "item.version.history.table.action.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
+  "item.version.history.table.action.hasDraft": "Novú verziu nemožno vytvoriť, pretože v histórii verzií už existuje rozpracované vloženie.",
+
+  // "item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
+  "item.version.notice": "Toto nie je najnovšia verzia tohto záznamu. Najnovšiu verziu nájdete <a href='{{destination}}'>tu</a>.",
+
+  // "item.version.create.modal.header": "New version",
+  "item.version.create.modal.header": "Nová verzia",
+
+  // "item.qa.withdrawn.modal.header": "Request withdrawal",
+  "item.qa.withdrawn.modal.header": "Žiadosť o stiahnutie",
+
+  // "item.qa.reinstate.modal.header": "Request reinstate",
+  "item.qa.reinstate.modal.header": "Žiadosť o obnovenie",
+
+  // "item.qa.reinstate.create.modal.header": "New version",
+  "item.qa.reinstate.create.modal.header": "Nová verzia",
+
+  // "item.version.create.modal.text": "Create a new version for this item",
+  "item.version.create.modal.text": "Vytvoriť novú verziu pre tento záznam",
+
+  // "item.version.create.modal.text.startingFrom": "starting from version {{version}}",
+  "item.version.create.modal.text.startingFrom": "počnúc verziou {{version}}",
+
+  // "item.version.create.modal.button.confirm": "Create",
+  "item.version.create.modal.button.confirm": "Vytvoriť",
+
+  // "item.version.create.modal.button.confirm.tooltip": "Create new version",
+  "item.version.create.modal.button.confirm.tooltip": "Vytvoriť novú verziu",
+
+  // "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Send request",
+  "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Odoslať žiadosť",
+
+  // "qa-withdrown.create.modal.button.confirm": "Withdraw",
+  "qa-withdrown.create.modal.button.confirm": "Stiahnuť",
+
+  // "qa-reinstate.create.modal.button.confirm": "Reinstate",
+  "qa-reinstate.create.modal.button.confirm": "Obnoviť",
+
+  // "item.version.create.modal.button.cancel": "Cancel",
+  "item.version.create.modal.button.cancel": "Zrušiť",
+
+  // "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Cancel",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Zrušiť",
+
+  // "item.version.create.modal.button.cancel.tooltip": "Do not create new version",
+  "item.version.create.modal.button.cancel.tooltip": "Nevytvárať novú verziu",
+
+  // "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Do not send request",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Neodosielať žiadosť",
+
+  // "item.version.create.modal.form.summary.label": "Summary",
+  "item.version.create.modal.form.summary.label": "Súhrn",
+
+  // "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
+  "qa-withdrawn.create.modal.form.summary.label": "Žiadate o stiahnutie tohto záznamu",
+
+  // "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
+  "qa-withdrawn.create.modal.form.summary2.label": "Uveďte prosím dôvod stiahnutia",
+
+  // "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
+  "qa-reinstate.create.modal.form.summary.label": "Žiadate o obnovenie tohto záznamu",
+
+  // "qa-reinstate.create.modal.form.summary2.label": "Please enter the reason for the reinstatment",
+  "qa-reinstate.create.modal.form.summary2.label": "Uveďte prosím dôvod obnovenia",
+
+  // "item.version.create.modal.form.summary.placeholder": "Insert the summary for the new version",
+  "item.version.create.modal.form.summary.placeholder": "Vložte súhrn novej verzie",
+
+  // "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
+  "qa-withdrown.modal.form.summary.placeholder": "Zadajte dôvod stiahnutia",
+
+  // "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
+  "qa-reinstate.modal.form.summary.placeholder": "Zadajte dôvod obnovenia",
+
+  // "item.version.create.modal.submitted.header": "Creating new version...",
+  "item.version.create.modal.submitted.header": "Vytvára sa nová verzia...",
+
+  // "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
+  "item.qa.withdrawn.modal.submitted.header": "Odosiela sa žiadosť o stiahnutie...",
+
+  // "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
+  "correction-type.manage-relation.action.notification.reinstate": "Žiadosť o obnovenie odoslaná.",
+
+  // "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
+  "correction-type.manage-relation.action.notification.withdrawn": "Žiadosť o stiahnutie odoslaná.",
+
+  // "item.version.create.modal.submitted.text": "The new version is being created. This may take some time if the item has a lot of relationships.",
+  "item.version.create.modal.submitted.text": "Vytvára sa nová verzia. Môže to chvíľu trvať, ak má záznam veľa vzťahov.",
+
+  // "item.version.create.notification.success": "New version has been created with version number {{version}}",
+  "item.version.create.notification.success": "Bola vytvorená nová verzia s číslom verzie {{version}}",
+
+  // "item.version.create.notification.failure": "New version has not been created",
+  "item.version.create.notification.failure": "Nová verzia nebola vytvorená",
+
+  // "item.version.create.notification.inProgress": "A new version cannot be created because there is an in-progress submission in the version history",
+  "item.version.create.notification.inProgress": "Novú verziu nemožno vytvoriť, pretože v histórii verzií už existuje rozpracované vloženie.",
+
+  // "item.version.delete.modal.header": "Delete version",
+  "item.version.delete.modal.header": "Odstrániť verziu",
+
+  // "item.version.delete.modal.text": "Do you want to delete version {{version}}?",
+  "item.version.delete.modal.text": "Chcete odstrániť verziu {{version}}?",
+
+  // "item.version.delete.modal.button.confirm": "Delete",
+  "item.version.delete.modal.button.confirm": "Odstrániť",
+
+  // "item.version.delete.modal.button.confirm.tooltip": "Delete this version",
+  "item.version.delete.modal.button.confirm.tooltip": "Odstrániť túto verziu",
+
+  // "item.version.delete.modal.button.cancel": "Cancel",
+  "item.version.delete.modal.button.cancel": "Zrušiť",
+
+  // "item.version.delete.modal.button.cancel.tooltip": "Do not delete this version",
+  "item.version.delete.modal.button.cancel.tooltip": "Neodstraňovať túto verziu",
+
+  // "item.version.delete.notification.success": "Version number {{version}} has been deleted",
+  "item.version.delete.notification.success": "Verzia číslo {{version}} bola odstránená",
+
+  // "item.version.delete.notification.failure": "Version number {{version}} has not been deleted",
+  "item.version.delete.notification.failure": "Verzia číslo {{version}} nebola odstránená",
+
+  // "item.version.edit.notification.success": "The summary of version number {{version}} has been changed",
+  "item.version.edit.notification.success": "Súhrn verzie číslo {{version}} bol zmenený",
+
+  // "item.version.edit.notification.failure": "The summary of version number {{version}} has not been changed",
+  "item.version.edit.notification.failure": "Súhrn verzie číslo {{version}} nebol zmenený",
+
+  // "itemtemplate.edit.metadata.add-button": "Add",
+  "itemtemplate.edit.metadata.add-button": "Pridať",
+
+  // "itemtemplate.edit.metadata.discard-button": "Discard",
+  "itemtemplate.edit.metadata.discard-button": "Zahodiť",
+
+  // "itemtemplate.edit.metadata.edit.language": "Edit language",
+  "itemtemplate.edit.metadata.edit.language": "Upraviť jazyk",
+
+  // "itemtemplate.edit.metadata.edit.authority": "Edit authority",
+  "itemtemplate.edit.metadata.edit.authority": "Upraviť autoritu",
+
+  // "itemtemplate.edit.metadata.edit.value": "Edit value",
+  "itemtemplate.edit.metadata.edit.value": "Upraviť hodnotu",
+
+  // "itemtemplate.edit.metadata.edit.buttons.confirm": "Confirm",
+  "itemtemplate.edit.metadata.edit.buttons.confirm": "Potvrdiť",
+
+  // "itemtemplate.edit.metadata.edit.buttons.drag": "Drag to reorder",
+  "itemtemplate.edit.metadata.edit.buttons.drag": "Presunutím zmeníte poradie",
+
+  // "itemtemplate.edit.metadata.edit.buttons.edit": "Edit",
+  "itemtemplate.edit.metadata.edit.buttons.edit": "Upraviť",
+
+  // "itemtemplate.edit.metadata.edit.buttons.remove": "Remove",
+  "itemtemplate.edit.metadata.edit.buttons.remove": "Odstrániť",
+
+  // "itemtemplate.edit.metadata.edit.buttons.undo": "Undo changes",
+  "itemtemplate.edit.metadata.edit.buttons.undo": "Vrátiť zmeny",
+
+  // "itemtemplate.edit.metadata.edit.buttons.unedit": "Stop editing",
+  "itemtemplate.edit.metadata.edit.buttons.unedit": "Ukončiť úpravy",
+
+  // "itemtemplate.edit.metadata.empty": "The item template currently doesn't contain any metadata. Click Add to start adding a metadata value.",
+  "itemtemplate.edit.metadata.empty": "Šablóna záznamu momentálne neobsahuje žiadne metadáta. Kliknutím na Pridať začnete pridávať hodnotu metadát.",
+
+  // "itemtemplate.edit.metadata.headers.edit": "Edit",
+  "itemtemplate.edit.metadata.headers.edit": "Upraviť",
+
+  // "itemtemplate.edit.metadata.headers.field": "Field",
+  "itemtemplate.edit.metadata.headers.field": "Pole",
+
+  // "itemtemplate.edit.metadata.headers.language": "Lang",
+  "itemtemplate.edit.metadata.headers.language": "Jazyk",
+
+  // "itemtemplate.edit.metadata.headers.value": "Value",
+  "itemtemplate.edit.metadata.headers.value": "Hodnota",
+
+  // "itemtemplate.edit.metadata.headers.authority": "Authority",
+  "itemtemplate.edit.metadata.headers.authority": "Autorita",
+
+  // "itemtemplate.edit.metadata.metadatafield": "Edit field",
+  "itemtemplate.edit.metadata.metadatafield": "Upraviť pole",
+
+  // "itemtemplate.edit.metadata.metadatafield.error": "An error occurred validating the metadata field",
+  "itemtemplate.edit.metadata.metadatafield.error": "Pri overovaní metadátového poľa došlo k chybe",
+
+  // "itemtemplate.edit.metadata.metadatafield.invalid": "Please choose a valid metadata field",
+  "itemtemplate.edit.metadata.metadatafield.invalid": "Vyberte prosím platné metadátové pole",
+
+  // "itemtemplate.edit.metadata.notifications.discarded.content": "Your changes were discarded. To reinstate your changes click the 'Undo' button",
+  "itemtemplate.edit.metadata.notifications.discarded.content": "Vaše zmeny boli zahodené. Na obnovenie zmien kliknite na tlačidlo „Vrátiť zmeny“",
+
+  // "itemtemplate.edit.metadata.notifications.discarded.title": "Changes discarded",
+  "itemtemplate.edit.metadata.notifications.discarded.title": "Zmeny zahodené",
+
+  // "itemtemplate.edit.metadata.notifications.error.title": "An error occurred",
+  "itemtemplate.edit.metadata.notifications.error.title": "Došlo k chybe",
+
+  // "itemtemplate.edit.metadata.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
+  "itemtemplate.edit.metadata.notifications.invalid.content": "Vaše zmeny neboli uložené. Pred uložením sa prosím uistite, že všetky polia sú platné.",
+
+  // "itemtemplate.edit.metadata.notifications.invalid.title": "Metadata invalid",
+  "itemtemplate.edit.metadata.notifications.invalid.title": "Neplatné metadáta",
+
+  // "itemtemplate.edit.metadata.notifications.outdated.content": "The item template you're currently working on has been changed by another user. Your current changes are discarded to prevent conflicts",
+  "itemtemplate.edit.metadata.notifications.outdated.content": "Šablónu záznamu, na ktorej práve pracujete, zmenil iný používateľ. Vaše aktuálne zmeny boli zahodené, aby sa zabránilo konfliktom",
+
+  // "itemtemplate.edit.metadata.notifications.outdated.title": "Changes outdated",
+  "itemtemplate.edit.metadata.notifications.outdated.title": "Zmeny sú zastarané",
+
+  // "itemtemplate.edit.metadata.notifications.saved.content": "Your changes to this item template's metadata were saved.",
+  "itemtemplate.edit.metadata.notifications.saved.content": "Vaše zmeny metadát tejto šablóny záznamu boli uložené.",
+
+  // "itemtemplate.edit.metadata.notifications.saved.title": "Metadata saved",
+  "itemtemplate.edit.metadata.notifications.saved.title": "Metadáta uložené",
+
+  // "itemtemplate.edit.metadata.reinstate-button": "Undo",
+  "itemtemplate.edit.metadata.reinstate-button": "Vrátiť späť",
+
+  // "itemtemplate.edit.metadata.reset-order-button": "Undo reorder",
+  "itemtemplate.edit.metadata.reset-order-button": "Vrátiť zmenu poradia",
+
+  // "itemtemplate.edit.metadata.save-button": "Save",
+  "itemtemplate.edit.metadata.save-button": "Uložiť",
+
+  // "journal.listelement.badge": "Journal",
+  "journal.listelement.badge": "Časopis",
+
+  // "journal.page.description": "Description",
+  "journal.page.description": "Popis",
+
+  // "journal.page.edit": "Administer",
+  "journal.page.edit": "Spravovať",
+
+  // "journal.page.editor": "Editor-in-Chief",
+  "journal.page.editor": "Šéfredaktor",
+
+  // "journal.page.issn": "ISSN",
+  "journal.page.issn": "ISSN",
+
+  // "journal.page.publisher": "Publisher",
+  "journal.page.publisher": "Vydavateľ",
+
+  // "journal.page.options": "Options",
+  "journal.page.options": "Možnosti",
+
+  // "journal.page.titleprefix": "Journal: ",
+  "journal.page.titleprefix": "Časopis: ",
+
+  // "journal.search.results.head": "Journal Search Results",
+  "journal.search.results.head": "Výsledky vyhľadávania časopisov",
+
+  // "journal-relationships.search.results.head": "Journal Search Results",
+  "journal-relationships.search.results.head": "Výsledky vyhľadávania časopisov",
+
+  // "journal.search.title": "Journal Search",
+  "journal.search.title": "Vyhľadávanie časopisov",
+
+  // "journalissue.listelement.badge": "Journal Issue",
+  "journalissue.listelement.badge": "Číslo časopisu",
+
+  // "journalissue.page.description": "Description",
+  "journalissue.page.description": "Popis",
+
+  // "journalissue.page.edit": "Administer",
+  "journalissue.page.edit": "Spravovať",
+
+  // "journalissue.page.issuedate": "Issue Date",
+  "journalissue.page.issuedate": "Dátum vydania",
+
+  // "journalissue.page.journal-issn": "Journal ISSN",
+  "journalissue.page.journal-issn": "ISSN časopisu",
+
+  // "journalissue.page.journal-title": "Journal Title",
+  "journalissue.page.journal-title": "Názov časopisu",
+
+  // "journalissue.page.keyword": "Keywords",
+  "journalissue.page.keyword": "Kľúčové slová",
+
+  // "journalissue.page.number": "Number",
+  "journalissue.page.number": "Číslo",
+
+  // "journalissue.page.options": "Options",
+  "journalissue.page.options": "Možnosti",
+
+  // "journalissue.page.titleprefix": "Journal Issue: ",
+  "journalissue.page.titleprefix": "Číslo časopisu: ",
+
+  // "journalissue.search.results.head": "Journal Issue Search Results",
+  "journalissue.search.results.head": "Výsledky vyhľadávania čísel časopisu",
+
+  // "journalvolume.listelement.badge": "Journal Volume",
+  "journalvolume.listelement.badge": "Ročník časopisu",
+
+  // "journalvolume.page.description": "Description",
+  "journalvolume.page.description": "Popis",
+
+  // "journalvolume.page.edit": "Administer",
+  "journalvolume.page.edit": "Spravovať",
+
+  // "journalvolume.page.issuedate": "Issue Date",
+  "journalvolume.page.issuedate": "Dátum vydania",
+
+  // "journalvolume.page.options": "Options",
+  "journalvolume.page.options": "Možnosti",
+
+  // "journalvolume.page.titleprefix": "Journal Volume: ",
+  "journalvolume.page.titleprefix": "Ročník časopisu: ",
+
+  // "journalvolume.page.volume": "Volume",
+  "journalvolume.page.volume": "Ročník",
+
+  // "journalvolume.search.results.head": "Journal Volume Search Results",
+  "journalvolume.search.results.head": "Výsledky vyhľadávania ročníkov časopisu",
+
+  // "iiifsearchable.listelement.badge": "Document Media",
+  "iiifsearchable.listelement.badge": "Médiá dokumentu",
+
+  // "iiifsearchable.page.titleprefix": "Document: ",
+  "iiifsearchable.page.titleprefix": "Dokument: ",
+
+  // "iiifsearchable.page.doi": "Permanent Link: ",
+  "iiifsearchable.page.doi": "Trvalý odkaz: ",
+
+  // "iiifsearchable.page.issue": "Issue: ",
+  "iiifsearchable.page.issue": "Číslo: ",
+
+  // "iiifsearchable.page.description": "Description: ",
+  "iiifsearchable.page.description": "Popis: ",
+
+  // "iiifviewer.fullscreen.notice": "Use full screen for better viewing.",
+  "iiifviewer.fullscreen.notice": "Pre lepšie zobrazenie použite celú obrazovku.",
+
+  // "iiif.listelement.badge": "Image Media",
+  "iiif.listelement.badge": "Obrázkové médiá",
+
+  // "iiif.page.titleprefix": "Image: ",
+  "iiif.page.titleprefix": "Obrázok: ",
+
+  // "iiif.page.doi": "Permanent Link: ",
+  "iiif.page.doi": "Trvalý odkaz: ",
+
+  // "iiif.page.issue": "Issue: ",
+  "iiif.page.issue": "Číslo: ",
+
+  // "iiif.page.description": "Description: ",
+  "iiif.page.description": "Popis: ",
+
+  // "layout.advanced-attachment.dc.title": "Name",
+  "layout.advanced-attachment.dc.title": "Názov",
+
+  // "layout.advanced-attachment.size": "Size",
+  "layout.advanced-attachment.size": "Veľkosť",
+
+  // "layout.advanced-attachment.checksum": "Checksum",
+  "layout.advanced-attachment.checksum": "Kontrolný súčet",
+
+  // "layout.advanced-attachment.checksum.info.MD5": "The <b>MD5 message-digest algorithm</b> can be used to verify the integrity of the file that you have uploaded. You can calculate its value locally via tools that are generally available in each operative system like <b>md5sum</b>",
+  "layout.advanced-attachment.checksum.info.MD5": "<b>Algoritmus MD5</b> možno použiť na overenie integrity súboru, ktorý ste nahrali. Jeho hodnotu môžete vypočítať lokálne pomocou nástrojov, ktoré sú bežne dostupné v každom operačnom systéme, napr. <b>md5sum</b>",
+
+  // "layout.advanced-attachment.format": "Format",
+  "layout.advanced-attachment.format": "Formát",
+
+  // "layout.advanced-attachment.dc.type": "Type",
+  "layout.advanced-attachment.dc.type": "Typ",
+
+  // "layout.advanced-attachment.dc.description": "Description",
+  "layout.advanced-attachment.dc.description": "Popis",
+
+  // "layout.advanced-attachment.no_thumbnail": "No Thumbnail Available",
+  "layout.advanced-attachment.no_thumbnail": "Náhľad nie je k dispozícii",
+
+  // "layout.advanced-attachment.download": "Download",
+  "layout.advanced-attachment.download": "Stiahnuť",
+
+  // "layout.advanced-attachment.requestACopy": "Request a copy",
+  "layout.advanced-attachment.requestACopy": "Požiadať o kópiu",
+
+  // "layout.advanced-attachment.viewMore": "View More",
+  "layout.advanced-attachment.viewMore": "Zobraziť viac",
+
+  // "layout.advanced-attachment.label.not-present": "(not present)",
+  "layout.advanced-attachment.label.not-present": "(chýba)",
+
+  // "loading.bitstream": "Loading bitstream...",
+  "loading.bitstream": "Načítava sa súbor...",
+
+  // "loading.bitstreams": "Loading bitstreams...",
+  "loading.bitstreams": "Načítavajú sa súbory...",
+
+  // "loading.browse-by": "Loading items...",
+  "loading.browse-by": "Načítavajú sa záznamy...",
+
+  // "loading.browse-by-page": "Loading page...",
+  "loading.browse-by-page": "Načítava sa stránka...",
+
+  // "loading.collection": "Loading collection...",
+  "loading.collection": "Načítava sa kolekcia...",
+
+  // "loading.collections": "Loading collections...",
+  "loading.collections": "Načítavajú sa kolekcie...",
+
+  // "loading.content-source": "Loading content source...",
+  "loading.content-source": "Načítava sa zdroj obsahu...",
+
+  // "loading.community": "Loading community...",
+  "loading.community": "Načítava sa komunita...",
+
+  // "loading.default": "Loading...",
+  "loading.default": "Načítava sa...",
+
+  // "loading.item": "Loading item...",
+  "loading.item": "Načítava sa záznam...",
+
+  // "loading.items": "Loading items...",
+  "loading.items": "Načítavajú sa záznamy...",
+
+  // "loading.mydspace-results": "Loading items...",
+  "loading.mydspace-results": "Načítavajú sa záznamy...",
+
+  // "loading.objects": "Loading...",
+  "loading.objects": "Načítava sa...",
+
+  // "loading.recent-submissions": "Loading recent submissions...",
+  "loading.recent-submissions": "Načítavajú sa najnovšie vloženia...",
+
+  // "loading.search-results": "Loading search results...",
+  "loading.search-results": "Načítavajú sa výsledky vyhľadávania...",
+
+  // "loading.sub-collections": "Loading sub-collections...",
+  "loading.sub-collections": "Načítavajú sa podkolekcie...",
+
+  // "loading.sub-communities": "Loading sub-communities...",
+  "loading.sub-communities": "Načítavajú sa podkomunity...",
+
+  // "loading.top-level-communities": "Loading top-level communities...",
+  "loading.top-level-communities": "Načítavajú sa komunity najvyššej úrovne...",
+
+  // "login.form.email": "Email address",
+  "login.form.email": "E-mailová adresa",
+
+  // "login.form.forgot-password": "Have you forgotten your password?",
+  "login.form.forgot-password": "Zabudli ste svoje heslo?",
+
+  // "login.form.header": "Please log in to DSpace",
+  "login.form.header": "Prihláste sa prosím do DSpace",
+
+  // "login.form.new-user": "New user? Click here to register.",
+  "login.form.new-user": "Ste nový používateľ? Kliknutím sem sa zaregistrujete.",
+
+  // "login.form.oidc": "Log in with OIDC",
+  "login.form.oidc": "Prihlásiť sa cez OIDC",
+
+  // "login.form.orcid": "Log in with ORCID",
+  "login.form.orcid": "Prihlásiť sa cez ORCID",
+
+  // "login.form.password": "Password",
+  "login.form.password": "Heslo",
+
+  // "login.form.saml": "Log in with SAML",
+  "login.form.saml": "Prihlásiť sa cez SAML",
+
+  // "login.form.shibboleth": "Log in with Shibboleth",
+  "login.form.shibboleth": "Prihlásiť sa cez Shibboleth",
+
+  // "login.form.submit": "Log in",
+  "login.form.submit": "Prihlásiť sa",
+
+  // "login.title": "Login",
+  "login.title": "Prihlásenie",
+
+  // "login.breadcrumbs": "Login",
+  "login.breadcrumbs": "Prihlásenie",
+
+  // "logout.form.header": "Log out from DSpace",
+  "logout.form.header": "Odhlásiť sa z DSpace",
+
+  // "logout.form.submit": "Log out",
+  "logout.form.submit": "Odhlásiť sa",
+
+  // "logout.title": "Logout",
+  "logout.title": "Odhlásenie",
+
+  // "menu.header.nav.description": "Admin navigation bar",
+  "menu.header.nav.description": "Navigačná lišta správcu",
+
+  // "menu.header.admin": "Management",
+  "menu.header.admin": "Správa",
+
+  // "menu.header.image.logo": "Repository logo",
+  "menu.header.image.logo": "Logo repozitára",
+
+  // "menu.header.admin.description": "Management menu",
+  "menu.header.admin.description": "Ponuka správy",
+
+  // "menu.section.access_control": "Access Control",
+  "menu.section.access_control": "Riadenie prístupu",
+
+  // "menu.section.access_control_authorizations": "Authorizations",
+  "menu.section.access_control_authorizations": "Oprávnenia",
+
+  // "menu.section.access_control_bulk": "Bulk Access Management",
+  "menu.section.access_control_bulk": "Hromadná správa prístupu",
+
+  // "menu.section.access_control_groups": "Groups",
+  "menu.section.access_control_groups": "Skupiny",
+
+  // "menu.section.access_control_people": "People",
+  "menu.section.access_control_people": "Ľudia",
+
+  // "menu.section.audit": "Audit Logs",
+  "menu.section.audit": "Auditné záznamy",
+
+  // "menu.section.reports": "Reports",
+  "menu.section.reports": "Zostavy",
+
+  // "menu.section.reports.collections": "Filtered Collections",
+  "menu.section.reports.collections": "Filtrované kolekcie",
+
+  // "menu.section.reports.queries": "Metadata Query",
+  "menu.section.reports.queries": "Dopyt na metadáta",
+
+  // "menu.section.admin_search": "Admin Search",
+  "menu.section.admin_search": "Administrátorské vyhľadávanie",
+
+  // "menu.section.browse_community": "This Community",
+  "menu.section.browse_community": "Táto komunita",
+
+  // "menu.section.browse_community_by_author": "By Author",
+  "menu.section.browse_community_by_author": "Podľa autora",
+
+  // "menu.section.browse_community_by_issue_date": "By Issue Date",
+  "menu.section.browse_community_by_issue_date": "Podľa dátumu vydania",
+
+  // "menu.section.browse_community_by_title": "By Title",
+  "menu.section.browse_community_by_title": "Podľa názvu",
+
+  // "menu.section.browse_global": "All of DSpace",
+  "menu.section.browse_global": "Celý DSpace",
+
+  // "menu.section.browse_global_by_author": "By Author",
+  "menu.section.browse_global_by_author": "Podľa autora",
+
+  // "menu.section.browse_global_by_dateissued": "By Issue Date",
+  "menu.section.browse_global_by_dateissued": "Podľa dátumu vydania",
+
+  // "menu.section.browse_global_by_subject": "By Subject",
+  "menu.section.browse_global_by_subject": "Podľa predmetu",
+
+  // "menu.section.browse_global_by_srsc": "By Subject Category",
+  "menu.section.browse_global_by_srsc": "Podľa predmetovej kategórie",
+
+  // "menu.section.browse_global_by_nsi": "By Norwegian Science Index",
+  "menu.section.browse_global_by_nsi": "Podľa Norwegian Science Index",
+
+  // "menu.section.browse_global_by_title": "By Title",
+  "menu.section.browse_global_by_title": "Podľa názvu",
+
+  // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
+  "menu.section.browse_global_communities_and_collections": "Komunity a kolekcie",
+
+  // "menu.section.browse_global_geospatial_map": "By Geolocation (Map)",
+  "menu.section.browse_global_geospatial_map": "Podľa geolokácie (mapa)",
+
+  // "menu.section.control_panel": "Control Panel",
+  "menu.section.control_panel": "Ovládací panel",
+
+  // "menu.section.curation_task": "Curation Task",
+  "menu.section.curation_task": "Kurátorská úloha",
+
+  // "menu.section.edit": "Edit",
+  "menu.section.edit": "Upraviť",
+
+  // "menu.section.edit_collection": "Collection",
+  "menu.section.edit_collection": "Kolekcia",
+
+  // "menu.section.edit_community": "Community",
+  "menu.section.edit_community": "Komunita",
+
+  // "menu.section.edit_item": "Item",
+  "menu.section.edit_item": "Záznam",
+
+  // "menu.section.export": "Export",
+  "menu.section.export": "Export",
+
+  // "menu.section.export_collection": "Collection",
+  "menu.section.export_collection": "Kolekcia",
+
+  // "menu.section.export_community": "Community",
+  "menu.section.export_community": "Komunita",
+
+  // "menu.section.export_item": "Item",
+  "menu.section.export_item": "Záznam",
+
+  // "menu.section.export_metadata": "Metadata",
+  "menu.section.export_metadata": "Metadáta",
+
+  // "menu.section.export_batch": "Batch Export (ZIP)",
+  "menu.section.export_batch": "Dávkový export (ZIP)",
+
+  // "menu.section.icon.access_control": "Access Control menu section",
+  "menu.section.icon.access_control": "Sekcia ponuky Riadenie prístupu",
+
+  // "menu.section.icon.reports": "Reports menu section",
+  "menu.section.icon.reports": "Sekcia ponuky Zostavy",
+
+  // "menu.section.icon.admin_search": "Admin search menu section",
+  "menu.section.icon.admin_search": "Sekcia ponuky Administrátorské vyhľadávanie",
+
+  // "menu.section.icon.control_panel": "Control Panel menu section",
+  "menu.section.icon.control_panel": "Sekcia ponuky Ovládací panel",
+
+  // "menu.section.icon.curation_tasks": "Curation Task menu section",
+  "menu.section.icon.curation_tasks": "Sekcia ponuky Kurátorská úloha",
+
+  // "menu.section.icon.edit": "Edit menu section",
+  "menu.section.icon.edit": "Sekcia ponuky Upraviť",
+
+  // "menu.section.icon.export": "Export menu section",
+  "menu.section.icon.export": "Sekcia ponuky Exportovať",
+
+  // "menu.section.icon.find": "Find menu section",
+  "menu.section.icon.find": "Sekcia ponuky Nájsť",
+
+  // "menu.section.icon.health": "Health check menu section",
+  "menu.section.icon.health": "Sekcia ponuky Kontrola stavu",
+
+  // "menu.section.icon.import": "Import menu section",
+  "menu.section.icon.import": "Sekcia ponuky Importovať",
+
+  // "menu.section.icon.new": "New menu section",
+  "menu.section.icon.new": "Sekcia ponuky Nový",
+
+  // "menu.section.icon.pin": "Pin sidebar",
+  "menu.section.icon.pin": "Pripnúť bočný panel",
+
+  // "menu.section.icon.unpin": "Unpin sidebar",
+  "menu.section.icon.unpin": "Odopnúť bočný panel",
+
+  // "menu.section.icon.notifications": "Notifications menu section",
+  "menu.section.icon.notifications": "Sekcia ponuky Oznámenia",
+
+  // "menu.section.import": "Import",
+  "menu.section.import": "Importovať",
+
+  // "menu.section.import_batch": "Batch Import (ZIP)",
+  "menu.section.import_batch": "Dávkový import (ZIP)",
+
+  // "menu.section.import_metadata": "Metadata",
+  "menu.section.import_metadata": "Metadáta",
+
+  // "menu.section.new": "New",
+  "menu.section.new": "Nový",
+
+  // "menu.section.new_collection": "Collection",
+  "menu.section.new_collection": "Kolekcia",
+
+  // "menu.section.new_community": "Community",
+  "menu.section.new_community": "Komunita",
+
+  // "menu.section.new_item": "Item",
+  "menu.section.new_item": "Záznam",
+
+  // "menu.section.new_item_version": "Item Version",
+  "menu.section.new_item_version": "Verzia záznamu",
+
+  // "menu.section.new_process": "Process",
+  "menu.section.new_process": "Proces",
+
+  // "menu.section.notifications": "Notifications",
+  "menu.section.notifications": "Oznámenia",
+
+  // "menu.section.quality-assurance": "Quality Assurance",
+  "menu.section.quality-assurance": "Zabezpečenie kvality",
+
+  // "menu.section.notifications_publication-claim": "Publication Claim",
+  "menu.section.notifications_publication-claim": "Nárokovanie publikácie",
+
+  // "menu.section.pin": "Pin sidebar",
+  "menu.section.pin": "Pripnúť bočný panel",
+
+  // "menu.section.unpin": "Unpin sidebar",
+  "menu.section.unpin": "Odopnúť bočný panel",
+
+  // "menu.section.processes": "Processes",
+  "menu.section.processes": "Procesy",
+
+  // "menu.section.health": "Health",
+  "menu.section.health": "Stav systému",
+
+  // "menu.section.registries": "Registries",
+  "menu.section.registries": "Registre",
+
+  // "menu.section.registries_format": "Format",
+  "menu.section.registries_format": "Formát",
+
+  // "menu.section.registries_metadata": "Metadata",
+  "menu.section.registries_metadata": "Metadáta",
+
+  // "menu.section.statistics": "Statistics",
+  "menu.section.statistics": "Štatistika",
+
+  // "menu.section.statistics_task": "Statistics Task",
+  "menu.section.statistics_task": "Štatistická úloha",
+
+  // "menu.section.toggle.access_control": "Toggle Access Control section",
+  "menu.section.toggle.access_control": "Prepnúť sekciu Riadenie prístupu",
+
+  // "menu.section.toggle.reports": "Toggle Reports section",
+  "menu.section.toggle.reports": "Prepnúť sekciu Zostavy",
+
+  // "menu.section.toggle.control_panel": "Toggle Control Panel section",
+  "menu.section.toggle.control_panel": "Prepnúť sekciu Ovládací panel",
+
+  // "menu.section.toggle.curation_task": "Toggle Curation Task section",
+  "menu.section.toggle.curation_task": "Prepnúť sekciu Kurátorská úloha",
+
+  // "menu.section.toggle.edit": "Toggle Edit section",
+  "menu.section.toggle.edit": "Prepnúť sekciu Úpravy",
+
+  // "menu.section.toggle.export": "Toggle Export section",
+  "menu.section.toggle.export": "Prepnúť sekciu Export",
+
+  // "menu.section.toggle.find": "Toggle Find section",
+  "menu.section.toggle.find": "Prepnúť sekciu Nájsť",
+
+  // "menu.section.toggle.import": "Toggle Import section",
+  "menu.section.toggle.import": "Prepnúť sekciu Import",
+
+  // "menu.section.toggle.new": "Toggle New section",
+  "menu.section.toggle.new": "Prepnúť sekciu Nová",
+
+  // "menu.section.toggle.registries": "Toggle Registries section",
+  "menu.section.toggle.registries": "Prepnúť sekciu Registre",
+
+  // "menu.section.toggle.statistics_task": "Toggle Statistics Task section",
+  "menu.section.toggle.statistics_task": "Prepnúť sekciu Štatistická úloha",
+
+  // "menu.section.workflow": "Administer Workflow",
+  "menu.section.workflow": "Spravovať workflow",
+
+  // "menu.section.FULL": "Edit",
+  "menu.section.FULL": "Upraviť",
+
+  // "menu.section.OWNER": "Edit",
+  "menu.section.OWNER": "Upraviť",
+
+  // "menu.section.DIRECTOR": "Edit",
+  "menu.section.DIRECTOR": "Upraviť",
+
+  // "menu.section.INVESTIGATOR": "Edit",
+  "menu.section.INVESTIGATOR": "Upraviť",
+
+  // "metadata-export-search.tooltip": "Export search results as CSV",
+  "metadata-export-search.tooltip": "Exportovať výsledky vyhľadávania ako CSV",
+
+  // "metadata-export-search.submit.success": "The export was started successfully",
+  "metadata-export-search.submit.success": "Export bol úspešne spustený",
+
+  // "metadata-export-search.submit.error": "Starting the export has failed",
+  "metadata-export-search.submit.error": "Spustenie exportu zlyhalo",
+
+  // "metadata.security.level.title": "Metatada security level {{level}}",
+  "metadata.security.level.title": "Úroveň zabezpečenia metadát {{level}}",
+
+  // "mydspace.breadcrumbs": "MyDSpace",
+  "mydspace.breadcrumbs": "Môj DSpace",
+
+  // "mydspace.description": "",
+  "mydspace.description": "",
+
+  // "mydspace.messages.controller-help": "Select this option to send a message to item's submitter.",
+  "mydspace.messages.controller-help": "Zvoľte túto možnosť, ak chcete odoslať správu vkladateľovi záznamu.",
+
+  // "mydspace.messages.description-placeholder": "Insert your message here...",
+  "mydspace.messages.description-placeholder": "Sem vložte svoju správu...",
+
+  // "mydspace.messages.hide-msg": "Hide message",
+  "mydspace.messages.hide-msg": "Skryť správu",
+
+  // "mydspace.messages.mark-as-read": "Mark as read",
+  "mydspace.messages.mark-as-read": "Označiť ako prečítané",
+
+  // "mydspace.messages.mark-as-unread": "Mark as unread",
+  "mydspace.messages.mark-as-unread": "Označiť ako neprečítané",
+
+  // "mydspace.messages.no-content": "No content.",
+  "mydspace.messages.no-content": "Žiadny obsah.",
+
+  // "mydspace.messages.no-messages": "No messages yet.",
+  "mydspace.messages.no-messages": "Zatiaľ žiadne správy.",
+
+  // "mydspace.messages.send-btn": "Send",
+  "mydspace.messages.send-btn": "Odoslať",
+
+  // "mydspace.messages.show-msg": "Show message",
+  "mydspace.messages.show-msg": "Zobraziť správu",
+
+  // "mydspace.messages.subject-placeholder": "Subject...",
+  "mydspace.messages.subject-placeholder": "Predmet...",
+
+  // "mydspace.messages.submitter-help": "Select this option to send a message to controller.",
+  "mydspace.messages.submitter-help": "Zvoľte túto možnosť, ak chcete odoslať správu správcovi.",
+
+  // "mydspace.messages.title": "Messages",
+  "mydspace.messages.title": "Správy",
+
+  // "mydspace.messages.to": "To",
+  "mydspace.messages.to": "Komu",
+
+  // "mydspace.new-submission": "New submission",
+  "mydspace.new-submission": "Nové vloženie",
+
+  // "mydspace.new-submission-external": "Import metadata from external source",
+  "mydspace.new-submission-external": "Importovať metadáta z externého zdroja",
+
+  // "mydspace.new-submission-external-short": "Import metadata",
+  "mydspace.new-submission-external-short": "Importovať metadáta",
+
+  // "mydspace.results.head": "Your submissions",
+  "mydspace.results.head": "Vaše vloženia",
+
+  // "mydspace.results.no-abstract": "No Abstract",
+  "mydspace.results.no-abstract": "Žiadny abstrakt",
+
+  // "mydspace.results.no-authors": "No Authors",
+  "mydspace.results.no-authors": "Žiadni autori",
+
+  // "mydspace.results.no-collections": "No Collections",
+  "mydspace.results.no-collections": "Žiadne kolekcie",
+
+  // "mydspace.results.no-date": "No Date",
+  "mydspace.results.no-date": "Žiadny dátum",
+
+  // "mydspace.results.no-files": "No Files",
+  "mydspace.results.no-files": "Žiadne súbory",
+
+  // "mydspace.results.no-results": "There were no items to show",
+  "mydspace.results.no-results": "Neboli žiadne záznamy na zobrazenie",
+
+  // "mydspace.results.no-title": "No title",
+  "mydspace.results.no-title": "Žiadny názov",
+
+  // "mydspace.results.no-uri": "No URI",
+  "mydspace.results.no-uri": "Žiadne URI",
+
+  // "mydspace.search-form.placeholder": "Search in MyDSpace...",
+  "mydspace.search-form.placeholder": "Hľadať v mojom DSpace...",
+
+  // "mydspace.show.workflow": "Workflow tasks",
+  "mydspace.show.workflow": "Úlohy workflow",
+
+  // "mydspace.show.workspace": "Your submissions",
+  "mydspace.show.workspace": "Vaše vloženia",
+
+  // "mydspace.show.otherWorkspace": "Shared Submissions",
+  "mydspace.show.otherWorkspace": "Zdieľané vloženia",
+
+  // "mydspace.show.supervisedWorkspace": "Supervised items",
+  "mydspace.show.supervisedWorkspace": "Záznamy pod dohľadom",
+
+  // "mydspace.status": "My DSpace status:",
+  "mydspace.status": "Stav môjho DSpace:",
+
+  // "mydspace.status.mydspaceArchived": "Archived",
+  "mydspace.status.mydspaceArchived": "Archivované",
+
+  // "mydspace.status.mydspaceValidation": "Validation",
+  "mydspace.status.mydspaceValidation": "Overovanie",
+
+  // "mydspace.status.mydspaceWaitingController": "Waiting for reviewer",
+  "mydspace.status.mydspaceWaitingController": "Čaká na posudzovateľa",
+
+  // "mydspace.status.mydspaceWorkflow": "Workflow",
+  "mydspace.status.mydspaceWorkflow": "Workflow",
+
+  // "mydspace.status.mydspaceWorkspace": "Workspace",
+  "mydspace.status.mydspaceWorkspace": "Pracovný priestor",
+
+  // "mydspace.title": "MyDSpace",
+  "mydspace.title": "Môj DSpace",
+
+  // "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+  "mydspace.upload.upload-failed": "Chyba pri vytváraní nového pracovného priestoru. Pred ďalším pokusom overte nahraný obsah.",
+
+  // "mydspace.upload.upload-failed-manyentries": "Unprocessable file. Detected too many entries but allowed only one for file.",
+  "mydspace.upload.upload-failed-manyentries": "Nespracovateľný súbor. Zistených priveľa záznamov, povolený je len jeden na súbor.",
+
+  // "mydspace.upload.upload-failed-moreonefile": "Unprocessable request. Only one file is allowed.",
+  "mydspace.upload.upload-failed-moreonefile": "Nespracovateľná požiadavka. Povolený je len jeden súbor.",
+
+  // "mydspace.upload.upload-multiple-successful": "{{qty}} new workspace items created.",
+  "mydspace.upload.upload-multiple-successful": "Vytvorených {{qty}} nových položiek pracovného priestoru.",
+
+  // "mydspace.view-btn": "View",
+  "mydspace.view-btn": "Zobraziť",
+
+  // "nav.expandable-navbar-section-suffix": "(submenu)",
+  "nav.expandable-navbar-section-suffix": "(podponuka)",
+
+  // "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
+  "notification.suggestion": "Našli sme <b>{{count}} publikácií</b> v zdroji {{source}}, ktoré zrejme súvisia s vaším profilom.<br>",
+
+  // "notification.suggestion.review": "review the suggestions",
+  "notification.suggestion.review": "skontrolujte odporúčania",
+
+  // "notification.suggestion.please": "Please",
+  "notification.suggestion.please": "Prosím",
+
+  // "nav.browse.header": "All of DSpace",
+  "nav.browse.header": "Celý repozitár",
+
+  // "nav.community-browse.header": "By Community",
+  "nav.community-browse.header": "Podľa komunity",
+
+  // "nav.context-help-toggle": "Toggle context help",
+  "nav.context-help-toggle": "Prepnúť kontextovú nápovedu",
+
+  // "nav.language": "Language switch",
+  "nav.language": "Prepínanie jazykov",
+
+  // "nav.login": "Log In",
+  "nav.login": "Prihlásiť sa",
+
+  // "nav.user-profile-menu-and-logout": "User profile menu and log out",
+  "nav.user-profile-menu-and-logout": "Ponuka používateľského profilu a odhlásenie",
+
+  // "nav.logout": "Log Out",
+  "nav.logout": "Odhlásiť sa",
+
+  // "nav.main.description": "Main navigation bar",
+  "nav.main.description": "Hlavný navigačný panel",
+
+  // "nav.mydspace": "MyDSpace",
+  "nav.mydspace": "Môj DSpace",
+
+  // "nav.profile": "Profile",
+  "nav.profile": "Profil",
+
+  // "nav.search": "Search",
+  "nav.search": "Hľadať",
+
+  // "nav.search.button": "Submit search",
+  "nav.search.button": "Vyhľadať",
+
+  // "nav.statistics.header": "Statistics",
+  "nav.statistics.header": "Štatistika",
+
+  // "nav.stop-impersonating": "Stop impersonating EPerson",
+  "nav.stop-impersonating": "Prestať vystupovať ako iný používateľ",
+
+  // "nav.subscriptions": "Subscriptions",
+  "nav.subscriptions": "Odbery",
+
+  // "nav.toggle": "Toggle navigation",
+  "nav.toggle": "Prepnúť navigáciu",
+
+  // "nav.user.description": "User profile bar",
+  "nav.user.description": "Panel používateľského profilu",
+
+  // "listelement.badge.dso-type": "Item type:",
+  "listelement.badge.dso-type": "Typ položky:",
+
+  // "none.listelement.badge": "Item",
+  "none.listelement.badge": "Záznam",
+
+  // "publication-claim.title": "Publication claim",
+  "publication-claim.title": "Nárokovanie publikácie",
+
+  // "publication-claim.source.description": "Below you can see all the sources.",
+  "publication-claim.source.description": "Nižšie sú zobrazené všetky zdroje.",
+
+  // "quality-assurance.title": "Quality Assurance",
+  "quality-assurance.title": "Zabezpečenie kvality",
+
+  // "quality-assurance.topics.description": "Below you can see all the topics received from the subscriptions to {{source}}.",
+  "quality-assurance.topics.description": "Nižšie vidíte všetky témy prijaté z odberov u {{source}}.",
+
+  // "quality-assurance.source.description": "Below you can see all the notification's sources.",
+  "quality-assurance.source.description": "Nižšie vidíte všetky zdroje oznámení.",
+
+  // "quality-assurance.topics": "Current Topics",
+  "quality-assurance.topics": "Aktuálne témy",
+
+  // "quality-assurance.source": "Current Sources",
+  "quality-assurance.source": "Aktuálne zdroje",
+
+  // "quality-assurance.table.topic": "Topic",
+  "quality-assurance.table.topic": "Téma",
+
+  // "quality-assurance.table.source": "Source",
+  "quality-assurance.table.source": "Zdroj",
+
+  // "quality-assurance.table.last-event": "Last Event",
+  "quality-assurance.table.last-event": "Posledná udalosť",
+
+  // "quality-assurance.table.actions": "Actions",
+  "quality-assurance.table.actions": "Akcie",
+
+  // "quality-assurance.source-list.button.detail": "Show topics for {{param}}",
+  "quality-assurance.source-list.button.detail": "Zobraziť témy pre {{param}}",
+
+  // "quality-assurance.topics-list.button.detail": "Show suggestions for {{param}}",
+  "quality-assurance.topics-list.button.detail": "Zobraziť odporúčania pre {{param}}",
+
+  // "quality-assurance.noTopics": "No topics found.",
+  "quality-assurance.noTopics": "Nenašli sa žiadne témy.",
+
+  // "quality-assurance.noSource": "No sources found.",
+  "quality-assurance.noSource": "Nenašli sa žiadne zdroje.",
+
+  // "notifications.events.title": "Quality Assurance Suggestions",
+  "notifications.events.title": "Odporúčania na zabezpečenie kvality",
+
+  // "quality-assurance.topic.error.service.retrieve": "An error occurred while loading the Quality Assurance topics",
+  "quality-assurance.topic.error.service.retrieve": "Pri načítaní tém zabezpečenia kvality došlo k chybe",
+
+  // "quality-assurance.source.error.service.retrieve": "An error occurred while loading the Quality Assurance source",
+  "quality-assurance.source.error.service.retrieve": "Pri načítaní zdrojov zabezpečenia kvality došlo k chybe",
+
+  // "quality-assurance.loading": "Loading ...",
+  "quality-assurance.loading": "Načítava sa ...",
+
+  // "quality-assurance.events.topic": "Topic:",
+  "quality-assurance.events.topic": "Téma:",
+
+  // "quality-assurance.noEvents": "No suggestions found.",
+  "quality-assurance.noEvents": "Nenašli sa žiadne odporúčania.",
+
+  // "quality-assurance.event.table.trust": "Trust",
+  "quality-assurance.event.table.trust": "Dôvera",
+
+  // "quality-assurance.event.table.publication": "Publication",
+  "quality-assurance.event.table.publication": "Publikácia",
+
+  // "quality-assurance.event.table.details": "Details",
+  "quality-assurance.event.table.details": "Podrobnosti",
+
+  // "quality-assurance.event.table.project-details": "Project details",
+  "quality-assurance.event.table.project-details": "Podrobnosti o projekte",
+
+  // "quality-assurance.event.table.reasons": "Reasons",
+  "quality-assurance.event.table.reasons": "Dôvody",
+
+  // "quality-assurance.event.table.actions": "Actions",
+  "quality-assurance.event.table.actions": "Akcie",
+
+  // "quality-assurance.event.action.accept": "Accept suggestion",
+  "quality-assurance.event.action.accept": "Prijať odporúčanie",
+
+  // "quality-assurance.event.action.ignore": "Ignore suggestion",
+  "quality-assurance.event.action.ignore": "Ignorovať odporúčanie",
+
+  // "quality-assurance.event.action.undo": "Delete",
+  "quality-assurance.event.action.undo": "Odstrániť",
+
+  // "quality-assurance.event.action.reject": "Reject suggestion",
+  "quality-assurance.event.action.reject": "Odmietnuť odporúčanie",
+
+  // "quality-assurance.event.action.import": "Import project and accept suggestion",
+  "quality-assurance.event.action.import": "Importovať projekt a prijať odporúčanie",
+
+  // "quality-assurance.event.table.pidtype": "PID Type:",
+  "quality-assurance.event.table.pidtype": "Typ PID:",
+
+  // "quality-assurance.event.table.pidvalue": "PID Value:",
+  "quality-assurance.event.table.pidvalue": "Hodnota PID:",
+
+  // "quality-assurance.event.table.subjectValue": "Subject Value:",
+  "quality-assurance.event.table.subjectValue": "Hodnota predmetu:",
+
+  // "quality-assurance.event.table.abstract": "Abstract:",
+  "quality-assurance.event.table.abstract": "Abstrakt:",
+
+  // "quality-assurance.event.table.suggestedProject": "OpenAIRE Suggested Project data",
+  "quality-assurance.event.table.suggestedProject": "Navrhované údaje projektu OpenAIRE",
+
+  // "quality-assurance.event.table.project": "Project title:",
+  "quality-assurance.event.table.project": "Názov projektu:",
+
+  // "quality-assurance.event.table.acronym": "Acronym:",
+  "quality-assurance.event.table.acronym": "Skratka:",
+
+  // "quality-assurance.event.table.code": "Code:",
+  "quality-assurance.event.table.code": "Kód:",
+
+  // "quality-assurance.event.table.funder": "Funder:",
+  "quality-assurance.event.table.funder": "Poskytovateľ financií:",
+
+  // "quality-assurance.event.table.fundingProgram": "Funding program:",
+  "quality-assurance.event.table.fundingProgram": "Program financovania:",
+
+  // "quality-assurance.event.table.jurisdiction": "Jurisdiction:",
+  "quality-assurance.event.table.jurisdiction": "Jurisdikcia:",
+
+  // "quality-assurance.events.back": "Back to topics",
+  "quality-assurance.events.back": "Späť na témy",
+
+  // "quality-assurance.events.back-to-sources": "Back to sources",
+  "quality-assurance.events.back-to-sources": "Späť na zdroje",
+
+  // "quality-assurance.event.table.less": "Show less",
+  "quality-assurance.event.table.less": "Zobraziť menej",
+
+  // "quality-assurance.event.table.more": "Show more",
+  "quality-assurance.event.table.more": "Zobraziť viac",
+
+  // "quality-assurance.event.project.found": "Bound to the local record:",
+  "quality-assurance.event.project.found": "Prepojené s lokálnym záznamom:",
+
+  // "quality-assurance.event.project.notFound": "No local record found",
+  "quality-assurance.event.project.notFound": "Nenašiel sa žiadny lokálny záznam",
+
+  // "quality-assurance.event.sure": "Are you sure?",
+  "quality-assurance.event.sure": "Ste si istí?",
+
+  // "quality-assurance.event.ignore.description": "This operation can't be undone. Ignore this suggestion?",
+  "quality-assurance.event.ignore.description": "Túto operáciu nemožno vrátiť. Ignorovať toto odporúčanie?",
+
+  // "quality-assurance.event.undo.description": "This operation can't be undone!",
+  "quality-assurance.event.undo.description": "Túto operáciu nemožno vrátiť!",
+
+  // "quality-assurance.event.reject.description": "This operation can't be undone. Reject this suggestion?",
+  "quality-assurance.event.reject.description": "Túto operáciu nemožno vrátiť. Odmietnuť toto odporúčanie?",
+
+  // "quality-assurance.event.accept.description": "No DSpace project selected. A new project will be created based on the suggestion data.",
+  "quality-assurance.event.accept.description": "Nebol vybraný žiadny projekt DSpace. Nový projekt sa vytvorí na základe údajov z odporúčania.",
+
+  // "quality-assurance.event.action.cancel": "Cancel",
+  "quality-assurance.event.action.cancel": "Zrušiť",
+
+  // "quality-assurance.event.action.saved": "Your decision has been saved successfully.",
+  "quality-assurance.event.action.saved": "Vaše rozhodnutie bolo úspešne uložené.",
+
+  // "quality-assurance.event.action.error": "An error has occurred. Your decision has not been saved.",
+  "quality-assurance.event.action.error": "Došlo k chybe. Vaše rozhodnutie nebolo uložené.",
+
+  // "quality-assurance.event.modal.project.title": "Choose a project to bound",
+  "quality-assurance.event.modal.project.title": "Zvoľte projekt na prepojenie",
+
+  // "quality-assurance.event.modal.project.publication": "Publication:",
+  "quality-assurance.event.modal.project.publication": "Publikácia:",
+
+  // "quality-assurance.event.modal.project.bountToLocal": "Bound to the local record:",
+  "quality-assurance.event.modal.project.bountToLocal": "Prepojené s lokálnym záznamom:",
+
+  // "quality-assurance.event.modal.project.select": "Project search",
+  "quality-assurance.event.modal.project.select": "Vyhľadávanie projektov",
+
+  // "quality-assurance.event.modal.project.search": "Search",
+  "quality-assurance.event.modal.project.search": "Hľadať",
+
+  // "quality-assurance.event.modal.project.clear": "Clear",
+  "quality-assurance.event.modal.project.clear": "Vymazať",
+
+  // "quality-assurance.event.modal.project.cancel": "Cancel",
+  "quality-assurance.event.modal.project.cancel": "Zrušiť",
+
+  // "quality-assurance.event.modal.project.bound": "Bound project",
+  "quality-assurance.event.modal.project.bound": "Prepojený projekt",
+
+  // "quality-assurance.event.modal.project.remove": "Remove",
+  "quality-assurance.event.modal.project.remove": "Odobrať",
+
+  // "quality-assurance.event.modal.project.placeholder": "Enter a project name",
+  "quality-assurance.event.modal.project.placeholder": "Zadajte názov projektu",
+
+  // "quality-assurance.event.modal.project.notFound": "No project found.",
+  "quality-assurance.event.modal.project.notFound": "Nenašiel sa žiadny projekt.",
+
+  // "quality-assurance.event.project.bounded": "The project has been linked successfully.",
+  "quality-assurance.event.project.bounded": "Projekt bol úspešne prepojený.",
+
+  // "quality-assurance.event.project.removed": "The project has been successfully unlinked.",
+  "quality-assurance.event.project.removed": "Prepojenie projektu bolo úspešne zrušené.",
+
+  // "quality-assurance.event.project.error": "An error has occurred. No operation performed.",
+  "quality-assurance.event.project.error": "Došlo k chybe. Nebola vykonaná žiadna operácia.",
+
+  // "quality-assurance.event.reason": "Reason",
+  "quality-assurance.event.reason": "Dôvod",
+
+  // "orcid.badge.tooltip": "Connected to ORCID",
+  "orcid.badge.tooltip": "Pripojené k ORCID",
+
+  // "orgunit.listelement.badge": "Organizational Unit",
+  "orgunit.listelement.badge": "Organizačná jednotka",
+
+  // "orgunit.listelement.no-title": "Untitled",
+  "orgunit.listelement.no-title": "Bez názvu",
+
+  // "orgunit.page.city": "City",
+  "orgunit.page.city": "Mesto",
+
+  // "orgunit.page.country": "Country",
+  "orgunit.page.country": "Krajina",
+
+  // "orgunit.page.dateestablished": "Date established",
+  "orgunit.page.dateestablished": "Dátum založenia",
+
+  // "orgunit.page.description": "Description",
+  "orgunit.page.description": "Popis",
+
+  // "orgunit.page.edit": "Administer",
+  "orgunit.page.edit": "Spravovať",
+
+  // "orgunit.page.id": "ID",
+  "orgunit.page.id": "ID",
+
+  // "orgunit.page.options": "Options",
+  "orgunit.page.options": "Možnosti",
+
+  // "orgunit.page.titleprefix": "Organizational Unit: ",
+  "orgunit.page.titleprefix": "Organizačná jednotka: ",
+
+  // "orgunit.page.ror": "ROR Identifier",
+  "orgunit.page.ror": "Identifikátor ROR",
+
+  // "orgunit.search.results.head": "Organizational Unit Search Results",
+  "orgunit.search.results.head": "Výsledky vyhľadávania organizačných jednotiek",
+
+  // "pagination.options.description": "Pagination options",
+  "pagination.options.description": "Možnosti stránkovania",
+
+  // "pagination.results-per-page": "Results Per Page",
+  "pagination.results-per-page": "Výsledkov na stranu",
+
+  // "pagination.showing.detail": "{{ range }} of {{ total }}",
+  "pagination.showing.detail": "{{ range }} z {{ total }}",
+
+  // "pagination.showing.label": "Now showing ",
+  "pagination.showing.label": "Teraz sa zobrazuje ",
+
+  // "pagination.sort-direction": "Sort Options",
+  "pagination.sort-direction": "Možnosti zoradenia",
+
+  // "person.listelement.badge": "Person",
+  "person.listelement.badge": "Osoba",
+
+  // "person.listelement.no-title": "No name found",
+  "person.listelement.no-title": "Nenašlo sa žiadne meno",
+
+  // "person.page.birthdate": "Birth Date",
+  "person.page.birthdate": "Dátum narodenia",
+
+  // "person.page.edit": "Administer",
+  "person.page.edit": "Spravovať",
+
+  // "person.page.email": "Email Address",
+  "person.page.email": "E-mailová adresa",
+
+  // "person.page.firstname": "First Name",
+  "person.page.firstname": "Krstné meno",
+
+  // "person.page.jobtitle": "Job Title",
+  "person.page.jobtitle": "Pracovná pozícia",
+
+  // "person.page.lastname": "Last Name",
+  "person.page.lastname": "Priezvisko",
+
+  // "person.page.name": "Name",
+  "person.page.name": "Meno",
+
+  // "person.page.link.full": "Show all metadata",
+  "person.page.link.full": "Zobraziť všetky metadáta",
+
+  // "person.page.options": "Options",
+  "person.page.options": "Možnosti",
+
+  // "person.page.orcid": "ORCID",
+  "person.page.orcid": "ORCID",
+
+  // "person.page.staffid": "Staff ID",
+  "person.page.staffid": "ID zamestnanca",
+
+  // "person.page.titleprefix": "Person: ",
+  "person.page.titleprefix": "Osoba: ",
+
+  // "person.search.results.head": "Person Search Results",
+  "person.search.results.head": "Výsledky vyhľadávania osôb",
+
+  // "person-relationships.search.results.head": "Person Search Results",
+  "person-relationships.search.results.head": "Výsledky vyhľadávania osôb",
+
+  // "person.search.title": "Person Search",
+  "person.search.title": "Vyhľadávanie osôb",
+
+  // "process.new.select-parameters": "Parameters",
+  "process.new.select-parameters": "Parametre",
+
+  // "process.new.select-parameter": "Select parameter",
+  "process.new.select-parameter": "Vyberte parameter",
+
+  // "process.new.add-parameter": "Add a parameter...",
+  "process.new.add-parameter": "Pridať parameter...",
+
+  // "process.new.delete-parameter": "Delete parameter",
+  "process.new.delete-parameter": "Odstrániť parameter",
+
+  // "process.new.parameter.label": "Parameter value",
+  "process.new.parameter.label": "Hodnota parametra",
+
+  // "process.new.cancel": "Cancel",
+  "process.new.cancel": "Zrušiť",
+
+  // "process.new.submit": "Save",
+  "process.new.submit": "Uložiť",
+
+  // "process.new.select-script": "Script",
+  "process.new.select-script": "Skript",
+
+  // "process.new.select-script.placeholder": "Choose a script...",
+  "process.new.select-script.placeholder": "Vyberte skript...",
+
+  // "process.new.select-script.required": "Script is required",
+  "process.new.select-script.required": "Skript je povinný",
+
+  // "process.new.parameter.file.upload-button": "Select file...",
+  "process.new.parameter.file.upload-button": "Vyberte súbor...",
+
+  // "process.new.parameter.file.required": "Please select a file",
+  "process.new.parameter.file.required": "Vyberte prosím súbor",
+
+  // "process.new.parameter.integer.required": "Parameter value is required",
+  "process.new.parameter.integer.required": "Hodnota parametra je povinná",
+
+  // "process.new.parameter.string.required": "Parameter value is required",
+  "process.new.parameter.string.required": "Hodnota parametra je povinná",
+
+  // "process.new.parameter.type.value": "value",
+  "process.new.parameter.type.value": "hodnota",
+
+  // "process.new.parameter.type.file": "file",
+  "process.new.parameter.type.file": "súbor",
+
+  // "process.new.parameter.required.missing": "The following parameters are required but still missing:",
+  "process.new.parameter.required.missing": "Nasledujúce parametre sú povinné, ale stále chýbajú:",
+
+  // "process.new.notification.success.title": "Success",
+  "process.new.notification.success.title": "Prebehlo úspešne",
+
+  // "process.new.notification.success.content": "The process was successfully created",
+  "process.new.notification.success.content": "Proces bol úspešne vytvorený",
+
+  // "process.new.notification.error.title": "Error",
+  "process.new.notification.error.title": "Chyba",
+
+  // "process.new.notification.error.content": "An error occurred while creating this process",
+  "process.new.notification.error.content": "Pri vytváraní tohto procesu došlo k chybe",
+
+  // "process.new.notification.error.max-upload.content": "The file exceeds the maximum upload size",
+  "process.new.notification.error.max-upload.content": "Súbor prekračuje maximálnu veľkosť nahrávania",
+
+  // "process.new.header": "Create a new process",
+  "process.new.header": "Vytvoriť nový proces",
+
+  // "process.new.title": "Create a new process",
+  "process.new.title": "Vytvoriť nový proces",
+
+  // "process.new.breadcrumbs": "Create a new process",
+  "process.new.breadcrumbs": "Vytvoriť nový proces",
+
+  // "process.detail.arguments": "Arguments",
+  "process.detail.arguments": "Argumenty",
+
+  // "process.detail.arguments.empty": "This process doesn't contain any arguments",
+  "process.detail.arguments.empty": "Tento proces neobsahuje žiadne argumenty",
+
+  // "process.detail.back": "Back",
+  "process.detail.back": "Späť",
+
+  // "process.detail.output": "Process Output",
+  "process.detail.output": "Výstup procesu",
+
+  // "process.detail.logs.button": "Retrieve process output",
+  "process.detail.logs.button": "Získať výstup procesu",
+
+  // "process.detail.logs.loading": "Retrieving",
+  "process.detail.logs.loading": "Načítava sa",
+
+  // "process.detail.logs.none": "This process has no output",
+  "process.detail.logs.none": "Tento proces nemá žiadny výstup",
+
+  // "process.detail.output-files": "Output Files",
+  "process.detail.output-files": "Výstupné súbory",
+
+  // "process.detail.output-files.empty": "This process doesn't contain any output files",
+  "process.detail.output-files.empty": "Tento proces neobsahuje žiadne výstupné súbory",
+
+  // "process.detail.script": "Script",
+  "process.detail.script": "Skript",
+
+  // "process.detail.title": "Process: {{ id }} - {{ name }}",
+  "process.detail.title": "Proces: {{ id }} - {{ name }}",
+
+  // "process.detail.start-time": "Start time",
+  "process.detail.start-time": "Čas začiatku",
+
+  // "process.detail.end-time": "Finish time",
+  "process.detail.end-time": "Čas ukončenia",
+
+  // "process.detail.status": "Status",
+  "process.detail.status": "Stav",
+
+  // "process.detail.create": "Create similar process",
+  "process.detail.create": "Vytvoriť podobný proces",
+
+  // "process.detail.actions": "Actions",
+  "process.detail.actions": "Akcie",
+
+  // "process.detail.delete.button": "Delete process",
+  "process.detail.delete.button": "Odstrániť proces",
+
+  // "process.detail.delete.header": "Delete process",
+  "process.detail.delete.header": "Odstrániť proces",
+
+  // "process.detail.delete.body": "Are you sure you want to delete the current process?",
+  "process.detail.delete.body": "Naozaj chcete odstrániť aktuálny proces?",
+
+  // "process.detail.delete.cancel": "Cancel",
+  "process.detail.delete.cancel": "Zrušiť",
+
+  // "process.detail.delete.confirm": "Delete process",
+  "process.detail.delete.confirm": "Odstrániť proces",
+
+  // "process.detail.delete.success": "The process was successfully deleted.",
+  "process.detail.delete.success": "Proces bol úspešne odstránený.",
+
+  // "process.detail.delete.error": "Something went wrong when deleting the process",
+  "process.detail.delete.error": "Pri odstraňovaní procesu sa niečo pokazilo",
+
+  // "process.detail.refreshing": "Auto-refreshing…",
+  "process.detail.refreshing": "Automatické obnovovanie…",
+
+  // "process.overview.table.completed.info": "Finish time (UTC)",
+  "process.overview.table.completed.info": "Čas dokončenia (UTC)",
+
+  // "process.overview.table.completed.title": "Succeeded processes",
+  "process.overview.table.completed.title": "Úspešné procesy",
+
+  // "process.overview.table.empty": "No matching processes found.",
+  "process.overview.table.empty": "Nenašli sa žiadne zodpovedajúce procesy.",
+
+  // "process.overview.table.failed.info": "Finish time (UTC)",
+  "process.overview.table.failed.info": "Čas dokončenia (UTC)",
+
+  // "process.overview.table.failed.title": "Failed processes",
+  "process.overview.table.failed.title": "Neúspešné procesy",
+
+  // "process.overview.table.finish": "Finish time (UTC)",
+  "process.overview.table.finish": "Čas ukončenia (UTC)",
+
+  // "process.overview.table.id": "Process ID",
+  "process.overview.table.id": "ID procesu",
+
+  // "process.overview.table.name": "Name",
+  "process.overview.table.name": "Názov",
+
+  // "process.overview.table.running.info": "Start time (UTC)",
+  "process.overview.table.running.info": "Čas začiatku (UTC)",
+
+  // "process.overview.table.running.title": "Running processes",
+  "process.overview.table.running.title": "Bežiace procesy",
+
+  // "process.overview.table.scheduled.info": "Creation time (UTC)",
+  "process.overview.table.scheduled.info": "Čas vytvorenia (UTC)",
+
+  // "process.overview.table.scheduled.title": "Scheduled processes",
+  "process.overview.table.scheduled.title": "Naplánované procesy",
+
+  // "process.overview.table.start": "Start time (UTC)",
+  "process.overview.table.start": "Čas začiatku (UTC)",
+
+  // "process.overview.table.status": "Status",
+  "process.overview.table.status": "Stav",
+
+  // "process.overview.table.user": "User",
+  "process.overview.table.user": "Používateľ",
+
+  // "process.overview.title": "Processes Overview",
+  "process.overview.title": "Prehľad procesov",
+
+  // "process.overview.breadcrumbs": "Processes Overview",
+  "process.overview.breadcrumbs": "Prehľad procesov",
+
+  // "process.overview.new": "New",
+  "process.overview.new": "Nový",
+
+  // "process.overview.table.actions": "Actions",
+  "process.overview.table.actions": "Akcie",
+
+  // "process.overview.delete": "Delete {{count}} processes",
+  "process.overview.delete": "Odstrániť {{count}} procesov",
+
+  // "process.overview.delete-process": "Delete process",
+  "process.overview.delete-process": "Odstrániť proces",
+
+  // "process.overview.delete.clear": "Clear delete selection",
+  "process.overview.delete.clear": "Zrušiť výber na odstránenie",
+
+  // "process.overview.delete.processing": "{{count}} process(es) are being deleted. Please wait for the deletion to fully complete. Note that this can take a while.",
+  "process.overview.delete.processing": "Odstraňuje sa {{count}} procesov. Počkajte prosím na úplné dokončenie odstraňovania. Môže to chvíľu trvať.",
+
+  // "process.overview.delete.body": "Are you sure you want to delete {{count}} process(es)?",
+  "process.overview.delete.body": "Naozaj chcete odstrániť {{count}} procesov?",
+
+  // "process.overview.delete.header": "Delete processes",
+  "process.overview.delete.header": "Odstrániť procesy",
+
+  // "process.overview.unknown.user": "Unknown",
+  "process.overview.unknown.user": "Neznámy",
+
+  // "process.bulk.delete.error.head": "Error on deleting process",
+  "process.bulk.delete.error.head": "Chyba pri odstraňovaní procesu",
+
+  // "process.bulk.delete.error.body": "The process with ID {{processId}} could not be deleted. The remaining processes will continue being deleted.",
+  "process.bulk.delete.error.body": "Proces s ID {{processId}} sa nepodarilo odstrániť. Zvyšné procesy sa budú naďalej odstraňovať.",
+
+  // "process.bulk.delete.success": "{{count}} process(es) have been successfully deleted",
+  "process.bulk.delete.success": "{{count}} procesov bolo úspešne odstránených",
+
+  // "profile.breadcrumbs": "Update Profile",
+  "profile.breadcrumbs": "Aktualizovať profil",
+
+  // "profile.card.accessibility.content": "Accessibility settings can be configured on the accessibility settings page.",
+  "profile.card.accessibility.content": "Nastavenia prístupnosti možno upraviť na stránke nastavení prístupnosti.",
+
+  // "profile.card.accessibility.header": "Accessibility",
+  "profile.card.accessibility.header": "Prístupnosť",
+
+  // "profile.card.accessibility.link": "Go to Accessibility Settings Page",
+  "profile.card.accessibility.link": "Prejsť na stránku nastavení prístupnosti",
+
+  // "profile.card.identify": "Identify",
+  "profile.card.identify": "Identifikácia",
+
+  // "profile.card.security": "Security",
+  "profile.card.security": "Zabezpečenie",
+
+  // "profile.form.submit": "Save",
+  "profile.form.submit": "Uložiť",
+
+  // "profile.groups.head": "Authorization groups you belong to",
+  "profile.groups.head": "Autorizačné skupiny, do ktorých patríte",
+
+  // "profile.special.groups.head": "Authorization special groups you belong to",
+  "profile.special.groups.head": "Špeciálne autorizačné skupiny, do ktorých patríte",
+
+  // "profile.metadata.form.error.firstname.required": "First Name is required",
+  "profile.metadata.form.error.firstname.required": "Krstné meno je povinné",
+
+  // "profile.metadata.form.error.lastname.required": "Last Name is required",
+  "profile.metadata.form.error.lastname.required": "Priezvisko je povinné",
+
+  // "profile.metadata.form.label.email": "Email Address",
+  "profile.metadata.form.label.email": "E-mailová adresa",
+
+  // "profile.metadata.form.label.firstname": "First Name",
+  "profile.metadata.form.label.firstname": "Krstné meno",
+
+  // "profile.metadata.form.label.language": "Language",
+  "profile.metadata.form.label.language": "Jazyk",
+
+  // "profile.metadata.form.label.lastname": "Last Name",
+  "profile.metadata.form.label.lastname": "Priezvisko",
+
+  // "profile.metadata.form.label.phone": "Contact Telephone",
+  "profile.metadata.form.label.phone": "Kontaktný telefón",
+
+  // "profile.metadata.form.notifications.success.content": "Your changes to the profile were saved.",
+  "profile.metadata.form.notifications.success.content": "Vaše zmeny v profile boli uložené.",
+
+  // "profile.metadata.form.notifications.success.title": "Profile saved",
+  "profile.metadata.form.notifications.success.title": "Profil uložený",
+
+  // "profile.notifications.warning.no-changes.content": "No changes were made to the Profile.",
+  "profile.notifications.warning.no-changes.content": "V profile neboli vykonané žiadne zmeny.",
+
+  // "profile.notifications.warning.no-changes.title": "No changes",
+  "profile.notifications.warning.no-changes.title": "Žiadne zmeny",
+
+  // "profile.security.form.error.matching-passwords": "The passwords do not match.",
+  "profile.security.form.error.matching-passwords": "Heslá sa nezhodujú.",
+
+  // "profile.security.form.info": "Optionally, you can enter a new password in the box below, and confirm it by typing it again into the second box.",
+  "profile.security.form.info": "Voliteľne môžete zadať nové heslo do poľa nižšie a potvrdiť ho opätovným zadaním do druhého poľa.",
+
+  // "profile.security.form.label.password": "Password",
+  "profile.security.form.label.password": "Heslo",
+
+  // "profile.security.form.label.passwordrepeat": "Retype to confirm",
+  "profile.security.form.label.passwordrepeat": "Zadajte znova pre potvrdenie",
+
+  // "profile.security.form.label.current-password": "Current password",
+  "profile.security.form.label.current-password": "Aktuálne heslo",
+
+  // "profile.security.form.notifications.success.content": "Your changes to the password were saved.",
+  "profile.security.form.notifications.success.content": "Vaše zmeny hesla boli uložené.",
+
+  // "profile.security.form.notifications.success.title": "Password saved",
+  "profile.security.form.notifications.success.title": "Heslo uložené",
+
+  // "profile.security.form.notifications.error.title": "Error changing passwords",
+  "profile.security.form.notifications.error.title": "Chyba pri zmene hesla",
+
+  // "profile.security.form.notifications.error.change-failed": "An error occurred while trying to change the password. Please check if the current password is correct.",
+  "profile.security.form.notifications.error.change-failed": "Pri pokuse o zmenu hesla došlo k chybe. Skontrolujte prosím, či je aktuálne heslo správne.",
+
+  // "profile.security.form.notifications.error.not-same": "The provided passwords are not the same.",
+  "profile.security.form.notifications.error.not-same": "Zadané heslá nie sú rovnaké.",
+
+  // "profile.security.form.notifications.error.general": "Please fill required fields of security form.",
+  "profile.security.form.notifications.error.general": "Vyplňte prosím povinné polia bezpečnostného formulára.",
+
+  // "profile.title": "Update Profile",
+  "profile.title": "Aktualizovať profil",
+
+  // "profile.card.researcher": "Researcher Profile",
+  "profile.card.researcher": "Profil výskumníka",
+
+  // "project.listelement.badge": "Research Project",
+  "project.listelement.badge": "Výskumný projekt",
+
+  // "project.page.contributor": "Contributors",
+  "project.page.contributor": "Prispievatelia",
+
+  // "project.page.description": "Description",
+  "project.page.description": "Popis",
+
+  // "project.page.edit": "Administer",
+  "project.page.edit": "Spravovať",
+
+  // "project.page.expectedcompletion": "Expected Completion",
+  "project.page.expectedcompletion": "Predpokladané dokončenie",
+
+  // "project.page.funder": "Funders",
+  "project.page.funder": "Poskytovatelia financií",
+
+  // "project.page.id": "ID",
+  "project.page.id": "ID",
+
+  // "project.page.keyword": "Keywords",
+  "project.page.keyword": "Kľúčové slová",
+
+  // "project.page.options": "Options",
+  "project.page.options": "Možnosti",
+
+  // "project.page.status": "Status",
+  "project.page.status": "Stav",
+
+  // "project.page.titleprefix": "Research Project: ",
+  "project.page.titleprefix": "Výskumný projekt: ",
+
+  // "project.search.results.head": "Project Search Results",
+  "project.search.results.head": "Výsledky vyhľadávania projektov",
+
+  // "project-relationships.search.results.head": "Project Search Results",
+  "project-relationships.search.results.head": "Výsledky vyhľadávania projektov",
+
+  // "publication.listelement.badge": "Publication",
+  "publication.listelement.badge": "Publikácia",
+
+  // "publication.page.description": "Description",
+  "publication.page.description": "Popis",
+
+  // "publication.page.edit": "Administer",
+  "publication.page.edit": "Spravovať",
+
+  // "publication.page.journal-issn": "Journal ISSN",
+  "publication.page.journal-issn": "ISSN časopisu",
+
+  // "publication.page.journal-title": "Journal Title",
+  "publication.page.journal-title": "Názov časopisu",
+
+  // "publication.page.publisher": "Publisher",
+  "publication.page.publisher": "Vydavateľ",
+
+  // "publication.page.options": "Options",
+  "publication.page.options": "Možnosti",
+
+  // "publication.page.titleprefix": "Publication: ",
+  "publication.page.titleprefix": "Publikácia: ",
+
+  // "publication.page.volume-title": "Volume Title",
+  "publication.page.volume-title": "Názov zväzku",
+
+  // "publication.page.doi": "DOI",
+  "publication.page.doi": "DOI",
+
+  // "publication.search.results.head": "Publication Search Results",
+  "publication.search.results.head": "Výsledky vyhľadávania publikácií",
+
+  // "publication-relationships.search.results.head": "Publication Search Results",
+  "publication-relationships.search.results.head": "Výsledky vyhľadávania publikácií",
+
+  // "publication.search.title": "Publication Search",
+  "publication.search.title": "Vyhľadávanie publikácií",
+
+  // "media-viewer.next": "Next",
+  "media-viewer.next": "Ďalej",
+
+  // "media-viewer.previous": "Previous",
+  "media-viewer.previous": "Predchádzajúce",
+
+  // "media-viewer.playlist": "Playlist",
+  "media-viewer.playlist": "Zoznam skladieb",
+
+  // "suggestion.loading": "Loading ...",
+  "suggestion.loading": "Načítava sa ...",
+
+  // "suggestion.title": "Publication Claim",
+  "suggestion.title": "Nárokovanie publikácie",
+
+  // "suggestion.title.breadcrumbs": "Publication Claim",
+  "suggestion.title.breadcrumbs": "Nárokovanie publikácie",
+
+  // "suggestion.targets.description": "Below you can see all the suggestions ",
+  "suggestion.targets.description": "Nižšie vidíte všetky odporúčania ",
+
+  // "suggestion.targets": "Current Suggestions",
+  "suggestion.targets": "Aktuálne odporúčania",
+
+  // "suggestion.table.name": "Researcher Name",
+  "suggestion.table.name": "Meno výskumníka",
+
+  // "suggestion.table.actions": "Actions",
+  "suggestion.table.actions": "Akcie",
+
+  // "suggestion.button.review": "Review {{ total }} suggestion(s)",
+  "suggestion.button.review": "Skontrolovať {{ total }} odporúčaní",
+
+  // "suggestion.button.review.title": "Review {{ total }} suggestion(s) for ",
+  "suggestion.button.review.title": "Skontrolovať {{ total }} odporúčaní pre ",
+
+  // "suggestion.noTargets": "No target found.",
+  "suggestion.noTargets": "Nenašiel sa žiadny cieľ.",
+
+  // "suggestion.target.error.service.retrieve": "An error occurred while loading the Suggestion targets",
+  "suggestion.target.error.service.retrieve": "Pri načítaní cieľov odporúčaní došlo k chybe",
+
+  // "suggestion.evidence.type": "Type",
+  "suggestion.evidence.type": "Typ",
+
+  // "suggestion.evidence.score": "Score",
+  "suggestion.evidence.score": "Skóre",
+
+  // "suggestion.evidence.notes": "Notes",
+  "suggestion.evidence.notes": "Poznámky",
+
+  // "suggestion.approveAndImport": "Approve & import",
+  "suggestion.approveAndImport": "Schváliť a importovať",
+
+  // "suggestion.approveAndImport.success": "The suggestion has been imported successfully. <a href='{{ url }}'>View.</a>",
+  "suggestion.approveAndImport.success": "Odporúčanie bolo úspešne importované. <a href='{{ url }}'>Zobraziť.</a>",
+
+  // "suggestion.approveAndImport.bulk": "Approve & import Selected",
+  "suggestion.approveAndImport.bulk": "Schváliť a importovať vybrané",
+
+  // "suggestion.approveAndImport.bulk.success": "{{ count }} suggestions have been imported successfully ",
+  "suggestion.approveAndImport.bulk.success": "{{ count }} odporúčaní bolo úspešne importovaných ",
+
+  // "suggestion.approveAndImport.bulk.error": "{{ count }} suggestions haven't been imported due to unexpected server errors",
+  "suggestion.approveAndImport.bulk.error": "{{ count }} odporúčaní nebolo importovaných z dôvodu neočakávaných chýb servera",
+
+  // "suggestion.ignoreSuggestion": "Ignore Suggestion",
+  "suggestion.ignoreSuggestion": "Ignorovať odporúčanie",
+
+  // "suggestion.ignoreSuggestion.success": "The suggestion has been discarded",
+  "suggestion.ignoreSuggestion.success": "Odporúčanie bolo zahodené",
+
+  // "suggestion.ignoreSuggestion.bulk": "Ignore Suggestion Selected",
+  "suggestion.ignoreSuggestion.bulk": "Ignorovať vybrané odporúčania",
+
+  // "suggestion.ignoreSuggestion.bulk.success": "{{ count }} suggestions have been discarded ",
+  "suggestion.ignoreSuggestion.bulk.success": "{{ count }} odporúčaní bolo zahodených ",
+
+  // "suggestion.ignoreSuggestion.bulk.error": "{{ count }} suggestions haven't been discarded due to unexpected server errors",
+  "suggestion.ignoreSuggestion.bulk.error": "{{ count }} odporúčaní nebolo zahodených z dôvodu neočakávaných chýb servera",
+
+  // "suggestion.seeEvidence": "See evidence",
+  "suggestion.seeEvidence": "Zobraziť podklady",
+
+  // "suggestion.hideEvidence": "Hide evidence",
+  "suggestion.hideEvidence": "Skryť podklady",
+
+  // "suggestion.suggestionFor": "Suggestions for",
+  "suggestion.suggestionFor": "Odporúčania pre",
+
+  // "suggestion.suggestionFor.breadcrumb": "Suggestions for {{ name }}",
+  "suggestion.suggestionFor.breadcrumb": "Odporúčania pre {{ name }}",
+
+  // "suggestion.source.openaire": "OpenAIRE Graph",
+  "suggestion.source.openaire": "OpenAIRE Graph",
+
+  // "suggestion.source.openalex": "OpenAlex",
+  "suggestion.source.openalex": "OpenAlex",
+
+  // "suggestion.from.source": "from the ",
+  "suggestion.from.source": "zo zdroja ",
+
+  // "suggestion.count.missing": "You have no publication claims left",
+  "suggestion.count.missing": "Nemáte žiadne ďalšie publikácie na nárokovanie.",
+
+  // "suggestion.totalScore": "Total Score",
+  "suggestion.totalScore": "Celkové skóre",
+
+  // "suggestion.type.openaire": "OpenAIRE",
+  "suggestion.type.openaire": "OpenAIRE",
+
+  // "register-email.title": "New user registration",
+  "register-email.title": "Registrácia nového používateľa",
+
+  // "register-page.create-profile.header": "Create Profile",
+  "register-page.create-profile.header": "Vytvoriť profil",
+
+  // "register-page.create-profile.identification.header": "Identify",
+  "register-page.create-profile.identification.header": "Identifikácia",
+
+  // "register-page.create-profile.identification.email": "Email Address",
+  "register-page.create-profile.identification.email": "E-mailová adresa",
+
+  // "register-page.create-profile.identification.first-name": "First Name *",
+  "register-page.create-profile.identification.first-name": "Krstné meno *",
+
+  // "register-page.create-profile.identification.first-name.error": "Please fill in a First Name",
+  "register-page.create-profile.identification.first-name.error": "Vyplňte prosím krstné meno",
+
+  // "register-page.create-profile.identification.last-name": "Last Name *",
+  "register-page.create-profile.identification.last-name": "Priezvisko *",
+
+  // "register-page.create-profile.identification.last-name.error": "Please fill in a Last Name",
+  "register-page.create-profile.identification.last-name.error": "Vyplňte prosím priezvisko",
+
+  // "register-page.create-profile.identification.contact": "Contact Telephone",
+  "register-page.create-profile.identification.contact": "Kontaktný telefón",
+
+  // "register-page.create-profile.identification.language": "Language",
+  "register-page.create-profile.identification.language": "Jazyk",
+
+  // "register-page.create-profile.security.header": "Security",
+  "register-page.create-profile.security.header": "Zabezpečenie",
+
+  // "register-page.create-profile.security.info": "Please enter a password in the box below, and confirm it by typing it again into the second box.",
+  "register-page.create-profile.security.info": "Zadajte prosím heslo do poľa nižšie a potvrďte ho opätovným zadaním do druhého poľa.",
+
+  // "register-page.create-profile.security.label.password": "Password *",
+  "register-page.create-profile.security.label.password": "Heslo *",
+
+  // "register-page.create-profile.security.label.passwordrepeat": "Retype to confirm *",
+  "register-page.create-profile.security.label.passwordrepeat": "Zadajte znova pre potvrdenie *",
+
+  // "register-page.create-profile.security.error.empty-password": "Please enter a password in the box below.",
+  "register-page.create-profile.security.error.empty-password": "Zadajte prosím heslo do poľa nižšie.",
+
+  // "register-page.create-profile.security.error.matching-passwords": "The passwords do not match.",
+  "register-page.create-profile.security.error.matching-passwords": "Heslá sa nezhodujú.",
+
+  // "register-page.create-profile.submit": "Complete Registration",
+  "register-page.create-profile.submit": "Dokončiť registráciu",
+
+  // "register-page.create-profile.submit.error.content": "Something went wrong while registering a new user.",
+  "register-page.create-profile.submit.error.content": "Pri registrácii nového používateľa sa niečo pokazilo.",
+
+  // "register-page.create-profile.submit.error.head": "Registration failed",
+  "register-page.create-profile.submit.error.head": "Registrácia zlyhala",
+
+  // "register-page.create-profile.submit.success.content": "The registration was successful. You have been logged in as the created user.",
+  "register-page.create-profile.submit.success.content": "Registrácia prebehla úspešne. Boli ste prihlásení ako vytvorený používateľ.",
+
+  // "register-page.create-profile.submit.success.head": "Registration completed",
+  "register-page.create-profile.submit.success.head": "Registrácia dokončená",
+
+  // "register-page.registration.header": "New user registration",
+  "register-page.registration.header": "Registrácia nového používateľa",
+
+  // "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to DSpace.",
+  "register-page.registration.info": "Zaregistrujte si účet, aby ste sa mohli prihlásiť na odber kolekcií pre e-mailové aktualizácie a vkladať nové záznamy do systému DSpace.",
+
+  // "register-page.registration.email": "Email Address *",
+  "register-page.registration.email": "E-mailová adresa *",
+
+  // "register-page.registration.email.error.required": "Please fill in an email address",
+  "register-page.registration.email.error.required": "Vyplňte prosím e-mailovú adresu",
+
+  // "register-page.registration.email.error.not-email-form": "Please fill in a valid email address.",
+  "register-page.registration.email.error.not-email-form": "Vyplňte prosím platnú e-mailovú adresu.",
+
+  // "register-page.registration.email.error.not-valid-domain": "Use email with allowed domains: {{ domains }}",
+  "register-page.registration.email.error.not-valid-domain": "Použite e-mail s povolenými doménami: {{ domains }}",
+
+  // "register-page.registration.email.hint": "This address will be verified and used as your login name.",
+  "register-page.registration.email.hint": "Táto adresa bude overená a použitá ako vaše prihlasovacie meno.",
+
+  // "register-page.registration.submit": "Register",
+  "register-page.registration.submit": "Registrovať",
+
+  // "register-page.registration.success.head": "Verification email sent",
+  "register-page.registration.success.head": "Overovací e-mail bol odoslaný",
+
+  // "register-page.registration.success.content": "An email has been sent to {{ email }} containing a special URL and further instructions.",
+  "register-page.registration.success.content": "Na adresu {{ email }} bol odoslaný e-mail obsahujúci špeciálnu URL adresu a ďalšie pokyny.",
+
+  // "register-page.registration.error.head": "Error when trying to register email",
+  "register-page.registration.error.head": "Chyba pri pokuse o registráciu e-mailu",
+
+  // "register-page.registration.error.content": "An error occurred when registering the following email address: {{ email }}",
+  "register-page.registration.error.content": "Pri registrácii nasledujúcej e-mailovej adresy došlo k chybe: {{ email }}",
+
+  // "register-page.registration.error.recaptcha": "Error when trying to authenticate with recaptcha",
+  "register-page.registration.error.recaptcha": "Chyba pri pokuse o overenie pomocou recaptcha",
+
+  // "register-page.registration.google-recaptcha.must-accept-cookies": "In order to register you must accept the <b>Registration and Password recovery</b> (Google reCaptcha) cookies.",
+  "register-page.registration.google-recaptcha.must-accept-cookies": "Na registráciu musíte prijať súbory cookie <b>Registrácia a obnova hesla</b> (Google reCaptcha).",
+
+  // "register-page.registration.error.maildomain": "This email address is not on the list of domains who can register. Allowed domains are {{ domains }}",
+  "register-page.registration.error.maildomain": "Táto e-mailová adresa nie je na zozname domén, ktoré sa môžu registrovať. Povolené domény sú {{ domains }}",
+
+  // "register-page.registration.google-recaptcha.open-cookie-settings": "Open cookie settings",
+  "register-page.registration.google-recaptcha.open-cookie-settings": "Otvoriť nastavenia súborov cookie",
+
+  // "register-page.registration.google-recaptcha.notification.title": "Google reCaptcha",
+  "register-page.registration.google-recaptcha.notification.title": "Google reCaptcha",
+
+  // "register-page.registration.google-recaptcha.notification.message.error": "An error occurred during reCaptcha verification",
+  "register-page.registration.google-recaptcha.notification.message.error": "Pri overovaní reCaptcha došlo k chybe",
+
+  // "register-page.registration.google-recaptcha.notification.message.expired": "Verification expired. Please verify again.",
+  "register-page.registration.google-recaptcha.notification.message.expired": "Overenie vypršalo. Zopakujte prosím overenie.",
+
+  // "register-page.registration.info.maildomain": "Accounts can be registered for mail addresses of the domains",
+  "register-page.registration.info.maildomain": "Účty možno registrovať len pre e-mailové adresy povolených domén.",
+
+  // "relationships.add.error.relationship-type.content": "No suitable match could be found for relationship type {{ type }} between the two items",
+  "relationships.add.error.relationship-type.content": "Pre typ vzťahu {{ type }} medzi dvoma záznamami sa nenašla žiadna vhodná zhoda.",
+
+  // "relationships.add.error.server.content": "The server returned an error",
+  "relationships.add.error.server.content": "Server vrátil chybu",
+
+  // "relationships.add.error.title": "Unable to add relationship",
+  "relationships.add.error.title": "Vzťah nemožno pridať",
+
+  // "relationships.Publication.isAuthorOfPublication.Person": "Authors (persons)",
+  "relationships.Publication.isAuthorOfPublication.Person": "Autori (osoby)",
+
+  // "relationships.Publication.isProjectOfPublication.Project": "Research Projects",
+  "relationships.Publication.isProjectOfPublication.Project": "Výskumné projekty",
+
+  // "relationships.Publication.isOrgUnitOfPublication.OrgUnit": "Organizational Units",
+  "relationships.Publication.isOrgUnitOfPublication.OrgUnit": "Organizačné jednotky",
+
+  // "relationships.Publication.isAuthorOfPublication.OrgUnit": "Authors (organizational units)",
+  "relationships.Publication.isAuthorOfPublication.OrgUnit": "Autori (organizačné jednotky)",
+
+  // "relationships.Publication.isJournalIssueOfPublication.JournalIssue": "Journal Issue",
+  "relationships.Publication.isJournalIssueOfPublication.JournalIssue": "Číslo časopisu",
+
+  // "relationships.Publication.isContributorOfPublication.Person": "Contributor",
+  "relationships.Publication.isContributorOfPublication.Person": "Prispievateľ",
+
+  // "relationships.Publication.isContributorOfPublication.OrgUnit": "Contributor (organizational units)",
+  "relationships.Publication.isContributorOfPublication.OrgUnit": "Prispievateľ (organizačné jednotky)",
+
+  // "relationships.Person.isPublicationOfAuthor.Publication": "Publications",
+  "relationships.Person.isPublicationOfAuthor.Publication": "Publikácie",
+
+  // "relationships.Person.isProjectOfPerson.Project": "Research Projects",
+  "relationships.Person.isProjectOfPerson.Project": "Výskumné projekty",
+
+  // "relationships.Person.isOrgUnitOfPerson.OrgUnit": "Organizational Units",
+  "relationships.Person.isOrgUnitOfPerson.OrgUnit": "Organizačné jednotky",
+
+  // "relationships.Person.isPublicationOfContributor.Publication": "Publications (contributor to)",
+  "relationships.Person.isPublicationOfContributor.Publication": "Publikácie (ako spoluautor)",
+
+  // "relationships.Project.isPublicationOfProject.Publication": "Publications",
+  "relationships.Project.isPublicationOfProject.Publication": "Publikácie",
+
+  // "relationships.Project.isPersonOfProject.Person": "Authors",
+  "relationships.Project.isPersonOfProject.Person": "Autori",
+
+  // "relationships.Project.isOrgUnitOfProject.OrgUnit": "Organizational Units",
+  "relationships.Project.isOrgUnitOfProject.OrgUnit": "Organizačné jednotky",
+
+  // "relationships.Project.isFundingAgencyOfProject.OrgUnit": "Funder",
+  "relationships.Project.isFundingAgencyOfProject.OrgUnit": "Poskytovateľ financií",
+
+  // "relationships.OrgUnit.isPublicationOfOrgUnit.Publication": "Organisation Publications",
+  "relationships.OrgUnit.isPublicationOfOrgUnit.Publication": "Publikácie organizácie",
+
+  // "relationships.OrgUnit.isPersonOfOrgUnit.Person": "Authors",
+  "relationships.OrgUnit.isPersonOfOrgUnit.Person": "Autori",
+
+  // "relationships.OrgUnit.isProjectOfOrgUnit.Project": "Research Projects",
+  "relationships.OrgUnit.isProjectOfOrgUnit.Project": "Výskumné projekty",
+
+  // "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Authored Publications",
+  "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Autorské publikácie",
+
+  // "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publications (contributor to)",
+  "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publikácie (ako spoluautor)",
+
+  // "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Research Projects (funder of)",
+  "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Výskumné projekty (poskytovateľ financií)",
+
+  // "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "Journal Volume",
+  "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "Ročník časopisu",
+
+  // "relationships.JournalIssue.isPublicationOfJournalIssue.Publication": "Publications",
+  "relationships.JournalIssue.isPublicationOfJournalIssue.Publication": "Publikácie",
+
+  // "relationships.JournalVolume.isJournalOfVolume.Journal": "Journals",
+  "relationships.JournalVolume.isJournalOfVolume.Journal": "Časopisy",
+
+  // "relationships.JournalVolume.isIssueOfJournalVolume.JournalIssue": "Journal Issue",
+  "relationships.JournalVolume.isIssueOfJournalVolume.JournalIssue": "Číslo časopisu",
+
+  // "relationships.Journal.isVolumeOfJournal.JournalVolume": "Journal Volume",
+  "relationships.Journal.isVolumeOfJournal.JournalVolume": "Ročník časopisu",
+
+  // "repository.image.logo": "Repository logo",
+  "repository.image.logo": "Logo repozitára",
+
+  // "repository.title": "DSpace Repository",
+  "repository.title": "Repozitár DSpace",
+
+  // "repository.title.prefix": "DSpace Repository :: ",
+  "repository.title.prefix": "Repozitár DSpace :: ",
+
+  // "resource-policies.add.button": "Add",
+  "resource-policies.add.button": "Pridať",
+
+  // "resource-policies.add.for.": "Add a new policy",
+  "resource-policies.add.for.": "Pridať nové pravidlo",
+
+  // "resource-policies.add.for.bitstream": "Add a new Bitstream policy",
+  "resource-policies.add.for.bitstream": "Pridať nové pravidlo súboru",
+
+  // "resource-policies.add.for.bundle": "Add a new Bundle policy",
+  "resource-policies.add.for.bundle": "Pridať nové pravidlo zväzku",
+
+  // "resource-policies.add.for.item": "Add a new Item policy",
+  "resource-policies.add.for.item": "Pridať nové pravidlo záznamu",
+
+  // "resource-policies.add.for.community": "Add a new Community policy",
+  "resource-policies.add.for.community": "Pridať nové pravidlo komunity",
+
+  // "resource-policies.add.for.collection": "Add a new Collection policy",
+  "resource-policies.add.for.collection": "Pridať nové pravidlo kolekcie",
+
+  // "resource-policies.create.page.heading": "Create new resource policy for ",
+  "resource-policies.create.page.heading": "Vytvoriť nové pravidlo zdroja pre ",
+
+  // "resource-policies.create.page.failure.content": "An error occurred while creating the resource policy.",
+  "resource-policies.create.page.failure.content": "Pri vytváraní pravidla zdroja došlo k chybe.",
+
+  // "resource-policies.create.page.success.content": "Operation successful",
+  "resource-policies.create.page.success.content": "Operácia bola úspešná",
+
+  // "resource-policies.create.page.title": "Create new resource policy",
+  "resource-policies.create.page.title": "Vytvorenie nového pravidla zdroja",
+
+  // "resource-policies.delete.btn": "Delete selected",
+  "resource-policies.delete.btn": "Odstrániť vybrané",
+
+  // "resource-policies.delete.btn.title": "Delete selected resource policies",
+  "resource-policies.delete.btn.title": "Odstrániť vybrané pravidlá zdrojov",
+
+  // "resource-policies.delete.failure.content": "An error occurred while deleting selected resource policies.",
+  "resource-policies.delete.failure.content": "Pri odstraňovaní vybraných pravidiel zdrojov došlo k chybe.",
+
+  // "resource-policies.delete.success.content": "Operation successful",
+  "resource-policies.delete.success.content": "Operácia prebehla úspešne",
+
+  // "resource-policies.edit.page.heading": "Edit resource policy ",
+  "resource-policies.edit.page.heading": "Upraviť pravidlo zdroja ",
+
+  // "resource-policies.edit.page.failure.content": "An error occurred while editing the resource policy.",
+  "resource-policies.edit.page.failure.content": "Pri úprave pravidla zdroja došlo k chybe.",
+
+  // "resource-policies.edit.page.target-failure.content": "An error occurred while editing the target (ePerson or group) of the resource policy.",
+  "resource-policies.edit.page.target-failure.content": "Pri úprave cieľa (používateľa alebo skupiny) pravidla zdroja došlo k chybe.",
+
+  // "resource-policies.edit.page.other-failure.content": "An error occurred while editing the resource policy. The target (ePerson or group) has been successfully updated.",
+  "resource-policies.edit.page.other-failure.content": "Pri úprave pravidla zdroja došlo k chybe. Cieľ (používateľ alebo skupina) bol úspešne aktualizovaný.",
+
+  // "resource-policies.edit.page.success.content": "Operation successful",
+  "resource-policies.edit.page.success.content": "Operácia bola úspešná",
+
+  // "resource-policies.edit.page.title": "Edit resource policy",
+  "resource-policies.edit.page.title": "Upraviť pravidlo zdroja",
+
+  // "resource-policies.form.action-type.label": "Select the action type",
+  "resource-policies.form.action-type.label": "Vyberte typ akcie",
+
+  // "resource-policies.form.action-type.required": "You must select the resource policy action.",
+  "resource-policies.form.action-type.required": "Musíte vybrať akciu pravidla zdroja.",
+
+  // "resource-policies.form.eperson-group-list.label": "The eperson or group that will be granted the permission",
+  "resource-policies.form.eperson-group-list.label": "Používateľ alebo skupina, ktorým bude udelené oprávnenie",
+
+  // "resource-policies.form.eperson-group-list.select.btn": "Select",
+  "resource-policies.form.eperson-group-list.select.btn": "Vybrať",
+
+  // "resource-policies.form.eperson-group-list.tab.eperson": "Search for an ePerson",
+  "resource-policies.form.eperson-group-list.tab.eperson": "Vyhľadať používateľa",
+
+  // "resource-policies.form.eperson-group-list.tab.group": "Search for a group",
+  "resource-policies.form.eperson-group-list.tab.group": "Vyhľadať skupinu",
+
+  // "resource-policies.form.eperson-group-list.table.headers.action": "Action",
+  "resource-policies.form.eperson-group-list.table.headers.action": "Akcia",
+
+  // "resource-policies.form.eperson-group-list.table.headers.id": "ID",
+  "resource-policies.form.eperson-group-list.table.headers.id": "ID",
+
+  // "resource-policies.form.eperson-group-list.table.headers.name": "Name",
+  "resource-policies.form.eperson-group-list.table.headers.name": "Názov",
+
+  // "resource-policies.form.eperson-group-list.modal.header": "Cannot change type",
+  "resource-policies.form.eperson-group-list.modal.header": "Typ nemožno zmeniť",
+
+  // "resource-policies.form.eperson-group-list.modal.text1.toGroup": "It is not possible to replace an ePerson with a group.",
+  "resource-policies.form.eperson-group-list.modal.text1.toGroup": "Nie je možné nahradiť používateľa skupinou.",
+
+  // "resource-policies.form.eperson-group-list.modal.text1.toEPerson": "It is not possible to replace a group with an ePerson.",
+  "resource-policies.form.eperson-group-list.modal.text1.toEPerson": "Nie je možné nahradiť skupinu používateľom.",
+
+  // "resource-policies.form.eperson-group-list.modal.text2": "Delete the current resource policy and create a new one with the desired type.",
+  "resource-policies.form.eperson-group-list.modal.text2": "Odstráňte aktuálne pravidlo zdroja a vytvorte nové s požadovaným typom.",
+
+  // "resource-policies.form.eperson-group-list.modal.close": "Ok",
+  "resource-policies.form.eperson-group-list.modal.close": "Ok",
+
+  // "resource-policies.form.date.end.label": "End Date",
+  "resource-policies.form.date.end.label": "Dátum ukončenia",
+
+  // "resource-policies.form.date.start.label": "Start Date",
+  "resource-policies.form.date.start.label": "Dátum začiatku",
+
+  // "resource-policies.form.description.label": "Description",
+  "resource-policies.form.description.label": "Popis",
+
+  // "resource-policies.form.name.label": "Name",
+  "resource-policies.form.name.label": "Názov",
+
+  // "resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Maximálne 30 znakov",
+
+  // "resource-policies.form.policy-type.label": "Select the policy type",
+  "resource-policies.form.policy-type.label": "Vyberte typ pravidla",
+
+  // "resource-policies.form.policy-type.required": "You must select the resource policy type.",
+  "resource-policies.form.policy-type.required": "Musíte vybrať typ pravidla zdroja.",
+
+  // "resource-policies.table.headers.action": "Action",
+  "resource-policies.table.headers.action": "Akcia",
+
+  // "resource-policies.table.headers.date.end": "End Date",
+  "resource-policies.table.headers.date.end": "Dátum ukončenia",
+
+  // "resource-policies.table.headers.date.start": "Start Date",
+  "resource-policies.table.headers.date.start": "Dátum začiatku",
+
+  // "resource-policies.table.headers.edit": "Edit",
+  "resource-policies.table.headers.edit": "Upraviť",
+
+  // "resource-policies.table.headers.edit.group": "Edit group",
+  "resource-policies.table.headers.edit.group": "Upraviť skupinu",
+
+  // "resource-policies.table.headers.edit.policy": "Edit policy",
+  "resource-policies.table.headers.edit.policy": "Upraviť pravidlo",
+
+  // "resource-policies.table.headers.eperson": "EPerson",
+  "resource-policies.table.headers.eperson": "Používateľ",
+
+  // "resource-policies.table.headers.group": "Group",
+  "resource-policies.table.headers.group": "Skupina",
+
+  // "resource-policies.table.headers.select-all": "Select all",
+  "resource-policies.table.headers.select-all": "Vybrať všetko",
+
+  // "resource-policies.table.headers.deselect-all": "Deselect all",
+  "resource-policies.table.headers.deselect-all": "Zrušiť výber všetkého",
+
+  // "resource-policies.table.headers.select": "Select",
+  "resource-policies.table.headers.select": "Vybrať",
+
+  // "resource-policies.table.headers.deselect": "Deselect",
+  "resource-policies.table.headers.deselect": "Zrušiť výber",
+
+  // "resource-policies.table.headers.id": "ID",
+  "resource-policies.table.headers.id": "ID",
+
+  // "resource-policies.table.headers.name": "Name",
+  "resource-policies.table.headers.name": "Názov",
+
+  // "resource-policies.table.headers.policyType": "type",
+  "resource-policies.table.headers.policyType": "Typ",
+
+  // "resource-policies.table.headers.title.for.bitstream": "Policies for Bitstream",
+  "resource-policies.table.headers.title.for.bitstream": "Pravidlá pre súbor",
+
+  // "resource-policies.table.headers.title.for.bundle": "Policies for Bundle",
+  "resource-policies.table.headers.title.for.bundle": "Pravidlá pre zväzok",
+
+  // "resource-policies.table.headers.title.for.item": "Policies for Item",
+  "resource-policies.table.headers.title.for.item": "Pravidlá pre záznam",
+
+  // "resource-policies.table.headers.title.for.community": "Policies for Community",
+  "resource-policies.table.headers.title.for.community": "Pravidlá pre komunitu",
+
+  // "resource-policies.table.headers.title.for.collection": "Policies for Collection",
+  "resource-policies.table.headers.title.for.collection": "Pravidlá pre kolekciu",
+
+  // "RELATION.Person.researchoutputs.search.results.head": "Research Output",
+  "RELATION.Person.researchoutputs.search.results.head": "Výskumné výstupy",
+
+  // "RELATION.Person.projects.search.results.head": "Projects",
+  "RELATION.Person.projects.search.results.head": "Projekty",
+
+  // "RELATION.Project.researchoutputs.search.results.head": "Publications",
+  "RELATION.Project.researchoutputs.search.results.head": "Publikácie",
+
+  // "RELATION.Project.fundings.search.results.head": "Fundings",
+  "RELATION.Project.fundings.search.results.head": "Financovania",
+
+  // "RELATION.Project.projects.search.results.head": "Projects",
+  "RELATION.Project.projects.search.results.head": "Projekty",
+
+  // "RELATION.OrgUnit.organizations.search.results.head": "Organizations",
+  "RELATION.OrgUnit.organizations.search.results.head": "Organizácie",
+
+  // "RELATION.OrgUnit.rppublications.search.results.head": "Researchers Publications",
+  "RELATION.OrgUnit.rppublications.search.results.head": "Publikácie výskumníkov",
+
+  // "RELATION.OrgUnit.publications.search.results.head": "Publications",
+  "RELATION.OrgUnit.publications.search.results.head": "Publikácie",
+
+  // "RELATION.OrgUnit.rpprojects.search.results.head": "Researchers Projects",
+  "RELATION.OrgUnit.rpprojects.search.results.head": "Projekty výskumníkov",
+
+  // "RELATION.OrgUnit.projects.search.results.head": "Projects",
+  "RELATION.OrgUnit.projects.search.results.head": "Projekty",
+
+  // "RELATION.OrgUnit.people.search.results.head": "People",
+  "RELATION.OrgUnit.people.search.results.head": "Ľudia",
+
+  // "root.skip-to-content": "Skip to main content",
+  "root.skip-to-content": "Prejsť na hlavný obsah",
+
+  // "search.description": "",
+  "search.description": "",
+
+  // "search.switch-configuration.title": "Show",
+  "search.switch-configuration.title": "Zobraziť",
+
+  // "search.title": "Search",
+  "search.title": "Hľadať",
+
+  // "search.breadcrumbs": "Search",
+  "search.breadcrumbs": "Hľadať",
+
+  // "search.search-form.placeholder": "Search the repository ...",
+  "search.search-form.placeholder": "Hľadať v repozitári...",
+
+  // "search.filters.remove": "Remove filter of type {{ type }} with value {{ value }}",
+  "search.filters.remove": "Odstrániť filter typu {{ type }} s hodnotou {{ value }}",
+
+  // "search.filters.applied.f.title": "Title",
+  "search.filters.applied.f.title": "Názov",
+
+  // "search.filters.applied.f.author": "Author",
+  "search.filters.applied.f.author": "Autor",
+
+  // "search.filters.applied.f.dateIssued.max": "End date",
+  "search.filters.applied.f.dateIssued.max": "Dátum ukončenia",
+
+  // "search.filters.applied.f.dateIssued.min": "Start date",
+  "search.filters.applied.f.dateIssued.min": "Dátum začiatku",
+
+  // "search.filters.applied.f.dateSubmitted": "Date submitted",
+  "search.filters.applied.f.dateSubmitted": "Dátum vloženia",
+
+  // "search.filters.applied.f.discoverable": "Non-discoverable",
+  "search.filters.applied.f.discoverable": "Nevyhľadateľné",
+
+  // "search.filters.applied.f.entityType": "Item Type",
+  "search.filters.applied.f.entityType": "Typ záznamu",
+
+  // "search.filters.applied.f.has_content_in_original_bundle": "Has files",
+  "search.filters.applied.f.has_content_in_original_bundle": "Má súbory",
+
+  // "search.filters.applied.f.original_bundle_filenames": "File name",
+  "search.filters.applied.f.original_bundle_filenames": "Názov súboru",
+
+  // "search.filters.applied.f.original_bundle_descriptions": "File description",
+  "search.filters.applied.f.original_bundle_descriptions": "Popis súboru",
+
+  // "search.filters.applied.f.has_geospatial_metadata": "Has geographical location",
+  "search.filters.applied.f.has_geospatial_metadata": "Má geografickú polohu",
+
+  // "search.filters.applied.f.itemtype": "Type",
+  "search.filters.applied.f.itemtype": "Typ",
+
+  // "search.filters.applied.f.namedresourcetype": "Status",
+  "search.filters.applied.f.namedresourcetype": "Stav",
+
+  // "search.filters.applied.f.subject": "Subject",
+  "search.filters.applied.f.subject": "Predmet",
+
+  // "search.filters.applied.f.submitter": "Submitter",
+  "search.filters.applied.f.submitter": "Vkladateľ",
+
+  // "search.filters.applied.f.jobTitle": "Job Title",
+  "search.filters.applied.f.jobTitle": "Pracovná pozícia",
+
+  // "search.filters.applied.f.birthDate.max": "End birth date",
+  "search.filters.applied.f.birthDate.max": "Dátum narodenia do",
+
+  // "search.filters.applied.f.birthDate.min": "Start birth date",
+  "search.filters.applied.f.birthDate.min": "Dátum narodenia od",
+
+  // "search.filters.applied.f.supervisedBy": "Supervised by",
+  "search.filters.applied.f.supervisedBy": "Pod dohľadom",
+
+  // "search.filters.applied.f.withdrawn": "Withdrawn",
+  "search.filters.applied.f.withdrawn": "Stiahnuté",
+
+  // "search.filters.applied.operator.equals": "",
+  "search.filters.applied.operator.equals": "",
+
+  // "search.filters.applied.operator.notequals": " not equals",
+  "search.filters.applied.operator.notequals": " sa nerovná",
+
+  // "search.filters.applied.operator.authority": "",
+  "search.filters.applied.operator.authority": "",
+
+  // "search.filters.applied.operator.notauthority": " not authority",
+  "search.filters.applied.operator.notauthority": " nie je autorita",
+
+  // "search.filters.applied.operator.contains": " contains",
+  "search.filters.applied.operator.contains": " obsahuje",
+
+  // "search.filters.applied.operator.notcontains": " not contains",
+  "search.filters.applied.operator.notcontains": " neobsahuje",
+
+  // "search.filters.applied.operator.query": "",
+  "search.filters.applied.operator.query": "",
+
+  // "search.filters.applied.f.point": "Coordinates",
+  "search.filters.applied.f.point": "Súradnice",
+
+  // "search.filters.filter.title.head": "Title",
+  "search.filters.filter.title.head": "Názov",
+
+  // "search.filters.filter.title.placeholder": "Title",
+  "search.filters.filter.title.placeholder": "Názov",
+
+  // "search.filters.filter.title.label": "Search Title",
+  "search.filters.filter.title.label": "Hľadať názov",
+
+  // "search.filters.filter.author.head": "Author",
+  "search.filters.filter.author.head": "Autor",
+
+  // "search.filters.filter.author.placeholder": "Author name",
+  "search.filters.filter.author.placeholder": "Meno autora",
+
+  // "search.filters.filter.author.label": "Search author name",
+  "search.filters.filter.author.label": "Hľadať meno autora",
+
+  // "search.filters.filter.birthDate.head": "Birth Date",
+  "search.filters.filter.birthDate.head": "Dátum narodenia",
+
+  // "search.filters.filter.birthDate.placeholder": "Birth Date",
+  "search.filters.filter.birthDate.placeholder": "Dátum narodenia",
+
+  // "search.filters.filter.birthDate.label": "Search birth date",
+  "search.filters.filter.birthDate.label": "Hľadať dátum narodenia",
+
+  // "search.filters.filter.collapse": "Collapse filter",
+  "search.filters.filter.collapse": "Zbaliť filter",
+
+  // "search.filters.filter.creativeDatePublished.head": "Date Published",
+  "search.filters.filter.creativeDatePublished.head": "Dátum publikovania",
+
+  // "search.filters.filter.creativeDatePublished.placeholder": "Date Published",
+  "search.filters.filter.creativeDatePublished.placeholder": "Dátum publikovania",
+
+  // "search.filters.filter.creativeDatePublished.label": "Search date published",
+  "search.filters.filter.creativeDatePublished.label": "Hľadať dátum publikovania",
+
+  // "search.filters.filter.creativeDatePublished.min.label": "Start",
+  "search.filters.filter.creativeDatePublished.min.label": "Začiatok",
+
+  // "search.filters.filter.creativeDatePublished.max.label": "End",
+  "search.filters.filter.creativeDatePublished.max.label": "Koniec",
+
+  // "search.filters.filter.creativeWorkEditor.head": "Editor",
+  "search.filters.filter.creativeWorkEditor.head": "Editor",
+
+  // "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+  "search.filters.filter.creativeWorkEditor.placeholder": "Editor",
+
+  // "search.filters.filter.creativeWorkEditor.label": "Search editor",
+  "search.filters.filter.creativeWorkEditor.label": "Hľadať editora",
+
+  // "search.filters.filter.creativeWorkKeywords.head": "Subject",
+  "search.filters.filter.creativeWorkKeywords.head": "Predmet",
+
+  // "search.filters.filter.creativeWorkKeywords.placeholder": "Subject",
+  "search.filters.filter.creativeWorkKeywords.placeholder": "Predmet",
+
+  // "search.filters.filter.creativeWorkKeywords.label": "Search subject",
+  "search.filters.filter.creativeWorkKeywords.label": "Hľadať predmet",
+
+  // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
+  "search.filters.filter.creativeWorkPublisher.head": "Vydavateľ",
+
+  // "search.filters.filter.creativeWorkPublisher.placeholder": "Publisher",
+  "search.filters.filter.creativeWorkPublisher.placeholder": "Vydavateľ",
+
+  // "search.filters.filter.creativeWorkPublisher.label": "Search publisher",
+  "search.filters.filter.creativeWorkPublisher.label": "Hľadať vydavateľa",
+
+  // "search.filters.filter.dateIssued.head": "Date",
+  "search.filters.filter.dateIssued.head": "Dátum",
+
+  // "search.filters.filter.dateIssued.max.placeholder": "Maximum Date",
+  "search.filters.filter.dateIssued.max.placeholder": "Maximálny dátum",
+
+  // "search.filters.filter.dateIssued.max.label": "End",
+  "search.filters.filter.dateIssued.max.label": "Koniec",
+
+  // "search.filters.filter.dateIssued.min.placeholder": "Minimum Date",
+  "search.filters.filter.dateIssued.min.placeholder": "Minimálny dátum",
+
+  // "search.filters.filter.dateIssued.min.label": "Start",
+  "search.filters.filter.dateIssued.min.label": "Začiatok",
+
+  // "search.filters.filter.dateSubmitted.head": "Date submitted",
+  "search.filters.filter.dateSubmitted.head": "Dátum vloženia",
+
+  // "search.filters.filter.dateSubmitted.placeholder": "Date submitted",
+  "search.filters.filter.dateSubmitted.placeholder": "Dátum vloženia",
+
+  // "search.filters.filter.dateSubmitted.label": "Search date submitted",
+  "search.filters.filter.dateSubmitted.label": "Hľadať dátum vloženia",
+
+  // "search.filters.filter.discoverable.head": "Non-discoverable",
+  "search.filters.filter.discoverable.head": "Nevyhľadateľné",
+
+  // "search.filters.filter.withdrawn.head": "Withdrawn",
+  "search.filters.filter.withdrawn.head": "Stiahnuté",
+
+  // "search.filters.filter.entityType.head": "Item Type",
+  "search.filters.filter.entityType.head": "Typ záznamu",
+
+  // "search.filters.filter.entityType.placeholder": "Item Type",
+  "search.filters.filter.entityType.placeholder": "Typ záznamu",
+
+  // "search.filters.filter.entityType.label": "Search item type",
+  "search.filters.filter.entityType.label": "Hľadať typ záznamu",
+
+  // "search.filters.filter.expand": "Expand filter",
+  "search.filters.filter.expand": "Rozbaliť filter",
+
+  // "search.filters.filter.has_content_in_original_bundle.head": "Has files",
+  "search.filters.filter.has_content_in_original_bundle.head": "Má súbory",
+
+  // "search.filters.filter.original_bundle_filenames.head": "File name",
+  "search.filters.filter.original_bundle_filenames.head": "Názov súboru",
+
+  // "search.filters.filter.has_geospatial_metadata.head": "Has geographical location",
+  "search.filters.filter.has_geospatial_metadata.head": "Má geografickú polohu",
+
+  // "search.filters.filter.original_bundle_filenames.placeholder": "File name",
+  "search.filters.filter.original_bundle_filenames.placeholder": "Názov súboru",
+
+  // "search.filters.filter.original_bundle_filenames.label": "Search File name",
+  "search.filters.filter.original_bundle_filenames.label": "Hľadať názov súboru",
+
+  // "search.filters.filter.original_bundle_descriptions.head": "File description",
+  "search.filters.filter.original_bundle_descriptions.head": "Popis súboru",
+
+  // "search.filters.filter.original_bundle_descriptions.placeholder": "File description",
+  "search.filters.filter.original_bundle_descriptions.placeholder": "Popis súboru",
+
+  // "search.filters.filter.original_bundle_descriptions.label": "Search File description",
+  "search.filters.filter.original_bundle_descriptions.label": "Hľadať popis súboru",
+
+  // "search.filters.filter.itemtype.head": "Type",
+  "search.filters.filter.itemtype.head": "Typ",
+
+  // "search.filters.filter.itemtype.placeholder": "Type",
+  "search.filters.filter.itemtype.placeholder": "Typ",
+
+  // "search.filters.filter.itemtype.label": "Search type",
+  "search.filters.filter.itemtype.label": "Hľadať typ",
+
+  // "search.filters.filter.jobTitle.head": "Job Title",
+  "search.filters.filter.jobTitle.head": "Pracovná pozícia",
+
+  // "search.filters.filter.jobTitle.placeholder": "Job Title",
+  "search.filters.filter.jobTitle.placeholder": "Pracovná pozícia",
+
+  // "search.filters.filter.jobTitle.label": "Search job title",
+  "search.filters.filter.jobTitle.label": "Hľadať pracovnú pozíciu",
+
+  // "search.filters.filter.knowsLanguage.head": "Known language",
+  "search.filters.filter.knowsLanguage.head": "Známy jazyk",
+
+  // "search.filters.filter.knowsLanguage.placeholder": "Known language",
+  "search.filters.filter.knowsLanguage.placeholder": "Známy jazyk",
+
+  // "search.filters.filter.knowsLanguage.label": "Search known language",
+  "search.filters.filter.knowsLanguage.label": "Hľadať známy jazyk",
+
+  // "search.filters.filter.namedresourcetype.head": "Status",
+  "search.filters.filter.namedresourcetype.head": "Stav",
+
+  // "search.filters.filter.namedresourcetype.placeholder": "Status",
+  "search.filters.filter.namedresourcetype.placeholder": "Stav",
+
+  // "search.filters.filter.namedresourcetype.label": "Search status",
+  "search.filters.filter.namedresourcetype.label": "Hľadať stav",
+
+  // "search.filters.filter.objectpeople.head": "People",
+  "search.filters.filter.objectpeople.head": "Ľudia",
+
+  // "search.filters.filter.objectpeople.placeholder": "People",
+  "search.filters.filter.objectpeople.placeholder": "Ľudia",
+
+  // "search.filters.filter.objectpeople.label": "Search people",
+  "search.filters.filter.objectpeople.label": "Hľadať osoby",
+
+  // "search.filters.filter.organizationAddressCountry.head": "Country",
+  "search.filters.filter.organizationAddressCountry.head": "Krajina",
+
+  // "search.filters.filter.organizationAddressCountry.placeholder": "Country",
+  "search.filters.filter.organizationAddressCountry.placeholder": "Krajina",
+
+  // "search.filters.filter.organizationAddressCountry.label": "Search country",
+  "search.filters.filter.organizationAddressCountry.label": "Hľadať krajinu",
+
+  // "search.filters.filter.organizationAddressLocality.head": "City",
+  "search.filters.filter.organizationAddressLocality.head": "Mesto",
+
+  // "search.filters.filter.organizationAddressLocality.placeholder": "City",
+  "search.filters.filter.organizationAddressLocality.placeholder": "Mesto",
+
+  // "search.filters.filter.organizationAddressLocality.label": "Search city",
+  "search.filters.filter.organizationAddressLocality.label": "Hľadať mesto",
+
+  // "search.filters.filter.organizationFoundingDate.head": "Date Founded",
+  "search.filters.filter.organizationFoundingDate.head": "Dátum založenia",
+
+  // "search.filters.filter.organizationFoundingDate.placeholder": "Date Founded",
+  "search.filters.filter.organizationFoundingDate.placeholder": "Dátum založenia",
+
+  // "search.filters.filter.organizationFoundingDate.label": "Search date founded",
+  "search.filters.filter.organizationFoundingDate.label": "Hľadať dátum založenia",
+
+  // "search.filters.filter.organizationFoundingDate.min.label": "Start",
+  "search.filters.filter.organizationFoundingDate.min.label": "Začiatok",
+
+  // "search.filters.filter.organizationFoundingDate.max.label": "End",
+  "search.filters.filter.organizationFoundingDate.max.label": "Koniec",
+
+  // "search.filters.filter.scope.head": "Scope",
+  "search.filters.filter.scope.head": "Rozsah",
+
+  // "search.filters.filter.scope.placeholder": "Scope filter",
+  "search.filters.filter.scope.placeholder": "Filter rozsahu",
+
+  // "search.filters.filter.scope.label": "Search scope filter",
+  "search.filters.filter.scope.label": "Filter rozsahu vyhľadávania",
+
+  // "search.filters.filter.show-less": "Collapse",
+  "search.filters.filter.show-less": "Zbaliť",
+
+  // "search.filters.filter.show-more": "Show more",
+  "search.filters.filter.show-more": "Zobraziť viac",
+
+  // "search.filters.filter.subject.head": "Subject",
+  "search.filters.filter.subject.head": "Predmet",
+
+  // "search.filters.filter.subject.placeholder": "Subject",
+  "search.filters.filter.subject.placeholder": "Predmet",
+
+  // "search.filters.filter.subject.label": "Search subject",
+  "search.filters.filter.subject.label": "Hľadať predmet",
+
+  // "search.filters.filter.submitter.head": "Submitter",
+  "search.filters.filter.submitter.head": "Vkladateľ",
+
+  // "search.filters.filter.submitter.placeholder": "Submitter",
+  "search.filters.filter.submitter.placeholder": "Vkladateľ",
+
+  // "search.filters.filter.submitter.label": "Search submitter",
+  "search.filters.filter.submitter.label": "Hľadať vkladateľa",
+
+  // "search.filters.filter.show-tree": "Browse {{ name }} tree",
+  "search.filters.filter.show-tree": "Prehliadať strom {{ name }}",
+
+  // "search.filters.filter.funding.head": "Funding",
+  "search.filters.filter.funding.head": "Financovanie",
+
+  // "search.filters.filter.funding.placeholder": "Funding",
+  "search.filters.filter.funding.placeholder": "Financovanie",
+
+  // "search.filters.filter.supervisedBy.head": "Supervised By",
+  "search.filters.filter.supervisedBy.head": "Pod dohľadom",
+
+  // "search.filters.filter.supervisedBy.placeholder": "Supervised By",
+  "search.filters.filter.supervisedBy.placeholder": "Pod dohľadom",
+
+  // "search.filters.filter.supervisedBy.label": "Search Supervised By",
+  "search.filters.filter.supervisedBy.label": "Hľadať podľa dohľadu",
+
+  // "search.filters.filter.access_status.head": "Access type",
+  "search.filters.filter.access_status.head": "Typ prístupu",
+
+  // "search.filters.filter.access_status.placeholder": "Access type",
+  "search.filters.filter.access_status.placeholder": "Typ prístupu",
+
+  // "search.filters.filter.access_status.label": "Search by access type",
+  "search.filters.filter.access_status.label": "Hľadať podľa typu prístupu",
+
+  // "search.filters.entityType.JournalIssue": "Journal Issue",
+  "search.filters.entityType.JournalIssue": "Číslo časopisu",
+
+  // "search.filters.entityType.JournalVolume": "Journal Volume",
+  "search.filters.entityType.JournalVolume": "Ročník časopisu",
+
+  // "search.filters.entityType.OrgUnit": "Organizational Unit",
+  "search.filters.entityType.OrgUnit": "Organizačná jednotka",
+
+  // "search.filters.entityType.Person": "Person",
+  "search.filters.entityType.Person": "Osoba",
+
+  // "search.filters.entityType.Project": "Project",
+  "search.filters.entityType.Project": "Projekt",
+
+  // "search.filters.entityType.Publication": "Publication",
+  "search.filters.entityType.Publication": "Publikácia",
+
+  // "search.filters.has_content_in_original_bundle.true": "Yes",
+  "search.filters.has_content_in_original_bundle.true": "Áno",
+
+  // "search.filters.has_content_in_original_bundle.false": "No",
+  "search.filters.has_content_in_original_bundle.false": "Nie",
+
+  // "search.filters.has_geospatial_metadata.true": "Yes",
+  "search.filters.has_geospatial_metadata.true": "Áno",
+
+  // "search.filters.has_geospatial_metadata.false": "No",
+  "search.filters.has_geospatial_metadata.false": "Nie",
+
+  // "search.filters.discoverable.true": "No",
+  "search.filters.discoverable.true": "Nie",
+
+  // "search.filters.discoverable.false": "Yes",
+  "search.filters.discoverable.false": "Áno",
+
+  // "search.filters.namedresourcetype.Archived": "Archived",
+  "search.filters.namedresourcetype.Archived": "Archivované",
+
+  // "search.filters.namedresourcetype.Validation": "Validation",
+  "search.filters.namedresourcetype.Validation": "Overovanie",
+
+  // "search.filters.namedresourcetype.Waiting for Controller": "Waiting for reviewer",
+  "search.filters.namedresourcetype.Waiting for Controller": "Čaká na posudzovateľa",
+
+  // "search.filters.namedresourcetype.Workflow": "Workflow",
+  "search.filters.namedresourcetype.Workflow": "Workflow",
+
+  // "search.filters.namedresourcetype.Workspace": "Workspace",
+  "search.filters.namedresourcetype.Workspace": "Pracovný priestor",
+
+  // "search.filters.withdrawn.true": "Yes",
+  "search.filters.withdrawn.true": "Áno",
+
+  // "search.filters.withdrawn.false": "No",
+  "search.filters.withdrawn.false": "Nie",
+
+  // "search.filters.head": "Filters",
+  "search.filters.head": "Filtre",
+
+  // "search.filters.reset": "Reset filters",
+  "search.filters.reset": "Resetovať filtre",
+
+  // "search.filters.search.submit": "Submit",
+  "search.filters.search.submit": "Odoslať",
+
+  // "search.filters.operator.equals.text": "Equals",
+  "search.filters.operator.equals.text": "Rovná sa",
+
+  // "search.filters.operator.notequals.text": "Not Equals",
+  "search.filters.operator.notequals.text": "Nerovná sa",
+
+  // "search.filters.operator.authority.text": "Authority",
+  "search.filters.operator.authority.text": "Autorita",
+
+  // "search.filters.operator.notauthority.text": "Not Authority",
+  "search.filters.operator.notauthority.text": "Nie je autorita",
+
+  // "search.filters.operator.contains.text": "Contains",
+  "search.filters.operator.contains.text": "Obsahuje",
+
+  // "search.filters.operator.notcontains.text": "Not Contains",
+  "search.filters.operator.notcontains.text": "Neobsahuje",
+
+  // "search.filters.operator.query.text": "Query",
+  "search.filters.operator.query.text": "Dopyt",
+
+  // "search.form.search": "Search",
+  "search.form.search": "Hľadať",
+
+  // "search.form.search_dspace": "All repository",
+  "search.form.search_dspace": "Celý repozitár",
+
+  // "search.form.scope.all": "All of DSpace",
+  "search.form.scope.all": "Celý repozitár",
+
+  // "search.results.head": "Search Results",
+  "search.results.head": "Výsledky vyhľadávania",
+
+  // "search.results.no-results": "Your search returned no results. Having trouble finding what you're looking for? Try putting",
+  "search.results.no-results": "Vaše vyhľadávanie nevrátilo žiadne výsledky. Máte problém nájsť to, čo hľadáte? Skúste vložiť",
+
+  // "search.results.no-results-link": "quotes around it",
+  "search.results.no-results-link": "do úvodzoviek",
+
+  // "search.results.empty": "Your search returned no results.",
+  "search.results.empty": "Vaše vyhľadávanie nevrátilo žiadne výsledky.",
+
+  // "search.results.geospatial-map.empty": "No results on this page with geospatial locations",
+  "search.results.geospatial-map.empty": "Na tejto stránke nie sú žiadne výsledky s geografickou polohou",
+
+  // "search.results.view-result": "View",
+  "search.results.view-result": "Zobraziť",
+
+  // "search.results.response.500": "An error occurred during query execution, please try again later",
+  "search.results.response.500": "Pri spracovaní dopytu došlo k chybe, skúste to prosím neskôr",
+
+  // "default.search.results.head": "Search Results",
+  "default.search.results.head": "Výsledky vyhľadávania",
+
+  // "default-relationships.search.results.head": "Search Results",
+  "default-relationships.search.results.head": "Výsledky vyhľadávania",
+
+  // "search.sidebar.close": "Back to results",
+  "search.sidebar.close": "Späť na výsledky",
+
+  // "search.sidebar.filters.title": "Filters",
+  "search.sidebar.filters.title": "Filtre",
+
+  // "search.sidebar.open": "Search Tools",
+  "search.sidebar.open": "Nástroje vyhľadávania",
+
+  // "search.sidebar.results": "results",
+  "search.sidebar.results": "výsledkov",
+
+  // "search.sidebar.settings.rpp": "Results per page",
+  "search.sidebar.settings.rpp": "Výsledkov na stranu",
+
+  // "search.sidebar.settings.sort-by": "Sort By",
+  "search.sidebar.settings.sort-by": "Zoradiť podľa",
+
+  // "search.sidebar.advanced-search.title": "Advanced Search",
+  "search.sidebar.advanced-search.title": "Pokročilé vyhľadávanie",
+
+  // "search.sidebar.advanced-search.filter-by": "Filter by",
+  "search.sidebar.advanced-search.filter-by": "Filtrovať podľa",
+
+  // "search.sidebar.advanced-search.filters": "Filters",
+  "search.sidebar.advanced-search.filters": "Filtre",
+
+  // "search.sidebar.advanced-search.operators": "Operators",
+  "search.sidebar.advanced-search.operators": "Operátory",
+
+  // "search.sidebar.advanced-search.add": "Add",
+  "search.sidebar.advanced-search.add": "Pridať",
+
+  // "search.sidebar.settings.title": "Settings",
+  "search.sidebar.settings.title": "Nastavenia",
+
+  // "search.view-switch.show-detail": "Show detail",
+  "search.view-switch.show-detail": "Zobraziť detail",
+
+  // "search.view-switch.show-grid": "Show as grid",
+  "search.view-switch.show-grid": "Zobraziť ako mriežku",
+
+  // "search.view-switch.show-list": "Show as list",
+  "search.view-switch.show-list": "Zobraziť ako zoznam",
+
+  // "search.view-switch.show-geospatialMap": "Show as map",
+  "search.view-switch.show-geospatialMap": "Zobraziť ako mapu",
+
+  // "selectable-list-item-control.deselect": "Deselect item",
+  "selectable-list-item-control.deselect": "Zrušiť výber položky",
+
+  // "selectable-list-item-control.select": "Select item",
+  "selectable-list-item-control.select": "Vybrať položku",
+
+  // "sorting.ASC": "Ascending",
+  "sorting.ASC": "Vzostupne",
+
+  // "sorting.DESC": "Descending",
+  "sorting.DESC": "Zostupne",
+
+  // "sorting.dc.title.ASC": "Title Ascending",
+  "sorting.dc.title.ASC": "Názov vzostupne",
+
+  // "sorting.dc.title.DESC": "Title Descending",
+  "sorting.dc.title.DESC": "Názov zostupne",
+
+  // "sorting.score.ASC": "Least Relevant",
+  "sorting.score.ASC": "Najmenej relevantné",
+
+  // "sorting.score.DESC": "Most Relevant",
+  "sorting.score.DESC": "Najrelevantnejšie",
+
+  // "sorting.dc.date.issued.ASC": "Date Issued Ascending",
+  "sorting.dc.date.issued.ASC": "Dátum vydania vzostupne",
+
+  // "sorting.dc.date.issued.DESC": "Date Issued Descending",
+  "sorting.dc.date.issued.DESC": "Dátum vydania zostupne",
+
+  // "sorting.dc.date.accessioned.ASC": "Accessioned Date Ascending",
+  "sorting.dc.date.accessioned.ASC": "Dátum zaradenia vzostupne",
+
+  // "sorting.dc.date.accessioned.DESC": "Accessioned Date Descending",
+  "sorting.dc.date.accessioned.DESC": "Dátum zaradenia zostupne",
+
+  // "sorting.lastModified.ASC": "Last modified Ascending",
+  "sorting.lastModified.ASC": "Naposledy upravené vzostupne",
+
+  // "sorting.lastModified.DESC": "Last modified Descending",
+  "sorting.lastModified.DESC": "Naposledy upravené zostupne",
+
+  // "sorting.person.familyName.ASC": "Surname Ascending",
+  "sorting.person.familyName.ASC": "Priezvisko vzostupne",
+
+  // "sorting.person.familyName.DESC": "Surname Descending",
+  "sorting.person.familyName.DESC": "Priezvisko zostupne",
+
+  // "sorting.person.givenName.ASC": "Name Ascending",
+  "sorting.person.givenName.ASC": "Meno vzostupne",
+
+  // "sorting.person.givenName.DESC": "Name Descending",
+  "sorting.person.givenName.DESC": "Meno zostupne",
+
+  // "sorting.person.birthDate.ASC": "Birth Date Ascending",
+  "sorting.person.birthDate.ASC": "Dátum narodenia vzostupne",
+
+  // "sorting.person.birthDate.DESC": "Birth Date Descending",
+  "sorting.person.birthDate.DESC": "Dátum narodenia zostupne",
+
+  // "sorting.ownerselection.ASC": "Owner Relevance Ascending",
+  "sorting.ownerselection.ASC": "Relevancia vlastníka vzostupne",
+
+  // "sorting.ownerselection.DESC": "Owner Relevance Descending",
+  "sorting.ownerselection.DESC": "Relevancia vlastníka zostupne",
+
+  // "statistics.title": "Statistics",
+  "statistics.title": "Štatistiky",
+
+  // "statistics.header": "Statistics for {{ scope }}",
+  "statistics.header": "Štatistiky pre {{ scope }}",
+
+  // "statistics.breadcrumbs": "Statistics",
+  "statistics.breadcrumbs": "Štatistika",
+
+  // "statistics.page.no-data": "No data available",
+  "statistics.page.no-data": "Nie sú k dispozícii žiadne údaje",
+
+  // "statistics.table.no-data": "No data available",
+  "statistics.table.no-data": "Nie sú k dispozícii žiadne údaje",
+
+  // "statistics.table.title.TotalVisits": "Total visits",
+  "statistics.table.title.TotalVisits": "Celkový počet návštev",
+
+  // "statistics.table.title.TotalVisitsPerMonth": "Total visits per month",
+  "statistics.table.title.TotalVisitsPerMonth": "Celkový počet návštev za mesiac",
+
+  // "statistics.table.title.TotalDownloads": "File Visits",
+  "statistics.table.title.TotalDownloads": "Stiahnutia súborov",
+
+  // "statistics.table.title.TopCountries": "Top country views",
+  "statistics.table.title.TopCountries": "Krajiny s najviac zobrazeniami",
+
+  // "statistics.table.title.TopCities": "Top city views",
+  "statistics.table.title.TopCities": "Mestá s najviac zobrazeniami",
+
+  // "statistics.table.header.views": "Views",
+  "statistics.table.header.views": "Zobrazenia",
+
+  // "statistics.table.no-name": "(object name could not be loaded)",
+  "statistics.table.no-name": "(názov objektu sa nepodarilo načítať)",
+
+  // "submission.edit.breadcrumbs": "Edit Submission",
+  "submission.edit.breadcrumbs": "Upraviť vloženie",
+
+  // "submission.edit.title": "Edit Submission",
+  "submission.edit.title": "Upraviť vloženie",
+
+  // "submission.edit.item.breadcrumbs": "Edit item",
+  "submission.edit.item.breadcrumbs": "Upraviť záznam",
+
+  // "submission.general.cancel": "Cancel",
+  "submission.general.cancel": "Zrušiť",
+
+  // "submission.general.cannot_submit": "You don't have permission to make a new submission.",
+  "submission.general.cannot_submit": "Nemáte oprávnenie na vytvorenie nového vloženia.",
+
+  // "submission.general.deposit": "Deposit",
+  "submission.general.deposit": "Uložiť do repozitára",
+
+  // "submission.general.discard.confirm.cancel": "Cancel",
+  "submission.general.discard.confirm.cancel": "Zrušiť",
+
+  // "submission.general.discard.confirm.info": "This operation can't be undone. Are you sure?",
+  "submission.general.discard.confirm.info": "Túto operáciu nemožno vrátiť späť. Ste si istí?",
+
+  // "submission.general.discard.confirm.submit": "Yes, I'm sure",
+  "submission.general.discard.confirm.submit": "Áno, som si istý",
+
+  // "submission.general.discard.confirm.title": "Discard submission",
+  "submission.general.discard.confirm.title": "Zahodiť vloženie",
+
+  // "submission.general.discard.submit": "Discard",
+  "submission.general.discard.submit": "Zahodiť",
+
+  // "submission.general.back.submit": "Back",
+  "submission.general.back.submit": "Späť",
+
+  // "submission.general.info.invalid": "The submission is invalid, check missing fields",
+  "submission.general.info.invalid": "Vloženie je neplatné, skontrolujte chýbajúce polia",
+
+  // "submission.general.info.saved": "Saved",
+  "submission.general.info.saved": "Uložené",
+
+  // "submission.general.info.pending-changes": "Unsaved changes",
+  "submission.general.info.pending-changes": "Neuložené zmeny",
+
+  // "submission.general.save": "Save",
+  "submission.general.save": "Uložiť",
+
+  // "submission.general.save-later": "Save for later",
+  "submission.general.save-later": "Uložiť na neskôr",
+
+  // "submission.general.save-later.edit-item": "Save and return",
+  "submission.general.save-later.edit-item": "Uložiť a vrátiť sa",
+
+  // "submission.import-external.page.title": "Import metadata from an external source",
+  "submission.import-external.page.title": "Importovať metadáta z externého zdroja",
+
+  // "submission.import-external.title": "Import metadata from an external source",
+  "submission.import-external.title": "Importovať metadáta z externého zdroja",
+
+  // "submission.import-external.title.Journal": "Import a journal from an external source",
+  "submission.import-external.title.Journal": "Importovať časopis z externého zdroja",
+
+  // "submission.import-external.title.JournalIssue": "Import a journal issue from an external source",
+  "submission.import-external.title.JournalIssue": "Importovať číslo časopisu z externého zdroja",
+
+  // "submission.import-external.title.JournalVolume": "Import a journal volume from an external source",
+  "submission.import-external.title.JournalVolume": "Importovať ročník časopisu z externého zdroja",
+
+  // "submission.import-external.title.OrgUnit": "Import an organizational unit from an external source",
+  "submission.import-external.title.OrgUnit": "Importovať organizačnú jednotku z externého zdroja",
+
+  // "submission.import-external.title.Person": "Import a person from an external source",
+  "submission.import-external.title.Person": "Importovať osobu z externého zdroja",
+
+  // "submission.import-external.title.Project": "Import a project from an external source",
+  "submission.import-external.title.Project": "Importovať projekt z externého zdroja",
+
+  // "submission.import-external.title.Publication": "Import a publication from an external source",
+  "submission.import-external.title.Publication": "Importovať publikáciu z externého zdroja",
+
+  // "submission.import-external.title.none": "Import metadata from an external source",
+  "submission.import-external.title.none": "Importovať metadáta z externého zdroja",
+
+  // "submission.import-external.page.hint": "Enter a query above to find items from the web to import in to DSpace.",
+  "submission.import-external.page.hint": "Zadajte vyššie dopyt na nájdenie záznamov z webu, ktoré chcete importovať do systému DSpace.",
+
+  // "submission.import-external.back-to-my-dspace": "Back to MyDSpace",
+  "submission.import-external.back-to-my-dspace": "Späť na Môj DSpace",
+
+  // "submission.import-external.search.placeholder": "Search the external source",
+  "submission.import-external.search.placeholder": "Prehľadať externý zdroj",
+
+  // "submission.import-external.search.button": "Search",
+  "submission.import-external.search.button": "Hľadať",
+
+  // "submission.import-external.search.button.hint": "Write some words to search",
+  "submission.import-external.search.button.hint": "Napíšte niekoľko slov na vyhľadávanie",
+
+  // "submission.import-external.search.source.hint": "Pick an external source",
+  "submission.import-external.search.source.hint": "Vyberte externý zdroj",
+
+  // "submission.import-external.source.arxiv": "arXiv",
+  "submission.import-external.source.arxiv": "arXiv",
+
+  // "submission.import-external.source.ads": "NASA/ADS",
+  "submission.import-external.source.ads": "NASA/ADS",
+
+  // "submission.import-external.source.cinii": "CiNii",
+  "submission.import-external.source.cinii": "CiNii",
+
+  // "submission.import-external.source.crossref": "Crossref",
+  "submission.import-external.source.crossref": "Crossref",
+
+  // "submission.import-external.source.datacite": "DataCite",
+  "submission.import-external.source.datacite": "DataCite",
+
+  // "submission.import-external.source.dataciteProject": "DataCite",
+  "submission.import-external.source.dataciteProject": "DataCite",
+
+  // "submission.import-external.source.doi": "DOI",
+  "submission.import-external.source.doi": "DOI",
+
+  // "submission.import-external.source.scielo": "SciELO",
+  "submission.import-external.source.scielo": "SciELO",
+
+  // "submission.import-external.source.scopus": "Scopus",
+  "submission.import-external.source.scopus": "Scopus",
+
+  // "submission.import-external.source.vufind": "VuFind",
+  "submission.import-external.source.vufind": "VuFind",
+
+  // "submission.import-external.source.wos": "Web Of Science",
+  "submission.import-external.source.wos": "Web Of Science",
+
+  // "submission.import-external.source.orcidWorks": "ORCID",
+  "submission.import-external.source.orcidWorks": "ORCID",
+
+  // "submission.import-external.source.epo": "European Patent Office (EPO)",
+  "submission.import-external.source.epo": "European Patent Office (EPO)",
+
+  // "submission.import-external.source.loading": "Loading ...",
+  "submission.import-external.source.loading": "Načítava sa ...",
+
+  // "submission.import-external.source.opfJournal": "Jisc Open policy finder Journals",
+  "submission.import-external.source.opfJournal": "Jisc Open policy finder – časopisy",
+
+  // "submission.import-external.source.opfJournalIssn": "Jisc Open policy finder Journals by ISSN",
+  "submission.import-external.source.opfJournalIssn": "Jisc Open policy finder – časopisy podľa ISSN",
+
+  // "submission.import-external.source.opfPublisher": "Jisc Open policy finder Publishers",
+  "submission.import-external.source.opfPublisher": "Jisc Open policy finder – vydavatelia",
+
+  // "submission.import-external.source.openaire": "OpenAIRE Search by Authors",
+  "submission.import-external.source.openaire": "OpenAIRE – vyhľadávanie podľa autorov",
+
+  // "submission.import-external.source.openaireTitle": "OpenAIRE Search by Title",
+  "submission.import-external.source.openaireTitle": "OpenAIRE – vyhľadávanie podľa názvu",
+
+  // "submission.import-external.source.openaireFunding": "OpenAIRE Search by Funder",
+  "submission.import-external.source.openaireFunding": "OpenAIRE – vyhľadávanie podľa poskytovateľa financií",
+
+  // "submission.import-external.source.orcid": "ORCID",
+  "submission.import-external.source.orcid": "ORCID",
+
+  // "submission.import-external.source.pubmed": "Pubmed",
+  "submission.import-external.source.pubmed": "Pubmed",
+
+  // "submission.import-external.source.pubmedeu": "Pubmed Europe",
+  "submission.import-external.source.pubmedeu": "Pubmed Europe",
+
+  // "submission.import-external.source.lcname": "Library of Congress Names",
+  "submission.import-external.source.lcname": "Library of Congress Names",
+
+  // "submission.import-external.source.ror": "Research Organization Registry (ROR)",
+  "submission.import-external.source.ror": "Register výskumných organizácií (ROR)",
+
+  // "submission.import-external.source.openalexPublication": "OpenAlex Search by Title",
+  "submission.import-external.source.openalexPublication": "OpenAlex – vyhľadávanie podľa názvu",
+
+  // "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex Search by Author ID",
+  "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex – vyhľadávanie podľa ID autora",
+
+  // "submission.import-external.source.openalexPublicationByDOI": "OpenAlex Search by DOI",
+  "submission.import-external.source.openalexPublicationByDOI": "OpenAlex – vyhľadávanie podľa DOI",
+
+  // "submission.import-external.source.openalexPerson": "OpenAlex Search by name",
+  "submission.import-external.source.openalexPerson": "OpenAlex – vyhľadávanie podľa mena",
+
+  // "submission.import-external.source.openalexJournal": "OpenAlex Journals",
+  "submission.import-external.source.openalexJournal": "OpenAlex – časopisy",
+
+  // "submission.import-external.source.openalexInstitution": "OpenAlex Institutions",
+  "submission.import-external.source.openalexInstitution": "OpenAlex – inštitúcie",
+
+  // "submission.import-external.source.openalexPublisher": "OpenAlex Publishers",
+  "submission.import-external.source.openalexPublisher": "OpenAlex – vydavatelia",
+
+  // "submission.import-external.source.openalexFunder": "OpenAlex Funders",
+  "submission.import-external.source.openalexFunder": "OpenAlex – poskytovatelia financií",
+
+  // "submission.import-external.preview.title": "Item Preview",
+  "submission.import-external.preview.title": "Náhľad záznamu",
+
+  // "submission.import-external.preview.title.Publication": "Publication Preview",
+  "submission.import-external.preview.title.Publication": "Náhľad publikácie",
+
+  // "submission.import-external.preview.title.none": "Item Preview",
+  "submission.import-external.preview.title.none": "Náhľad záznamu",
+
+  // "submission.import-external.preview.title.Journal": "Journal Preview",
+  "submission.import-external.preview.title.Journal": "Náhľad časopisu",
+
+  // "submission.import-external.preview.title.OrgUnit": "Organizational Unit Preview",
+  "submission.import-external.preview.title.OrgUnit": "Náhľad organizačnej jednotky",
+
+  // "submission.import-external.preview.title.Person": "Person Preview",
+  "submission.import-external.preview.title.Person": "Náhľad osoby",
+
+  // "submission.import-external.preview.title.Project": "Project Preview",
+  "submission.import-external.preview.title.Project": "Náhľad projektu",
+
+  // "submission.import-external.preview.subtitle": "The metadata below was imported from an external source. It will be pre-filled when you start the submission.",
+  "submission.import-external.preview.subtitle": "Nižšie uvedené metadáta boli importované z externého zdroja. Budú predvyplnené pri začatí vkladania.",
+
+  // "submission.import-external.preview.button.import": "Start submission",
+  "submission.import-external.preview.button.import": "Začať vkladanie",
+
+  // "submission.import-external.preview.error.import.title": "Submission error",
+  "submission.import-external.preview.error.import.title": "Chyba vkladania",
+
+  // "submission.import-external.preview.error.import.body": "An error occurs during the external source entry import process.",
+  "submission.import-external.preview.error.import.body": "Počas procesu importu záznamu z externého zdroja došlo k chybe.",
+
+  // "submission.sections.describe.relationship-lookup.close": "Close",
+  "submission.sections.describe.relationship-lookup.close": "Zavrieť",
+
+  // "submission.sections.describe.relationship-lookup.external-source.added": "Successfully added local entry to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.added": "Lokálny záznam bol úspešne pridaný do výberu.",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Import remote author",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isAuthorOfPublication": "Importovať vzdialeného autora",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Import remote journal",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal": "Importovať vzdialený časopis",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Issue": "Import remote journal issue",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Issue": "Importovať vzdialené číslo časopisu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Import remote journal volume",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Journal Volume": "Importovať vzdialený ročník časopisu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.isProjectOfPublication": "Project",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.isProjectOfPublication": "Projekt",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.none": "Import remote item",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.none": "Importovať vzdialený záznam",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Event": "Import remote event",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Event": "Importovať vzdialenú udalosť",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Product": "Import remote product",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Product": "Importovať vzdialený produkt",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Equipment": "Import remote equipment",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Equipment": "Importovať vzdialené vybavenie",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.OrgUnit": "Import remote organizational unit",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.OrgUnit": "Importovať vzdialenú organizačnú jednotku",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Funding": "Import remote fund",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Funding": "Importovať vzdialený fond",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Person": "Import remote person",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Person": "Importovať vzdialenú osobu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Patent": "Import remote patent",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Patent": "Importovať vzdialený patent",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Project": "Import remote project",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Project": "Importovať vzdialený projekt",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Publication": "Import remote publication",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Publication": "Importovať vzdialenú publikáciu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.added.new-entity": "New Entity Added!",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.added.new-entity": "Pridaná nová entita!",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.title": "Project",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfPublication.title": "Projekt",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Import Remote Author",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.title": "Importovať vzdialeného autora",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Successfully added local author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.local-entity": "Lokálny autor bol úspešne pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Successfully imported and added external author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfPublication.added.new-entity": "Externý autor bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isJournalOfVolume.added.new-entity": "Successfully imported and added external journal to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isJournalOfVolume.added.new-entity": "Externý časopis bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.authority": "Authority",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.authority": "Autorita",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.authority.new": "Import as a new local authority entry",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.authority.new": "Importovať ako nový záznam lokálnej autority",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.cancel": "Cancel",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.cancel": "Zrušiť",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.collection": "Select a collection to import new entries to",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.collection": "Vyberte kolekciu, do ktorej chcete importovať nové záznamy",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.entities": "Entities",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.entities": "Entity",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.entities.new": "Import as a new local entity",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.entities.new": "Importovať ako novú lokálnu entitu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.lcname": "Importing from LC Name",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.lcname": "Import z LC Name",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Importing from ORCID",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Import z ORCID",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Import z OpenAIRE",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Import z OpenAIRE",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Import z OpenAIRE",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.jiscJournal": "Importing from Jisc Open policy finder Journal",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.jiscJournal": "Import z Jisc Open policy finder – časopis",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.jiscPublisher": "Importing from Jisc Open policy finder Publisher",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.jiscPublisher": "Import z Jisc Open policy finder – vydavateľ",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Importing from PubMed",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.pubmed": "Import z PubMed",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Importing from arXiv",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Import z arXiv",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.ror": "Import from ROR",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.ror": "Import z ROR",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.title": "Import Remote Journal",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.title": "Importovať vzdialený časopis",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.local-entity": "Successfully added local journal to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.local-entity": "Lokálny časopis bol úspešne pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.new-entity": "Successfully imported and added external journal to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal.added.new-entity": "Externý časopis bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.title": "Import Remote Journal Issue",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.title": "Importovať vzdialené číslo časopisu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.local-entity": "Successfully added local journal issue to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.local-entity": "Lokálne číslo časopisu bolo úspešne pridané do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.new-entity": "Successfully imported and added external journal issue to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Issue.added.new-entity": "Externé číslo časopisu bolo úspešne importované a pridané do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.title": "Import Remote Journal Volume",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.title": "Importovať vzdialený ročník časopisu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.local-entity": "Successfully added local journal volume to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.local-entity": "Lokálny ročník časopisu bol úspešne pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.new-entity": "Successfully imported and added external journal volume to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.Journal Volume.added.new-entity": "Externý ročník časopisu bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.select": "Select a local match:",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.select": "Vyberte lokálnu zhodu:",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.title": "Import Remote Organization",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.title": "Importovať vzdialenú organizáciu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.local-entity": "Successfully added local organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.local-entity": "Lokálna organizácia bola úspešne pridaná do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.new-entity": "Successfully imported and added external organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.new-entity": "Externá organizácia bola úspešne importovaná a pridaná do výberu",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.deselect-all": "Deselect all",
+  "submission.sections.describe.relationship-lookup.search-tab.deselect-all": "Zrušiť výber všetkých",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.deselect-page": "Deselect page",
+  "submission.sections.describe.relationship-lookup.search-tab.deselect-page": "Zrušiť výber stránky",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.loading": "Loading...",
+  "submission.sections.describe.relationship-lookup.search-tab.loading": "Načítava sa...",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.placeholder": "Search query",
+  "submission.sections.describe.relationship-lookup.search-tab.placeholder": "Vyhľadávací dopyt",
+
+  // "submission.sections.describe.relationship-lookup.toggle-dropdown": "Toggle dropdown",
+  "submission.sections.describe.relationship-lookup.toggle-dropdown": "Prepnúť rozbaľovací zoznam",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.search": "Go",
+  "submission.sections.describe.relationship-lookup.search-tab.search": "Prejsť",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.search-form.placeholder": "Search...",
+  "submission.sections.describe.relationship-lookup.search-tab.search-form.placeholder": "Hľadať...",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.select-all": "Select all",
+  "submission.sections.describe.relationship-lookup.search-tab.select-all": "Vybrať všetko",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.select-page": "Select page",
+  "submission.sections.describe.relationship-lookup.search-tab.select-page": "Vybrať stránku",
+
+  // "submission.sections.describe.relationship-lookup.selected": "Selected {{ size }} items",
+  "submission.sections.describe.relationship-lookup.selected": "Vybraných {{ size }} záznamov",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfPublication": "Local Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfPublication": "Lokálni autori ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Local Journals ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Lokálne časopisy ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Local Projects ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Lokálne projekty ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Publication": "Local Publications ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Publication": "Lokálne publikácie ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Person": "Local Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Person": "Lokálni autori ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.OrgUnit": "Local Organizational Units ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.OrgUnit": "Lokálne organizačné jednotky ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.DataPackage": "Local Data Packages ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.DataPackage": "Lokálne dátové balíky ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.DataFile": "Local Data Files ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.DataFile": "Lokálne dátové súbory ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Journal": "Local Journals ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Journal": "Lokálne časopisy ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalIssueOfPublication": "Local Journal Issues ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalIssueOfPublication": "Lokálne čísla časopisu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "Local Journal Issues ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "Lokálne čísla časopisu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Local Journal Volumes ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Lokálne ročníky časopisu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Local Journal Volumes ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Lokálne ročníky časopisu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalVolume": "Local Journal Volumes ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalVolume": "Lokálne ročníky časopisu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscJournal": "Jisc Open policy finder Journals ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscJournal": "Jisc Open policy finder – časopisy ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscPublisher": "Jisc Open policy finder Publishers ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscPublisher": "Jisc Open policy finder – vydavatelia ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcid": "ORCID ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcid": "ORCID ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "LC Names ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.lcname": "LC Names ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.pubmed": "PubMed ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.pubmed": "PubMed ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.arxiv": "arXiv ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.arxiv": "arXiv ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.ror": "ROR ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.ror": "ROR ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcidWorks": "ORCID ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcidWorks": "ORCID ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "Crossref ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "Crossref ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE – vyhľadávanie podľa autorov ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE Search by Title ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE – vyhľadávanie podľa názvu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE Search by Funder ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE – vyhľadávanie podľa poskytovateľa financií ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscJournalIssn": "Jisc Open policy finder Journals by ISSN ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.jiscJournalIssn": "Jisc Open policy finder – časopisy podľa ISSN ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex – vyhľadávanie podľa inštitúcie ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex Search by Publisher ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex – vyhľadávanie podľa vydavateľa ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex Search by Funder ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex – vyhľadávanie podľa poskytovateľa financií ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite Search by Project ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite – vyhľadávanie podľa projektu ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Search for Funding Agencies",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Vyhľadať financujúce agentúry",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Search for Funding",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingOfPublication": "Vyhľadať financovanie",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isChildOrgUnitOf": "Search for Organizational Units",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isChildOrgUnitOf": "Vyhľadať organizačné jednotky",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isProjectOfPublication": "Projects",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isProjectOfPublication": "Projekty",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfProject": "Funder of the Project",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfProject": "Poskytovateľ financií projektu",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfAuthor": "Publication of the Author",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfAuthor": "Publikácia autora",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isOrgUnitOfProject": "OrgUnit of the Project",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isOrgUnitOfProject": "Organizačné jednotky projektu",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfVolume": "Journal of the Volume",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfVolume": "Časopis ročníka",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.opfJournal": "Jisc Open policy finder of Journal",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.opfJournal": "Jisc Open policy finder – časopis",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Project",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Projekt",
+
+  // "submission.sections.describe.relationship-lookup.title.isProjectOfPublication": "Projects",
+  "submission.sections.describe.relationship-lookup.title.isProjectOfPublication": "Projekty",
+
+  // "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "Funder of the Project",
+  "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "Poskytovateľ financií projektu",
+
+  // "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Person of the Project",
+  "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Osoba projektu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Search...",
+  "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Hľadať...",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.tab-title": "Current Selection ({{ count }})",
+  "submission.sections.describe.relationship-lookup.selection-tab.tab-title": "Aktuálny výber ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.title.Journal": "Journal",
+  "submission.sections.describe.relationship-lookup.title.Journal": "Časopis",
+
+  // "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Journal Issues",
+  "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Čísla časopisu",
+
+  // "submission.sections.describe.relationship-lookup.title.JournalIssue": "Journal Issues",
+  "submission.sections.describe.relationship-lookup.title.JournalIssue": "Čísla časopisu",
+
+  // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Journal Volumes",
+  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Ročníky časopisov",
+
+  // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Journal Volumes",
+  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Ročníky časopisov",
+
+  // "submission.sections.describe.relationship-lookup.title.JournalVolume": "Journal Volumes",
+  "submission.sections.describe.relationship-lookup.title.JournalVolume": "Ročníky časopisov",
+
+  // "submission.sections.describe.relationship-lookup.title.isJournalOfPublication": "Journals",
+  "submission.sections.describe.relationship-lookup.title.isJournalOfPublication": "Časopisy",
+
+  // "submission.sections.describe.relationship-lookup.title.isAuthorOfPublication": "Authors",
+  "submission.sections.describe.relationship-lookup.title.isAuthorOfPublication": "Autori",
+
+  // "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfPublication": "Funding Agency",
+  "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfPublication": "Financujúca agentúra",
+
+  // "submission.sections.describe.relationship-lookup.title.Project": "Projects",
+  "submission.sections.describe.relationship-lookup.title.Project": "Projekty",
+
+  // "submission.sections.describe.relationship-lookup.title.Publication": "Publications",
+  "submission.sections.describe.relationship-lookup.title.Publication": "Publikácie",
+
+  // "submission.sections.describe.relationship-lookup.title.Person": "Authors",
+  "submission.sections.describe.relationship-lookup.title.Person": "Autori",
+
+  // "submission.sections.describe.relationship-lookup.title.OrgUnit": "Organizational Units",
+  "submission.sections.describe.relationship-lookup.title.OrgUnit": "Organizačné jednotky",
+
+  // "submission.sections.describe.relationship-lookup.title.DataPackage": "Data Packages",
+  "submission.sections.describe.relationship-lookup.title.DataPackage": "Dátové balíky",
+
+  // "submission.sections.describe.relationship-lookup.title.DataFile": "Data Files",
+  "submission.sections.describe.relationship-lookup.title.DataFile": "Dátové súbory",
+
+  // "submission.sections.describe.relationship-lookup.title.Funding Agency": "Funding Agency",
+  "submission.sections.describe.relationship-lookup.title.Funding Agency": "Financujúca agentúra",
+
+  // "submission.sections.describe.relationship-lookup.title.isFundingOfPublication": "Funding",
+  "submission.sections.describe.relationship-lookup.title.isFundingOfPublication": "Financovanie",
+
+  // "submission.sections.describe.relationship-lookup.title.isChildOrgUnitOf": "Parent Organizational Unit",
+  "submission.sections.describe.relationship-lookup.title.isChildOrgUnitOf": "Nadradená organizačná jednotka",
+
+  // "submission.sections.describe.relationship-lookup.title.isPublicationOfAuthor": "Publication",
+  "submission.sections.describe.relationship-lookup.title.isPublicationOfAuthor": "Publikácia",
+
+  // "submission.sections.describe.relationship-lookup.title.isOrgUnitOfProject": "OrgUnit",
+  "submission.sections.describe.relationship-lookup.title.isOrgUnitOfProject": "OrgUnit",
+
+  // "submission.sections.describe.relationship-lookup.title.isJournalOfVolume": "Journal",
+  "submission.sections.describe.relationship-lookup.title.isJournalOfVolume": "Časopis",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Toggle dropdown",
+  "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Prepnúť rozbaľovací zoznam",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.settings": "Settings",
+  "submission.sections.describe.relationship-lookup.selection-tab.settings": "Nastavenia",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.no-selection": "Your selection is currently empty.",
+  "submission.sections.describe.relationship-lookup.selection-tab.no-selection": "Váš výber je momentálne prázdny.",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isAuthorOfPublication": "Selected Authors",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isAuthorOfPublication": "Vybraní autori",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalOfPublication": "Selected Journals",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalOfPublication": "Vybrané časopisy",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Selected Journal Volume",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Vybraný ročník časopisu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Selected Journal Volume",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Vybraný ročník časopisu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.Project": "Selected Projects",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Project": "Vybrané projekty",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Selected Publications",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Vybrané publikácie",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Selected Authors",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Vybraní autori",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.OrgUnit": "Selected Organizational Units",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.OrgUnit": "Vybrané organizačné jednotky",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.DataPackage": "Selected Data Packages",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.DataPackage": "Vybrané dátové balíky",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.DataFile": "Selected Data Files",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.DataFile": "Vybrané dátové súbory",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.Journal": "Selected Journals",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Journal": "Vybrané časopisy",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalIssueOfPublication": "Selected Issue",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalIssueOfPublication": "Vybrané číslo časopisu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.JournalVolume": "Selected Journal Volume",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.JournalVolume": "Vybraný ročník časopisu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingAgencyOfPublication": "Selected Funding Agency",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingAgencyOfPublication": "Vybraná financujúca agentúra",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingOfPublication": "Selected Funding",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isFundingOfPublication": "Vybrané financovanie",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.JournalIssue": "Selected Issue",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.JournalIssue": "Vybrané číslo časopisu",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Selected Organizational Unit",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Vybraná organizačná jednotka",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.jiscJournal": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.jiscJournal": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.jiscPublisher": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.jiscPublisher": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.orcid": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.orcid": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.orcidv2": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.orcidv2": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.pubmed": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.pubmed": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.arxiv": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.arxiv": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.crossref": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.crossref": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.epo": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.epo": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.scopus": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.scopus": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.scielo": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.scielo": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.wos": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.wos": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.opfJournal": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.opfJournal": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Would you like to save \"{{ value }}\" as a name variant for this person so you and others can reuse it for future submissions? If you don't you can still use it for this submission.",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.content": "Chcete uložiť \"{{ value }}\" ako variant mena pre túto osobu, aby ste ho vy aj ostatní mohli opakovane použiť pri budúcich vloženiach? Ak nie, môžete ho aj tak použiť pre toto vloženie.",
+
+  // "submission.sections.describe.relationship-lookup.name-variant.notification.confirm": "Save a new name variant",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.confirm": "Uložiť nový variant mena",
+
+  // "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Use only for this submission",
+  "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Použiť len pre toto vloženie",
+
+  // "submission.sections.ccLicense.type": "License Type",
+  "submission.sections.ccLicense.type": "Typ licencie",
+
+  // "submission.sections.ccLicense.select": "Select a license type…",
+  "submission.sections.ccLicense.select": "Vyberte typ licencie...",
+
+  // "submission.sections.ccLicense.change": "Change your license type…",
+  "submission.sections.ccLicense.change": "Zmeniť typ licencie...",
+
+  // "submission.sections.ccLicense.none": "No licenses available",
+  "submission.sections.ccLicense.none": "Nie sú k dispozícii žiadne licencie",
+
+  // "submission.sections.ccLicense.option.select": "Select an option…",
+  "submission.sections.ccLicense.option.select": "Vyberte možnosť...",
+
+  // "submission.sections.ccLicense.link": "You’ve selected the following license:",
+  "submission.sections.ccLicense.link": "Vybrali ste nasledujúcu licenciu:",
+
+  // "submission.sections.ccLicense.confirmation": "I grant the license above",
+  "submission.sections.ccLicense.confirmation": "Udeľujem vyššie uvedenú licenciu",
+
+  // "submission.sections.general.add-more": "Add more",
+  "submission.sections.general.add-more": "Pridať ďalšie",
+
+  // "submission.sections.general.cannot_deposit": "Deposit cannot be completed due to errors in the form.<br>Please fill out all required fields to complete the deposit.",
+  "submission.sections.general.cannot_deposit": "Vloženie nemožno dokončiť kvôli chybám vo formulári.<br>Na dokončenie vloženia vyplňte všetky povinné polia.",
+
+  // "submission.sections.general.collection": "Collection",
+  "submission.sections.general.collection": "Kolekcia",
+
+  // "submission.sections.general.deposit_error_notice": "There was an issue when submitting the item, please try again later.",
+  "submission.sections.general.deposit_error_notice": "Pri odosielaní záznamu došlo k problému, skúste to prosím neskôr.",
+
+  // "submission.sections.general.invalid_state_error": "Cannot save current changes, mandatory fields are missing. Please resolve problems and save again later.",
+  "submission.sections.general.invalid_state_error": "Aktuálne zmeny nemožno uložiť, chýbajú povinné polia. Vyriešte prosím problémy a uložte znova neskôr.",
+
+  // "submission.sections.general.deposit_success_notice": "Submission deposited successfully.",
+  "submission.sections.general.deposit_success_notice": "Vloženie bolo úspešne uložené do repozitára.",
+
+  // "submission.sections.general.discard_error_notice": "There was an issue when discarding the item, please try again later.",
+  "submission.sections.general.discard_error_notice": "Pri zahadzovaní záznamu došlo k problému, skúste to prosím neskôr.",
+
+  // "submission.sections.general.discard_success_notice": "Submission discarded successfully.",
+  "submission.sections.general.discard_success_notice": "Vloženie bolo úspešne zahodené.",
+
+  // "submission.sections.general.metadata-extracted": "New metadata have been extracted and added to the <strong>{{sectionId}}</strong> section.",
+  "submission.sections.general.metadata-extracted": "Do sekcie <strong>{{sectionId}}</strong> boli extrahované a pridané nové metadáta.",
+
+  // "submission.sections.general.metadata-extracted-new-section": "New <strong>{{sectionId}}</strong> section has been added to submission.",
+  "submission.sections.general.metadata-extracted-new-section": "Do vloženia bola pridaná nová sekcia <strong>{{sectionId}}</strong>.",
+
+  // "submission.sections.general.no-collection": "No collection found",
+  "submission.sections.general.no-collection": "Nenašla sa žiadna kolekcia",
+
+  // "submission.sections.general.no-entity": "No entity types found",
+  "submission.sections.general.no-entity": "Nenašiel sa žiadny typ entity",
+
+  // "submission.sections.general.no-sections": "No options available",
+  "submission.sections.general.no-sections": "Nie sú k dispozícii žiadne možnosti",
+
+  // "submission.sections.general.save_error_notice": "There was an issue when saving the item, please try again later.",
+  "submission.sections.general.save_error_notice": "Pri ukladaní záznamu došlo k problému, skúste to prosím neskôr.",
+
+  // "submission.sections.general.save_success_notice": "Submission saved successfully.",
+  "submission.sections.general.save_success_notice": "Vloženie bolo úspešne uložené.",
+
+  // "submission.sections.general.search-collection": "Search for a collection",
+  "submission.sections.general.search-collection": "Vyhľadať kolekciu",
+
+  // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  "submission.sections.general.sections_not_valid": "Existujú neúplné sekcie.",
+
+  // "submission.sections.identifiers.info": "The following identifiers will be created for your item:",
+  "submission.sections.identifiers.info": "Pre tento záznam budú vytvorené nasledujúce identifikátory:",
+
+  // "submission.sections.identifiers.no_handle": "No handles have been minted for this item.",
+  "submission.sections.identifiers.no_handle": "Tomuto záznamu nebol pridelený žiadny handle.",
+
+  // "submission.sections.identifiers.no_doi": "No DOIs have been minted for this item.",
+  "submission.sections.identifiers.no_doi": "Tomuto záznamu nebolo pridelené žiadne DOI.",
+
+  // "submission.sections.identifiers.handle_label": "Handle: ",
+  "submission.sections.identifiers.handle_label": "Handle: ",
+
+  // "submission.sections.identifiers.doi_label": "DOI: ",
+  "submission.sections.identifiers.doi_label": "DOI: ",
+
+  // "submission.sections.identifiers.otherIdentifiers_label": "Other identifiers: ",
+  "submission.sections.identifiers.otherIdentifiers_label": "Iné identifikátory: ",
+
+  // "submission.sections.submit.progressbar.accessCondition": "Item access conditions",
+  "submission.sections.submit.progressbar.accessCondition": "Podmienky prístupu k záznamu",
+
+  // "submission.sections.submit.progressbar.CClicense": "Creative commons license",
+  "submission.sections.submit.progressbar.CClicense": "Licencia Creative Commons",
+
+  // "submission.sections.submit.progressbar.CustomUrlStep": "Custom Url",
+  "submission.sections.submit.progressbar.CustomUrlStep": "Vlastná URL",
+
+  // "submission.sections.submit.progressbar.describe.recycle": "Recycle",
+  "submission.sections.submit.progressbar.describe.recycle": "Opätovne použiť",
+
+  // "submission.sections.submit.progressbar.describe.stepcustom": "Describe",
+  "submission.sections.submit.progressbar.describe.stepcustom": "Popis",
+
+  // "submission.sections.submit.progressbar.describe.stepone": "Describe",
+  "submission.sections.submit.progressbar.describe.stepone": "Základné informácie o dokumente",
+
+  // "submission.sections.submit.progressbar.describe.steptwo": "Describe",
+  "submission.sections.submit.progressbar.describe.steptwo": "Popísať",
+
+  // "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
+  "submission.sections.submit.progressbar.duplicates": "Potenciálne duplicity",
+
+  // "submission.sections.submit.progressbar.identifiers": "Identifiers",
+  "submission.sections.submit.progressbar.identifiers": "Identifikátory",
+
+  // "submission.sections.submit.progressbar.license": "Deposit license",
+  "submission.sections.submit.progressbar.license": "Licencia na uloženie",
+
+  // "submission.sections.submit.progressbar.describe.owner": "Owner",
+  "submission.sections.submit.progressbar.describe.owner": "Vlastník",
+
+  // "submission.sections.submit.progressbar.opfpolicy": "Publisher open access policy information",
+  "submission.sections.submit.progressbar.opfpolicy": "Informácie o politike otvoreného prístupu vydavateľa",
+
+  // "submission.sections.submit.progressbar.upload": "Upload files",
+  "submission.sections.submit.progressbar.upload": "Nahrať súbory",
+
+  // "submission.sections.jisc-policy.title-empty": "No publisher policy information available. If your work has an associated ISSN, please enter it above to see any related publisher open access policies.",
+  "submission.sections.jisc-policy.title-empty": "Nie sú k dispozícii žiadne informácie o politike vydavateľa. Ak má vaša práca priradené ISSN, zadajte ho vyššie, aby ste videli všetky súvisiace politiky otvoreného prístupu vydavateľa.",
+
+  // "submission.sections.status.errors.title": "Errors",
+  "submission.sections.status.errors.title": "Chyby",
+
+  // "submission.sections.status.valid.title": "Valid",
+  "submission.sections.status.valid.title": "Platné",
+
+  // "submission.sections.status.warnings.title": "Warnings",
+  "submission.sections.status.warnings.title": "Upozornenia",
+
+  // "submission.sections.status.errors.aria": "has errors",
+  "submission.sections.status.errors.aria": "má chyby",
+
+  // "submission.sections.status.valid.aria": "is valid",
+  "submission.sections.status.valid.aria": "je platné",
+
+  // "submission.sections.status.warnings.aria": "has warnings",
+  "submission.sections.status.warnings.aria": "má upozornenia",
+
+  // "submission.sections.status.info.title": "Additional Information",
+  "submission.sections.status.info.title": "Doplňujúce informácie",
+
+  // "submission.sections.status.info.aria": "Additional Information",
+  "submission.sections.status.info.aria": "Doplňujúce informácie",
+
+  // "submission.sections.toggle.open": "Open section",
+  "submission.sections.toggle.open": "Otvoriť sekciu",
+
+  // "submission.sections.toggle.close": "Close section",
+  "submission.sections.toggle.close": "Zavrieť sekciu",
+
+  // "submission.sections.toggle.aria.open": "Expand {{sectionHeader}} section",
+  "submission.sections.toggle.aria.open": "Rozbaliť sekciu {{sectionHeader}}",
+
+  // "submission.sections.toggle.aria.close": "Collapse {{sectionHeader}} section",
+  "submission.sections.toggle.aria.close": "Zbaliť sekciu {{sectionHeader}}",
+
+  // "submission.sections.upload.primary.make": "Make {{fileName}} the primary bitstream",
+  "submission.sections.upload.primary.make": "Nastaviť {{fileName}} ako primárny súbor",
+
+  // "submission.sections.upload.primary.remove": "Remove {{fileName}} as the primary bitstream",
+  "submission.sections.upload.primary.remove": "Odobrať {{fileName}} z pozície primárneho súboru",
+
+  // "submission.sections.upload.delete.confirm.cancel": "Cancel",
+  "submission.sections.upload.delete.confirm.cancel": "Zrušiť",
+
+  // "submission.sections.upload.delete.confirm.info": "This operation can't be undone. Are you sure?",
+  "submission.sections.upload.delete.confirm.info": "Túto operáciu nemožno vrátiť späť. Ste si istí?",
+
+  // "submission.sections.upload.delete.confirm.submit": "Yes, I'm sure",
+  "submission.sections.upload.delete.confirm.submit": "Áno, som si istý",
+
+  // "submission.sections.upload.delete.confirm.title": "Delete bitstream",
+  "submission.sections.upload.delete.confirm.title": "Odstrániť súbor",
+
+  // "submission.sections.upload.delete.submit": "Delete",
+  "submission.sections.upload.delete.submit": "Odstrániť",
+
+  // "submission.sections.upload.download.title": "Download bitstream",
+  "submission.sections.upload.download.title": "Stiahnuť súbor",
+
+  // "submission.sections.upload.drop-message": "Drop files to attach them to the item",
+  "submission.sections.upload.drop-message": "Presuňte sem súbory a pripojte ich k záznamu",
+
+  // "submission.sections.upload.edit.title": "Edit bitstream",
+  "submission.sections.upload.edit.title": "Upraviť súbor",
+
+  // "submission.sections.upload.file.edit.form.file-type.label": "Audio or video media type",
+  "submission.sections.upload.file.edit.form.file-type.label": "Typ audio alebo video média",
+
+  // "submission.sections.upload.file.edit.form.file-type.hint": "Choose how this bitstream should be interpreted.",
+  "submission.sections.upload.file.edit.form.file-type.hint": "Zvoľte, ako sa má tento súbor interpretovať.",
+
+  // "submission.sections.upload.file.edit.form.file-type.option.audio-video": "Audio and video",
+  "submission.sections.upload.file.edit.form.file-type.option.audio-video": "Audio a video",
+
+  // "submission.sections.upload.file.edit.form.file-type.option.neither": "Neither",
+  "submission.sections.upload.file.edit.form.file-type.option.neither": "Ani jedno",
+
+  // "submission.sections.upload.file.edit.form.file-type.option.audio": "Audio",
+  "submission.sections.upload.file.edit.form.file-type.option.audio": "Audio",
+
+  // "submission.sections.upload.file.edit.form.file-type.option.video": "Video",
+  "submission.sections.upload.file.edit.form.file-type.option.video": "Video",
+
+  // "submission.sections.upload.file.edit.form.audio-transcript.label": "Audio transcript",
+  "submission.sections.upload.file.edit.form.audio-transcript.label": "Prepis zvuku",
+
+  // "submission.sections.upload.file.edit.form.audio-transcript.hint": "Provide a transcript for audio content.",
+  "submission.sections.upload.file.edit.form.audio-transcript.hint": "Poskytnite prepis pre zvukový obsah.",
+
+  // "submission.sections.upload.file.edit.form.video-description.label": "Video description",
+  "submission.sections.upload.file.edit.form.video-description.label": "Popis videa",
+
+  // "submission.sections.upload.file.edit.form.video-description.hint": "Provide a description for video content.",
+  "submission.sections.upload.file.edit.form.video-description.hint": "Poskytnite popis pre obrazový obsah.",
+
+  // "submission.sections.upload.form.access-condition-label": "Access condition type",
+  "submission.sections.upload.form.access-condition-label": "Typ podmienky prístupu",
+
+  // "submission.sections.upload.form.access-condition-hint": "Select an access condition to apply on the bitstream once the item is deposited",
+  "submission.sections.upload.form.access-condition-hint": "Vyberte podmienku prístupu, ktorá sa použije na súbor po uložení záznamu",
+
+  // "submission.sections.upload.form.date-required": "Date is required.",
+  "submission.sections.upload.form.date-required": "Dátum je povinný.",
+
+  // "submission.sections.upload.form.date-required-from": "Grant access from date is required.",
+  "submission.sections.upload.form.date-required-from": "Dátum „Udeliť prístup od“ je povinný.",
+
+  // "submission.sections.upload.form.date-required-until": "Grant access until date is required.",
+  "submission.sections.upload.form.date-required-until": "Dátum „Udeliť prístup do“ je povinný.",
+
+  // "submission.sections.upload.form.from-label": "Grant access from",
+  "submission.sections.upload.form.from-label": "Udeliť prístup od",
+
+  // "submission.sections.upload.form.from-hint": "Select the date from which the related access condition is applied",
+  "submission.sections.upload.form.from-hint": "Vyberte dátum, od ktorého sa použije súvisiaca podmienka prístupu",
+
+  // "submission.sections.upload.form.from-placeholder": "From",
+  "submission.sections.upload.form.from-placeholder": "Od",
+
+  // "submission.sections.upload.form.group-label": "Group",
+  "submission.sections.upload.form.group-label": "Skupina",
+
+  // "submission.sections.upload.form.group-required": "Group is required.",
+  "submission.sections.upload.form.group-required": "Skupina je povinná.",
+
+  // "submission.sections.upload.form.until-label": "Grant access until",
+  "submission.sections.upload.form.until-label": "Udeliť prístup do",
+
+  // "submission.sections.upload.form.until-hint": "Select the date until which the related access condition is applied",
+  "submission.sections.upload.form.until-hint": "Vyberte dátum, do ktorého platí súvisiaca podmienka prístupu",
+
+  // "submission.sections.upload.form.until-placeholder": "Until",
+  "submission.sections.upload.form.until-placeholder": "Do",
+
+  // "submission.sections.upload.header.policy.default.nolist": "Uploaded files in the {{collectionName}} collection will be accessible according to the following group(s):",
+  "submission.sections.upload.header.policy.default.nolist": "Nahrané súbory v kolekcii {{collectionName}} budú prístupné podľa nasledujúcich skupín:",
+
+  // "submission.sections.upload.header.policy.default.withlist": "Please note that uploaded files in the {{collectionName}} collection will be accessible, in addition to what is explicitly decided for the single file, with the following group(s):",
+  "submission.sections.upload.header.policy.default.withlist": "Upozorňujeme, že nahrané súbory v kolekcii {{collectionName}} budú okrem toho, čo je explicitne určené pre jednotlivý súbor, prístupné aj nasledujúcim skupinám:",
+
+  // "submission.sections.upload.info": "Here you will find all the files currently in the item. You can update the file metadata and access conditions or <strong>upload additional files by dragging & dropping them anywhere on the page.</strong>",
+  "submission.sections.upload.info": "Tu nájdete všetky súbory, ktoré sú aktuálne v zázname. Môžete aktualizovať metadáta súborov a podmienky prístupu alebo <strong>nahrať ďalšie súbory ich presunutím kamkoľvek na stránku.</strong>",
+
+  // "submission.sections.upload.no-entry": "No",
+  "submission.sections.upload.no-entry": "Nie",
+
+  // "submission.sections.upload.no-file-uploaded": "No file uploaded yet.",
+  "submission.sections.upload.no-file-uploaded": "Zatiaľ nebol nahraný žiadny súbor.",
+
+  // "submission.sections.upload.save-metadata": "Save metadata",
+  "submission.sections.upload.save-metadata": "Uložiť metadáta",
+
+  // "submission.sections.upload.undo": "Cancel",
+  "submission.sections.upload.undo": "Zrušiť",
+
+  // "submission.sections.upload.upload-failed": "Upload failed",
+  "submission.sections.upload.upload-failed": "Nahrávanie zlyhalo",
+
+  // "submission.sections.upload.upload-successful": "Upload successful",
+  "submission.sections.upload.upload-successful": "Úspešne nahrané",
+
+  // "submission.sections.custom-url.label.previous-urls": "Previous Urls",
+  "submission.sections.custom-url.label.previous-urls": "Predchádzajúce URL adresy",
+
+  // "submission.sections.custom-url.alert.info": "Define here a custom URL which will be used to reach the item instead of using an internal randomly generated UUID identifier. ",
+  "submission.sections.custom-url.alert.info": "Tu definujte vlastnú URL adresu, ktorá bude použitá na prístup k záznamu namiesto interne generovaného náhodného UUID identifikátora. ",
+
+  // "submission.sections.custom-url.url.placeholder": "Custom URL",
+  "submission.sections.custom-url.url.placeholder": "Vlastná URL",
+
+  // "submission.sections.custom-url.label.remove": "Remove",
+  "submission.sections.custom-url.label.remove": "Odstrániť",
+
+  // "submission.sections.accesses.form.discoverable-description": "When checked, this item will be discoverable in search/browse. When unchecked, the item will only be available via a direct link and will never appear in search/browse.",
+  "submission.sections.accesses.form.discoverable-description": "Keď je zaškrtnuté, tento záznam bude vyhľadateľný vo vyhľadávaní/prehliadaní. Keď nie je zaškrtnuté, záznam bude dostupný len prostredníctvom priameho odkazu a nikdy sa nezobrazí vo vyhľadávaní/prehliadaní.",
+
+  // "submission.sections.accesses.form.discoverable-label": "Discoverable",
+  "submission.sections.accesses.form.discoverable-label": "Vyhľadateľné",
+
+  // "submission.sections.accesses.form.access-condition-label": "Access condition type",
+  "submission.sections.accesses.form.access-condition-label": "Typ podmienky prístupu",
+
+  // "submission.sections.accesses.form.access-condition-hint": "Select an access condition to apply on the item once it is deposited",
+  "submission.sections.accesses.form.access-condition-hint": "Vyberte podmienku prístupu, ktorá sa použije na záznam po jeho uložení",
+
+  // "submission.sections.accesses.form.date-required": "Date is required.",
+  "submission.sections.accesses.form.date-required": "Dátum je povinný.",
+
+  // "submission.sections.accesses.form.date-required-from": "Grant access from date is required.",
+  "submission.sections.accesses.form.date-required-from": "Dátum „Udeliť prístup od“ je povinný.",
+
+  // "submission.sections.accesses.form.date-required-until": "Grant access until date is required.",
+  "submission.sections.accesses.form.date-required-until": "Dátum „Udeliť prístup do“ je povinný.",
+
+  // "submission.sections.accesses.form.from-label": "Grant access from",
+  "submission.sections.accesses.form.from-label": "Udeliť prístup od",
+
+  // "submission.sections.accesses.form.from-hint": "Select the date from which the related access condition is applied",
+  "submission.sections.accesses.form.from-hint": "Vyberte dátum, od ktorého sa použije súvisiaca podmienka prístupu",
+
+  // "submission.sections.accesses.form.from-placeholder": "From",
+  "submission.sections.accesses.form.from-placeholder": "Od",
+
+  // "submission.sections.accesses.form.group-label": "Group",
+  "submission.sections.accesses.form.group-label": "Skupina",
+
+  // "submission.sections.accesses.form.group-required": "Group is required.",
+  "submission.sections.accesses.form.group-required": "Skupina je povinná.",
+
+  // "submission.sections.accesses.form.until-label": "Grant access until",
+  "submission.sections.accesses.form.until-label": "Udeliť prístup do",
+
+  // "submission.sections.accesses.form.until-hint": "Select the date until which the related access condition is applied",
+  "submission.sections.accesses.form.until-hint": "Vyberte dátum, do ktorého platí súvisiaca podmienka prístupu",
+
+  // "submission.sections.accesses.form.until-placeholder": "Until",
+  "submission.sections.accesses.form.until-placeholder": "Do",
+
+  // "submission.sections.duplicates.none": "No duplicates were detected.",
+  "submission.sections.duplicates.none": "Nezistili sa žiadne duplicity.",
+
+  // "submission.sections.duplicates.detected": "Potential duplicates were detected. Please review the list below.",
+  "submission.sections.duplicates.detected": "Zistili sa možné duplicity. Skontrolujte prosím zoznam nižšie.",
+
+  // "submission.sections.duplicates.in-workspace": "This item is in workspace",
+  "submission.sections.duplicates.in-workspace": "Tento záznam je v pracovnom priestore",
+
+  // "submission.sections.duplicates.in-workflow": "This item is in workflow",
+  "submission.sections.duplicates.in-workflow": "Tento záznam je vo workflow",
+
+  // "submission.sections.license.granted-label": "I confirm the license above",
+  "submission.sections.license.granted-label": "Potvrdzujem vyššie uvedenú licenciu",
+
+  // "submission.sections.license.required": "You must accept the license",
+  "submission.sections.license.required": "Musíte súhlasiť s licenciou",
+
+  // "submission.sections.license.notgranted": "You must accept the license",
+  "submission.sections.license.notgranted": "Musíte licenciu prijať",
+
+  // "submission.sections.jisc.publication.information": "Publication information",
+  "submission.sections.jisc.publication.information": "Informácie o publikácii",
+
+  // "submission.sections.jisc.publication.information.title": "Title",
+  "submission.sections.jisc.publication.information.title": "Názov",
+
+  // "submission.sections.jisc.publication.information.issns": "ISSNs",
+  "submission.sections.jisc.publication.information.issns": "ISSN",
+
+  // "submission.sections.jisc.publication.information.url": "URL",
+  "submission.sections.jisc.publication.information.url": "URL",
+
+  // "submission.sections.jisc.publication.information.publishers": "Publisher",
+  "submission.sections.jisc.publication.information.publishers": "Vydavateľ",
+
+  // "submission.sections.jisc.publication.information.romeoPub": "Romeo Pub",
+  "submission.sections.jisc.publication.information.romeoPub": "Romeo Pub",
+
+  // "submission.sections.jisc.publication.information.zetoPub": "Zeto Pub",
+  "submission.sections.jisc.publication.information.zetoPub": "Zeto Pub",
+
+  // "submission.sections.jisc.publisher.policy": "Publisher Policy",
+  "submission.sections.jisc.publisher.policy": "Politika vydavateľa",
+
+  // "submission.sections.jisc.publisher.policy.description": "The below information was found via Jisc Open policy finder. Based on the policies of your publisher, it provides advice regarding whether an embargo may be necessary and/or which files you are allowed to upload. If you have questions, please contact your site administrator via the feedback form in the footer.",
+  "submission.sections.jisc.publisher.policy.description": "Nižšie uvedené informácie boli zistené prostredníctvom Jisc Open policy finder. Na základe politík vášho vydavateľa poskytujú rady o tom, či môže byť potrebné embargo a/alebo ktoré súbory smiete nahrať. Ak máte otázky, kontaktujte prosím správcu webu prostredníctvom formulára spätnej väzby v pätičke.",
+
+  // "submission.sections.jisc.publisher.policy.openaccess": "Open Access pathways permitted by this journal's policy are listed below by article version. Click on a pathway for a more detailed view",
+  "submission.sections.jisc.publisher.policy.openaccess": "Cesty otvoreného prístupu povolené politikou tohto časopisu sú uvedené nižšie podľa verzie článku. Kliknutím na cestu získate podrobnejšie zobrazenie",
+
+  // "submission.sections.jisc.publisher.policy.more.information": "For more information, please see the following links:",
+  "submission.sections.jisc.publisher.policy.more.information": "Ďalšie informácie nájdete na nasledujúcich odkazoch:",
+
+  // "submission.sections.jisc.publisher.policy.version": "Version",
+  "submission.sections.jisc.publisher.policy.version": "Verzia",
+
+  // "submission.sections.jisc.publisher.policy.embargo": "Embargo",
+  "submission.sections.jisc.publisher.policy.embargo": "Embargo",
+
+  // "submission.sections.jisc.publisher.policy.noembargo": "No Embargo",
+  "submission.sections.jisc.publisher.policy.noembargo": "Bez embarga",
+
+  // "submission.sections.jisc.publisher.policy.nolocation": "None",
+  "submission.sections.jisc.publisher.policy.nolocation": "Bez miesta",
+
+  // "submission.sections.jisc.publisher.policy.license": "License",
+  "submission.sections.jisc.publisher.policy.license": "Licencia",
+
+  // "submission.sections.jisc.publisher.policy.prerequisites": "Prerequisites",
+  "submission.sections.jisc.publisher.policy.prerequisites": "Predpoklady",
+
+  // "submission.sections.jisc.publisher.policy.location": "Location",
+  "submission.sections.jisc.publisher.policy.location": "Miesto",
+
+  // "submission.sections.jisc.publisher.policy.conditions": "Conditions",
+  "submission.sections.jisc.publisher.policy.conditions": "Podmienky",
+
+  // "submission.sections.jisc.publisher.policy.refresh": "Refresh",
+  "submission.sections.jisc.publisher.policy.refresh": "Obnoviť",
+
+  // "submission.sections.jisc.record.information": "Record Information",
+  "submission.sections.jisc.record.information": "Informácie o zázname",
+
+  // "submission.sections.jisc.record.information.id": "ID",
+  "submission.sections.jisc.record.information.id": "ID",
+
+  // "submission.sections.jisc.record.information.date.created": "Date Created",
+  "submission.sections.jisc.record.information.date.created": "Dátum vytvorenia",
+
+  // "submission.sections.jisc.record.information.date.modified": "Last Modified",
+  "submission.sections.jisc.record.information.date.modified": "Naposledy upravené",
+
+  // "submission.sections.jisc.record.information.uri": "URI",
+  "submission.sections.jisc.record.information.uri": "URI",
+
+  // "submission.sections.jisc.error.message": "There was an error retrieving Jisc Open policy finder information",
+  "submission.sections.jisc.error.message": "Pri načítaní informácií z Jisc Open policy finder došlo k chybe",
+
+  // "submission.submit.breadcrumbs": "New submission",
+  "submission.submit.breadcrumbs": "Nové vloženie",
+
+  // "submission.submit.title": "New submission",
+  "submission.submit.title": "Nové vloženie",
+
+  // "submission.workflow.generic.delete": "Delete",
+  "submission.workflow.generic.delete": "Odstrániť",
+
+  // "submission.workflow.generic.delete-help": "Select this option to discard this item. You will then be asked to confirm it.",
+  "submission.workflow.generic.delete-help": "Túto možnosť zvoľte, ak chcete tento záznam zahodiť. Potom budete vyzvaní na potvrdenie.",
+
+  // "submission.workflow.generic.edit": "Edit",
+  "submission.workflow.generic.edit": "Upraviť",
+
+  // "submission.workflow.generic.edit-help": "Select this option to change the item's metadata.",
+  "submission.workflow.generic.edit-help": "Zvoľte túto možnosť, ak chcete zmeniť metadáta záznamu.",
+
+  // "submission.workflow.generic.view": "View",
+  "submission.workflow.generic.view": "Zobraziť",
+
+  // "submission.workflow.generic.view-help": "Select this option to view the item's metadata.",
+  "submission.workflow.generic.view-help": "Zvoľte túto možnosť, ak chcete zobraziť metadáta záznamu.",
+
+  // "submission.workflow.generic.submit_select_reviewer": "Select Reviewer",
+  "submission.workflow.generic.submit_select_reviewer": "Vybrať recenzenta",
+
+  // "submission.workflow.generic.submit_select_reviewer-help": "",
+  "submission.workflow.generic.submit_select_reviewer-help": "",
+
+  // "submission.workflow.generic.submit_score": "Rate",
+  "submission.workflow.generic.submit_score": "Hodnotiť",
+
+  // "submission.workflow.generic.submit_score-help": "",
+  "submission.workflow.generic.submit_score-help": "",
+
+  // "submission.workflow.tasks.claimed.approve": "Approve",
+  "submission.workflow.tasks.claimed.approve": "Schváliť",
+
+  // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
+  "submission.workflow.tasks.claimed.approve_help": "Ak ste záznam skontrolovali a je vhodný na zaradenie do kolekcie, vyberte možnosť „Schváliť“.",
+
+  // "submission.workflow.tasks.claimed.edit": "Edit",
+  "submission.workflow.tasks.claimed.edit": "Upraviť",
+
+  // "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",
+  "submission.workflow.tasks.claimed.edit_help": "Zvoľte túto možnosť, ak chcete zmeniť metadáta záznamu.",
+
+  // "submission.workflow.tasks.claimed.decline": "Decline",
+  "submission.workflow.tasks.claimed.decline": "Odmietnuť",
+
+  // "submission.workflow.tasks.claimed.decline_help": "",
+  "submission.workflow.tasks.claimed.decline_help": "",
+
+  // "submission.workflow.tasks.claimed.reject.reason.info": "Please enter your reason for rejecting the submission into the box below, indicating whether the submitter may fix a problem and resubmit.",
+  "submission.workflow.tasks.claimed.reject.reason.info": "Do poľa nižšie zadajte dôvod odmietnutia vloženia a uveďte, či môže vkladateľ problém odstrániť a vložiť znova.",
+
+  // "submission.workflow.tasks.claimed.reject.reason.placeholder": "Describe the reason of reject",
+  "submission.workflow.tasks.claimed.reject.reason.placeholder": "Popíšte dôvod odmietnutia",
+
+  // "submission.workflow.tasks.claimed.reject.reason.submit": "Reject item",
+  "submission.workflow.tasks.claimed.reject.reason.submit": "Odmietnuť záznam",
+
+  // "submission.workflow.tasks.claimed.reject.reason.title": "Reason",
+  "submission.workflow.tasks.claimed.reject.reason.title": "Dôvod",
+
+  // "submission.workflow.tasks.claimed.reject.submit": "Reject",
+  "submission.workflow.tasks.claimed.reject.submit": "Odmietnuť",
+
+  // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\". You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
+  "submission.workflow.tasks.claimed.reject_help": "Ak ste záznam skontrolovali a zistili, že <strong>nie je</strong> vhodný na zaradenie do kolekcie, vyberte „Odmietnuť“. Potom budete vyzvaní na zadanie správy, v ktorej uvediete, prečo je záznam nevhodný, a či by mal vkladateľ niečo zmeniť a vložiť znova.",
+
+  // "submission.workflow.tasks.claimed.return": "Return to pool",
+  "submission.workflow.tasks.claimed.return": "Vrátiť do fondu",
+
+  // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
+  "submission.workflow.tasks.claimed.return_help": "Vrátiť úlohu do fondu, aby ju mohol vykonať iný používateľ.",
+
+  // "submission.workflow.tasks.generic.error": "Error occurred during operation...",
+  "submission.workflow.tasks.generic.error": "Počas operácie došlo k chybe...",
+
+  // "submission.workflow.tasks.generic.processing": "Processing...",
+  "submission.workflow.tasks.generic.processing": "Spracúva sa...",
+
+  // "submission.workflow.tasks.generic.submitter": "Submitter",
+  "submission.workflow.tasks.generic.submitter": "Vkladateľ",
+
+  // "submission.workflow.tasks.generic.success": "Operation successful",
+  "submission.workflow.tasks.generic.success": "Operácia prebehla úspešne",
+
+  // "submission.workflow.tasks.pool.claim": "Claim",
+  "submission.workflow.tasks.pool.claim": "Prevziať",
+
+  // "submission.workflow.tasks.pool.claim_help": "Assign this task to yourself.",
+  "submission.workflow.tasks.pool.claim_help": "Priraďte si túto úlohu.",
+
+  // "submission.workflow.tasks.pool.hide-detail": "Hide detail",
+  "submission.workflow.tasks.pool.hide-detail": "Skryť detail",
+
+  // "submission.workflow.tasks.pool.show-detail": "Show detail",
+  "submission.workflow.tasks.pool.show-detail": "Zobraziť detail",
+
+  // "submission.workflow.tasks.duplicates": "potential duplicates were detected for this item. Claim and edit this item to see details.",
+  "submission.workflow.tasks.duplicates": "pre tento záznam sa zistili možné duplicity. Prevezmite a upravte tento záznam, aby ste videli podrobnosti.",
+
+  // "submission.workspace.generic.view": "View",
+  "submission.workspace.generic.view": "Zobraziť",
+
+  // "submission.workspace.generic.view-help": "Select this option to view the item's metadata.",
+  "submission.workspace.generic.view-help": "Zvoľte túto možnosť na zobrazenie metadát záznamu.",
+
+  // "submitter.empty": "N/A",
+  "submitter.empty": "N/A",
+
+  // "subscriptions.title": "Subscriptions",
+  "subscriptions.title": "Odbery",
+
+  // "subscriptions.item": "Subscriptions for items",
+  "subscriptions.item": "Odbery pre záznamy",
+
+  // "subscriptions.collection": "Subscriptions for collections",
+  "subscriptions.collection": "Odbery pre kolekcie",
+
+  // "subscriptions.community": "Subscriptions for communities",
+  "subscriptions.community": "Odbery pre komunity",
+
+  // "subscriptions.subscription_type": "Subscription type",
+  "subscriptions.subscription_type": "Typ odberu",
+
+  // "subscriptions.frequency": "Subscription frequency",
+  "subscriptions.frequency": "Frekvencia odberu",
+
+  // "subscriptions.frequency.D": "Daily",
+  "subscriptions.frequency.D": "Denne",
+
+  // "subscriptions.frequency.M": "Monthly",
+  "subscriptions.frequency.M": "Mesačne",
+
+  // "subscriptions.frequency.W": "Weekly",
+  "subscriptions.frequency.W": "Týždenne",
+
+  // "subscriptions.tooltip": "Subscribe",
+  "subscriptions.tooltip": "Odoberať",
+
+  // "subscriptions.manage": "Manage Subscription",
+  "subscriptions.manage": "Spravovať odber",
+
+  // "subscriptions.modal.title": "Subscriptions",
+  "subscriptions.modal.title": "Odbery",
+
+  // "subscriptions.modal.type-frequency": "Type and frequency",
+  "subscriptions.modal.type-frequency": "Typ a frekvencia",
+
+  // "subscriptions.modal.close": "Close",
+  "subscriptions.modal.close": "Zavrieť",
+
+  // "subscriptions.modal.delete-info": "To remove this subscription, please visit the \"Subscriptions\" page under your user profile",
+  "subscriptions.modal.delete-info": "Ak chcete zrušiť tento odber, navštívte prosím stránku „Odbery“ vo vašom používateľskom profile",
+
+  // "subscriptions.modal.new-subscription-form.type.content": "Content",
+  "subscriptions.modal.new-subscription-form.type.content": "Obsah",
+
+  // "subscriptions.modal.new-subscription-form.frequency.D": "Daily",
+  "subscriptions.modal.new-subscription-form.frequency.D": "Denne",
+
+  // "subscriptions.modal.new-subscription-form.frequency.W": "Weekly",
+  "subscriptions.modal.new-subscription-form.frequency.W": "Týždenne",
+
+  // "subscriptions.modal.new-subscription-form.frequency.M": "Monthly",
+  "subscriptions.modal.new-subscription-form.frequency.M": "Mesačne",
+
+  // "subscriptions.modal.new-subscription-form.submit": "Submit",
+  "subscriptions.modal.new-subscription-form.submit": "Potvrdiť",
+
+  // "subscriptions.modal.new-subscription-form.processing": "Processing...",
+  "subscriptions.modal.new-subscription-form.processing": "Spracúva sa...",
+
+  // "subscriptions.modal.create.success": "Subscribed to {{ type }} successfully.",
+  "subscriptions.modal.create.success": "Odber {{ type }} bol úspešne nastavený.",
+
+  // "subscriptions.modal.delete.success": "Subscription deleted successfully",
+  "subscriptions.modal.delete.success": "Odber bol úspešne zrušený.",
+
+  // "subscriptions.modal.update.success": "Subscription to {{ type }} updated successfully",
+  "subscriptions.modal.update.success": "Odber {{ type }} bol úspešne aktualizovaný.",
+
+  // "subscriptions.modal.create.error": "An error occurs during the subscription creation",
+  "subscriptions.modal.create.error": "Pri vytváraní odberu došlo k chybe.",
+
+  // "subscriptions.modal.delete.error": "An error occurs during the subscription delete",
+  "subscriptions.modal.delete.error": "Pri rušení odberu došlo k chybe.",
+
+  // "subscriptions.modal.update.error": "An error occurs during the subscription update",
+  "subscriptions.modal.update.error": "Pri aktualizácii odberu došlo k chybe.",
+
+  // "subscriptions.table.dso": "Subject",
+  "subscriptions.table.dso": "Predmet",
+
+  // "subscriptions.table.subscription_type": "Subscription Type",
+  "subscriptions.table.subscription_type": "Typ odberu",
+
+  // "subscriptions.table.subscription_frequency": "Subscription Frequency",
+  "subscriptions.table.subscription_frequency": "Frekvencia odberu",
+
+  // "subscriptions.table.action": "Action",
+  "subscriptions.table.action": "Akcia",
+
+  // "subscriptions.table.edit": "Edit",
+  "subscriptions.table.edit": "Upraviť",
+
+  // "subscriptions.table.delete": "Delete",
+  "subscriptions.table.delete": "Odstrániť",
+
+  // "subscriptions.table.not-available": "Not available",
+  "subscriptions.table.not-available": "Nedostupné",
+
+  // "subscriptions.table.not-available-message": "The subscribed item has been deleted, or you don't currently have the permission to view it",
+  "subscriptions.table.not-available-message": "Odoberaný záznam bol odstránený alebo momentálne nemáte oprávnenie na jeho zobrazenie.",
+
+  // "subscriptions.table.empty.message": "You do not have any subscriptions at this time. To subscribe to email updates for a community or collection, use the subscription button on the object's page.",
+  "subscriptions.table.empty.message": "Momentálne nemáte nastavené žiadne odbery. Na prihlásenie sa na e-mailové aktualizácie komunity alebo kolekcie použite tlačidlo odberu na stránke daného objektu.",
+
+  // "thumbnail.default.alt": "Thumbnail Image",
+  "thumbnail.default.alt": "Náhľad",
+
+  // "thumbnail.default.placeholder": "No Thumbnail Available",
+  "thumbnail.default.placeholder": "Náhľad nie je k dispozícii",
+
+  // "thumbnail.project.alt": "Project Logo",
+  "thumbnail.project.alt": "Logo projektu",
+
+  // "thumbnail.project.placeholder": "Project Placeholder Image",
+  "thumbnail.project.placeholder": "Zástupný obrázok projektu",
+
+  // "thumbnail.orgunit.alt": "OrgUnit Logo",
+  "thumbnail.orgunit.alt": "Logo organizačnej jednotky",
+
+  // "thumbnail.orgunit.placeholder": "OrgUnit Placeholder Image",
+  "thumbnail.orgunit.placeholder": "Zástupný obrázok organizačnej jednotky",
+
+  // "thumbnail.person.alt": "Profile Picture",
+  "thumbnail.person.alt": "Profilový obrázok",
+
+  // "thumbnail.person.placeholder": "No Profile Picture Available",
+  "thumbnail.person.placeholder": "Profilový obrázok nie je k dispozícii",
+
+  // "title": "DSpace",
+  "title": "DSpace",
+
+  // "vocabulary-treeview.header": "Hierarchical tree view",
+  "vocabulary-treeview.header": "Hierarchické stromové zobrazenie",
+
+  // "vocabulary-treeview.load-more": "Load more",
+  "vocabulary-treeview.load-more": "Načítať ďalšie",
+
+  // "vocabulary-treeview.search.form.reset": "Reset",
+  "vocabulary-treeview.search.form.reset": "Resetovať",
+
+  // "vocabulary-treeview.search.form.search": "Search",
+  "vocabulary-treeview.search.form.search": "Hľadať",
+
+  // "vocabulary-treeview.search.form.search-placeholder": "Filter results by typing the first few letters",
+  "vocabulary-treeview.search.form.search-placeholder": "Filtrovať výsledky zadaním niekoľkých prvých písmen",
+
+  // "vocabulary-treeview.search.no-result": "There were no items to show",
+  "vocabulary-treeview.search.no-result": "Neboli žiadne položky na zobrazenie",
+
+  // "vocabulary-treeview.tree.description.nsi": "The Norwegian Science Index",
+  "vocabulary-treeview.tree.description.nsi": "Nórsky vedecký index",
+
+  // "vocabulary-treeview.tree.description.srsc": "Research Subject Categories",
+  "vocabulary-treeview.tree.description.srsc": "Predmetové kategórie výskumu",
+
+  // "vocabulary-treeview.info": "Select a subject to add as search filter",
+  "vocabulary-treeview.info": "Vyberte predmet, ktorý sa pridá ako filter vyhľadávania",
+
+  // "uploader.browse": "browse",
+  "uploader.browse": "prehliadať",
+
+  // "uploader.drag-message": "Drag & Drop your files here",
+  "uploader.drag-message": "Presuňte sem svoje súbory",
+
+  // "uploader.delete.btn-title": "Delete",
+  "uploader.delete.btn-title": "Odstrániť",
+
+  // "uploader.or": ", or ",
+  "uploader.or": ", alebo ",
+
+  // "uploader.processing": "Processing uploaded file(s)... (it's now safe to close this page)",
+  "uploader.processing": "Spracúvajú sa nahrané súbory... (teraz je bezpečné túto stránku zavrieť)",
+
+  // "uploader.queue-length": "Queue length",
+  "uploader.queue-length": "Dĺžka fronty",
+
+  // "virtual-metadata.delete-item.info": "Select the types for which you want to save the virtual metadata as real metadata",
+  "virtual-metadata.delete-item.info": "Vyberte typy, pre ktoré chcete uložiť virtuálne metadáta ako skutočné metadáta",
+
+  // "virtual-metadata.delete-item.modal-head": "The virtual metadata of this relation",
+  "virtual-metadata.delete-item.modal-head": "Virtuálne metadáta tohto vzťahu",
+
+  // "virtual-metadata.delete-relationship.modal-head": "Select the items for which you want to save the virtual metadata as real metadata",
+  "virtual-metadata.delete-relationship.modal-head": "Vyberte záznamy, pre ktoré chcete uložiť virtuálne metadáta ako skutočné metadáta",
+
+  // "supervisedWorkspace.search.results.head": "Supervised Items",
+  "supervisedWorkspace.search.results.head": "Záznamy pod dohľadom",
+
+  // "workspace.search.results.head": "Your submissions",
+  "workspace.search.results.head": "Vaše vloženia",
+
+  // "workflowAdmin.search.results.head": "Administer Workflow",
+  "workflowAdmin.search.results.head": "Spravovať workflow",
+
+  // "workflow.search.results.head": "Workflow tasks",
+  "workflow.search.results.head": "Úlohy workflow",
+
+  // "otherWorkspace.search.results.head": "Shared workspace",
+  "otherWorkspace.search.results.head": "Zdieľaný pracovný priestor",
+
+  // "supervision.search.results.head": "Workflow and Workspace tasks",
+  "supervision.search.results.head": "Úlohy workflow a pracovného priestoru",
+
+  // "workflow-item.edit.breadcrumbs": "Edit workflowitem",
+  "workflow-item.edit.breadcrumbs": "Upraviť záznam vo workflow",
+
+  // "workflow-item.edit.title": "Edit workflowitem",
+  "workflow-item.edit.title": "Upraviť záznam vo workflow",
+
+  // "workflow-item.delete.notification.success.title": "Deleted",
+  "workflow-item.delete.notification.success.title": "Odstránené",
+
+  // "workflow-item.delete.notification.success.content": "This workflow item was successfully deleted",
+  "workflow-item.delete.notification.success.content": "Tento záznam vo workflow bol úspešne odstránený",
+
+  // "workflow-item.delete.notification.error.title": "Something went wrong",
+  "workflow-item.delete.notification.error.title": "Niečo sa pokazilo",
+
+  // "workflow-item.delete.notification.error.content": "The workflow item could not be deleted",
+  "workflow-item.delete.notification.error.content": "Záznam vo workflow sa nepodarilo odstrániť",
+
+  // "workflow-item.delete.title": "Delete workflow item",
+  "workflow-item.delete.title": "Odstrániť záznam vo workflow",
+
+  // "workflow-item.delete.header": "Delete workflow item",
+  "workflow-item.delete.header": "Odstrániť záznam vo workflow",
+
+  // "workflow-item.delete.button.cancel": "Cancel",
+  "workflow-item.delete.button.cancel": "Zrušiť",
+
+  // "workflow-item.delete.button.confirm": "Delete",
+  "workflow-item.delete.button.confirm": "Odstrániť",
+
+  // "workflow-item.send-back.notification.success.title": "Sent back to submitter",
+  "workflow-item.send-back.notification.success.title": "Vrátené späť vkladateľovi",
+
+  // "workflow-item.send-back.notification.success.content": "This workflow item was successfully sent back to the submitter",
+  "workflow-item.send-back.notification.success.content": "Tento záznam vo workflow bol úspešne vrátený späť vkladateľovi",
+
+  // "workflow-item.send-back.notification.error.title": "Something went wrong",
+  "workflow-item.send-back.notification.error.title": "Niečo sa pokazilo",
+
+  // "workflow-item.send-back.notification.error.content": "The workflow item could not be sent back to the submitter",
+  "workflow-item.send-back.notification.error.content": "Záznam vo workflow sa nepodarilo vrátiť späť vkladateľovi",
+
+  // "workflow-item.send-back.title": "Send workflow item back to submitter",
+  "workflow-item.send-back.title": "Vrátiť záznam vo workflow späť vkladateľovi",
+
+  // "workflow-item.send-back.header": "Send workflow item back to submitter",
+  "workflow-item.send-back.header": "Vrátiť záznam vo workflow späť vkladateľovi",
+
+  // "workflow-item.send-back.button.cancel": "Cancel",
+  "workflow-item.send-back.button.cancel": "Zrušiť",
+
+  // "workflow-item.send-back.button.confirm": "Send back",
+  "workflow-item.send-back.button.confirm": "Odoslať späť",
+
+  // "workflow-item.view.breadcrumbs": "Workflow View",
+  "workflow-item.view.breadcrumbs": "Zobrazenie workflow",
+
+  // "workspace-item.view.breadcrumbs": "Workspace View",
+  "workspace-item.view.breadcrumbs": "Zobrazenie pracovného priestoru",
+
+  // "workspace-item.view.title": "Workspace View",
+  "workspace-item.view.title": "Zobrazenie pracovného priestoru",
+
+  // "workspace-item.delete.breadcrumbs": "Workspace Delete",
+  "workspace-item.delete.breadcrumbs": "Odstránenie z pracovného priestoru",
+
+  // "workspace-item.delete.header": "Delete workspace item",
+  "workspace-item.delete.header": "Odstrániť záznam z pracovného priestoru",
+
+  // "workspace-item.delete.button.confirm": "Delete",
+  "workspace-item.delete.button.confirm": "Odstrániť",
+
+  // "workspace-item.delete.button.cancel": "Cancel",
+  "workspace-item.delete.button.cancel": "Zrušiť",
+
+  // "workspace-item.delete.notification.success.title": "Deleted",
+  "workspace-item.delete.notification.success.title": "Odstránené",
+
+  // "workspace-item.delete.title": "This workspace item was successfully deleted",
+  "workspace-item.delete.title": "Záznam v pracovnom priestore bol úspešne odstránený",
+
+  // "workspace-item.delete.notification.error.title": "Something went wrong",
+  "workspace-item.delete.notification.error.title": "Niečo sa pokazilo",
+
+  // "workspace-item.delete.notification.error.content": "The workspace item could not be deleted",
+  "workspace-item.delete.notification.error.content": "Záznam v pracovnom priestore sa nepodarilo odstrániť",
+
+  // "workflow-item.advanced.title": "Advanced workflow",
+  "workflow-item.advanced.title": "Pokročilé workflow",
+
+  // "workflow-item.selectrevieweraction.notification.success.title": "Selected reviewer",
+  "workflow-item.selectrevieweraction.notification.success.title": "Recenzent vybraný",
+
+  // "workflow-item.selectrevieweraction.notification.success.content": "The reviewer for this workflow item has been successfully selected",
+  "workflow-item.selectrevieweraction.notification.success.content": "Recenzent pre tento záznam bol úspešne vybraný",
+
+  // "workflow-item.selectrevieweraction.notification.error.title": "Something went wrong",
+  "workflow-item.selectrevieweraction.notification.error.title": "Niečo sa pokazilo",
+
+  // "workflow-item.selectrevieweraction.notification.error.content": "Couldn't select the reviewer for this workflow item",
+  "workflow-item.selectrevieweraction.notification.error.content": "Nepodarilo sa vybrať recenzenta pre tento záznam",
+
+  // "workflow-item.selectrevieweraction.title": "Select Reviewer",
+  "workflow-item.selectrevieweraction.title": "Vybrať recenzenta",
+
+  // "workflow-item.selectrevieweraction.header": "Select Reviewer",
+  "workflow-item.selectrevieweraction.header": "Vybrať recenzenta",
+
+  // "workflow-item.selectrevieweraction.button.cancel": "Cancel",
+  "workflow-item.selectrevieweraction.button.cancel": "Zrušiť",
+
+  // "workflow-item.selectrevieweraction.button.confirm": "Confirm",
+  "workflow-item.selectrevieweraction.button.confirm": "Potvrdiť",
+
+  // "workflow-item.scorereviewaction.notification.success.title": "Rating review",
+  "workflow-item.scorereviewaction.notification.success.title": "Hodnotenie posudku",
+
+  // "workflow-item.scorereviewaction.notification.success.content": "The rating for this item workflow item has been successfully submitted",
+  "workflow-item.scorereviewaction.notification.success.content": "Hodnotenie tohto záznamu bolo úspešne odoslané",
+
+  // "workflow-item.scorereviewaction.notification.error.title": "Something went wrong",
+  "workflow-item.scorereviewaction.notification.error.title": "Niečo sa pokazilo",
+
+  // "workflow-item.scorereviewaction.notification.error.content": "Couldn't rate this item",
+  "workflow-item.scorereviewaction.notification.error.content": "Tento záznam sa nepodarilo ohodnotiť",
+
+  // "workflow-item.scorereviewaction.title": "Rate this item",
+  "workflow-item.scorereviewaction.title": "Ohodnotiť tento záznam",
+
+  // "workflow-item.scorereviewaction.header": "Rate this item",
+  "workflow-item.scorereviewaction.header": "Ohodnotiť tento záznam",
+
+  // "workflow-item.scorereviewaction.button.cancel": "Cancel",
+  "workflow-item.scorereviewaction.button.cancel": "Zrušiť",
+
+  // "workflow-item.scorereviewaction.button.confirm": "Confirm",
+  "workflow-item.scorereviewaction.button.confirm": "Potvrdiť",
+
+  // "idle-modal.header": "Session will expire soon",
+  "idle-modal.header": "Relácia čoskoro vyprší",
+
+  // "idle-modal.info": "For security reasons, user sessions expire after {{ timeToExpire }} minutes of inactivity. Your session will expire soon. Would you like to extend it or log out?",
+  "idle-modal.info": "Z bezpečnostných dôvodov relácie používateľov vypršia po {{ timeToExpire }} minútach nečinnosti. Vaša relácia čoskoro vyprší. Chcete ju predĺžiť alebo sa odhlásiť?",
+
+  // "idle-modal.log-out": "Log out",
+  "idle-modal.log-out": "Odhlásiť sa",
+
+  // "idle-modal.extend-session": "Extend session",
+  "idle-modal.extend-session": "Predĺžiť reláciu",
+
+  // "researcher.profile.action.processing": "Processing...",
+  "researcher.profile.action.processing": "Spracúva sa...",
+
+  // "researcher.profile.associated": "Researcher profile associated",
+  "researcher.profile.associated": "Profil výskumníka prepojený",
+
+  // "researcher.profile.change-visibility.fail": "An unexpected error occurs while changing the profile visibility",
+  "researcher.profile.change-visibility.fail": "Pri zmene viditeľnosti profilu došlo k neočakávanej chybe",
+
+  // "researcher.profile.create.new": "Create new",
+  "researcher.profile.create.new": "Vytvoriť nový",
+
+  // "researcher.profile.create.success": "Researcher profile created successfully",
+  "researcher.profile.create.success": "Profil výskumníka bol úspešne vytvorený",
+
+  // "researcher.profile.create.fail": "An error occurs during the researcher profile creation",
+  "researcher.profile.create.fail": "Pri vytváraní profilu výskumníka došlo k chybe",
+
+  // "researcher.profile.delete": "Delete",
+  "researcher.profile.delete": "Odstrániť",
+
+  // "researcher.profile.expose": "Expose",
+  "researcher.profile.expose": "Zverejniť",
+
+  // "researcher.profile.hide": "Hide",
+  "researcher.profile.hide": "Skryť",
+
+  // "researcher.profile.not.associated": "Researcher profile not yet associated",
+  "researcher.profile.not.associated": "Profil výskumníka zatiaľ nie je prepojený",
+
+  // "researcher.profile.view": "View",
+  "researcher.profile.view": "Zobraziť",
+
+  // "researcher.profile.private.visibility": "PRIVATE",
+  "researcher.profile.private.visibility": "SÚKROMNÉ",
+
+  // "researcher.profile.public.visibility": "PUBLIC",
+  "researcher.profile.public.visibility": "VEREJNÉ",
+
+  // "researcher.profile.status": "Status:",
+  "researcher.profile.status": "Stav:",
+
+  // "researcherprofile.claim.not-authorized": "You are not authorized to claim this item. For more details contact the administrator(s).",
+  "researcherprofile.claim.not-authorized": "Nemáte oprávnenie nárokovať si tento záznam. Podrobnosti získate od správcu(ov).",
+
+  // "researcherprofile.error.claim.body": "An error occurred while claiming the profile, please try again later",
+  "researcherprofile.error.claim.body": "Pri nárokovaní profilu došlo k chybe, skúste to prosím neskôr",
+
+  // "researcherprofile.error.claim.title": "Error",
+  "researcherprofile.error.claim.title": "Chyba",
+
+  // "researcherprofile.success.claim.body": "Profile claimed with success",
+  "researcherprofile.success.claim.body": "Profil bol úspešne nárokovaný",
+
+  // "researcherprofile.success.claim.title": "Success",
+  "researcherprofile.success.claim.title": "Úspech",
+
+  // "person.page.orcid.create": "Create an ORCID ID",
+  "person.page.orcid.create": "Vytvoriť ORCID ID",
+
+  // "person.page.orcid.granted-authorizations": "Granted authorizations",
+  "person.page.orcid.granted-authorizations": "Udelené oprávnenia",
+
+  // "person.page.orcid.grant-authorizations": "Grant authorizations",
+  "person.page.orcid.grant-authorizations": "Udeliť oprávnenia",
+
+  // "person.page.orcid.link": "Connect to ORCID ID",
+  "person.page.orcid.link": "Prepojiť s ORCID ID",
+
+  // "person.page.orcid.link.processing": "Linking profile to ORCID...",
+  "person.page.orcid.link.processing": "Prepája sa profil s ORCID...",
+
+  // "person.page.orcid.link.error.message": "Something went wrong while connecting the profile with ORCID. If the problem persists, contact the administrator.",
+  "person.page.orcid.link.error.message": "Pri prepájaní profilu s ORCID sa niečo pokazilo. Ak problém pretrváva, kontaktujte správcu.",
+
+  // "person.page.orcid.orcid-not-linked-message": "The ORCID iD of this profile ({{ orcid }}) has not yet been connected to an account on the ORCID registry or the connection is expired.",
+  "person.page.orcid.orcid-not-linked-message": "ORCID iD tohto profilu ({{ orcid }}) ešte nebolo prepojené s účtom v registri ORCID alebo platnosť prepojenia vypršala.",
+
+  // "person.page.orcid.unlink": "Disconnect from ORCID",
+  "person.page.orcid.unlink": "Odpojiť od ORCID",
+
+  // "person.page.orcid.unlink.processing": "Processing...",
+  "person.page.orcid.unlink.processing": "Spracúva sa...",
+
+  // "person.page.orcid.missing-authorizations": "Missing authorizations",
+  "person.page.orcid.missing-authorizations": "Chýbajúce oprávnenia",
+
+  // "person.page.orcid.missing-authorizations-message": "The following authorizations are missing:",
+  "person.page.orcid.missing-authorizations-message": "Chýbajú nasledujúce oprávnenia:",
+
+  // "person.page.orcid.no-missing-authorizations-message": "Great! This box is empty, so you have granted all access rights to use all functions offers by your institution.",
+  "person.page.orcid.no-missing-authorizations-message": "Skvelé! Toto pole je prázdne, takže ste udelili všetky prístupové práva na používanie všetkých funkcií, ktoré vaša inštitúcia ponúka.",
+
+  // "person.page.orcid.no-orcid-message": "No ORCID iD associated yet. By clicking on the button below it is possible to link this profile with an ORCID account.",
+  "person.page.orcid.no-orcid-message": "Zatiaľ nie je priradené žiadne ORCID iD. Kliknutím na tlačidlo nižšie je možné tento profil prepojiť s účtom ORCID.",
+
+  // "person.page.orcid.profile-preferences": "Profile preferences",
+  "person.page.orcid.profile-preferences": "Predvoľby profilu",
+
+  // "person.page.orcid.funding-preferences": "Funding preferences",
+  "person.page.orcid.funding-preferences": "Predvoľby financovania",
+
+  // "person.page.orcid.publications-preferences": "Publication preferences",
+  "person.page.orcid.publications-preferences": "Predvoľby publikácií",
+
+  // "person.page.orcid.remove-orcid-message": "If you need to remove your ORCID, please contact the repository administrator",
+  "person.page.orcid.remove-orcid-message": "Ak potrebujete odstrániť svoje ORCID, kontaktujte prosím správcu repozitára",
+
+  // "person.page.orcid.save.preference.changes": "Update settings",
+  "person.page.orcid.save.preference.changes": "Aktualizovať nastavenia",
+
+  // "person.page.orcid.sync-profile.affiliation": "Affiliation",
+  "person.page.orcid.sync-profile.affiliation": "Afiliácia",
+
+  // "person.page.orcid.sync-profile.biographical": "Biographical data",
+  "person.page.orcid.sync-profile.biographical": "Biografické údaje",
+
+  // "person.page.orcid.sync-profile.education": "Education",
+  "person.page.orcid.sync-profile.education": "Vzdelanie",
+
+  // "person.page.orcid.sync-profile.identifiers": "Identifiers",
+  "person.page.orcid.sync-profile.identifiers": "Identifikátory",
+
+  // "person.page.orcid.sync-fundings.all": "All fundings",
+  "person.page.orcid.sync-fundings.all": "Všetky financovania",
+
+  // "person.page.orcid.sync-fundings.mine": "My fundings",
+  "person.page.orcid.sync-fundings.mine": "Moje financovania",
+
+  // "person.page.orcid.sync-fundings.my_selected": "Selected fundings",
+  "person.page.orcid.sync-fundings.my_selected": "Vybrané financovania",
+
+  // "person.page.orcid.sync-fundings.disabled": "Disabled",
+  "person.page.orcid.sync-fundings.disabled": "Zakázané",
+
+  // "person.page.orcid.sync-publications.all": "All publications",
+  "person.page.orcid.sync-publications.all": "Všetky publikácie",
+
+  // "person.page.orcid.sync-publications.mine": "My publications",
+  "person.page.orcid.sync-publications.mine": "Moje publikácie",
+
+  // "person.page.orcid.sync-publications.my_selected": "Selected publications",
+  "person.page.orcid.sync-publications.my_selected": "Vybrané publikácie",
+
+  // "person.page.orcid.sync-publications.disabled": "Disabled",
+  "person.page.orcid.sync-publications.disabled": "Zakázané",
+
+  // "person.page.orcid.sync-queue.discard": "Discard the change and do not synchronize with the ORCID registry",
+  "person.page.orcid.sync-queue.discard": "Zahodiť zmenu a nesynchronizovať s registrom ORCID",
+
+  // "person.page.orcid.sync-queue.discard.error": "The discarding of the ORCID queue record failed",
+  "person.page.orcid.sync-queue.discard.error": "Zahodenie záznamu vo fronte ORCID zlyhalo",
+
+  // "person.page.orcid.sync-queue.discard.success": "The ORCID queue record have been discarded successfully",
+  "person.page.orcid.sync-queue.discard.success": "Záznam vo fronte ORCID bol úspešne zahodený",
+
+  // "person.page.orcid.sync-queue.empty-message": "The ORCID queue registry is empty",
+  "person.page.orcid.sync-queue.empty-message": "Register fronty ORCID je prázdny",
+
+  // "person.page.orcid.sync-queue.table.header.type": "Type",
+  "person.page.orcid.sync-queue.table.header.type": "Typ",
+
+  // "person.page.orcid.sync-queue.table.header.description": "Description",
+  "person.page.orcid.sync-queue.table.header.description": "Popis",
+
+  // "person.page.orcid.sync-queue.table.header.action": "Action",
+  "person.page.orcid.sync-queue.table.header.action": "Akcia",
+
+  // "person.page.orcid.sync-queue.description.affiliation": "Affiliations",
+  "person.page.orcid.sync-queue.description.affiliation": "Afiliácie",
+
+  // "person.page.orcid.sync-queue.description.country": "Country",
+  "person.page.orcid.sync-queue.description.country": "Krajina",
+
+  // "person.page.orcid.sync-queue.description.education": "Educations",
+  "person.page.orcid.sync-queue.description.education": "Vzdelanie",
+
+  // "person.page.orcid.sync-queue.description.external_ids": "External ids",
+  "person.page.orcid.sync-queue.description.external_ids": "Externé identifikátory",
+
+  // "person.page.orcid.sync-queue.description.other_names": "Other names",
+  "person.page.orcid.sync-queue.description.other_names": "Ďalšie mená",
+
+  // "person.page.orcid.sync-queue.description.qualification": "Qualifications",
+  "person.page.orcid.sync-queue.description.qualification": "Kvalifikácie",
+
+  // "person.page.orcid.sync-queue.description.researcher_urls": "Researcher urls",
+  "person.page.orcid.sync-queue.description.researcher_urls": "URL výskumníka",
+
+  // "person.page.orcid.sync-queue.description.keywords": "Keywords",
+  "person.page.orcid.sync-queue.description.keywords": "Kľúčové slová",
+
+  // "person.page.orcid.sync-queue.tooltip.insert": "Add a new entry in the ORCID registry",
+  "person.page.orcid.sync-queue.tooltip.insert": "Pridať nový záznam do registra ORCID",
+
+  // "person.page.orcid.sync-queue.tooltip.update": "Update this entry on the ORCID registry",
+  "person.page.orcid.sync-queue.tooltip.update": "Aktualizovať tento záznam v registri ORCID",
+
+  // "person.page.orcid.sync-queue.tooltip.delete": "Remove this entry from the ORCID registry",
+  "person.page.orcid.sync-queue.tooltip.delete": "Odstrániť tento záznam z registra ORCID",
+
+  // "person.page.orcid.sync-queue.tooltip.publication": "Publication",
+  "person.page.orcid.sync-queue.tooltip.publication": "Publikácia",
+
+  // "person.page.orcid.sync-queue.tooltip.project": "Project",
+  "person.page.orcid.sync-queue.tooltip.project": "Projekt",
+
+  // "person.page.orcid.sync-queue.tooltip.affiliation": "Affiliation",
+  "person.page.orcid.sync-queue.tooltip.affiliation": "Afiliácia",
+
+  // "person.page.orcid.sync-queue.tooltip.education": "Education",
+  "person.page.orcid.sync-queue.tooltip.education": "Vzdelanie",
+
+  // "person.page.orcid.sync-queue.tooltip.qualification": "Qualification",
+  "person.page.orcid.sync-queue.tooltip.qualification": "Kvalifikácia",
+
+  // "person.page.orcid.sync-queue.tooltip.other_names": "Other name",
+  "person.page.orcid.sync-queue.tooltip.other_names": "Ďalšie meno",
+
+  // "person.page.orcid.sync-queue.tooltip.country": "Country",
+  "person.page.orcid.sync-queue.tooltip.country": "Krajina",
+
+  // "person.page.orcid.sync-queue.tooltip.keywords": "Keyword",
+  "person.page.orcid.sync-queue.tooltip.keywords": "Kľúčové slovo",
+
+  // "person.page.orcid.sync-queue.tooltip.external_ids": "External identifier",
+  "person.page.orcid.sync-queue.tooltip.external_ids": "Externý identifikátor",
+
+  // "person.page.orcid.sync-queue.tooltip.researcher_urls": "Researcher url",
+  "person.page.orcid.sync-queue.tooltip.researcher_urls": "URL výskumníka",
+
+  // "person.page.orcid.sync-queue.send": "Synchronize with ORCID registry",
+  "person.page.orcid.sync-queue.send": "Synchronizovať s registrom ORCID",
+
+  // "person.page.orcid.sync-queue.send.unauthorized-error.title": "The submission to ORCID failed for missing authorizations.",
+  "person.page.orcid.sync-queue.send.unauthorized-error.title": "Odoslanie do ORCID zlyhalo pre chýbajúce oprávnenia.",
+
+  // "person.page.orcid.sync-queue.send.unauthorized-error.content": "Click <a href='{{orcid}}'>here</a> to grant again the required permissions. If the problem persists, contact the administrator",
+  "person.page.orcid.sync-queue.send.unauthorized-error.content": "Kliknite <a href='{{orcid}}'>sem</a> a znova udeľte požadované oprávnenia. Ak problém pretrváva, kontaktujte správcu",
+
+  // "person.page.orcid.sync-queue.send.bad-request-error": "The submission to ORCID failed because the resource sent to ORCID registry is not valid",
+  "person.page.orcid.sync-queue.send.bad-request-error": "Odoslanie do ORCID zlyhalo, pretože zdroj odoslaný do registra ORCID nie je platný",
+
+  // "person.page.orcid.sync-queue.send.error": "The submission to ORCID failed",
+  "person.page.orcid.sync-queue.send.error": "Odoslanie do ORCID zlyhalo",
+
+  // "person.page.orcid.sync-queue.send.conflict-error": "The submission to ORCID failed because the resource is already present on the ORCID registry",
+  "person.page.orcid.sync-queue.send.conflict-error": "Odoslanie do ORCID zlyhalo, pretože zdroj sa už nachádza v registri ORCID",
+
+  // "person.page.orcid.sync-queue.send.not-found-warning": "The resource does not exists anymore on the ORCID registry.",
+  "person.page.orcid.sync-queue.send.not-found-warning": "Zdroj už v registri ORCID neexistuje.",
+
+  // "person.page.orcid.sync-queue.send.success": "The submission to ORCID was completed successfully",
+  "person.page.orcid.sync-queue.send.success": "Odoslanie do ORCID bolo úspešne dokončené",
+
+  // "person.page.orcid.sync-queue.send.validation-error": "The data that you want to synchronize with ORCID is not valid",
+  "person.page.orcid.sync-queue.send.validation-error": "Údaje, ktoré chcete synchronizovať s ORCID, nie sú platné",
+
+  // "person.page.orcid.sync-queue.send.validation-error.amount-currency.required": "The amount's currency is required",
+  "person.page.orcid.sync-queue.send.validation-error.amount-currency.required": "Mena sumy je povinná",
+
+  // "person.page.orcid.sync-queue.send.validation-error.external-id.required": "The resource to be sent requires at least one identifier",
+  "person.page.orcid.sync-queue.send.validation-error.external-id.required": "Odosielaný zdroj vyžaduje aspoň jeden identifikátor",
+
+  // "person.page.orcid.sync-queue.send.validation-error.title.required": "The title is required",
+  "person.page.orcid.sync-queue.send.validation-error.title.required": "Názov je povinný",
+
+  // "person.page.orcid.sync-queue.send.validation-error.type.required": "The dc.type is required",
+  "person.page.orcid.sync-queue.send.validation-error.type.required": "Pole dc.type je povinné",
+
+  // "person.page.orcid.sync-queue.send.validation-error.start-date.required": "The start date is required",
+  "person.page.orcid.sync-queue.send.validation-error.start-date.required": "Dátum začiatku je povinný",
+
+  // "person.page.orcid.sync-queue.send.validation-error.funder.required": "The funder is required",
+  "person.page.orcid.sync-queue.send.validation-error.funder.required": "Poskytovateľ financií je povinný",
+
+  // "person.page.orcid.sync-queue.send.validation-error.country.invalid": "Invalid 2 digits ISO 3166 country",
+  "person.page.orcid.sync-queue.send.validation-error.country.invalid": "Neplatný dvojmiestny kód krajiny podľa ISO 3166",
+
+  // "person.page.orcid.sync-queue.send.validation-error.organization.required": "The organization is required",
+  "person.page.orcid.sync-queue.send.validation-error.organization.required": "Organizácia je povinná",
+
+  // "person.page.orcid.sync-queue.send.validation-error.organization.name-required": "The organization's name is required",
+  "person.page.orcid.sync-queue.send.validation-error.organization.name-required": "Názov organizácie je povinný",
+
+  // "person.page.orcid.sync-queue.send.validation-error.publication.date-invalid": "The publication date must be one year after 1900",
+  "person.page.orcid.sync-queue.send.validation-error.publication.date-invalid": "Dátum publikovania musí byť aspoň jeden rok po roku 1900",
+
+  // "person.page.orcid.sync-queue.send.validation-error.organization.address-required": "The organization to be sent requires an address",
+  "person.page.orcid.sync-queue.send.validation-error.organization.address-required": "Odosielaná organizácia vyžaduje adresu",
+
+  // "person.page.orcid.sync-queue.send.validation-error.organization.city-required": "The address of the organization to be sent requires a city",
+  "person.page.orcid.sync-queue.send.validation-error.organization.city-required": "Adresa organizácie vyžaduje uvedenie mesta",
+
+  // "person.page.orcid.sync-queue.send.validation-error.organization.country-required": "The address of the organization to be sent requires a valid 2 digits ISO 3166 country",
+  "person.page.orcid.sync-queue.send.validation-error.organization.country-required": "Adresa organizácie vyžaduje platný dvojmiestny kód krajiny podľa ISO 3166",
+
+  // "person.page.orcid.sync-queue.send.validation-error.disambiguated-organization.required": "An identifier to disambiguate organizations is required. Supported ids are GRID, Ringgold, Legal Entity identifiers (LEIs) and Crossref Funder Registry identifiers",
+  "person.page.orcid.sync-queue.send.validation-error.disambiguated-organization.required": "Vyžaduje sa identifikátor na jednoznačné rozlíšenie organizácií. Podporované sú identifikátory GRID, Ringgold, identifikátory právnických osôb (LEI) a identifikátory registra poskytovateľov financií Crossref",
+
+  // "person.page.orcid.sync-queue.send.validation-error.disambiguated-organization.value-required": "The organization's identifiers requires a value",
+  "person.page.orcid.sync-queue.send.validation-error.disambiguated-organization.value-required": "Identifikátory organizácie vyžadujú hodnotu",
+
+  // "person.page.orcid.sync-queue.send.validation-error.disambiguation-source.required": "The organization's identifiers requires a source",
+  "person.page.orcid.sync-queue.send.validation-error.disambiguation-source.required": "Identifikátory organizácie vyžadujú zdroj",
+
+  // "person.page.orcid.sync-queue.send.validation-error.disambiguation-source.invalid": "The source of one of the organization identifiers is invalid. Supported sources are RINGGOLD, GRID, LEI and FUNDREF",
+  "person.page.orcid.sync-queue.send.validation-error.disambiguation-source.invalid": "Zdroj jedného z identifikátorov organizácie je neplatný. Podporované zdroje sú RINGGOLD, GRID, LEI a FUNDREF",
+
+  // "person.page.orcid.synchronization-mode": "Synchronization mode",
+  "person.page.orcid.synchronization-mode": "Režim synchronizácie",
+
+  // "person.page.orcid.synchronization-mode.batch": "Batch",
+  "person.page.orcid.synchronization-mode.batch": "Dávkovo",
+
+  // "person.page.orcid.synchronization-mode.label": "Synchronization mode",
+  "person.page.orcid.synchronization-mode.label": "Režim synchronizácie",
+
+  // "person.page.orcid.synchronization-mode-message": "Please select how you would like synchronization to ORCID to occur. The options include \"Manual\" (you must send your data to ORCID manually), or \"Batch\" (the system will send your data to ORCID via a scheduled script).",
+  "person.page.orcid.synchronization-mode-message": "Vyberte prosím, akým spôsobom chcete vykonávať synchronizáciu s ORCID. Medzi možnosti patrí „Manuálne“ (údaje do ORCID musíte odoslať ručne) alebo „Dávkovo“ (systém odošle vaše údaje do ORCID prostredníctvom naplánovaného skriptu).",
+
+  // "person.page.orcid.synchronization-mode-funding-message": "Select whether to send your linked Project entities to your ORCID record's list of funding information.",
+  "person.page.orcid.synchronization-mode-funding-message": "Zvoľte, či sa majú prepojené entity projektu odoslať do zoznamu informácií o financovaní vášho záznamu ORCID.",
+
+  // "person.page.orcid.synchronization-mode-publication-message": "Select whether to send your linked Publication entities to your ORCID record's list of works.",
+  "person.page.orcid.synchronization-mode-publication-message": "Zvoľte, či sa majú vaše prepojené entity Publikácie odoslať do zoznamu diel vášho záznamu ORCID.",
+
+  // "person.page.orcid.synchronization-mode-profile-message": "Select whether to send your biographical data or personal identifiers to your ORCID record.",
+  "person.page.orcid.synchronization-mode-profile-message": "Zvoľte, či sa majú do vášho záznamu ORCID odoslať vaše biografické údaje alebo osobné identifikátory.",
+
+  // "person.page.orcid.synchronization-settings-update.success": "The synchronization settings have been updated successfully",
+  "person.page.orcid.synchronization-settings-update.success": "Nastavenia synchronizácie boli úspešne aktualizované",
+
+  // "person.page.orcid.synchronization-settings-update.error": "The update of the synchronization settings failed",
+  "person.page.orcid.synchronization-settings-update.error": "Aktualizácia nastavení synchronizácie zlyhala",
+
+  // "person.page.orcid.synchronization-mode.manual": "Manual",
+  "person.page.orcid.synchronization-mode.manual": "Manuálne",
+
+  // "person.page.orcid.scope.authenticate": "Get your ORCID iD",
+  "person.page.orcid.scope.authenticate": "Získajte svoje ORCID iD",
+
+  // "person.page.orcid.scope.read-limited": "Read your information with visibility set to Trusted Parties",
+  "person.page.orcid.scope.read-limited": "Čítať vaše informácie s viditeľnosťou nastavenou na dôveryhodné strany.",
+
+  // "person.page.orcid.scope.activities-update": "Add/update your research activities",
+  "person.page.orcid.scope.activities-update": "Pridať/aktualizovať vaše výskumné aktivity",
+
+  // "person.page.orcid.scope.person-update": "Add/update other information about you",
+  "person.page.orcid.scope.person-update": "Pridať/aktualizovať ďalšie informácie o vás",
+
+  // "person.page.orcid.unlink.success": "The disconnection between the profile and the ORCID registry was successful",
+  "person.page.orcid.unlink.success": "Odpojenie profilu od registra ORCID prebehlo úspešne",
+
+  // "person.page.orcid.unlink.error": "An error occurred while disconnecting between the profile and the ORCID registry. Try again",
+  "person.page.orcid.unlink.error": "Pri odpájaní profilu od registra ORCID došlo k chybe. Skúste to znova",
+
+  // "person.orcid.sync.setting": "ORCID Synchronization settings",
+  "person.orcid.sync.setting": "Nastavenia synchronizácie ORCID",
+
+  // "person.orcid.registry.queue": "ORCID Registry Queue",
+  "person.orcid.registry.queue": "Fronta registra ORCID",
+
+  // "person.orcid.registry.auth": "ORCID Authorizations",
+  "person.orcid.registry.auth": "Oprávnenia ORCID",
+
+  // "person.orcid-tooltip.authenticated": "{{orcid}}",
+  "person.orcid-tooltip.authenticated": "{{orcid}}",
+
+  // "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
+  "person.orcid-tooltip.not-authenticated": "{{orcid}} (nepotvrdené)",
+
+  // "home.recent-submissions.head": "Recent Submissions",
+  "home.recent-submissions.head": "Nedávne vloženia",
+
+  // "authority-confidence.search-label": "Search",
+  "authority-confidence.search-label": "Hľadať",
+
+  // "listable-notification-object.default-message": "This object couldn't be retrieved",
+  "listable-notification-object.default-message": "Tento objekt sa nepodarilo načítať",
+
+  // "system-wide-alert-banner.retrieval.error": "Something went wrong retrieving the system-wide alert banner",
+  "system-wide-alert-banner.retrieval.error": "Pri načítaní systémového upozornenia sa niečo pokazilo",
+
+  // "system-wide-alert-banner.countdown.prefix": "In",
+  "system-wide-alert-banner.countdown.prefix": "O",
+
+  // "system-wide-alert-banner.countdown.days": "{{days}} day(s),",
+  "system-wide-alert-banner.countdown.days": "{{days}} dní,",
+
+  // "system-wide-alert-banner.countdown.hours": "{{hours}} hour(s) and",
+  "system-wide-alert-banner.countdown.hours": "{{hours}} hodín a",
+
+  // "system-wide-alert-banner.countdown.minutes": "{{minutes}} minute(s):",
+  "system-wide-alert-banner.countdown.minutes": "{{minutes}} minút:",
+
+  // "menu.section.system-wide-alert": "System-wide Alert",
+  "menu.section.system-wide-alert": "Systémové upozornenie",
+
+  // "system-wide-alert.form.header": "System-wide Alert",
+  "system-wide-alert.form.header": "Systémové upozornenie",
+
+  // "system-wide-alert-form.retrieval.error": "Something went wrong retrieving the system-wide alert",
+  "system-wide-alert-form.retrieval.error": "Pri načítaní systémového upozornenia sa niečo pokazilo",
+
+  // "system-wide-alert.form.cancel": "Cancel",
+  "system-wide-alert.form.cancel": "Zrušiť",
+
+  // "system-wide-alert.form.save": "Save",
+  "system-wide-alert.form.save": "Uložiť",
+
+  // "system-wide-alert.form.label.active": "ACTIVE",
+  "system-wide-alert.form.label.active": "AKTÍVNE",
+
+  // "system-wide-alert.form.label.inactive": "INACTIVE",
+  "system-wide-alert.form.label.inactive": "NEAKTÍVNE",
+
+  // "system-wide-alert.form.error.message": "The system wide alert must have a message",
+  "system-wide-alert.form.error.message": "Systémové upozornenie musí mať správu",
+
+  // "system-wide-alert.form.label.message": "Alert message",
+  "system-wide-alert.form.label.message": "Text upozornenia",
+
+  // "system-wide-alert.form.label.countdownTo.enable": "Enable a countdown timer",
+  "system-wide-alert.form.label.countdownTo.enable": "Povoliť odpočítavanie",
+
+  // "system-wide-alert.form.label.countdownTo.hint": "Hint: Set a countdown timer. When enabled, a date can be set in the future and the system-wide alert banner will perform a countdown to the set date. When this timer ends, it will disappear from the alert. The server will NOT be automatically stopped.",
+  "system-wide-alert.form.label.countdownTo.hint": "Rada: Nastavte odpočítavanie. Keď je povolené, možno nastaviť dátum v budúcnosti a systémové upozornenie bude odpočítavať do nastaveného dátumu. Keď odpočítavanie skončí, z upozornenia zmizne. Server NEBUDE automaticky zastavený.",
+
+  // "system-wide-alert-form.select-date-by-calendar": "Select date using calendar",
+  "system-wide-alert-form.select-date-by-calendar": "Vyberte dátum pomocou kalendára",
+
+  // "system-wide-alert.form.label.preview": "System-wide alert preview",
+  "system-wide-alert.form.label.preview": "Náhľad systémového upozornenia",
+
+  // "system-wide-alert.form.update.success": "The system-wide alert was successfully updated",
+  "system-wide-alert.form.update.success": "Systémové upozornenie bolo úspešne aktualizované",
+
+  // "system-wide-alert.form.update.error": "Something went wrong when updating the system-wide alert",
+  "system-wide-alert.form.update.error": "Pri aktualizácii systémového upozornenia sa niečo pokazilo",
+
+  // "system-wide-alert.form.create.success": "The system-wide alert was successfully created",
+  "system-wide-alert.form.create.success": "Systémové upozornenie bolo úspešne vytvorené",
+
+  // "system-wide-alert.form.create.error": "Something went wrong when creating the system-wide alert",
+  "system-wide-alert.form.create.error": "Pri vytváraní systémového upozornenia sa niečo pokazilo",
+
+  // "admin.system-wide-alert.breadcrumbs": "System-wide Alerts",
+  "admin.system-wide-alert.breadcrumbs": "Systémové upozornenia",
+
+  // "admin.system-wide-alert.title": "System-wide Alerts",
+  "admin.system-wide-alert.title": "Systémové upozornenia",
+
+  // "discover.filters.head": "Discover",
+  "discover.filters.head": "Objavovať",
+
+  // "item-access-control-title": "This form allows you to perform changes to the access conditions of the item's metadata or its bitstreams.",
+  "item-access-control-title": "Tento formulár umožňuje vykonať zmeny podmienok prístupu k metadátam záznamu alebo jeho súborom.",
+
+  // "collection-access-control-title": "This form allows you to perform changes to the access conditions of all the items owned by this collection. Changes may be performed to either all Item metadata or all content (bitstreams).",
+  "collection-access-control-title": "Tento formulár umožňuje vykonať zmeny podmienok prístupu pri všetkých záznamoch patriacich do tejto kolekcie. Zmeny možno uplatniť buď na všetky metadáta záznamov, alebo na všetok obsah (súbory).",
+
+  // "community-access-control-title": "This form allows you to perform changes to the access conditions of all the items owned by any collection under this community. Changes may be performed to either all Item metadata or all content (bitstreams).",
+  "community-access-control-title": "Tento formulár umožňuje vykonať zmeny podmienok prístupu pri všetkých záznamoch patriacich do ktorejkoľvek kolekcie tejto komunity. Zmeny možno uplatniť buď na všetky metadáta záznamov, alebo na všetok obsah (súbory).",
+
+  // "access-control-item-header-toggle": "Item's Metadata",
+  "access-control-item-header-toggle": "Metadáta záznamu",
+
+  // "access-control-item-toggle.enable": "Enable option to perform changes on the item's metadata",
+  "access-control-item-toggle.enable": "Povoliť možnosť vykonávať zmeny v metadátach záznamu",
+
+  // "access-control-item-toggle.disable": "Disable option to perform changes on the item's metadata",
+  "access-control-item-toggle.disable": "Zakázať možnosť vykonávať zmeny v metadátach záznamu",
+
+  // "access-control-bitstream-header-toggle": "Bitstreams",
+  "access-control-bitstream-header-toggle": "Súbory",
+
+  // "access-control-bitstream-toggle.enable": "Enable option to perform changes on the bitstreams",
+  "access-control-bitstream-toggle.enable": "Povoliť možnosť vykonávať zmeny v súboroch",
+
+  // "access-control-bitstream-toggle.disable": "Disable option to perform changes on the bitstreams",
+  "access-control-bitstream-toggle.disable": "Zakázať možnosť vykonávať zmeny v súboroch",
+
+  // "access-control-mode": "Mode",
+  "access-control-mode": "Režim",
+
+  // "access-control-access-conditions": "Access conditions",
+  "access-control-access-conditions": "Podmienky prístupu",
+
+  // "access-control-no-access-conditions-warning-message": "Currently, no access conditions are specified below. If executed, this will replace the current access conditions with the default access conditions inherited from the owning collection.",
+  "access-control-no-access-conditions-warning-message": "Momentálne nie sú nižšie zadané žiadne podmienky prístupu. Ak akciu vykonáte, aktuálne podmienky prístupu sa nahradia predvolenými podmienkami prístupu zdedenými z vlastniacej kolekcie.",
+
+  // "access-control-replace-all": "Replace access conditions",
+  "access-control-replace-all": "Nahradiť podmienky prístupu",
+
+  // "access-control-add-to-existing": "Add to existing ones",
+  "access-control-add-to-existing": "Pridať k existujúcim",
+
+  // "access-control-limit-to-specific": "Limit the changes to specific bitstreams",
+  "access-control-limit-to-specific": "Obmedziť zmeny na konkrétne súbory",
+
+  // "access-control-process-all-bitstreams": "Update all the bitstreams in the item",
+  "access-control-process-all-bitstreams": "Aktualizovať všetky súbory v zázname",
+
+  // "access-control-bitstreams-selected": "bitstreams selected",
+  "access-control-bitstreams-selected": "vybraných súborov",
+
+  // "access-control-bitstreams-select": "Select bitstreams",
+  "access-control-bitstreams-select": "Vybrať súbory",
+
+  // "access-control-cancel": "Cancel",
+  "access-control-cancel": "Zrušiť",
+
+  // "access-control-execute": "Execute",
+  "access-control-execute": "Vykonať",
+
+  // "access-control-add-more": "Add more",
+  "access-control-add-more": "Pridať ďalšie",
+
+  // "access-control-remove": "Remove access condition",
+  "access-control-remove": "Odstrániť podmienku prístupu",
+
+  // "access-control-select-bitstreams-modal.title": "Select bitstreams",
+  "access-control-select-bitstreams-modal.title": "Vybrať súbory",
+
+  // "access-control-select-bitstreams-modal.no-items": "No items to show.",
+  "access-control-select-bitstreams-modal.no-items": "Žiadne záznamy na zobrazenie.",
+
+  // "access-control-select-bitstreams-modal.close": "Close",
+  "access-control-select-bitstreams-modal.close": "Zavrieť",
+
+  // "access-control-option-label": "Access condition type",
+  "access-control-option-label": "Typ podmienky prístupu",
+
+  // "access-control-option-note": "Choose an access condition to apply to selected objects.",
+  "access-control-option-note": "Vyberte podmienku prístupu, ktorá sa použije na vybrané objekty.",
+
+  // "access-control-option-start-date": "Grant access from",
+  "access-control-option-start-date": "Udeliť prístup od",
+
+  // "access-control-option-start-date-note": "Select the date from which the related access condition is applied",
+  "access-control-option-start-date-note": "Vyberte dátum, od ktorého sa použije súvisiaca podmienka prístupu",
+
+  // "access-control-option-end-date": "Grant access until",
+  "access-control-option-end-date": "Udeliť prístup do",
+
+  // "access-control-option-end-date-note": "Select the date until which the related access condition is applied",
+  "access-control-option-end-date-note": "Vyberte dátum, do ktorého platí súvisiaca podmienka prístupu",
+
+  // "vocabulary-treeview.search.form.add": "Add",
+  "vocabulary-treeview.search.form.add": "Pridať",
+
+  // "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
+  "admin.notifications.publicationclaim.breadcrumbs": "Nárokovanie publikácie",
+
+  // "admin.notifications.publicationclaim.page.title": "Publication Claim",
+  "admin.notifications.publicationclaim.page.title": "Nárokovanie publikácie",
+
+  // "coar-notify-support.title": "COAR Notify Protocol",
+  "coar-notify-support.title": "Protokol COAR Notify",
+
+  // "coar-notify-support-title.content": "Here, we fully support the COAR Notify protocol, which is designed to enhance the communication between repositories. To learn more about the COAR Notify protocol, visit the <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">COAR Notify website</a>.",
+  "coar-notify-support-title.content": "Tu plne podporujeme protokol COAR Notify, ktorý je navrhnutý na zlepšenie komunikácie medzi repozitármi. Ak sa chcete o protokole COAR Notify dozvedieť viac, navštívte <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">web COAR Notify</a>.",
+
+  // "coar-notify-support.ldn-inbox.title": "LDN InBox",
+  "coar-notify-support.ldn-inbox.title": "LDN schránka",
+
+  // "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
+  "coar-notify-support.ldn-inbox.content": "Pre vaše pohodlie je naša schránka LDN (Linked Data Notifications) ľahko dostupná na {{ ldnInboxUrl }}. Schránka LDN umožňuje bezproblémovú komunikáciu a výmenu dát, čím zaisťuje efektívnu spoluprácu.",
+
+  // "coar-notify-support.message-moderation.title": "Message Moderation",
+  "coar-notify-support.message-moderation.title": "Moderovanie správ",
+
+  // "coar-notify-support.message-moderation.content": "To ensure a secure and productive environment, all incoming LDN messages are moderated. If you are planning to exchange information with us, kindly reach out via our dedicated",
+  "coar-notify-support.message-moderation.content": "Aby bolo zaistené bezpečné a produktívne prostredie, všetky prichádzajúce správy LDN sú moderované. Ak plánujete s nami vymieňať informácie, kontaktujte nás prosím prostredníctvom nášho",
+
+  // "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
+  "coar-notify-support.message-moderation.feedback-form": " formulára spätnej väzby.",
+
+  // "service.overview.delete.header": "Delete Service",
+  "service.overview.delete.header": "Odstrániť službu",
+
+  // "ldn-registered-services.title": "Registered Services",
+  "ldn-registered-services.title": "Registrované služby",
+
+  // "ldn-registered-services.table.name": "Name",
+  "ldn-registered-services.table.name": "Názov",
+
+  // "ldn-registered-services.table.description": "Description",
+  "ldn-registered-services.table.description": "Popis",
+
+  // "ldn-registered-services.table.status": "Status",
+  "ldn-registered-services.table.status": "Stav",
+
+  // "ldn-registered-services.table.action": "Action",
+  "ldn-registered-services.table.action": "Akcia",
+
+  // "ldn-registered-services.new": "NEW",
+  "ldn-registered-services.new": "NOVÉ",
+
+  // "ldn-registered-services.new.breadcrumbs": "Registered Services",
+  "ldn-registered-services.new.breadcrumbs": "Registrované služby",
+
+  // "ldn-service.overview.table.enabled": "Enabled",
+  "ldn-service.overview.table.enabled": "Povolené",
+
+  // "ldn-service.overview.table.disabled": "Disabled",
+  "ldn-service.overview.table.disabled": "Zakázané",
+
+  // "ldn-service.overview.table.clickToEnable": "Click to enable",
+  "ldn-service.overview.table.clickToEnable": "Kliknutím povoliť",
+
+  // "ldn-service.overview.table.clickToDisable": "Click to disable",
+  "ldn-service.overview.table.clickToDisable": "Kliknutím zakázať",
+
+  // "ldn-edit-registered-service.title": "Edit Service",
+  "ldn-edit-registered-service.title": "Upraviť službu",
+
+  // "ldn-create-service.title": "Create service",
+  "ldn-create-service.title": "Vytvoriť službu",
+
+  // "service.overview.create.modal": "Create Service",
+  "service.overview.create.modal": "Vytvoriť službu",
+
+  // "service.overview.create.body": "Please confirm the creation of this service.",
+  "service.overview.create.body": "Potvrďte prosím vytvorenie tejto služby.",
+
+  // "ldn-service-status": "Status",
+  "ldn-service-status": "Stav",
+
+  // "service.confirm.create": "Create",
+  "service.confirm.create": "Vytvoriť",
+
+  // "service.refuse.create": "Cancel",
+  "service.refuse.create": "Zrušiť",
+
+  // "ldn-register-new-service.title": "Register a new service",
+  "ldn-register-new-service.title": "Zaregistrovať novú službu",
+
+  // "ldn-new-service.form.label.submit": "Save",
+  "ldn-new-service.form.label.submit": "Uložiť",
+
+  // "ldn-new-service.form.label.name": "Name",
+  "ldn-new-service.form.label.name": "Názov",
+
+  // "ldn-new-service.form.label.description": "Description",
+  "ldn-new-service.form.label.description": "Popis",
+
+  // "ldn-new-service.form.label.url": "Service URL",
+  "ldn-new-service.form.label.url": "URL služby",
+
+  // "ldn-new-service.form.label.ip-range": "Service IP range",
+  "ldn-new-service.form.label.ip-range": "Rozsah IP služby",
+
+  // "ldn-new-service.form.label.score": "Level of trust",
+  "ldn-new-service.form.label.score": "Úroveň dôvery",
+
+  // "ldn-new-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-new-service.form.label.ldnUrl": "URL LDN schránky",
+
+  // "ldn-new-service.form.placeholder.name": "Please provide service name",
+  "ldn-new-service.form.placeholder.name": "Zadajte názov služby",
+
+  // "ldn-new-service.form.placeholder.description": "Please provide a description regarding your service",
+  "ldn-new-service.form.placeholder.description": "Zadajte popis vašej služby",
+
+  // "ldn-new-service.form.placeholder.url": "Please input the URL for users to check out more information about the service",
+  "ldn-new-service.form.placeholder.url": "Zadajte URL, na ktorom si používatelia môžu prečítať viac informácií o službe",
+
+  // "ldn-new-service.form.placeholder.lowerIp": "IPv4 range lower bound",
+  "ldn-new-service.form.placeholder.lowerIp": "Dolná hranica rozsahu IPv4",
+
+  // "ldn-new-service.form.placeholder.upperIp": "IPv4 range upper bound",
+  "ldn-new-service.form.placeholder.upperIp": "Horná hranica rozsahu IPv4",
+
+  // "ldn-new-service.form.placeholder.ldnUrl": "Please specify the URL of the LDN Inbox",
+  "ldn-new-service.form.placeholder.ldnUrl": "Uveďte URL LDN schránky",
+
+  // "ldn-new-service.form.placeholder.score": "Please enter a value between 0 and 1. Use the “.” as decimal separator",
+  "ldn-new-service.form.placeholder.score": "Zadajte hodnotu medzi 0 a 1. Ako desatinný oddeľovač použite „.“",
+
+  // "ldn-service.form.label.placeholder.default-select": "Select a pattern",
+  "ldn-service.form.label.placeholder.default-select": "Vyberte vzor",
+
+  // "ldn-service.form.pattern.ack-accept.label": "Acknowledge and Accept",
+  "ldn-service.form.pattern.ack-accept.label": "Potvrdiť a prijať",
+
+  // "ldn-service.form.pattern.ack-accept.description": "This pattern is used to acknowledge and accept a request (offer). It implies an intention to act on the request.",
+  "ldn-service.form.pattern.ack-accept.description": "Tento vzor sa používa na potvrdenie a prijatie požiadavky (ponuky). Vyjadruje zámer na požiadavku reagovať.",
+
+  // "ldn-service.form.pattern.ack-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-accept.category": "Potvrdenia",
+
+  // "ldn-service.form.pattern.ack-reject.label": "Acknowledge and Reject",
+  "ldn-service.form.pattern.ack-reject.label": "Potvrdiť a odmietnuť",
+
+  // "ldn-service.form.pattern.ack-reject.description": "This pattern is used to acknowledge and reject a request (offer). It signifies no further action regarding the request.",
+  "ldn-service.form.pattern.ack-reject.description": "Tento vzor sa používa na potvrdenie a odmietnutie požiadavky (ponuky). Neznamená žiadnu ďalšiu akciu vo vzťahu k požiadavke.",
+
+  // "ldn-service.form.pattern.ack-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-reject.category": "Potvrdenia",
+
+  // "ldn-service.form.pattern.ack-tentative-accept.label": "Acknowledge and Tentatively Accept",
+  "ldn-service.form.pattern.ack-tentative-accept.label": "Potvrdiť a predbežne prijať",
+
+  // "ldn-service.form.pattern.ack-tentative-accept.description": "This pattern is used to acknowledge and tentatively accept a request (offer). It implies an intention to act, which may change.",
+  "ldn-service.form.pattern.ack-tentative-accept.description": "Tento vzor sa používa na potvrdenie a predbežné prijatie požiadavky (ponuky). Vyjadruje zámer konať, ktorý sa môže zmeniť.",
+
+  // "ldn-service.form.pattern.ack-tentative-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-accept.category": "Potvrdenia",
+
+  // "ldn-service.form.pattern.ack-tentative-reject.label": "Acknowledge and Tentatively Reject",
+  "ldn-service.form.pattern.ack-tentative-reject.label": "Potvrdiť a predbežne odmietnuť",
+
+  // "ldn-service.form.pattern.ack-tentative-reject.description": "This pattern is used to acknowledge and tentatively reject a request (offer). It signifies no further action, subject to change.",
+  "ldn-service.form.pattern.ack-tentative-reject.description": "Tento vzor sa používa na potvrdenie a predbežné odmietnutie požiadavky (ponuky). Neznamená žiadnu ďalšiu akciu, môže sa zmeniť.",
+
+  // "ldn-service.form.pattern.ack-tentative-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-reject.category": "Potvrdenia",
+
+  // "ldn-service.form.pattern.announce-endorsement.label": "Announce Endorsement",
+  "ldn-service.form.pattern.announce-endorsement.label": "Oznámiť odporúčanie",
+
+  // "ldn-service.form.pattern.announce-endorsement.description": "This pattern is used to announce the existence of an endorsement, referencing the endorsed resource.",
+  "ldn-service.form.pattern.announce-endorsement.description": "Tento vzor sa používa na oznámenie existencie odporúčania s odkazom na odporúčaný zdroj.",
+
+  // "ldn-service.form.pattern.announce-endorsement.category": "Announcements",
+  "ldn-service.form.pattern.announce-endorsement.category": "Oznámenia",
+
+  // "ldn-service.form.pattern.announce-ingest.label": "Announce Ingest",
+  "ldn-service.form.pattern.announce-ingest.label": "Oznámiť prevzatie",
+
+  // "ldn-service.form.pattern.announce-ingest.description": "This pattern is used to announce that a resource has been ingested.",
+  "ldn-service.form.pattern.announce-ingest.description": "Tento vzor sa používa na oznámenie, že zdroj bol prevzatý.",
+
+  // "ldn-service.form.pattern.announce-ingest.category": "Announcements",
+  "ldn-service.form.pattern.announce-ingest.category": "Oznámenia",
+
+  // "ldn-service.form.pattern.announce-relationship.label": "Announce Relationship",
+  "ldn-service.form.pattern.announce-relationship.label": "Oznámiť vzťah",
+
+  // "ldn-service.form.pattern.announce-relationship.description": "This pattern is used to announce a relationship between two resources.",
+  "ldn-service.form.pattern.announce-relationship.description": "Tento vzor sa používa na oznámenie vzťahu medzi dvoma zdrojmi.",
+
+  // "ldn-service.form.pattern.announce-relationship.category": "Announcements",
+  "ldn-service.form.pattern.announce-relationship.category": "Oznámenia",
+
+  // "ldn-service.form.pattern.announce-review.label": "Announce Review",
+  "ldn-service.form.pattern.announce-review.label": "Oznámiť recenziu",
+
+  // "ldn-service.form.pattern.announce-review.description": "This pattern is used to announce the existence of a review, referencing the reviewed resource.",
+  "ldn-service.form.pattern.announce-review.description": "Tento vzor sa používa na oznámenie existencie recenzie s odkazom na recenzovaný zdroj.",
+
+  // "ldn-service.form.pattern.announce-review.category": "Announcements",
+  "ldn-service.form.pattern.announce-review.category": "Oznámenia",
+
+  // "ldn-service.form.pattern.announce-service-result.label": "Announce Service Result",
+  "ldn-service.form.pattern.announce-service-result.label": "Oznámiť výsledok služby",
+
+  // "ldn-service.form.pattern.announce-service-result.description": "This pattern is used to announce the existence of a 'service result', referencing the relevant resource.",
+  "ldn-service.form.pattern.announce-service-result.description": "Tento vzor sa používa na oznámenie existencie „výsledku služby“ s odkazom na príslušný zdroj.",
+
+  // "ldn-service.form.pattern.announce-service-result.category": "Announcements",
+  "ldn-service.form.pattern.announce-service-result.category": "Oznámenia",
+
+  // "ldn-service.form.pattern.request-endorsement.label": "Request Endorsement",
+  "ldn-service.form.pattern.request-endorsement.label": "Požiadať o odporúčanie",
+
+  // "ldn-service.form.pattern.request-endorsement.description": "This pattern is used to request endorsement of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-endorsement.description": "Tento vzor sa používa na vyžiadanie odporúčania pre zdroj vlastnený zdrojovým systémom.",
+
+  // "ldn-service.form.pattern.request-endorsement.category": "Requests",
+  "ldn-service.form.pattern.request-endorsement.category": "Žiadosti",
+
+  // "ldn-service.form.pattern.request-ingest.label": "Request Ingest",
+  "ldn-service.form.pattern.request-ingest.label": "Požiadať o prevzatie",
+
+  // "ldn-service.form.pattern.request-ingest.description": "This pattern is used to request that the target system ingest a resource.",
+  "ldn-service.form.pattern.request-ingest.description": "Tento vzor sa používa na požiadavku, aby cieľový systém prevzal zdroj.",
+
+  // "ldn-service.form.pattern.request-ingest.category": "Requests",
+  "ldn-service.form.pattern.request-ingest.category": "Žiadosti",
+
+  // "ldn-service.form.pattern.request-review.label": "Request Review",
+  "ldn-service.form.pattern.request-review.label": "Požiadať o recenziu",
+
+  // "ldn-service.form.pattern.request-review.description": "This pattern is used to request a review of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-review.description": "Tento vzor sa používa na požiadavku o recenziu zdroja vlastneného zdrojovým systémom.",
+
+  // "ldn-service.form.pattern.request-review.category": "Requests",
+  "ldn-service.form.pattern.request-review.category": "Žiadosti",
+
+  // "ldn-service.form.pattern.undo-offer.label": "Undo Offer",
+  "ldn-service.form.pattern.undo-offer.label": "Zrušiť ponuku",
+
+  // "ldn-service.form.pattern.undo-offer.description": "This pattern is used to undo (retract) an offer previously made.",
+  "ldn-service.form.pattern.undo-offer.description": "Tento vzor sa používa na zrušenie (stiahnutie) predtým predloženej ponuky.",
+
+  // "ldn-service.form.pattern.undo-offer.category": "Undo",
+  "ldn-service.form.pattern.undo-offer.category": "Zrušenie",
+
+  // "ldn-new-service.form.label.placeholder.selectedItemFilter": "No Item Filter Selected",
+  "ldn-new-service.form.label.placeholder.selectedItemFilter": "Nie je vybraný žiadny filter záznamov",
+
+  // "ldn-new-service.form.label.ItemFilter": "Item Filter",
+  "ldn-new-service.form.label.ItemFilter": "Filter záznamov",
+
+  // "ldn-new-service.form.label.automatic": "Automatic",
+  "ldn-new-service.form.label.automatic": "Automaticky",
+
+  // "ldn-new-service.form.error.name": "Name is required",
+  "ldn-new-service.form.error.name": "Názov je povinný",
+
+  // "ldn-new-service.form.error.url": "URL is required",
+  "ldn-new-service.form.error.url": "URL je povinné",
+
+  // "ldn-new-service.form.error.ipRange": "Please enter a valid IP range",
+  "ldn-new-service.form.error.ipRange": "Zadajte platný rozsah IP",
+
+  // "ldn-new-service.form.hint.ipRange": "Please enter a valid IpV4 in both range bounds (note: for single IP, please enter the same value in both fields)",
+  "ldn-new-service.form.hint.ipRange": "Zadajte platnú adresu IPv4 v oboch hraniciach rozsahu (pozn.: pre jednu IP zadajte rovnakú hodnotu do oboch polí)",
+
+  // "ldn-new-service.form.error.ldnurl": "LDN URL is required",
+  "ldn-new-service.form.error.ldnurl": "URL LDN je povinné",
+
+  // "ldn-new-service.form.error.ldnurl.ldnUrlAlreadyAssociated": "This LDN URL is already associated with another service",
+  "ldn-new-service.form.error.ldnurl.ldnUrlAlreadyAssociated": "Táto URL LDN je už priradená k inej službe",
+
+  // "ldn-new-service.form.error.patterns": "At least a pattern is required",
+  "ldn-new-service.form.error.patterns": "Vyžaduje sa aspoň jeden vzor",
+
+  // "ldn-new-service.form.error.score": "Please enter a valid score (between 0 and 1). Use the “.” as decimal separator",
+  "ldn-new-service.form.error.score": "Zadajte platné hodnotenie (medzi 0 a 1). Ako desatinný oddeľovač použite „.“",
+
+  // "ldn-new-service.form.label.inboundPattern": "Supported Pattern",
+  "ldn-new-service.form.label.inboundPattern": "Podporovaný vzor",
+
+  // "ldn-new-service.form.label.addPattern": "+ Add more",
+  "ldn-new-service.form.label.addPattern": "+ Pridať ďalšie",
+
+  // "ldn-new-service.form.label.removeItemFilter": "Remove",
+  "ldn-new-service.form.label.removeItemFilter": "Odobrať",
+
+  // "ldn-register-new-service.breadcrumbs": "New Service",
+  "ldn-register-new-service.breadcrumbs": "Nová služba",
+
+  // "service.overview.delete.body": "Are you sure you want to delete this service?",
+  "service.overview.delete.body": "Naozaj chcete túto službu odstrániť?",
+
+  // "service.overview.edit.body": "Do you confirm the changes?",
+  "service.overview.edit.body": "Potvrdzujete zmeny?",
+
+  // "service.overview.edit.modal": "Edit Service",
+  "service.overview.edit.modal": "Upraviť službu",
+
+  // "service.detail.update": "Confirm",
+  "service.detail.update": "Potvrdiť",
+
+  // "service.detail.return": "Cancel",
+  "service.detail.return": "Zrušiť",
+
+  // "service.overview.reset-form.body": "Are you sure you want to discard the changes and leave?",
+  "service.overview.reset-form.body": "Naozaj chcete zahodiť zmeny a odísť?",
+
+  // "service.overview.reset-form.modal": "Discard Changes",
+  "service.overview.reset-form.modal": "Zahodiť zmeny",
+
+  // "service.overview.reset-form.reset-confirm": "Discard",
+  "service.overview.reset-form.reset-confirm": "Zahodiť",
+
+  // "admin.registries.services-formats.modify.success.head": "Successful Edit",
+  "admin.registries.services-formats.modify.success.head": "Úspešná úprava",
+
+  // "admin.registries.services-formats.modify.success.content": "The service has been edited",
+  "admin.registries.services-formats.modify.success.content": "Služba bola upravená",
+
+  // "admin.registries.services-formats.modify.failure.head": "Failed Edit",
+  "admin.registries.services-formats.modify.failure.head": "Neúspešná úprava",
+
+  // "admin.registries.services-formats.modify.failure.content": "The service has not been edited",
+  "admin.registries.services-formats.modify.failure.content": "Služba nebola upravená",
+
+  // "ldn-service-notification.created.success.title": "Successful Create",
+  "ldn-service-notification.created.success.title": "Úspešné vytvorenie",
+
+  // "ldn-service-notification.created.success.body": "The service has been created",
+  "ldn-service-notification.created.success.body": "Služba bola vytvorená",
+
+  // "ldn-service-notification.created.failure.title": "Failed Create",
+  "ldn-service-notification.created.failure.title": "Neúspešné vytvorenie",
+
+  // "ldn-service-notification.created.failure.body": "The service has not been created",
+  "ldn-service-notification.created.failure.body": "Služba nebola vytvorená",
+
+  // "ldn-service-notification.created.warning.title": "Please select at least one Inbound Pattern",
+  "ldn-service-notification.created.warning.title": "Vyberte aspoň jeden prichádzajúci vzor",
+
+  // "ldn-enable-service.notification.success.title": "Successful status updated",
+  "ldn-enable-service.notification.success.title": "Stav úspešne aktualizovaný",
+
+  // "ldn-enable-service.notification.success.content": "The service status has been updated",
+  "ldn-enable-service.notification.success.content": "Stav služby bol aktualizovaný",
+
+  // "ldn-service-delete.notification.success.title": "Successful Deletion",
+  "ldn-service-delete.notification.success.title": "Úspešné odstránenie",
+
+  // "ldn-service-delete.notification.success.content": "The service has been deleted",
+  "ldn-service-delete.notification.success.content": "Služba bola odstránená",
+
+  // "ldn-service-delete.notification.error.title": "Failed Deletion",
+  "ldn-service-delete.notification.error.title": "Neúspešné odstránenie",
+
+  // "ldn-service-delete.notification.error.content": "The service has not been deleted",
+  "ldn-service-delete.notification.error.content": "Služba nebola odstránená",
+
+  // "service.overview.reset-form.reset-return": "Cancel",
+  "service.overview.reset-form.reset-return": "Zrušiť",
+
+  // "service.overview.delete": "Delete service",
+  "service.overview.delete": "Odstrániť službu",
+
+  // "ldn-edit-service.title": "Edit service",
+  "ldn-edit-service.title": "Upraviť službu",
+
+  // "ldn-edit-service.form.label.name": "Name",
+  "ldn-edit-service.form.label.name": "Názov",
+
+  // "ldn-edit-service.form.label.description": "Description",
+  "ldn-edit-service.form.label.description": "Popis",
+
+  // "ldn-edit-service.form.label.url": "Service URL",
+  "ldn-edit-service.form.label.url": "URL služby",
+
+  // "ldn-edit-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-edit-service.form.label.ldnUrl": "URL LDN schránky",
+
+  // "ldn-edit-service.form.label.inboundPattern": "Inbound Pattern",
+  "ldn-edit-service.form.label.inboundPattern": "Prichádzajúci vzor",
+
+  // "ldn-edit-service.form.label.noInboundPatternSelected": "No Inbound Pattern",
+  "ldn-edit-service.form.label.noInboundPatternSelected": "Žiadny prichádzajúci vzor",
+
+  // "ldn-edit-service.form.label.selectedItemFilter": "Selected Item Filter",
+  "ldn-edit-service.form.label.selectedItemFilter": "Vybraný filter záznamov",
+
+  // "ldn-edit-service.form.label.selectItemFilter": "No Item Filter",
+  "ldn-edit-service.form.label.selectItemFilter": "Žiadny filter záznamov",
+
+  // "ldn-edit-service.form.label.automatic": "Automatic",
+  "ldn-edit-service.form.label.automatic": "Automaticky",
+
+  // "ldn-edit-service.form.label.addInboundPattern": "+ Add more",
+  "ldn-edit-service.form.label.addInboundPattern": "+ Pridať ďalšie",
+
+  // "ldn-edit-service.form.label.submit": "Save",
+  "ldn-edit-service.form.label.submit": "Uložiť",
+
+  // "ldn-edit-service.breadcrumbs": "Edit Service",
+  "ldn-edit-service.breadcrumbs": "Upraviť službu",
+
+  // "ldn-service.control-constaint-select-none": "Select none",
+  "ldn-service.control-constaint-select-none": "Zrušiť výber",
+
+  // "ldn-register-new-service.notification.error.title": "Error",
+  "ldn-register-new-service.notification.error.title": "Chyba",
+
+  // "ldn-register-new-service.notification.error.content": "An error occurred while creating this process",
+  "ldn-register-new-service.notification.error.content": "Pri vytváraní tohto procesu došlo k chybe",
+
+  // "ldn-register-new-service.notification.success.title": "Success",
+  "ldn-register-new-service.notification.success.title": "Úspech",
+
+  // "ldn-register-new-service.notification.success.content": "The process was successfully created",
+  "ldn-register-new-service.notification.success.content": "Proces bol úspešne vytvorený",
+
+  // "submission.sections.notify.info": "The selected service is compatible with the item according to its current status. {{ service.name }}: {{ service.description }}",
+  "submission.sections.notify.info": "Vybraná služba je kompatibilná so záznamom podľa jeho aktuálneho stavu. {{ service.name }}: {{ service.description }}",
+
+  // "item.page.endorsement": "Endorsement",
+  "item.page.endorsement": "Odporúčanie",
+
+  // "item.page.places": "Related places",
+  "item.page.places": "Súvisiace miesta",
+
+  // "item.page.review": "Review",
+  "item.page.review": "Recenzia",
+
+  // "item.page.referenced": "Referenced By",
+  "item.page.referenced": "Odkazované z",
+
+  // "item.page.supplemented": "Supplemented By",
+  "item.page.supplemented": "Doplnené o",
+
+  // "menu.section.icon.ldn_services": "LDN Services overview",
+  "menu.section.icon.ldn_services": "Prehľad služieb LDN",
+
+  // "menu.section.services": "LDN Services",
+  "menu.section.services": "Služby LDN",
+
+  // "menu.section.services_new": "LDN Service",
+  "menu.section.services_new": "Služba LDN",
+
+  // "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
+  "quality-assurance.topics.description-with-target": "Nižšie vidíte všetky témy získané z odberov od {{source}} týkajúce sa ",
+
+  // "quality-assurance.events.description": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b>.",
+  "quality-assurance.events.description": "Nižšie je zoznam všetkých odporúčaní pre vybranú tému <b>{{topic}}</b>, súvisiacich s <b>{{source}}</b>.",
+
+  // "quality-assurance.events.description-with-topic-and-target": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b> and ",
+  "quality-assurance.events.description-with-topic-and-target": "Nižšie je zoznam všetkých odporúčaní pre vybranú tému <b>{{topic}}</b>, súvisiacich s <b>{{source}}</b> a ",
+
+  // "quality-assurance.event.table.event.message.serviceUrl": "Actor:",
+  "quality-assurance.event.table.event.message.serviceUrl": "Aktér:",
+
+  // "quality-assurance.event.table.event.message.link": "Link:",
+  "quality-assurance.event.table.event.message.link": "Odkaz:",
+
+  // "service.detail.delete.cancel": "Cancel",
+  "service.detail.delete.cancel": "Zrušiť",
+
+  // "service.detail.delete.button": "Delete service",
+  "service.detail.delete.button": "Odstrániť službu",
+
+  // "service.detail.delete.header": "Delete service",
+  "service.detail.delete.header": "Odstrániť službu",
+
+  // "service.detail.delete.body": "Are you sure you want to delete the current service?",
+  "service.detail.delete.body": "Naozaj chcete odstrániť túto službu?",
+
+  // "service.detail.delete.confirm": "Delete service",
+  "service.detail.delete.confirm": "Odstrániť službu",
+
+  // "service.detail.delete.success": "The service was successfully deleted.",
+  "service.detail.delete.success": "Služba bola úspešne odstránená.",
+
+  // "service.detail.delete.error": "Something went wrong when deleting the service",
+  "service.detail.delete.error": "Pri odstraňovaní služby sa niečo pokazilo",
+
+  // "service.overview.table.id": "Services ID",
+  "service.overview.table.id": "ID služby",
+
+  // "service.overview.table.name": "Name",
+  "service.overview.table.name": "Názov",
+
+  // "service.overview.table.start": "Start time (UTC)",
+  "service.overview.table.start": "Čas začiatku (UTC)",
+
+  // "service.overview.table.status": "Status",
+  "service.overview.table.status": "Stav",
+
+  // "service.overview.table.user": "User",
+  "service.overview.table.user": "Používateľ",
+
+  // "service.overview.title": "Services Overview",
+  "service.overview.title": "Prehľad služieb",
+
+  // "service.overview.breadcrumbs": "Services Overview",
+  "service.overview.breadcrumbs": "Prehľad služieb",
+
+  // "service.overview.table.actions": "Actions",
+  "service.overview.table.actions": "Akcie",
+
+  // "service.overview.table.description": "Description",
+  "service.overview.table.description": "Popis",
+
+  // "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
+  "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
+
+  // "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
+  "submission.section.section-coar-notify.control.request-review.label": "Môžete požiadať o recenziu jednu z nasledujúcich služieb",
+
+  // "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
+  "submission.section.section-coar-notify.control.request-endorsement.label": "Môžete požiadať o odporúčanie jeden z nasledujúcich overlay časopisov",
+
+  // "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
+  "submission.section.section-coar-notify.control.request-ingest.label": "Môžete požiadať o prevzatie kópie vášho vloženia do jednej z nasledujúcich služieb",
+
+  // "submission.section.section-coar-notify.dropdown.no-data": "No data available",
+  "submission.section.section-coar-notify.dropdown.no-data": "Žiadne dostupné údaje",
+
+  // "submission.section.section-coar-notify.dropdown.select-none": "Select none",
+  "submission.section.section-coar-notify.dropdown.select-none": "Zrušiť výber",
+
+  // "submission.section.section-coar-notify.small.notification": "Select a service for {{ pattern }} of this item",
+  "submission.section.section-coar-notify.small.notification": "Vyberte službu pre {{ pattern }} tohto záznamu",
+
+  // "submission.section.section-coar-notify.selection.description": "Selected service's description:",
+  "submission.section.section-coar-notify.selection.description": "Popis vybranej služby:",
+
+  // "submission.section.section-coar-notify.selection.no-description": "No further information is available",
+  "submission.section.section-coar-notify.selection.no-description": "Nie sú dostupné žiadne ďalšie informácie",
+
+  // "submission.section.section-coar-notify.notification.error": "The selected service is not suitable for the current item. Please check the description for details about which record can be managed by this service.",
+  "submission.section.section-coar-notify.notification.error": "Vybraná služba nie je vhodná pre aktuálny záznam. Podrobnosti o tom, ktorý záznam môže táto služba spravovať, nájdete v popise.",
+
+  // "submission.section.section-coar-notify.info.no-pattern": "No configurable patterns found.",
+  "submission.section.section-coar-notify.info.no-pattern": "Nenašli sa žiadne konfigurovateľné vzory.",
+
+  // "error.validation.coarnotify.invalidfilter": "Invalid filter, try to select another service or none.",
+  "error.validation.coarnotify.invalidfilter": "Neplatný filter, skúste vybrať inú službu alebo žiadnu.",
+
+  // "request-status-alert-box.accepted": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> has been taken in charge.",
+  "request-status-alert-box.accepted": "Požadovaná {{ offerType }} pre <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> bola prevzatá.",
+
+  // "request-status-alert-box.rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> has been rejected.",
+  "request-status-alert-box.rejected": "Požadovaná {{ offerType }} pre <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> bola zamietnutá.",
+
+  // "request-status-alert-box.tentative_rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> has been tentatively rejected. Revisions are required",
+  "request-status-alert-box.tentative_rejected": "Požadovaná {{ offerType }} pre <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> bola predbežne zamietnutá. Vyžadujú sa revízie",
+
+  // "request-status-alert-box.requested": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> is pending.",
+  "request-status-alert-box.requested": "Požadovaná {{ offerType }} pre <a href='{{serviceUrl}}' target='_blank'>{{ serviceName }}</a> čaká na vybavenie.",
+
+  // "ldn-service-button-mark-inbound-deletion": "Mark supported pattern for deletion",
+  "ldn-service-button-mark-inbound-deletion": "Označiť podporovaný vzor na odstránenie",
+
+  // "ldn-service-button-unmark-inbound-deletion": "Unmark supported pattern for deletion",
+  "ldn-service-button-unmark-inbound-deletion": "Zrušiť označenie podporovaného vzoru na odstránenie",
+
+  // "ldn-service-input-inbound-item-filter-dropdown": "Select Item filter for the pattern",
+  "ldn-service-input-inbound-item-filter-dropdown": "Vyberte filter záznamov pre vzor",
+
+  // "ldn-service-input-inbound-pattern-dropdown": "Select a pattern for service",
+  "ldn-service-input-inbound-pattern-dropdown": "Vyberte vzor pre službu",
+
+  // "ldn-service-overview-select-delete": "Select service for deletion",
+  "ldn-service-overview-select-delete": "Vyberte službu na odstránenie",
+
+  // "ldn-service-overview-select-edit": "Edit LDN service",
+  "ldn-service-overview-select-edit": "Upraviť službu LDN",
+
+  // "ldn-service-overview-close-modal": "Close modal",
+  "ldn-service-overview-close-modal": "Zavrieť okno",
+
+  // "ldn-service-usesActorEmailId": "Requires actor email in notifications",
+  "ldn-service-usesActorEmailId": "Vyžaduje e-mail aktéra v oznámeniach",
+
+  // "ldn-service-usesActorEmailId-description": "If enabled, initial notifications sent will include the submitter email rather than the repository URL. This is usually the case for endorsement or review services.",
+  "ldn-service-usesActorEmailId-description": "Ak je povolené, počiatočné odoslané oznámenia budú obsahovať e-mail vkladateľa namiesto URL repozitára. Toto je obvyklé pri službách odporúčania alebo recenzie.",
+
+  // "a-common-or_statement.label": "Item type is Journal Article or Dataset",
+  "a-common-or_statement.label": "Typ záznamu je Článok v časopise alebo Dátová sada",
+
+  // "always_true_filter.label": "Always true",
+  "always_true_filter.label": "Vždy pravda",
+
+  // "automatic_processing_collection_filter_16.label": "Automatic processing",
+  "automatic_processing_collection_filter_16.label": "Automatické spracovanie",
+
+  // "dc-identifier-uri-contains-doi_condition.label": "URI contains DOI",
+  "dc-identifier-uri-contains-doi_condition.label": "URI obsahuje DOI",
+
+  // "doi-filter.label": "DOI filter",
+  "doi-filter.label": "Filter DOI",
+
+  // "driver-document-type_condition.label": "Document type equals driver",
+  "driver-document-type_condition.label": "Typ dokumentu sa rovná driver",
+
+  // "has-at-least-one-bitstream_condition.label": "Has at least one Bitstream",
+  "has-at-least-one-bitstream_condition.label": "Má aspoň jeden súbor",
+
+  // "has-bitstream_filter.label": "Has Bitstream",
+  "has-bitstream_filter.label": "Má súbor",
+
+  // "has-one-bitstream_condition.label": "Has one Bitstream",
+  "has-one-bitstream_condition.label": "Má jeden súbor",
+
+  // "is-archived_condition.label": "Is archived",
+  "is-archived_condition.label": "Je archivovaný",
+
+  // "is-withdrawn_condition.label": "Is withdrawn",
+  "is-withdrawn_condition.label": "Je stiahnutý",
+
+  // "item-is-public_condition.label": "Item is public",
+  "item-is-public_condition.label": "Záznam je verejný",
+
+  // "journals_ingest_suggestion_collection_filter_18.label": "Journals ingest",
+  "journals_ingest_suggestion_collection_filter_18.label": "Prevzatie časopisov",
+
+  // "title-starts-with-pattern_condition.label": "Title starts with pattern",
+  "title-starts-with-pattern_condition.label": "Názov začína vzorom",
+
+  // "type-equals-dataset_condition.label": "Type equals Dataset",
+  "type-equals-dataset_condition.label": "Typ sa rovná Dátová sada",
+
+  // "type-equals-journal-article_condition.label": "Type equals Journal Article",
+  "type-equals-journal-article_condition.label": "Typ sa rovná Článok v časopise",
+
+  // "ldn.no-filter.label": "None",
+  "ldn.no-filter.label": "Žiadny",
+
+  // "admin.notify.dashboard": "Dashboard",
+  "admin.notify.dashboard": "Nástenka",
+
+  // "menu.section.notify_dashboard": "Dashboard",
+  "menu.section.notify_dashboard": "Nástenka",
+
+  // "menu.section.coar_notify": "COAR Notify",
+  "menu.section.coar_notify": "COAR Notify",
+
+  // "admin-notify-dashboard.title": "Notify Dashboard",
+  "admin-notify-dashboard.title": "Nástenka Notify",
+
+  // "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
+  "admin-notify-dashboard.description": "Nástenka Notify sleduje celkové používanie protokolu COAR Notify v repozitári. Na karte „Metriky“ sú štatistiky o používaní protokolu COAR Notify. Na kartách „Protokoly/Prichádzajúce“ a „Protokoly/Odchádzajúce“ je možné vyhľadávať a kontrolovať individuálny stav každej správy LDN, prijatej alebo odoslanej.",
+
+  // "admin-notify-dashboard.metrics": "Metrics",
+  "admin-notify-dashboard.metrics": "Metriky",
+
+  // "admin-notify-dashboard.received-ldn": "Number of received LDN",
+  "admin-notify-dashboard.received-ldn": "Počet prijatých LDN",
+
+  // "admin-notify-dashboard.generated-ldn": "Number of generated LDN",
+  "admin-notify-dashboard.generated-ldn": "Počet vytvorených LDN",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.accepted": "Accepted",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted": "Prijaté",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Accepted inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Prijaté prichádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.incoming.accepted": "Currently displaying: Accepted notifications",
+  "admin-notify-logs.NOTIFY.incoming.accepted": "Zobrazuje sa: Prijaté oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.processed": "Processed LDN",
+  "admin-notify-dashboard.NOTIFY.incoming.processed": "Spracované LDN",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Processed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Spracované prichádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.incoming.processed": "Currently displaying: Processed LDN",
+  "admin-notify-logs.NOTIFY.incoming.processed": "Zobrazuje sa: Spracované LDN",
+
+  // "admin-notify-logs.NOTIFY.incoming.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.incoming.failure": "Zobrazuje sa: Neúspešné oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.incoming.failure": "Chyba",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Failed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Neúspešné prichádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.outgoing.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.outgoing.failure": "Zobrazuje sa: Neúspešné oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure": "Chyba",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Failed outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Neúspešné odchádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.incoming.untrusted": "Currently displaying: Untrusted notifications",
+  "admin-notify-logs.NOTIFY.incoming.untrusted": "Zobrazuje sa: Nedôveryhodné oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Untrusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Nedôveryhodné",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Inbound notifications not trusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Nedôveryhodné prichádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.incoming.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.incoming.delivered": "Zobrazuje sa: Doručené oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Inbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Úspešne doručené prichádzajúce oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Doručené",
+
+  // "admin-notify-logs.NOTIFY.outgoing.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.outgoing.delivered": "Zobrazuje sa: Doručené oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Outbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Úspešne doručené odchádzajúce oznámenia",
+
+  // "admin-notify-logs.NOTIFY.outgoing.queued": "Currently displaying: Queued notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued": "Zobrazuje sa: Zaradené oznámenia",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Notifications currently queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Oznámenia aktuálne vo fronte",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.queued": "Queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued": "Vo fronte",
+
+  // "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Currently displaying: Queued for retry notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Zobrazuje sa: Oznámenia vo fronte na opakovanie",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Vo fronte na opakovanie",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Notifications currently queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Oznámenia aktuálne vo fronte na opakovanie",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Zapojené záznamy",
+
+  // "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Items related to inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Záznamy súvisiace s prichádzajúcimi oznámeniami",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Zapojené záznamy",
+
+  // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Items related to outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Záznamy súvisiace s odchádzajúcimi oznámeniami",
+
+  // "admin.notify.dashboard.breadcrumbs": "Dashboard",
+  "admin.notify.dashboard.breadcrumbs": "Nástenka",
+
+  // "admin.notify.dashboard.inbound": "Inbound messages",
+  "admin.notify.dashboard.inbound": "Prichádzajúce správy",
+
+  // "admin.notify.dashboard.inbound-logs": "Logs/Inbound",
+  "admin.notify.dashboard.inbound-logs": "Protokoly/Prichádzajúce",
+
+  // "admin.notify.dashboard.filter": "Filter: ",
+  "admin.notify.dashboard.filter": "Filter: ",
+
+  // "search.filters.applied.f.relateditem": "Related items",
+  "search.filters.applied.f.relateditem": "Súvisiace záznamy",
+
+  // "search.filters.applied.f.ldn_service": "LDN Service",
+  "search.filters.applied.f.ldn_service": "Služba LDN",
+
+  // "search.filters.applied.f.notifyReview": "Notify Review",
+  "search.filters.applied.f.notifyReview": "Notify recenzia",
+
+  // "search.filters.applied.f.notifyEndorsement": "Notify Endorsement",
+  "search.filters.applied.f.notifyEndorsement": "Notify odporúčanie",
+
+  // "search.filters.applied.f.notifyRelation": "Notify Relation",
+  "search.filters.applied.f.notifyRelation": "Notify vzťah",
+
+  // "search.filters.applied.f.access_status": "Access type",
+  "search.filters.applied.f.access_status": "Typ prístupu",
+
+  // "search.filters.filter.queue_last_start_time.head": "Last processing time ",
+  "search.filters.filter.queue_last_start_time.head": "Čas posledného spracovania ",
+
+  // "search.filters.filter.queue_last_start_time.min.label": "Min range",
+  "search.filters.filter.queue_last_start_time.min.label": "Minimálny rozsah",
+
+  // "search.filters.filter.queue_last_start_time.max.label": "Max range",
+  "search.filters.filter.queue_last_start_time.max.label": "Maximálny rozsah",
+
+  // "search.filters.applied.f.queue_last_start_time.min": "Min range",
+  "search.filters.applied.f.queue_last_start_time.min": "Minimálny rozsah",
+
+  // "search.filters.applied.f.queue_last_start_time.max": "Max range",
+  "search.filters.applied.f.queue_last_start_time.max": "Maximálny rozsah",
+
+  // "admin.notify.dashboard.outbound": "Outbound messages",
+  "admin.notify.dashboard.outbound": "Odchádzajúce správy",
+
+  // "admin.notify.dashboard.outbound-logs": "Logs/Outbound",
+  "admin.notify.dashboard.outbound-logs": "Protokoly/Odchádzajúce",
+
+  // "NOTIFY.incoming.search.results.head": "Incoming",
+  "NOTIFY.incoming.search.results.head": "Prichádzajúce",
+
+  // "search.filters.filter.relateditem.head": "Related item",
+  "search.filters.filter.relateditem.head": "Súvisiaci záznam",
+
+  // "search.filters.filter.origin.head": "Origin",
+  "search.filters.filter.origin.head": "Pôvod",
+
+  // "search.filters.filter.ldn_service.head": "LDN Service",
+  "search.filters.filter.ldn_service.head": "Služba LDN",
+
+  // "search.filters.filter.target.head": "Target",
+  "search.filters.filter.target.head": "Cieľ",
+
+  // "search.filters.filter.queue_status.head": "Queue status",
+  "search.filters.filter.queue_status.head": "Stav fronty",
+
+  // "search.filters.filter.activity_stream_type.head": "Activity stream type",
+  "search.filters.filter.activity_stream_type.head": "Typ prúdu aktivít",
+
+  // "search.filters.filter.coar_notify_type.head": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.head": "Typ COAR Notify",
+
+  // "search.filters.filter.notification_type.head": "Notification type",
+  "search.filters.filter.notification_type.head": "Typ oznámenia",
+
+  // "search.filters.filter.relateditem.label": "Search related items",
+  "search.filters.filter.relateditem.label": "Hľadať súvisiace záznamy",
+
+  // "search.filters.filter.queue_status.label": "Search queue status",
+  "search.filters.filter.queue_status.label": "Hľadať stav fronty",
+
+  // "search.filters.filter.target.label": "Search target",
+  "search.filters.filter.target.label": "Hľadať cieľ",
+
+  // "search.filters.filter.activity_stream_type.label": "Search activity stream type",
+  "search.filters.filter.activity_stream_type.label": "Hľadať typ prúdu aktivít",
+
+  // "search.filters.applied.f.queue_status": "Queue Status",
+  "search.filters.applied.f.queue_status": "Stav fronty",
+
+  // "search.filters.queue_status.0,authority": "Untrusted Ip",
+  "search.filters.queue_status.0,authority": "Nedôveryhodná IP",
+
+  // "search.filters.queue_status.1,authority": "Queued",
+  "search.filters.queue_status.1,authority": "Vo fronte",
+
+  // "search.filters.queue_status.2,authority": "Processing",
+  "search.filters.queue_status.2,authority": "Spracúva sa",
+
+  // "search.filters.queue_status.3,authority": "Processed",
+  "search.filters.queue_status.3,authority": "Spracované",
+
+  // "search.filters.queue_status.4,authority": "Failed",
+  "search.filters.queue_status.4,authority": "Zlyhalo",
+
+  // "search.filters.queue_status.5,authority": "Untrusted",
+  "search.filters.queue_status.5,authority": "Nedôveryhodné",
+
+  // "search.filters.queue_status.6,authority": "Unmapped Action",
+  "search.filters.queue_status.6,authority": "Nemapovaná akcia",
+
+  // "search.filters.queue_status.7,authority": "Queued for retry",
+  "search.filters.queue_status.7,authority": "Vo fronte na opakovanie",
+
+  // "search.filters.applied.f.activity_stream_type": "Activity stream type",
+  "search.filters.applied.f.activity_stream_type": "Typ prúdu aktivít",
+
+  // "search.filters.applied.f.coar_notify_type": "COAR Notify type",
+  "search.filters.applied.f.coar_notify_type": "Typ COAR Notify",
+
+  // "search.filters.applied.f.notification_type": "Notification type",
+  "search.filters.applied.f.notification_type": "Typ oznámenia",
+
+  // "search.filters.filter.coar_notify_type.label": "Search COAR Notify type",
+  "search.filters.filter.coar_notify_type.label": "Hľadať typ COAR Notify",
+
+  // "search.filters.filter.notification_type.label": "Search notification type",
+  "search.filters.filter.notification_type.label": "Hľadať typ oznámenia",
+
+  // "search.filters.filter.relateditem.placeholder": "Related items",
+  "search.filters.filter.relateditem.placeholder": "Súvisiace záznamy",
+
+  // "search.filters.filter.target.placeholder": "Target",
+  "search.filters.filter.target.placeholder": "Cieľ",
+
+  // "search.filters.filter.origin.label": "Search source",
+  "search.filters.filter.origin.label": "Hľadať zdroj",
+
+  // "search.filters.filter.origin.placeholder": "Source",
+  "search.filters.filter.origin.placeholder": "Zdroj",
+
+  // "search.filters.filter.ldn_service.label": "Search LDN Service",
+  "search.filters.filter.ldn_service.label": "Hľadať službu LDN",
+
+  // "search.filters.filter.ldn_service.placeholder": "LDN Service",
+  "search.filters.filter.ldn_service.placeholder": "Služba LDN",
+
+  // "search.filters.filter.queue_status.placeholder": "Queue status",
+  "search.filters.filter.queue_status.placeholder": "Stav fronty",
+
+  // "search.filters.filter.activity_stream_type.placeholder": "Activity stream type",
+  "search.filters.filter.activity_stream_type.placeholder": "Typ prúdu aktivít",
+
+  // "search.filters.filter.coar_notify_type.placeholder": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.placeholder": "Typ COAR Notify",
+
+  // "search.filters.filter.notification_type.placeholder": "Notification",
+  "search.filters.filter.notification_type.placeholder": "Oznámenie",
+
+  // "search.filters.filter.notifyRelation.head": "Notify Relation",
+  "search.filters.filter.notifyRelation.head": "Notify vzťah",
+
+  // "search.filters.filter.notifyRelation.label": "Search Notify Relation",
+  "search.filters.filter.notifyRelation.label": "Hľadať Notify vzťah",
+
+  // "search.filters.filter.notifyRelation.placeholder": "Notify Relation",
+  "search.filters.filter.notifyRelation.placeholder": "Notify vzťah",
+
+  // "search.filters.filter.notifyReview.head": "Notify Review",
+  "search.filters.filter.notifyReview.head": "Notify recenzia",
+
+  // "search.filters.filter.notifyReview.label": "Search Notify Review",
+  "search.filters.filter.notifyReview.label": "Hľadať Notify recenzia",
+
+  // "search.filters.filter.notifyReview.placeholder": "Notify Review",
+  "search.filters.filter.notifyReview.placeholder": "Notify recenzia",
+
+  // "search.filters.coar_notify_type.coar-notify:ReviewAction": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction": "Akcia recenzie",
+
+  // "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Akcia recenzie",
+
+  // "notify-detail-modal.coar-notify:ReviewAction": "Review action",
+  "notify-detail-modal.coar-notify:ReviewAction": "Akcia recenzie",
+
+  // "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Akcia odporúčania",
+
+  // "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Akcia odporúčania",
+
+  // "notify-detail-modal.coar-notify:EndorsementAction": "Endorsement action",
+  "notify-detail-modal.coar-notify:EndorsementAction": "Akcia odporúčania",
+
+  // "search.filters.coar_notify_type.coar-notify:IngestAction": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction": "Akcia prevzatia",
+
+  // "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Akcia prevzatia",
+
+  // "notify-detail-modal.coar-notify:IngestAction": "Ingest action",
+  "notify-detail-modal.coar-notify:IngestAction": "Akcia prevzatia",
+
+  // "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Akcia vzťahu",
+
+  // "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Akcia vzťahu",
+
+  // "notify-detail-modal.coar-notify:RelationshipAction": "Relationship action",
+  "notify-detail-modal.coar-notify:RelationshipAction": "Akcia vzťahu",
+
+  // "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Queued",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Vo fronte",
+
+  // "notify-detail-modal.QUEUE_STATUS_QUEUED": "Queued",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED": "Vo fronte",
+
+  // "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Vo fronte na opakovanie",
+
+  // "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Vo fronte na opakovanie",
+
+  // "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Processing",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Spracúva sa",
+
+  // "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Processing",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Spracúva sa",
+
+  // "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Processed",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Spracované",
+
+  // "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Processed",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Spracované",
+
+  // "search.filters.queue_status.QUEUE_STATUS_FAILED": "Failed",
+  "search.filters.queue_status.QUEUE_STATUS_FAILED": "Zlyhalo",
+
+  // "notify-detail-modal.QUEUE_STATUS_FAILED": "Failed",
+  "notify-detail-modal.QUEUE_STATUS_FAILED": "Zlyhalo",
+
+  // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Nedôveryhodné",
+
+  // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Nedôveryhodná IP",
+
+  // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Nedôveryhodné",
+
+  // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Nedôveryhodná IP",
+
+  // "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Nemapovaná akcia",
+
+  // "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Nemapovaná akcia",
+
+  // "sorting.queue_last_start_time.DESC": "Last started queue Descending",
+  "sorting.queue_last_start_time.DESC": "Posledné spustenie fronty zostupne",
+
+  // "sorting.queue_last_start_time.ASC": "Last started queue Ascending",
+  "sorting.queue_last_start_time.ASC": "Posledné spustenie fronty vzostupne",
+
+  // "sorting.queue_attempts.DESC": "Queue attempted Descending",
+  "sorting.queue_attempts.DESC": "Pokusy fronty zostupne",
+
+  // "sorting.queue_attempts.ASC": "Queue attempted Ascending",
+  "sorting.queue_attempts.ASC": "Pokusy fronty vzostupne",
+
+  // "NOTIFY.incoming.involvedItems.search.results.head": "Items involved in incoming LDN",
+  "NOTIFY.incoming.involvedItems.search.results.head": "Záznamy zapojené v prichádzajúcich LDN",
+
+  // "NOTIFY.outgoing.involvedItems.search.results.head": "Items involved in outgoing LDN",
+  "NOTIFY.outgoing.involvedItems.search.results.head": "Záznamy zapojené v odchádzajúcich LDN",
+
+  // "type.notify-detail-modal": "Type",
+  "type.notify-detail-modal": "Typ",
+
+  // "id.notify-detail-modal": "Id",
+  "id.notify-detail-modal": "ID",
+
+  // "coarNotifyType.notify-detail-modal": "COAR Notify type",
+  "coarNotifyType.notify-detail-modal": "Typ COAR Notify",
+
+  // "activityStreamType.notify-detail-modal": "Activity stream type",
+  "activityStreamType.notify-detail-modal": "Typ prúdu aktivít",
+
+  // "inReplyTo.notify-detail-modal": "In reply to",
+  "inReplyTo.notify-detail-modal": "V odpovedi na",
+
+  // "object.notify-detail-modal": "Repository Item",
+  "object.notify-detail-modal": "Záznam v repozitári",
+
+  // "context.notify-detail-modal": "Repository Item",
+  "context.notify-detail-modal": "Záznam v repozitári",
+
+  // "queueAttempts.notify-detail-modal": "Queue attempts",
+  "queueAttempts.notify-detail-modal": "Pokusy fronty",
+
+  // "queueLastStartTime.notify-detail-modal": "Queue last started",
+  "queueLastStartTime.notify-detail-modal": "Fronta naposledy spustená",
+
+  // "origin.notify-detail-modal": "LDN Service",
+  "origin.notify-detail-modal": "Služba LDN",
+
+  // "target.notify-detail-modal": "LDN Service",
+  "target.notify-detail-modal": "Služba LDN",
+
+  // "queueStatusLabel.notify-detail-modal": "Queue status",
+  "queueStatusLabel.notify-detail-modal": "Stav fronty",
+
+  // "queueTimeout.notify-detail-modal": "Queue timeout",
+  "queueTimeout.notify-detail-modal": "Časový limit fronty",
+
+  // "notify-message-modal.title": "Message Detail",
+  "notify-message-modal.title": "Detail správy",
+
+  // "notify-message-modal.show-message": "Show message",
+  "notify-message-modal.show-message": "Zobraziť správu",
+
+  // "notify-message-result.timestamp": "Timestamp",
+  "notify-message-result.timestamp": "Časová značka",
+
+  // "notify-message-result.repositoryItem": "Repository Item",
+  "notify-message-result.repositoryItem": "Záznam v repozitári",
+
+  // "notify-message-result.ldnService": "LDN Service",
+  "notify-message-result.ldnService": "Služba LDN",
+
+  // "notify-message-result.type": "Type",
+  "notify-message-result.type": "Typ",
+
+  // "notify-message-result.status": "Status",
+  "notify-message-result.status": "Stav",
+
+  // "notify-message-result.action": "Action",
+  "notify-message-result.action": "Akcia",
+
+  // "notify-message-result.detail": "Detail",
+  "notify-message-result.detail": "Detail",
+
+  // "notify-message-result.reprocess": "Reprocess",
+  "notify-message-result.reprocess": "Znovu spracovať",
+
+  // "notify-queue-status.processed": "Processed",
+  "notify-queue-status.processed": "Spracované",
+
+  // "notify-queue-status.failed": "Failed",
+  "notify-queue-status.failed": "Zlyhalo",
+
+  // "notify-queue-status.queue_retry": "Queued for retry",
+  "notify-queue-status.queue_retry": "Vo fronte na opakovanie",
+
+  // "notify-queue-status.unmapped_action": "Unmapped action",
+  "notify-queue-status.unmapped_action": "Nemapovaná akcia",
+
+  // "notify-queue-status.processing": "Processing",
+  "notify-queue-status.processing": "Spracúva sa",
+
+  // "notify-queue-status.queued": "Queued",
+  "notify-queue-status.queued": "Vo fronte",
+
+  // "notify-queue-status.untrusted": "Untrusted",
+  "notify-queue-status.untrusted": "Nedôveryhodné",
+
+  // "ldnService.notify-detail-modal": "LDN Service",
+  "ldnService.notify-detail-modal": "Služba LDN",
+
+  // "relatedItem.notify-detail-modal": "Related Item",
+  "relatedItem.notify-detail-modal": "Súvisiaci záznam",
+
+  // "search.filters.filter.notifyEndorsement.head": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.head": "Notify odporúčanie",
+
+  // "search.filters.filter.notifyEndorsement.placeholder": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.placeholder": "Notify odporúčanie",
+
+  // "search.filters.filter.notifyEndorsement.label": "Search Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.label": "Hľadať Notify odporúčanie",
+
+  // "form.date-picker.placeholder.year": "Year",
+  "form.date-picker.placeholder.year": "Rok",
+
+  // "form.date-picker.placeholder.month": "Month",
+  "form.date-picker.placeholder.month": "Mesiac",
+
+  // "form.date-picker.placeholder.day": "Day",
+  "form.date-picker.placeholder.day": "Deň",
+
+  // "item.page.license.title": "Rights and licensing",
+  "item.page.license.title": "Práva a licencie",
+
+  // "item.page.cc.license.title": "Creative Commons license",
+  "item.page.cc.license.title": "Licencia Creative Commons",
+
+  // "item.page.cc.license.disclaimer": "Except where otherwise noted, this item's license is described as",
+  "item.page.cc.license.disclaimer": "Pokiaľ nie je uvedené inak, licencia tohto záznamu je popísaná ako",
+
+  // "file-download-link.download": "Download ",
+  "file-download-link.download": "Stiahnuť ",
+
+  // "file-download-button.download": "Download",
+  "file-download-button.download": "Stiahnuť",
+
+  // "register-page.registration.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "Zadajte svoju e-mailovú adresu",
+
+  // "forgot-email.form.aria.label": "Enter your e-mail address",
+  "forgot-email.form.aria.label": "Zadajte svoju e-mailovú adresu",
+
+  // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
+  "search-facet-option.update.announcement": "Stránka bude znovu načítaná. Filter {{ filter }} je vybraný.",
+
+  // "live-region.ordering.instructions": "Press spacebar to reorder {{ itemName }}.",
+  "live-region.ordering.instructions": "Stlačte medzerník na preusporiadanie {{ itemName }}.",
+
+  // "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.status": "{{ itemName }}, uchopené. Aktuálna pozícia v zozname: {{ index }} z {{ length }}. Použite klávesy šípka hore a dole na zmenu pozície, medzerník na pustenie, Escape na zrušenie.",
+
+  // "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.moved": "{{ itemName }}, presunuté na pozíciu {{ index }} z {{ length }}. Použite klávesy šípka hore/dole na zmenu pozície, medzerník na pustenie, Escape na zrušenie.",
+
+  // "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
+  "live-region.ordering.dropped": "{{ itemName }}, pustené na pozícii {{ index }} z {{ length }}.",
+
+  // "dynamic-form-array.sortable-list.label": "Sortable list",
+  "dynamic-form-array.sortable-list.label": "Zoraditeľný zoznam",
+
+  // "external-login.component.or": "or",
+  "external-login.component.or": "alebo",
+
+  // "external-login.confirmation.header": "Information needed to complete the login process",
+  "external-login.confirmation.header": "Informácie potrebné na dokončenie prihlásenia",
+
+  // "external-login.noEmail.informationText": "The information received from {{authMethod}} are not sufficient to complete the login process. Please provide the missing information below, or login via a different method to associate your {{authMethod}} to an existing account.",
+  "external-login.noEmail.informationText": "Informácie získané od {{authMethod}} nie sú dostatočné na dokončenie prihlásenia. Poskytnite prosím chýbajúce údaje nižšie alebo sa prihláste inou metódou a priraďte svoj {{authMethod}} k existujúcemu účtu.",
+
+  // "external-login.haveEmail.informationText": "It seems that you have not yet an account in this system. If this is the case, please confirm the data received from {{authMethod}} and a new account will be created for you. Otherwise, if you already have an account in the system, please update the email address to match the one already in use in the system or login via a different method to associate your {{authMethod}} to your existing account.",
+  "external-login.haveEmail.informationText": "Zdá sa, že v tomto systéme ešte nemáte účet. Ak je to tak, potvrďte prosím údaje získané od {{authMethod}} a bude vám vytvorený nový účet. V opačnom prípade, ak už účet máte, aktualizujte e-mailovú adresu tak, aby zodpovedala tej, ktorú už v systéme používate, alebo sa prihláste inou metódou a priraďte svoj {{authMethod}} k svojmu existujúcemu účtu.",
+
+  // "external-login.confirm-email.header": "Confirm or update email",
+  "external-login.confirm-email.header": "Potvrďte alebo aktualizujte e-mail",
+
+  // "external-login.confirmation.email-required": "Email is required.",
+  "external-login.confirmation.email-required": "E-mail je povinný.",
+
+  // "external-login.confirmation.email-label": "User Email",
+  "external-login.confirmation.email-label": "E-mail používateľa",
+
+  // "external-login.confirmation.email": "Email",
+  "external-login.confirmation.email": "E-mail",
+
+  // "external-login.confirmation.email-invalid": "Invalid email format.",
+  "external-login.confirmation.email-invalid": "Neplatný formát e-mailu.",
+
+  // "external-login.confirm.button.label": "Confirm this email",
+  "external-login.confirm.button.label": "Potvrdiť tento e-mail",
+
+  // "external-login.confirm-email-sent.header": "Confirmation email sent",
+  "external-login.confirm-email-sent.header": "Potvrdzovací e-mail odoslaný",
+
+  // "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
+  "external-login.confirm-email-sent.info": " Na zadanú adresu sme poslali e-mail na overenie vašich údajov. <br> Postupujte prosím podľa pokynov v e-maile na dokončenie prihlásenia.",
+
+  // "external-login.provide-email.header": "Provide email",
+  "external-login.provide-email.header": "Zadajte e-mail",
+
+  // "external-login.provide-email.button.label": "Send Verification link",
+  "external-login.provide-email.button.label": "Odoslať overovací odkaz",
+
+  // "external-login-validation.review-account-info.header": "Review your account information",
+  "external-login-validation.review-account-info.header": "Skontrolujte informácie o svojom účte",
+
+  // "external-login-validation.review-account-info.info": "The information received from ORCID differs from the one recorded in your profile. <br /> Please review them and decide if you want to update any of them.After saving you will be redirected to your profile page.",
+  "external-login-validation.review-account-info.info": "Informácie získané z ORCID sa líšia od tých uložených vo vašom profile. <br /> Skontrolujte ich a rozhodnite sa, či chcete niektoré aktualizovať. Po uložení budete presmerovaní na stránku svojho profilu.",
+
+  // "external-login-validation.review-account-info.table.header.information": "Information",
+  "external-login-validation.review-account-info.table.header.information": "Informácia",
+
+  // "external-login-validation.review-account-info.table.header.received-value": "Received value",
+  "external-login-validation.review-account-info.table.header.received-value": "Získaná hodnota",
+
+  // "external-login-validation.review-account-info.table.header.current-value": "Current value",
+  "external-login-validation.review-account-info.table.header.current-value": "Aktuálna hodnota",
+
+  // "external-login-validation.review-account-info.table.header.action": "Override",
+  "external-login-validation.review-account-info.table.header.action": "Prepísať",
+
+  // "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
+  "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
+
+  // "on-label": "ON",
+  "on-label": "ZAP",
+
+  // "off-label": "OFF",
+  "off-label": "VYP",
+
+  // "review-account-info.merge-data.notification.success": "Your account information has been updated successfully",
+  "review-account-info.merge-data.notification.success": "Informácie o vašom účte boli úspešne aktualizované",
+
+  // "review-account-info.merge-data.notification.error": "Something went wrong while updating your account information",
+  "review-account-info.merge-data.notification.error": "Pri aktualizácii informácií o vašom účte sa niečo pokazilo",
+
+  // "review-account-info.alert.error.content": "Something went wrong. Please try again later.",
+  "review-account-info.alert.error.content": "Došlo k chybe. Skúste to prosím neskôr.",
+
+  // "external-login-page.provide-email.notifications.error": "Something went wrong.Email address was omitted or the operation is not valid.",
+  "external-login-page.provide-email.notifications.error": "Niečo sa pokazilo. E-mailová adresa chýba alebo operácia nie je platná.",
+
+  // "external-login.error.notification": "There was an error while processing your request. Please try again later.",
+  "external-login.error.notification": "Pri spracovaní vašej požiadavky došlo k chybe. Skúste to prosím neskôr.",
+
+  // "external-login.connect-to-existing-account.label": "Connect to an existing user",
+  "external-login.connect-to-existing-account.label": "Pripojiť k existujúcemu používateľovi",
+
+  // "external-login.modal.label.close": "Close",
+  "external-login.modal.label.close": "Zavrieť",
+
+  // "external-login-page.provide-email.create-account.notifications.error.header": "Something went wrong",
+  "external-login-page.provide-email.create-account.notifications.error.header": "Niečo sa pokazilo",
+
+  // "external-login-page.provide-email.create-account.notifications.error.content": "Please check again your email address and try again.",
+  "external-login-page.provide-email.create-account.notifications.error.content": "Skontrolujte prosím znova svoju e-mailovú adresu a skúste to znova.",
+
+  // "external-login-page.confirm-email.create-account.notifications.error.no-netId": "Something went wrong with this email account. Try again or use a different method to login.",
+  "external-login-page.confirm-email.create-account.notifications.error.no-netId": "S týmto e-mailovým účtom sa niečo pokazilo. Skúste to znova alebo použite na prihlásenie inú metódu.",
+
+  // "external-login-page.orcid-confirmation.firstname": "First name",
+  "external-login-page.orcid-confirmation.firstname": "Meno",
+
+  // "external-login-page.orcid-confirmation.firstname.label": "First name",
+  "external-login-page.orcid-confirmation.firstname.label": "Meno",
+
+  // "external-login-page.orcid-confirmation.lastname": "Last name",
+  "external-login-page.orcid-confirmation.lastname": "Priezvisko",
+
+  // "external-login-page.orcid-confirmation.lastname.label": "Last name",
+  "external-login-page.orcid-confirmation.lastname.label": "Priezvisko",
+
+  // "external-login-page.orcid-confirmation.netid": "Account Identifier",
+  "external-login-page.orcid-confirmation.netid": "Identifikátor účtu",
+
+  // "external-login-page.orcid-confirmation.netid.label": "Account Identifier",
+  "external-login-page.orcid-confirmation.netid.label": "Identifikátor účtu",
+
+  // "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
+  "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
+
+  // "external-login-page.orcid-confirmation.email": "Email",
+  "external-login-page.orcid-confirmation.email": "E-mail",
+
+  // "external-login-page.orcid-confirmation.email.label": "Email",
+  "external-login-page.orcid-confirmation.email.label": "E-mail",
+
+  // "search.filters.access_status.open.access": "Open access",
+  "search.filters.access_status.open.access": "Otvorený prístup",
+
+  // "search.filters.access_status.restricted": "Restricted access",
+  "search.filters.access_status.restricted": "Obmedzený prístup",
+
+  // "search.filters.access_status.embargo": "Embargoed access",
+  "search.filters.access_status.embargo": "Prístup pod embargom",
+
+  // "search.filters.access_status.metadata.only": "Metadata only",
+  "search.filters.access_status.metadata.only": "Iba metadáta",
+
+  // "search.filters.access_status.unknown": "Unknown",
+  "search.filters.access_status.unknown": "Neznáme",
+
+  // "metadata-export-filtered-items.tooltip": "Export report output as CSV",
+  "metadata-export-filtered-items.tooltip": "Exportovať výstup zostavy ako CSV",
+
+  // "metadata-export-filtered-items.submit.success": "CSV export succeeded.",
+  "metadata-export-filtered-items.submit.success": "Export CSV bol úspešný.",
+
+  // "metadata-export-filtered-items.submit.error": "CSV export failed.",
+  "metadata-export-filtered-items.submit.error": "Export CSV zlyhal.",
+
+  // "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
+  "metadata-export-filtered-items.columns.warning": "Export CSV automaticky zahŕňa všetky relevantné polia, preto sa výbery v tomto zozname neberú do úvahy.",
+
+  // "embargo.listelement.badge": "Embargo until {{ date }}",
+  "embargo.listelement.badge": "Embargo do {{ date }}",
+
+  // "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
+  "metadata-export-search.submit.error.limit-exceeded": "Exportuje sa iba prvých {{limit}} položiek",
+
+  // "file-download-link.request-copy": "Request a copy of ",
+  "file-download-link.request-copy": "Požiadať o kópiu ",
+
+  // "file-download-button.request-copy": "Request a copy",
+  "file-download-button.request-copy": "Požiadať o kópiu",
+
+  // "file-download-link.audio-transcript.label": "Transcript",
+  "file-download-link.audio-transcript.label": "Prepis",
+
+  // "file-download-link.audio-transcript.title": "Audio transcript",
+  "file-download-link.audio-transcript.title": "Prepis zvuku",
+
+  // "file-download-link.audio-transcript.aria": "Open audio transcript",
+  "file-download-link.audio-transcript.aria": "Otvoriť prepis zvuku",
+
+  // "file-download-link.video-description.label": "Video description",
+  "file-download-link.video-description.label": "Popis videa",
+
+  // "file-download-link.video-description.title": "Video description",
+  "file-download-link.video-description.title": "Popis videa",
+
+  // "file-download-link.video-description.aria": "Open video description",
+  "file-download-link.video-description.aria": "Otvoriť popis videa",
+
+  // "item.preview.organization.url": "URL",
+  "item.preview.organization.url": "URL",
+
+  // "item.preview.organization.address.addressLocality": "City",
+  "item.preview.organization.address.addressLocality": "Mesto",
+
+  // "item.preview.organization.alternateName": "Alternative name",
+  "item.preview.organization.alternateName": "Alternatívny názov",
+
+  // "metadata-link-view.orcid.logo": "ORCID logo",
+  "metadata-link-view.orcid.logo": "Logo ORCID",
+
+  // "metadata-link-view.source.logo": "Source logo",
+  "metadata-link-view.source.logo": "Logo zdroja",
+
+  // "metadata-link-view.popover.label.Person.dc.title": "Fullname",
+  "metadata-link-view.popover.label.Person.dc.title": "Celé meno",
+
+  // "metadata-link-view.popover.label.Person.person.affiliation.name": "Main affiliation",
+  "metadata-link-view.popover.label.Person.person.affiliation.name": "Hlavná afiliácia",
+
+  // "metadata-link-view.popover.label.Person.person.email": "Email",
+  "metadata-link-view.popover.label.Person.person.email": "E-mail",
+
+  // "metadata-link-view.popover.label.Person.person.identifier.orcid": "ORCID",
+  "metadata-link-view.popover.label.Person.person.identifier.orcid": "ORCID",
+
+  // "metadata-link-view.popover.label.Person.dc.description.abstract": "Abstract",
+  "metadata-link-view.popover.label.Person.dc.description.abstract": "Abstrakt",
+
+  // "metadata-link-view.popover.label.Person.person.jobTitle": "Job title",
+  "metadata-link-view.popover.label.Person.person.jobTitle": "Pracovná pozícia",
+
+  // "metadata-link-view.popover.label.other.dc.title": "Title",
+  "metadata-link-view.popover.label.other.dc.title": "Názov",
+
+  // "metadata-link-view.popover.label.other.dc.description.abstract": "Description",
+  "metadata-link-view.popover.label.other.dc.description.abstract": "Popis",
+
+  // "metadata-link-view.popover.label.more-info": "More info",
+  "metadata-link-view.popover.label.more-info": "Viac informácií",
+
+  // "item.page.extended-file-section": "Bitstreams",
+  "item.page.extended-file-section": "Súbory",
+
+  // "file.section.name": "Document",
+  "file.section.name": "Dokument",
+
+  // "file.section.type": "Type",
+  "file.section.type": "Typ",
+
+  // "file.section.size": "Size",
+  "file.section.size": "Veľkosť",
+
+  // "dataset.page.titleprefix": "Dataset",
+  "dataset.page.titleprefix": "Dátová sada",
+
+  // "dataset.listelement.badge": "Dataset",
+  "dataset.listelement.badge": "Dátová sada",
+
+  // "dataset.page.options": "Options",
+  "dataset.page.options": "Možnosti",
+
+  // "dataset.page.edit": "Edit this Dataset",
+  "dataset.page.edit": "Upraviť túto dátovú sadu",
+
+  // "relationships.Dataset.isAuthorOfDataset.Person": "Authors (Persons)",
+  "relationships.Dataset.isAuthorOfDataset.Person": "Autori (osoby)",
+
+  // "relationships.Dataset.isProjectOfDataset.Project": "Research Projects",
+  "relationships.Dataset.isProjectOfDataset.Project": "Výskumné projekty",
+
+  // "relationships.Dataset.isAuthorOfDataset.OrgUnit": "Organizational Units",
+  "relationships.Dataset.isAuthorOfDataset.OrgUnit": "Organizačné jednotky",
+
+  // "relationships.Dataset.isOrgUnitOfDataset.OrgUnit": "Authors (Organizational Units)",
+  "relationships.Dataset.isOrgUnitOfDataset.OrgUnit": "Autori (organizačné jednotky)",
+
+  // "relationships.Dataset.isPublicationOfDataset.Publication": "Publications",
+  "relationships.Dataset.isPublicationOfDataset.Publication": "Publikácie",
+
+  // "relationships.Publication.isDatasetOfPublication.Dataset": "Datasets",
+  "relationships.Publication.isDatasetOfPublication.Dataset": "Dátové sady",
+
+  // "relationships.Person.isDatasetOfAuthor.Dataset": "Datasets",
+  "relationships.Person.isDatasetOfAuthor.Dataset": "Dátové sady",
+
+  // "relationships.Project.isDatasetOfProject.Dataset": "Datasets",
+  "relationships.Project.isDatasetOfProject.Dataset": "Dátové sady",
+
+  // "relationships.OrgUnit.isDatasetOfAuthor.Dataset": "Authored Datasets",
+  "relationships.OrgUnit.isDatasetOfAuthor.Dataset": "Autorské dátové sady",
+
+  // "relationships.OrgUnit.isDatasetOfOrgUnit.Dataset": "Organisation Datasets",
+  "relationships.OrgUnit.isDatasetOfOrgUnit.Dataset": "Dátové sady organizácie",
+
+  // "submission.sections.describe.relationship-lookup.title.Dataset": "Datasets",
+  "submission.sections.describe.relationship-lookup.title.Dataset": "Dátové sady",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Dataset": "Local Datasets",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.Dataset": "Lokálne dátové sady",
+
+  // "dataset.search.results.head": "Dataset Search Results",
+  "dataset.search.results.head": "Výsledky vyhľadávania dátových sád",
+
+  // "submission.sections.describe.relationship-lookup.title.isAuthorOfDataset": "Authors",
+  "submission.sections.describe.relationship-lookup.title.isAuthorOfDataset": "Autori",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfDataset": "Local Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfDataset": "Lokálni autori ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.title.isPublicationOfDataset": "Publications",
+  "submission.sections.describe.relationship-lookup.title.isPublicationOfDataset": "Publikácie",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfDataset": "Local Publications ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfDataset": "Lokálne publikácie ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.cinii": "CiNii ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.cinii": "CiNii ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.cinii": "Importing from CiNii",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.cinii": "Import z CiNii",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.cinii": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.cinii": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.datacite": "DataCite ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.datacite": "DataCite ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.datacite": "Importing from DataCite",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.datacite": "Import z DataCite",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.datacite": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.datacite": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.search-tab.tab-title.doi": "DOI ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.doi": "DOI ({{ count }})",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.doi": "Importing from DOI",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.doi": "Import z DOI",
+
+  // "submission.sections.describe.relationship-lookup.selection-tab.title.doi": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.doi": "Výsledky vyhľadávania",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.title": "Import Remote Publication",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.title": "Importovať vzdialenú publikáciu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.local-entity": "Successfully added local publication to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.local-entity": "Lokálna publikácia bola úspešne pridaná do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.new-entity": "Successfully imported and added external publication to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isPublicationOfDataset.added.new-entity": "Externá publikácia bola úspešne importovaná a pridaná do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.title": "Import Remote Author",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.title": "Importovať vzdialeného autora",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.local-entity": "Successfully added local author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.local-entity": "Lokálny autor bol úspešne pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.new-entity": "Successfully imported and added external author to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isAuthorOfDataset.added.new-entity": "Externý autor bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.title": "Import Remote Project",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.title": "Importovať vzdialený projekt",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.local-entity": "Successfully added local project to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.local-entity": "Lokálny projekt bol úspešne pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.new-entity": "Successfully imported and added external project to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isProjectOfDataset.added.new-entity": "Externý projekt bol úspešne importovaný a pridaný do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.title": "Import Remote Organization",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.title": "Importovať vzdialenú organizáciu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.local-entity": "Successfully added local organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.local-entity": "Lokálna organizácia bola úspešne pridaná do výberu",
+
+  // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.new-entity": "Successfully imported and added external organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfDataset.added.new-entity": "Externá organizácia bola úspešne importovaná a pridaná do výberu",
+
+  // "admin.edit-cms-metadata.success": "Metadata successfully updated",
+  "admin.edit-cms-metadata.success": "Metadáta boli úspešne aktualizované",
+
+  // "admin.edit-cms-metadata.back-button": "Back",
+  "admin.edit-cms-metadata.back-button": "Späť",
+
+  // "admin.edit-cms-metadata.save-button": "Save",
+  "admin.edit-cms-metadata.save-button": "Uložiť",
+
+  // "admin.edit-cms-metadata.select-metadata": "Select metadata to edit",
+  "admin.edit-cms-metadata.select-metadata": "Vyberte metadáta na úpravu",
+
+  // "admin.edit-cms-metadata.edit-button": "Edit",
+  "admin.edit-cms-metadata.edit-button": "Upraviť",
+
+  // "admin.edit-cms-metadata.breadcrumbs": "Edit CMS Metadata",
+  "admin.edit-cms-metadata.breadcrumbs": "Upraviť CMS metadáta",
+
+  // "admin.edit-cms-metadata.title": "Edit CMS Metadata",
+  "admin.edit-cms-metadata.title": "Upraviť CMS metadáta",
+
+  // "admin.edit-cms-metadata.error": "An error occurred while updating the metadata",
+  "admin.edit-cms-metadata.error": "Pri aktualizácii metadát došlo k chybe",
+
+  // "menu.section.edit-cms-metadata": "Edit CMS Metadata",
+  "menu.section.edit-cms-metadata": "Upraviť CMS metadáta",
+
+  // "menu.section.cms.edit.metadata.head": "Edit Metadata",
+  "menu.section.cms.edit.metadata.head": "Upraviť metadáta",
+
+  // "admin.edit-user-agreement.breadcrumbs": "Edit User Agreement",
+  "admin.edit-user-agreement.breadcrumbs": "Upraviť používateľskú zmluvu",
+
+  // "admin.edit-user-agreement.confirm.title": "Force acceptance",
+  "admin.edit-user-agreement.confirm.title": "Vynútiť prijatie",
+
+  // "admin.edit-user-agreement.confirm.info": "Do you want to force all users to accept the new user agreement?",
+  "admin.edit-user-agreement.confirm.info": "Chcete vynútiť všetkým používateľom prijatie novej používateľskej zmluvy?",
+
+  // "admin.edit-user-agreement.confirm.cancel": "Cancel",
+  "admin.edit-user-agreement.confirm.cancel": "Zrušiť",
+
+  // "admin.edit-user-agreement.confirm.no": "No, update only",
+  "admin.edit-user-agreement.confirm.no": "Nie, iba aktualizovať",
+
+  // "admin.edit-user-agreement.confirm.yes": "Yes, update and force",
+  "admin.edit-user-agreement.confirm.yes": "Áno, aktualizovať a vynútiť",
+
+  // "menu.section.edit-user-agreement": "Edit User Agreement",
+  "menu.section.edit-user-agreement": "Upraviť používateľskú zmluvu",
+
+  // "admin.edit-user-agreement.save-button": "Save",
+  "admin.edit-user-agreement.save-button": "Uložiť",
+
+  // "admin.edit-user-agreement.markdown": "<i>End User Agreement</i> text supports <a href=\"https://www.markdownguide.org/basic-syntax/\" target=\"_blank\">Markdown</a> language.",
+  "admin.edit-user-agreement.markdown": "Text <i>Zmluvy s koncovým používateľom</i> podporuje jazyk <a href=\"https://www.markdownguide.org/basic-syntax/\" target=\"_blank\">Markdown</a>.",
+
+  // "admin.edit-cms-metadata.markdown": "<i>CMS Metadata</i> text supports <a href=\"https://www.markdownguide.org/basic-syntax/\" target=\"_blank\">Markdown</a> language.",
+  "admin.edit-cms-metadata.markdown": "Text <i>CMS metadát</i> podporuje jazyk <a href=\"https://www.markdownguide.org/basic-syntax/\" target=\"_blank\">Markdown</a>.",
+
+  // "admin.edit-user-agreement.header": "Edit User Agreement",
+  "admin.edit-user-agreement.header": "Upraviť používateľskú zmluvu",
+
+  // "admin.edit-user-agreement.success": "User agreement successfully updated",
+  "admin.edit-user-agreement.success": "Používateľská zmluva bola úspešne aktualizovaná",
+
+  // "admin.edit-user-agreement.error": "An error occurred while updating the user agreement",
+  "admin.edit-user-agreement.error": "Pri aktualizácii používateľskej zmluvy došlo k chybe",
+
+  // "admin.edit-user-agreement.title": "Edit User Agreement",
+  "admin.edit-user-agreement.title": "Upraviť používateľskú zmluvu",
+
+  // "bitstream.replace.page.title": "Replace File",
+  "bitstream.replace.page.title": "Nahradiť súbor",
+
+  // "bitstream.replace.page.header": "Replace {{fileName}} ({{fileSize}})",
+  "bitstream.replace.page.header": "Nahradiť {{fileName}} ({{fileSize}})",
+
+  // "bitstream.replace.page.content": "Select a file to replace {{fileName}}. Note that this transfer can take a while to process, and may not start immediately.",
+  "bitstream.replace.page.content": "Vyberte súbor, ktorým chcete nahradiť {{fileName}}. Upozorňujeme, že spracovanie tohto prenosu môže chvíľu trvať a nemusí sa spustiť okamžite.",
+
+  // "bitstream.replace.page.button.return": "Back",
+  "bitstream.replace.page.button.return": "Späť",
+
+  // "bitstream.replace.page.disclaimer": "The original file will be deleted. This operation can't be undone.",
+  "bitstream.replace.page.disclaimer": "Pôvodný súbor bude odstránený. Túto operáciu nemožno vrátiť späť.",
+
+  // "bitstream.replace.page.button.cancel": "Cancel",
+  "bitstream.replace.page.button.cancel": "Zrušiť",
+
+  // "bitstream.replace.page.button.save": "Replace file",
+  "bitstream.replace.page.button.save": "Nahradiť súbor",
+
+  // "bitstream.replace.page.upload.failed": "Bitstream upload failed",
+  "bitstream.replace.page.upload.failed": "Nahrávanie súboru zlyhalo",
+
+  // "bitstream.replace.page.breadcrumbs": "Replace File",
+  "bitstream.replace.page.breadcrumbs": "Nahradiť súbor",
+
+  // "item.edit.bitstreams.edit.buttons.replace": "Replace",
+  "item.edit.bitstreams.edit.buttons.replace": "Nahradiť",
+
+  // "bitstream.replace.page.upload.success": "Bitstream successfully replaced",
+  "bitstream.replace.page.upload.success": "Súbor bol úspešne nahradený",
+
+  // "bitstream.edit.replace.link": "Replace file",
+  "bitstream.edit.replace.link": "Nahradiť súbor",
+
+  // "bitstream.replace.page.replace-name": "Use new filename",
+  "bitstream.replace.page.replace-name": "Použiť nový názov súboru",
+
+  // "bitstream.replace.page.replace-name-hint": "The new file extension will be retained in order to match the content of the replacement file.",
+  "bitstream.replace.page.replace-name-hint": "Nová prípona súboru bude zachovaná, aby zodpovedala obsahu náhradného súboru.",
+
+  // "bitstream.related.isCopyOf": "Is copy of",
+  "bitstream.related.isCopyOf": "Je kópiou",
+
+  // "bitstream.related.hasCopies": "Has copies",
+  "bitstream.related.hasCopies": "Má kópie",
+
+  // "bitstream.related.isReplacementOf": "Is replacement of",
+  "bitstream.related.isReplacementOf": "Je náhradou za",
+
+  // "bitstream.related.isReplacedBy": "Is replaced by",
+  "bitstream.related.isReplacedBy": "Je nahradený súborom",
+
+  // "bitstream.related.deleted": "deleted",
+  "bitstream.related.deleted": "odstránené",
+
+
+}

--- a/src/assets/i18n/sk.json5
+++ b/src/assets/i18n/sk.json5
@@ -1011,10 +1011,10 @@
   "admin.reports.commons.filters.property.is_item": "Je záznam – vždy pravda",
 
   // "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
-  "admin.reports.commons.filters.property.is_withdrawn": "Stiahnuté záznamy",
+  "admin.reports.commons.filters.property.is_withdrawn": "Vyradené záznamy",
 
   // "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
-  "admin.reports.commons.filters.property.is_not_withdrawn": "Dostupné záznamy – nestiahnuté",
+  "admin.reports.commons.filters.property.is_not_withdrawn": "Dostupné záznamy – nevyradené",
 
   // "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
   "admin.reports.commons.filters.property.is_discoverable": "Vyhľadateľné záznamy – nie sú súkromné",
@@ -1152,7 +1152,7 @@
   "admin.search.item.reinstate": "Obnoviť",
 
   // "admin.search.item.withdraw": "Withdraw",
-  "admin.search.item.withdraw": "Stiahnuť",
+  "admin.search.item.withdraw": "Vyradiť",
 
   // "admin.search.title": "Administrative Search",
   "admin.search.title": "Administrátorské vyhľadávanie",
@@ -3701,7 +3701,7 @@
   "item.alerts.private": "Tento záznam je nevyhľadateľný",
 
   // "item.alerts.withdrawn": "This item has been withdrawn",
-  "item.alerts.withdrawn": "Tento záznam bol stiahnutý",
+  "item.alerts.withdrawn": "Tento záznam bol vyradený",
 
   // "item.alerts.reinstate-request": "Request reinstate",
   "item.alerts.reinstate-request": "Požiadať o obnovenie",
@@ -3722,7 +3722,7 @@
   "item.badge.private": "Nevyhľadateľný",
 
   // "item.badge.withdrawn": "Withdrawn",
-  "item.badge.withdrawn": "Stiahnutý",
+  "item.badge.withdrawn": "Vyradený",
 
   // "item.bitstreams.upload.bundle": "Bundle",
   "item.bitstreams.upload.bundle": "Zväzok",
@@ -4397,13 +4397,13 @@
   "item.edit.tabs.status.buttons.unauthorized": "Nie ste oprávnení vykonať túto akciu",
 
   // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw this item",
-  "item.edit.tabs.status.buttons.withdraw.button": "Stiahnuť tento záznam",
+  "item.edit.tabs.status.buttons.withdraw.button": "Vyradiť tento záznam",
 
   // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
-  "item.edit.tabs.status.buttons.withdraw.label": "Stiahnuť záznam z repozitára",
+  "item.edit.tabs.status.buttons.withdraw.label": "Vyradiť záznam z repozitára",
 
   // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
-  "item.edit.tabs.status.description": "Vitajte na stránke správy záznamu. Odtiaľto môžete záznam stiahnuť, obnoviť, presunúť alebo odstrániť. Na ostatných kartách môžete tiež aktualizovať alebo pridávať nové metadáta / súbory.",
+  "item.edit.tabs.status.description": "Vitajte na stránke správy záznamu. Odtiaľto môžete záznam vyradiť, obnoviť, presunúť alebo odstrániť. Na ostatných kartách môžete tiež aktualizovať alebo pridávať nové metadáta / súbory.",
 
   // "item.edit.tabs.status.head": "Status",
   "item.edit.tabs.status.head": "Stav",
@@ -4442,19 +4442,19 @@
   "item.edit.withdraw.cancel": "Zrušiť",
 
   // "item.edit.withdraw.confirm": "Withdraw",
-  "item.edit.withdraw.confirm": "Stiahnuť",
+  "item.edit.withdraw.confirm": "Vyradiť",
 
   // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
-  "item.edit.withdraw.description": "Naozaj má byť tento záznam stiahnutý z archívu?",
+  "item.edit.withdraw.description": "Naozaj má byť tento záznam vyradený z archívu?",
 
   // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
-  "item.edit.withdraw.error": "Pri sťahovaní záznamu došlo k chybe",
+  "item.edit.withdraw.error": "Pri vyraďovaní záznamu došlo k chybe",
 
   // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
-  "item.edit.withdraw.header": "Stiahnuť záznam: {{ id }}",
+  "item.edit.withdraw.header": "Vyradiť záznam: {{ id }}",
 
   // "item.edit.withdraw.success": "The item was withdrawn successfully",
-  "item.edit.withdraw.success": "Záznam bol úspešne stiahnutý",
+  "item.edit.withdraw.success": "Záznam bol úspešne vyradený",
 
   // "item.orcid.return": "Back",
   "item.orcid.return": "Späť",
@@ -4767,7 +4767,7 @@
   "item.page.version.create": "Vytvoriť novú verziu",
 
   // "item.page.withdrawn": "Request a withdrawal for this item",
-  "item.page.withdrawn": "Požiadať o stiahnutie tohto záznamu",
+  "item.page.withdrawn": "Požiadať o vyradenie tohto záznamu",
 
   // "item.page.reinstate": "Request reinstatement",
   "item.page.reinstate": "Požiadať o obnovenie",
@@ -5019,7 +5019,7 @@
   "item.version.create.modal.header": "Nová verzia",
 
   // "item.qa.withdrawn.modal.header": "Request withdrawal",
-  "item.qa.withdrawn.modal.header": "Žiadosť o stiahnutie",
+  "item.qa.withdrawn.modal.header": "Žiadosť o vyradenie",
 
   // "item.qa.reinstate.modal.header": "Request reinstate",
   "item.qa.reinstate.modal.header": "Žiadosť o obnovenie",
@@ -5043,7 +5043,7 @@
   "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Odoslať žiadosť",
 
   // "qa-withdrown.create.modal.button.confirm": "Withdraw",
-  "qa-withdrown.create.modal.button.confirm": "Stiahnuť",
+  "qa-withdrown.create.modal.button.confirm": "Vyradiť",
 
   // "qa-reinstate.create.modal.button.confirm": "Reinstate",
   "qa-reinstate.create.modal.button.confirm": "Obnoviť",
@@ -5064,10 +5064,10 @@
   "item.version.create.modal.form.summary.label": "Súhrn",
 
   // "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
-  "qa-withdrawn.create.modal.form.summary.label": "Žiadate o stiahnutie tohto záznamu",
+  "qa-withdrawn.create.modal.form.summary.label": "Žiadate o vyradenie tohto záznamu",
 
   // "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
-  "qa-withdrawn.create.modal.form.summary2.label": "Uveďte prosím dôvod stiahnutia",
+  "qa-withdrawn.create.modal.form.summary2.label": "Uveďte prosím dôvod vyradenia",
 
   // "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
   "qa-reinstate.create.modal.form.summary.label": "Žiadate o obnovenie tohto záznamu",
@@ -5079,7 +5079,7 @@
   "item.version.create.modal.form.summary.placeholder": "Vložte súhrn novej verzie",
 
   // "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
-  "qa-withdrown.modal.form.summary.placeholder": "Zadajte dôvod stiahnutia",
+  "qa-withdrown.modal.form.summary.placeholder": "Zadajte dôvod vyradenia",
 
   // "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
   "qa-reinstate.modal.form.summary.placeholder": "Zadajte dôvod obnovenia",
@@ -5088,13 +5088,13 @@
   "item.version.create.modal.submitted.header": "Vytvára sa nová verzia...",
 
   // "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
-  "item.qa.withdrawn.modal.submitted.header": "Odosiela sa žiadosť o stiahnutie...",
+  "item.qa.withdrawn.modal.submitted.header": "Odosiela sa žiadosť o vyradenie...",
 
   // "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
   "correction-type.manage-relation.action.notification.reinstate": "Žiadosť o obnovenie odoslaná.",
 
   // "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
-  "correction-type.manage-relation.action.notification.withdrawn": "Žiadosť o stiahnutie odoslaná.",
+  "correction-type.manage-relation.action.notification.withdrawn": "Žiadosť o vyradenie odoslaná.",
 
   // "item.version.create.modal.submitted.text": "The new version is being created. This may take some time if the item has a lot of relationships.",
   "item.version.create.modal.submitted.text": "Vytvára sa nová verzia. Môže to chvíľu trvať, ak má záznam veľa vzťahov.",
@@ -7335,7 +7335,7 @@
   "search.filters.applied.f.supervisedBy": "Pod dohľadom",
 
   // "search.filters.applied.f.withdrawn": "Withdrawn",
-  "search.filters.applied.f.withdrawn": "Stiahnuté",
+  "search.filters.applied.f.withdrawn": "Vyradené",
 
   // "search.filters.applied.operator.equals": "",
   "search.filters.applied.operator.equals": "",
@@ -7461,7 +7461,7 @@
   "search.filters.filter.discoverable.head": "Nevyhľadateľné",
 
   // "search.filters.filter.withdrawn.head": "Withdrawn",
-  "search.filters.filter.withdrawn.head": "Stiahnuté",
+  "search.filters.filter.withdrawn.head": "Vyradené",
 
   // "search.filters.filter.entityType.head": "Item Type",
   "search.filters.filter.entityType.head": "Typ záznamu",
@@ -10770,7 +10770,7 @@
   "is-archived_condition.label": "Je archivovaný",
 
   // "is-withdrawn_condition.label": "Is withdrawn",
-  "is-withdrawn_condition.label": "Je stiahnutý",
+  "is-withdrawn_condition.label": "Je vyradený",
 
   // "item-is-public_condition.label": "Item is public",
   "item-is-public_condition.label": "Záznam je verejný",


### PR DESCRIPTION
## Add Slovak (sk) translation

### Description
Adds a complete Slovak translation of the DSpace Angular UI (`src/assets/i18n/sk.json5`),
translated from the English source with the Czech (`cs`) translation used as a secondary reference.

### What's included
- All **3943** keys translated, matching `en.json5` 1:1 (no missing/extra keys, identical order).
- Previously untranslated `// TODO New key` entries are now translated (media type, ORCID,
  COAR Notify / LDN services, bitstream replace/related, audio/video transcript, etc.).
- Consistent terminology (e.g. *bitstream* → „súbor", *policies* → „pravidlá",
  *EPerson* → „používateľ", *submitter* → „vkladateľ", *namespace* → „menný priestor").
- All `{{ placeholder }}` variables and HTML tags preserved unchanged.

### Validation
- Validated as JSON5 (parses cleanly).
- Key-level diff against `en.json5`: 0 missing, 0 extra, identical order, 0 duplicates,
  0 placeholder mismatches.

### Notes
- Deployment-specific defaults (`repository.title`, `info.end-user-agreement.hosting-country`)
  use generic/Slovak placeholders that instances can override.
