### PR TITLE
Multi image hint bugfix

### DIFF
--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -78,7 +78,7 @@ export class MiradorViewerService {
         return bundlesRD.payload;
       }),
       map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
-      mergeMap((bundles: Bundle[]) => bundles),
+      switchMap((bundles: Bundle[]) => bundles),
       filter((b: Bundle) => this.isIiifBundle(b.name)),
       mergeMap((bundle: Bundle) => {
         return bitstreamDataService.findAllByItemAndBundleName(item, bundle.name, {

--- a/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
+++ b/src/app/item-page/mirador-viewer/mirador-viewer.service.ts
@@ -21,6 +21,7 @@ import {
 } from '@dspace/core/shared/operators';
 import { Observable } from 'rxjs';
 import {
+  concatMap,
   filter,
   last,
   map,
@@ -77,7 +78,7 @@ export class MiradorViewerService {
         return bundlesRD.payload;
       }),
       map((paginatedList: PaginatedList<Bundle>) => paginatedList.page),
-      switchMap((bundles: Bundle[]) => bundles),
+      mergeMap((bundles: Bundle[]) => bundles),
       filter((b: Bundle) => this.isIiifBundle(b.name)),
       mergeMap((bundle: Bundle) => {
         return bitstreamDataService.findAllByItemAndBundleName(item, bundle.name, {
@@ -90,7 +91,7 @@ export class MiradorViewerService {
           }),
           map((paginatedList: PaginatedList<Bitstream>) => paginatedList.page),
           switchMap((bitstreams: Bitstream[]) => bitstreams),
-          switchMap((bitstream: Bitstream) => bitstream.format.pipe(
+          concatMap((bitstream: Bitstream) => bitstream.format.pipe(
             getFirstCompletedRemoteData(),
             map((formatRD: RemoteData<BitstreamFormat>) => {
               return formatRD.payload;


### PR DESCRIPTION

## Description
`mirador-viewer.service` has a method to determine whether or not multiple images exist in an Item's IIIF Bundles.  When the image count is greater than one a "multi" query parameter is passed as a hint to the viewer. The hint can be used to modify the Mirador viewer layout (in the default mirador configuration thumbnail navigation panel is added to the right). 

At some point in recent releases this stopped working and the "multi" parameter is never added, probably because switchMap is unsubscribing before the count is incremented in the inner observable.

## Instructions for Reviewers

List of changes in this PR:
* Changed operators in the getImageCount() method. The original version relied only on switchMap. 

If you compile  the frontend in production and view an IIIF-enabled item with more than one image you should see the multi parameter in the iframe URL and see a right navigation thumbnail menu in the viewer.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
