### PR TITLE
Fix browser back navigation when viewing a bitstream

### DIFF
--- a/src/app/bitstream-page/bitstream-page-routes.spec.ts
+++ b/src/app/bitstream-page/bitstream-page-routes.spec.ts
@@ -1,0 +1,24 @@
+import { BitstreamDownloadPageComponent } from './bitstream-download-page/bitstream-download-page.component';
+import { bitstreamPageResolver } from './bitstream-page.resolver';
+import { ROUTES } from './bitstream-page-routes';
+import { legacyBitstreamURLRedirectGuard } from './legacy-bitstream-url-redirect.guard';
+
+describe('bitstream page routes', () => {
+  it('should activate the Angular bitstream download page before redirecting to content', () => {
+    const downloadRoute = ROUTES.find((route) => route.path === ':id/download')!;
+
+    expect(downloadRoute).toBeDefined();
+    expect(downloadRoute.component).toBe(BitstreamDownloadPageComponent);
+    expect(downloadRoute.resolve?.bitstream).toBe(bitstreamPageResolver);
+    expect(downloadRoute.canActivate).toBeUndefined();
+  });
+
+  it('should keep redirect guards on legacy bitstream URL routes', () => {
+    const legacyRoutes = ROUTES.filter((route) => route.path !== ':id/download' && route.component === BitstreamDownloadPageComponent);
+
+    expect(legacyRoutes.length).toBe(2);
+    legacyRoutes.forEach((route) => {
+      expect(route.canActivate).toContain(legacyBitstreamURLRedirectGuard);
+    });
+  });
+});

--- a/src/app/bitstream-page/bitstream-page-routes.ts
+++ b/src/app/bitstream-page/bitstream-page-routes.ts
@@ -9,7 +9,6 @@ import { resourcePolicyResolver } from '../shared/resource-policies/resolvers/re
 import { resourcePolicyTargetResolver } from '../shared/resource-policies/resolvers/resource-policy-target.resolver';
 import { BitstreamAuthorizationsComponent } from './bitstream-authorizations/bitstream-authorizations.component';
 import { BitstreamDownloadPageComponent } from './bitstream-download-page/bitstream-download-page.component';
-import { bitstreamDownloadRedirectGuard } from './bitstream-download-redirect.guard';
 import { bitstreamPageResolver } from './bitstream-page.resolver';
 import { bitstreamPageAuthorizationsGuard } from './bitstream-page-authorizations.guard';
 import { ThemedEditBitstreamPageComponent } from './edit-bitstream-page/themed-edit-bitstream-page.component';
@@ -44,7 +43,6 @@ export const ROUTES: Route[] = [
     resolve: {
       bitstream: bitstreamPageResolver,
     },
-    canActivate: [bitstreamDownloadRedirectGuard],
   },
   {
     path: EDIT_BITSTREAM_PATH,


### PR DESCRIPTION
## References
* Fixes #5964

## Description
Fixes bitstream browser-back behavior by allowing the Angular bitstream download route to activate before redirecting to the actual bitstream content URL.

## Instructions for Reviewers
List of changes in this PR:
- Removed the pre-activation guard from `bitstream-page-routes.ts`.
- Added a focused route spec in `bitstream-page-routes.spec.ts` verifying:
  - The Angular bitstream download route activates without a pre-activation redirect guard.
  - Legacy bitstream URL routes still keep their redirect guards.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
