### PR TITLE
Hide duplicate back/cancel button on the collection mapper page

### DIFF
--- a/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
+++ b/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
@@ -50,9 +50,16 @@
                 (confirm)="mapItems($event)"
                 (cancel)="onCancel()"></ds-item-select>
             </div>
-            <div *ngIf="!performedSearch" class="alert alert-info w-100" role="alert">
-              {{'collection.edit.item-mapper.no-search' | translate}}
-            </div>
+            <ng-container *ngIf="!performedSearch">
+              <div class="alert alert-info w-100" role="alert">
+                {{'collection.edit.item-mapper.no-search' | translate}}
+              </div>
+              <div class="d-flex justify-content-end">
+                <button class="btn btn-outline-secondary collection-cancel" (click)="onCancel()">
+                  <i class="fas fa-times"></i> {{ 'collection.edit.item-mapper.cancel' | translate }}
+                </button>
+              </div>
+            </ng-container>
           </ng-template>
         </li>
       </ul>

--- a/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
+++ b/src/app/collection-page/collection-item-mapper/collection-item-mapper.component.html
@@ -57,7 +57,7 @@
               </div>
               <div class="d-flex justify-content-end">
                 <button class="btn btn-outline-secondary collection-cancel" (click)="onCancel()">
-                  <i class="fas fa-times"></i> {{ 'collection.edit.item-mapper.cancel' | translate }}
+                  <i aria-hidden="true" class="fas fa-times"></i> {{ 'collection.edit.item-mapper.cancel' | translate }}
                 </button>
               </div>
             }

