### PR TITLE
W2P-141449 Add heartbeat support to process overview and detail UI

### DIFF
--- a/src/app/core/processes/process.model.ts
+++ b/src/app/core/processes/process.model.ts
@@ -71,6 +71,11 @@ export class Process implements CacheableObject {
   endTime: string;
 
   /**
+   * The heartbeat for this process
+   */
+  @autoserialize
+  heartbeat: string;
+  /**
    * The name of the script run by this process
    */
   @autoserialize

--- a/src/app/process-page/detail/process-detail.component.html
+++ b/src/app/process-page/detail/process-detail.component.html
@@ -44,6 +44,10 @@
         <div>{{ process.startTime | date:dateFormat:'UTC' }}</div>
       </ds-process-detail-field>
     }
+      <ds-process-detail-field id="process-heartbeat"
+                              [title]="'process.detail.heartbeat' | translate">
+          <div>{{ process.heartbeat ? (process.heartbeat | date:dateFormat:'UTC') : 'N/A' }}</div>
+      </ds-process-detail-field>
     @if (process && process.endTime) {
       <ds-process-detail-field id="process-end-time"
         [title]="'process.detail.end-time' | translate">

--- a/src/app/process-page/overview/table/process-overview-table.component.html
+++ b/src/app/process-page/overview/table/process-overview-table.component.html
@@ -35,6 +35,9 @@
                   <th scope="col" class="name-header">{{'process.overview.table.name' | translate}}</th>
                   <th scope="col" class="user-header">{{'process.overview.table.user' | translate}}</th>
                   <th scope="col" class="info-header">{{'process.overview.table.' + processStatus.toLowerCase() + '.info' | translate}}</th>
+                  @if (processStatus === ProcessStatus.RUNNING) {
+                    <th scope="col" class="heartbeat-header">{{'process.overview.table.heartbeat' | translate}}</th>
+                  }
                   <th scope="col" class="actions-header">{{'process.overview.table.actions' | translate}}</th>
                 </tr>
               </thead>
@@ -46,6 +49,9 @@
                     <td><a [routerLink]="['/processes/', tableEntry.process.processId]">{{tableEntry.process.scriptName}}</a></td>
                     <td>{{tableEntry.user}}</td>
                     <td>{{tableEntry.info}}</td>
+                    @if (processStatus === ProcessStatus.RUNNING) {
+                      <td>{{tableEntry.process.heartbeat ? (tableEntry.process.heartbeat | date:dateFormat:'UTC') : 'N/A'}}</td>
+                    }
                     <td>
                       <button [attr.aria-label]="'process.overview.delete-process' | translate"
                         (click)="processBulkDeleteService.toggleDelete(tableEntry.process.processId)"

--- a/src/app/process-page/overview/table/process-overview-table.component.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.ts
@@ -84,6 +84,7 @@ export interface ProcessOverviewTableEntry {
   templateUrl: './process-overview-table.component.html',
   imports: [
     AsyncPipe,
+    DatePipe,
     NgbCollapseModule,
     NgClass,
     PaginationComponent,
@@ -91,7 +92,6 @@ export interface ProcessOverviewTableEntry {
     ThemedLoadingComponent,
     TranslateModule,
     VarDirective,
-    DatePipe,
   ],
 })
 export class ProcessOverviewTableComponent implements OnInit, OnDestroy {

--- a/src/app/process-page/overview/table/process-overview-table.component.ts
+++ b/src/app/process-page/overview/table/process-overview-table.component.ts
@@ -1,5 +1,6 @@
 import {
   AsyncPipe,
+  DatePipe,
   isPlatformBrowser,
   NgClass,
 } from '@angular/common';
@@ -90,9 +91,20 @@ export interface ProcessOverviewTableEntry {
     ThemedLoadingComponent,
     TranslateModule,
     VarDirective,
+    DatePipe,
   ],
 })
 export class ProcessOverviewTableComponent implements OnInit, OnDestroy {
+
+  /**
+   * Expose the ProcessStatus enum to the template
+   */
+  readonly ProcessStatus = ProcessStatus;
+
+  /**
+   * Date format used to display the heartbeat timestamp
+   */
+  readonly dateFormat = 'yyyy-MM-dd HH:mm:ss';
 
   /**
    * The status of the processes this sections should show

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7913,7 +7913,7 @@
   "bitstream.related.isReplacedBy": "Is replaced by",
 
   "bitstream.related.deleted": "deleted",
-  
+
   "process.overview.table.heartbeat": "Heartbeat (UTC)",
 
   "process.detail.heartbeat": "Heartbeat",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7913,4 +7913,8 @@
   "bitstream.related.isReplacedBy": "Is replaced by",
 
   "bitstream.related.deleted": "deleted",
+  "process.overview.table.heartbeat": "Heartbeat",
+  
+  "process.detail.heartbeat": "Heartbeat"
+
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7913,8 +7913,9 @@
   "bitstream.related.isReplacedBy": "Is replaced by",
 
   "bitstream.related.deleted": "deleted",
-  "process.overview.table.heartbeat": "Heartbeat",
   
-  "process.detail.heartbeat": "Heartbeat"
+  "process.overview.table.heartbeat": "Heartbeat (UTC)",
+
+  "process.detail.heartbeat": "Heartbeat",
 
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/DSpace/DSpace/issues/12967
Requires backend PR: https://github.com/DSpace/DSpace/pull/12840

Displays the process heartbeat timestamp in the UI: as a column in the running processes table on /processes, and as a field on the process detail page. Shows "N/A" when no heartbeat has been registered yet.

## Instructions for Reviewers
* Added a `heartbeat` field to the `Process` model
* Process detail page (`/processes/{id}`) shows the heartbeat below Start time (N/A if absent)
* Process overview table shows a heartbeat column, only for processes with status RUNNING
* Requires the corresponding backend PR exposing `heartbeat` via `ProcessRest`

To test: start a long-running process (e.g. reindex with enough items) and observe the heartbeat updating in the running processes table and in the process detail page.