### PR TITLE
fix(auth): ensure isTokenExpired returns strict boolean #6002

### DIFF
--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -425,6 +425,20 @@ describe('AuthService test', () => {
       expect(result).toBe(true);
     });
 
+    it('should return false when getToken() returns null (example: cleared storage)', () => {
+      spyOn(authService, 'getToken').and.returnValue(null);
+      const result = authService.isTokenExpired();
+      expect(result).toBe(false);
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should return false when getToken() returns undefined (example: uninitialized store)', () => {
+      spyOn(authService, 'getToken').and.returnValue(undefined);
+      const result = authService.isTokenExpired();
+      expect(result).toBe(false);
+      expect(typeof result).toBe('boolean');
+    });
+
     it('should save token into storage', () => {
       authService.storeToken(token);
       expect(storage.set).toHaveBeenCalled();

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -482,7 +482,7 @@ export class AuthService {
    */
   public isTokenExpired(token?: AuthTokenInfo): boolean {
     token = token || this.getToken();
-    return token && token.expires < Date.now();
+    return !!token && token.expires < Date.now();
   }
 
   /**


### PR DESCRIPTION
## References
* DSpace/dspace-angular#6002

## Description
This PR fixes `isTokenExpired()` to return `true` for **missing tokens** (`null` or `undefined`), which could potentially reoslve DSpace/dspace-angular#6002.

## Instructions for Reviewers

This PR:
* adds two test cases for null/undefined token scenarios
* changes the `return` clause in `isTokenExpired()`

```typescript
// original
public isTokenExpired(token?: AuthTokenInfo): boolean {
  token = token || this.getToken();
  return token && token.expires < Date.now();
}
```
[source](https://github.com/MMilosz/dspace-angular/blob/444edd4981726bdd872ffacd9302cd824cbd929f/src/app/core/auth/auth.service.ts#L483-L486)

A `return` value here can be `true`, `false`, or `null` if local storage has no token, or `undefined` if NgRx store hasn't initialized yet-these cases could cause problems when methods expected a boolean return value.

The fix ensures `isTokenExpired()` always returns a proper true/false boolean.

To test, please verify if that all unit tests pass and that no token behavior changes occur after logging into a site.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [X] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
