### PR TITLE
fix(cookies): skip Orejime init when consent popup is disabled

### DIFF
--- a/src/app/core/cookies/browser-orejime.service.spec.ts
+++ b/src/app/core/cookies/browser-orejime.service.spec.ts
@@ -185,6 +185,28 @@ describe('BrowserOrejimeService', () => {
     });
   });
 
+  describe('initialize when cookie consent popup is disabled', () => {
+    it('should skip Orejime init so an empty apps list is never validated', () => {
+      const init = jasmine.createSpy('init');
+      (service as any).appConfig = {
+        info: {
+          enablePrivacyStatement: true,
+          enableCookieConsentPopup: false,
+        },
+        fallbackLanguage: 'en',
+      };
+      (service as any).lazyOrejime = Promise.resolve({ init });
+      spyOn(service, 'addAppMessages');
+      spyOn(service, 'translateConfiguration');
+
+      service.initialize();
+
+      expect(service.addAppMessages).not.toHaveBeenCalled();
+      expect(service.translateConfiguration).not.toHaveBeenCalled();
+      expect(init).not.toHaveBeenCalled();
+    });
+  });
+
   it('addAppMessages', () => {
     service.addAppMessages();
     expect(mockConfig.translations.zz[appName]).toBeDefined();

--- a/src/app/core/cookies/browser-orejime.service.ts
+++ b/src/app/core/cookies/browser-orejime.service.ts
@@ -124,6 +124,11 @@ export class BrowserOrejimeService extends OrejimeService {
    *  - Add and translate orejime configuration messages
    */
   initialize() {
+    // Orejime rejects an empty apps list; skip entirely when the consent UI is disabled.
+    if (!this.appConfig.info?.enableCookieConsentPopup) {
+      return;
+    }
+
     if (!this.appConfig.info.enablePrivacyStatement) {
       this.orejimeConfig.translations.zz.consentModal.privacyPolicy.text = 'cookies.consent.content-modal.no-privacy-policy.text';
     }
@@ -195,11 +200,7 @@ export class BrowserOrejimeService extends OrejimeService {
          */
         this.translateConfiguration();
 
-        if (!this.appConfig.info?.enableCookieConsentPopup) {
-          this.orejimeConfig.apps = [];
-        } else {
-          this.orejimeConfig.apps = this.filterConfigApps(appsToHide);
-        }
+        this.orejimeConfig.apps = this.filterConfigApps(appsToHide);
         this.applyUpdateSettingsCallbackToApps(user);
         this.lazyOrejime.then(({ init }) => {
           this.orejimeInstance = init(this.orejimeConfig);
@@ -328,7 +329,9 @@ export class BrowserOrejimeService extends OrejimeService {
    * Show the cookie consent form
    */
   showSettings() {
-    this.orejimeInstance.show();
+    if (hasValue(this.orejimeInstance)) {
+      this.orejimeInstance.show();
+    }
   }
 
   /**


### PR DESCRIPTION
## References
* Fixes #6009

## Description
When `enableCookieConsentPopup` is false, the UI no longer initializes Orejime with an empty `apps` list (which Orejime rejects and logs to the console).

## Instructions for Reviewers
List of changes in this PR:
* Return early from `BrowserOrejimeService.initialize()` when the cookie consent popup is disabled, instead of calling `init()` with `apps: []`.
* Guard `showSettings()` so it is a no-op if Orejime was never initialized.
* Add a unit test covering the disabled-popup path.

**How to test:**
1. Set `info.enableCookieConsentPopup: false` in config (or use the existing CI env that sets this).
2. Open any page and confirm the Orejime "you must define apps" console error is gone.
3. Confirm the cookie settings footer link stays hidden.
4. `npm run test -- --include=src/app/core/cookies/browser-orejime.service.spec.ts --browsers=ChromeHeadless` (22 tests passing locally).

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [ ] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).