### PR TITLE
[GitHub Actions] Don't run tests or docker build if the only changes are to markdown files or static docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,29 @@
 name: Build
 
 # Run this Build for all pushes / PRs to current branch
-on: [push, pull_request]
+on:
+  push:
+    # Don't run if PR is only updating static documentation or IDE/editor rules
+    paths-ignore:
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/*'
+      - 'docs/*'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
+  pull_request:
+    # Don't run if PR is only updating static documentation or IDE/editor rules
+    paths-ignore:
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/*'
+      - 'docs/*'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -15,10 +15,16 @@ on:
     branches:
       - main
       - 'dspace-**'
-    # Don't run if PR is only updating static documentation
+    # Don't run if PR is only updating static documentation or IDE/editor rules
     paths-ignore:
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/*'
+      - 'docs/*'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
       - '**/*.md'
-      - '**/*.txt'
   schedule:
     - cron: "37 0 * * 1"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,27 @@ on:
       - 'dspace-**'
     tags:
       - 'dspace-**'
+    # Don't run if PR is only updating static documentation or IDE/editor rules
+    paths-ignore:
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/*'
+      - 'docs/*'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
   pull_request:
+    # Don't run if PR is only updating static documentation or IDE/editor rules
+    paths-ignore:
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/*'
+      - 'docs/*'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
 
 permissions:
   contents: read  # to fetch code (actions/checkout)


### PR DESCRIPTION
## References
* This is a port of the changes in https://github.com/DSpace/DSpace/pull/12787 to the frontend repository

## Description
This small PR updates our GitHub actions to **skip running** any tests (both Unit and Integration) or Docker builds when a PR or commit **only includes changes to Markdown files** (`*.md`).

The reason for this PR is to streamline our ability to update Markdown files without triggering CI, e.g. with https://github.com/DSpace/DSpace/pull/12739

This PR is nearly identical to https://github.com/DSpace/DSpace/pull/12787, but it adds a few other files/directories to ignore
* `docs/*` - this is static documentation
* `.editorconfig` - this is only used by IDEs/editors
* `.vscode/*` - this is only used by VS Code IDE