--- a/src/app/collection-page/edit-collection-page/edit-collection-page.component.spec.ts
+++ b/src/app/collection-page/edit-collection-page/edit-collection-page.component.spec.ts
@@ -28,6 +28,7 @@ describe('EditCollectionPageComponent', () => {
       ]
     },
     snapshot: {
+      data: {},
       firstChild: {
         routeConfig: {
           path: 'mockUrl'

--- a/src/app/community-page/edit-community-page/edit-community-page.component.spec.ts
+++ b/src/app/community-page/edit-community-page/edit-community-page.component.spec.ts
@@ -28,6 +28,7 @@ describe('EditCommunityPageComponent', () => {
       ]
     },
     snapshot: {
+      data: {},
       firstChild: {
         routeConfig: {
           path: 'mockUrl'

--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -3,7 +3,7 @@
         <div class="col-12">
             <h2 class="border-bottom">{{'item.edit.head' | translate}}</h2>
             <div class="pt-2">
-                <ul class="nav nav-tabs justify-content-start" role="tablist">
+                <ul class="nav nav-tabs justify-content-start mb-2" role="tablist">
                     <li *ngFor="let page of pages" class="nav-item" [attr.aria-selected]="page.page === currentPage" role="tab">
                         <a *ngIf="(page.enabled | async)"
                            class="nav-link"
@@ -25,7 +25,7 @@
                     </div>
                     <div class="button-row bottom">
                       <div class="text-right">
-                        <a [routerLink]="getItemPage((itemRD$ | async)?.payload)" role="button" class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{'item.edit.return' | translate}}</a>
+                        <a *ngIf="!hideReturnButton" [routerLink]="getItemPage((itemRD$ | async)?.payload)" role="button" class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{'item.edit.return' | translate}}</a>
                       </div>
                     </div>
                 </div>

--- a/src/app/item-page/edit-item-page/edit-item-page.component.html
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.html
@@ -37,7 +37,9 @@
           <div class="button-row bottom">
             <div class="text-end">
               @if (!hideReturnButton) {
-                <a [routerLink]="getItemPage((itemRD$ | async)?.payload)" role="button" class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{'item.edit.return' | translate}}</a>
+                <a [routerLink]="getItemPage((itemRD$ | async)?.payload)" role="button" class="btn btn-outline-secondary">
+                  <i aria-hidden="true" class="fas fa-arrow-left"></i> {{ 'item.edit.return' | translate }}
+                </a>
               }
             </div>
           </div>

--- a/src/app/item-page/edit-item-page/edit-item-page.component.spec.ts
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.spec.ts
@@ -30,6 +30,7 @@ describe('ItemPageComponent', () => {
   const inaccesiblePages = ['inaccessible', 'inaccessibleDoubleGuard'];
   const mockRoute = {
     snapshot: {
+      data: {},
       firstChild: {
         routeConfig: {
           path: accesiblePages[0]

--- a/src/app/item-page/edit-item-page/edit-item-page.component.ts
+++ b/src/app/item-page/edit-item-page/edit-item-page.component.ts
@@ -38,6 +38,11 @@ export class EditItemPageComponent implements OnInit {
    */
   pages: { page: string, enabled: Observable<boolean> }[];
 
+  /**
+   * Hide the default return button?
+   */
+  public hideReturnButton: boolean;
+
   constructor(private route: ActivatedRoute, private router: Router, private injector: Injector) {
     this.router.events.subscribe(() => this.initPageParamsByRoute());
   }
@@ -75,5 +80,11 @@ export class EditItemPageComponent implements OnInit {
    */
   initPageParamsByRoute() {
     this.currentPage = this.route.snapshot.firstChild.routeConfig.path;
+
+    let current: ActivatedRoute = this.route;
+    while (current.firstChild) {
+      current = current.firstChild;
+    }
+    this.hideReturnButton = current.snapshot.data.hideReturnButton ?? false;
   }
 }

--- a/src/app/item-page/edit-item-page/edit-item-page.routing.module.ts
+++ b/src/app/item-page/edit-item-page/edit-item-page.routing.module.ts
@@ -101,12 +101,6 @@ import { ItemAccessControlComponent } from './item-access-control/item-access-co
                 component: ItemBitstreamsComponent,
                 data: { title: 'item.edit.tabs.view.title', showBreadcrumbs: true }
               }, */
-              /* TODO - uncomment & fix when curate page exists
-              {
-                path: 'curate',
-                component: ItemBitstreamsComponent,
-                data: { title: 'item.edit.tabs.curate.title', showBreadcrumbs: true }
-              }, */
               {
                 path: 'versionhistory',
                 component: ItemVersionHistoryComponent,
@@ -121,7 +115,11 @@ import { ItemAccessControlComponent } from './item-access-control/item-access-co
               {
                 path: 'mapper',
                 component: ItemCollectionMapperComponent,
-                data: { title: 'item.edit.tabs.item-mapper.title', showBreadcrumbs: true },
+                data: {
+                  hideReturnButton: true,
+                  title: 'item.edit.tabs.item-mapper.title',
+                  showBreadcrumbs: true,
+                },
                 canActivate: [ItemPageCollectionMapperGuard]
               }
             ]

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
@@ -1,4 +1,4 @@
-<div class="container mt-2">
+<div class="container">
   <div class="row">
     <div class="col-12">
       <h2>{{'item.edit.item-mapper.head' | translate}}</h2>
@@ -48,9 +48,16 @@
                 (confirm)="mapCollections($event)"
                 (cancel)="onCancel()"></ds-collection-select>
             </div>
-            <div *ngIf="!performedSearch" class="alert alert-info w-100" role="alert">
-              {{'item.edit.item-mapper.no-search' | translate}}
-            </div>
+            <ng-container *ngIf="!performedSearch">
+              <div class="alert alert-info w-100" role="alert">
+                {{'item.edit.item-mapper.no-search' | translate}}
+              </div>
+              <div class="d-flex justify-content-end">
+                <button class="btn btn-outline-secondary collection-cancel" (click)="onCancel()">
+                  <i class="fas fa-times"></i> {{ 'item.edit.item-mapper.cancel' | translate }}
+                </button>
+              </div>
+            </ng-container>
           </ng-template>
         </li>
       </ul>

--- a/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
+++ b/src/app/item-page/edit-item-page/item-collection-mapper/item-collection-mapper.component.html
@@ -55,7 +55,7 @@
               </div>
               <div class="d-flex justify-content-end">
                 <button class="btn btn-outline-secondary collection-cancel" (click)="onCancel()">
-                  <i class="fas fa-times"></i> {{ 'item.edit.item-mapper.cancel' | translate }}
+                  <i aria-hidden="true" class="fas fa-times"></i> {{ 'item.edit.item-mapper.cancel' | translate }}
                 </button>
               </div>
             }

--- a/src/app/item-page/edit-item-page/item-curate/item-curate.component.html
+++ b/src/app/item-page/edit-item-page/item-curate/item-curate.component.html
@@ -1,4 +1,4 @@
-<div class="container mt-3">
+<div class="container">
     <h3>{{'item.edit.curate.title' |translate:{item: (itemName$ |async)} }}</h3>
     <ds-curation-form
       *ngIf="dsoRD$ | async as dsoRD"

--- a/src/app/item-page/edit-item-page/item-status/item-status.component.html
+++ b/src/app/item-page/edit-item-page/item-status/item-status.component.html
@@ -1,4 +1,4 @@
-<p class="mt-2">{{'item.edit.tabs.status.description' | translate}}</p>
+<p>{{'item.edit.tabs.status.description' | translate}}</p>
 <div class="row">
   <div *ngFor="let statusKey of statusDataKeys" class="w-100">
     <div class="col-3 float-left status-label">

--- a/src/app/item-page/edit-item-page/item-version-history/item-version-history.component.html
+++ b/src/app/item-page/edit-item-page/item-version-history/item-version-history.component.html
@@ -1,4 +1,4 @@
-<div class="mt-2" *ngVar="(itemRD$ | async)?.payload as item">
+<div *ngVar="(itemRD$ | async)?.payload as item">
   <ds-item-versions *ngIf="item" [item]="item" [displayWhenEmpty]="true" [displayTitle]="false"
                     [displayActions]="true"></ds-item-versions>
 </div>

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.spec.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.spec.ts
@@ -49,6 +49,7 @@ describe('EditComColPageComponent', () => {
         ]
       },
       snapshot: {
+        data: {},
         firstChild: {
           routeConfig: {
             path: 'mockUrl'

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/edit-comcol-page.component.ts
@@ -70,7 +70,11 @@ export class EditComColPageComponent<TDomain extends DSpaceObject> implements On
    */
   initPageParamsByRoute() {
     this.currentPage = this.route.snapshot.firstChild.routeConfig.path;
-    this.hideReturnButton = this.route.routeConfig.children
-      .find((child: any) => child.path === this.currentPage).data.hideReturnButton;
+
+    let current: ActivatedRoute = this.route;
+    while (current.firstChild) {
+      current = current.firstChild;
+    }
+    this.hideReturnButton = current.snapshot.data.hideReturnButton ?? false;
   }
 }

--- a/src/app/shared/object-select/collection-select/collection-select.component.html
+++ b/src/app/shared/object-select/collection-select/collection-select.component.html
@@ -37,7 +37,7 @@
             [ngClass]="{'btn-danger': dangerConfirm, 'btn-primary': !dangerConfirm}"
             [disabled]="selectedIds?.length === 0"
             (click)="confirmSelected()">
-      <i class="fas fa-trash"></i> {{confirmButton | translate}}
+      <i class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{confirmButton | translate}}
     </button>
   </div>
 </ng-container>

--- a/src/app/shared/object-select/collection-select/collection-select.component.html
+++ b/src/app/shared/object-select/collection-select/collection-select.component.html
@@ -39,13 +39,13 @@
   }
   <div class="space-children-mr float-end" *ngVar="(selectedIds$ | async) as selectedIds">
     <button class="btn btn-outline-secondary collection-cancel" (click)="onCancel()">
-      <i class="fas fa-times"></i> {{cancelButton | translate}}
+      <i aria-hidden="true" class="fas fa-times"></i> {{ cancelButton | translate }}
     </button>
     <button class="btn collection-confirm"
       [ngClass]="{'btn-danger': dangerConfirm, 'btn-primary': !dangerConfirm}"
       [dsBtnDisabled]="selectedIds?.length === 0"
       (click)="confirmSelected()">
-      <i class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{confirmButton | translate}}
+      <i aria-hidden="true" class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{ confirmButton | translate }}
     </button>
   </div>
 </ng-container>

--- a/src/app/shared/object-select/item-select/item-select.component.html
+++ b/src/app/shared/object-select/item-select/item-select.component.html
@@ -39,13 +39,15 @@
   </div>
   <ds-error *ngIf="itemsRD?.hasFailed" message="{{'error.items' | translate}}"></ds-error>
   <ds-themed-loading *ngIf="!itemsRD || itemsRD?.isLoading" message="{{'loading.items' | translate}}"></ds-themed-loading>
-  <div *ngVar="(selectedIds$ | async) as selectedIds">
-    <button class="btn btn-outline-secondary item-cancel float-left" (click)="onCancel()">{{cancelButton | translate}}</button>
-    <button class="btn item-confirm float-right"
+  <div class="space-children-mr float-right" *ngVar="(selectedIds$ | async) as selectedIds">
+    <button class="btn btn-outline-secondary item-cancel" (click)="onCancel()">
+      <i class="fas fa-times"></i> {{cancelButton | translate}}
+    </button>
+    <button class="btn item-confirm"
             [ngClass]="{'btn-danger': dangerConfirm, 'btn-primary': !dangerConfirm}"
             [disabled]="selectedIds?.length === 0"
             (click)="confirmSelected()">
-      {{confirmButton | translate}}
+      <i class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{confirmButton | translate}}
     </button>
   </div>
 </ng-container>

--- a/src/app/shared/object-select/item-select/item-select.component.html
+++ b/src/app/shared/object-select/item-select/item-select.component.html
@@ -59,13 +59,13 @@
   }
   <div class="space-children-mr float-end" *ngVar="(selectedIds$ | async) as selectedIds">
     <button class="btn btn-outline-secondary item-cancel" (click)="onCancel()">
-      <i class="fas fa-times"></i> {{cancelButton | translate}}
+      <i aria-hidden="true" class="fas fa-times"></i> {{ cancelButton | translate }}
     </button>
     <button class="btn item-confirm"
       [ngClass]="{'btn-danger': dangerConfirm, 'btn-primary': !dangerConfirm}"
       [dsBtnDisabled]="selectedIds?.length === 0"
       (click)="confirmSelected()">
-      <i class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{confirmButton | translate}}
+      <i aria-hidden="true" class="fas" [ngClass]="{'fa-trash': dangerConfirm, 'fa-save': !dangerConfirm}"></i> {{ confirmButton | translate }}
     </button>
   </div>
 </ng-container>


### PR DESCRIPTION
## Description
Hide the Back button on the collection mapper, similar to the item mapper page. Also aligned the buttons in the same way and added icons to the item mapper buttons.

<img width="1332" height="504" alt="image" src="https://github.com/user-attachments/assets/525881e0-e36a-4d1b-aa3a-c318f6a74bff" />

## Instructions for Reviewers
List of changes in this PR:
- Aligned the cancel & save/discard buttons
- Added the same Font Awesome icons from the item mapper to the collection mapper
- Made it possible to hide the Back button on edit item pages
- Updated the hide Back button logic on comcol pages to also work for specific nested child routes. Previously this was only configurable for direct edit bitstream routes. So for example now you can hide the back button for the `/collections/{uuid}/edit/authorizations/create` route without automatically having to hide it for the `/collections/{uuid}/edit/authorizations` route
- Also updated the default edit item page to have a default margin bottom on the group of tabs similar to the comcol pages

**Guidance for how to test or review this PR:**
- Verify the collection mapper in the edit item view doesn't display the Back button

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
