### PR TITLE
Replace direct `body-parser` dependency with Express built-in parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@terraformer/wkt": "^2.2.2",
         "altcha": "^2.3.0",
         "angulartics2": "^12.2.0",
-        "body-parser": "^1.20.5",
         "bootstrap": "^5.3",
         "cerialize": "0.1.18",
         "cli-progress": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "@terraformer/wkt": "^2.2.2",
     "altcha": "^2.3.0",
     "angulartics2": "^12.2.0",
-    "body-parser": "^1.20.5",
     "bootstrap": "^5.3",
     "cerialize": "0.1.18",
     "cli-progress": "^3.12.0",

--- a/server.ts
+++ b/server.ts
@@ -27,7 +27,6 @@ import { LRUCache } from 'lru-cache';
 import { isbot } from 'isbot';
 import { createCertificate } from 'pem';
 import { createServer } from 'https';
-import { json } from 'body-parser';
 import { createHttpTerminator } from 'http-terminator';
 
 import { readFileSync } from 'fs';
@@ -134,7 +133,7 @@ export function app() {
    * Add JSON parser for request bodies
    * See [body-parser](https://github.com/expressjs/body-parser)
    */
-  server.use(json());
+  server.use(express.json());
 
   server.engine('ejs', ejs.renderFile);
 


### PR DESCRIPTION
## References
none

## Description
Before Express 4.16 (released in 2017), applications needed to add the separate `body-parser` dependency. Express now provides built-in body parsing middleware, so there is no need to add the dependency directly, especially since we rely on the default configuration.

This PR:
- removes the direct `body-parser` dependency
- changes server.ts to use Express's built-in parser

**No functional changes intended**

## Instructions for Reviewers
List of changes in this PR:
* `package.json`: removed the direct `body-parser` dependency
* `server.ts`: uses `server.use(express.json())` instead of `server.use(json())`

Before:
```console
$ npm ls body-parser --depth=0
dspace-angular@11.0.0-next /tmp/dspace-angular
└── body-parser@1.20.5
```

After:
```console
$ npm ls body-parser --depth=0
dspace-angular@11.0.0-next /tmp/dspace-angular
└── (empty)
```

(Note that `--depth=0` checks direct dependencies only. `body-parser` will still appear as a transitive dependency of other packages e.g. Express, Karma)

To review:
* Verify that the frontend builds and starts successfully.
* Verify that frontend<>API communication works as before.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/display/DSDOC9x/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).