### PR TITLE
fix undefined error when duplicates section is not present for workspace item

### DIFF
--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -111,7 +111,8 @@ export class SubmissionObjectEffects {
 
         // Duplicates will ignore mandatory and display only when "always display" is set or there is data to show
         if (sectionDefinition.sectionType === SectionsType.Duplicates) {
-          enabled = (alwaysDisplayDuplicates() || isNotEmpty((action.payload.sections[sectionId] as WorkspaceitemSectionDuplicatesObject).potentialDuplicates));
+          const duplicatesSection = action.payload.sections?.[sectionId] as WorkspaceitemSectionDuplicatesObject | undefined;
+          enabled = (alwaysDisplayDuplicates() || isNotEmpty(duplicatesSection?.potentialDuplicates));
         }
 
         let sectionData;


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/12865
* Related to https://github.com/DSpace/DSpace/pull/12867

## Description
Adds an additional undefined safety check for when the duplicates section is not present in the workspace item json data.

## Instructions for Reviewers

1. Have the duplicates section enabled in the submission form
2. Have a duplicate of the item you'd like to create a new version of in a workflow state
3. Try to create a new version of the item as an admin. Observe that you are able to create and edit the new version.

### Additional tests
Check that the duplicates section still shows up for unaffected items

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

## LLM Disclosure
I used ChatGPT (Model GPT-5.5 Instant) to help me with the investigation of the bug and to help with the undefined safety check. I fully understand the code and why it fixes the bug. No LLM was used in writing the bug report and the PR text.