### PR TITLE
Creative Commons Licenses (Frontend)

### DIFF
--- a/src/app/core/submission/models/submission-cc-license.model.ts
+++ b/src/app/core/submission/models/submission-cc-license.model.ts
@@ -43,4 +43,5 @@ export interface Option {
   id: string;
   label: string;
   description: string;
+  default: boolean;
 }

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
@@ -1,147 +1,142 @@
 @if (submissionCcLicenses) {
-  <div class="mb-4 ccLicense-select">
-    <div ngbDropdown>
-      <input id="cc-license-dropdown"
-        class="form-control"
-        [(ngModel)]="selectedCcLicense.name"
-        placeholder="{{ !storedCcLicenseLink ? ('submission.sections.ccLicense.select' | translate) : ('submission.sections.ccLicense.change' | translate)}}"
-        [ngModelOptions]="{standalone: true}"
-        ngbDropdownToggle
-        role="combobox"
-        #script="ngModel">
-      <div ngbDropdownMenu aria-labelledby="cc-license-dropdown" class="w-100 scrollable-menu"
-        role="menu"
-        infiniteScroll
-        (scroll)="onScroll($event)"
-        [infiniteScrollDistance]="5"
-        [infiniteScrollThrottle]="300"
-        [infiniteScrollUpDistance]="1.5"
-        [fromRoot]="true"
-        [scrollWindow]="false">
-
-        @if(submissionCcLicenses?.length === 0) {
-          <button class="dropdown-item disabled">
-            {{ 'submission.sections.ccLicense.none' | translate }}
-          </button>
-        } @else {
-          @for(license of submissionCcLicenses; track license.id) {
-            <button class="dropdown-item" (click)="selectCcLicense(license)">
-              {{ license.name }}
-            </button>
-          }
-        }
-      </div>
-    </div>
-  </div>
+<div class="mb-4 ccLicense-select">
+  <p [dsMarkdown]="'submission.sections.ccLicense.info' | translate "></p>
+  <ds-select [disabled]="!submissionCcLicenses">
+    <ng-container class="selection">
+      <span *ngIf="getSelectedCcLicense()">
+        {{ getSelectedCcLicense().name }}
+      </span>
+      <span *ngIf="submissionCcLicenses && !getSelectedCcLicense()">
+        <ng-container *ngIf="storedCcLicenseLink">
+          {{ 'submission.sections.ccLicense.change' | translate }}
+        </ng-container>
+        <ng-container *ngIf="!storedCcLicenseLink">
+          {{ 'submission.sections.ccLicense.select' | translate }}
+        </ng-container>
+      </span>
+    </ng-container>
+    <ng-container class="menu">
+      <button *ngIf="submissionCcLicenses?.length == 0"
+              class="dropdown-item disabled">
+        {{ 'submission.sections.ccLicense.none' | translate }}
+      </button>
+      <button *ngFor="let license of submissionCcLicenses"
+              class="dropdown-item"
+              (click)="selectCcLicense(license)">
+        {{ license.name }}
+      </button>
+    </ng-container>
+  </ds-select>
+</div>
 }
 
-@if (getSelectedCcLicense()) {
-  @for (field of getSelectedCcLicense().fields; track field) {
-    <div
-      class="mb-4">
+<ng-container *ngIf="getSelectedCcLicense()">
+  <div class="form-control" style="height: auto">
+    <div *ngFor="let field of getSelectedCcLicense().fields" class="m-0">
+
       <div class="d-flex flex-row">
-        <div class="fw-bold {{ field.id }}">
-          {{ field.label }}
+        <div class="font-weight-bold {{ field.id }}">{{ field.label }}
+          <button class="btn btn-outline-info btn-sm ml-2 mb-1" (click)="openInfoModal(infoModal)">
+            <i class="fas fa-question"></i>
+          </button>
         </div>
-        <button
-          class="btn btn-outline-info btn-sm ms-2"
-          (click)="openInfoModal(infoModal)">
-          <i class="fas fa-question"></i>
-        </button>
       </div>
+
       <ng-template #infoModal>
         <div>
           <div class="modal-header mb-4 ">
             <div>
-              <h4>
-                {{ field.label }}
-              </h4>
+              <h4>{{ field.label }}</h4>
               <div [innerHTML]="field.description"></div>
             </div>
-            <button type="button" class="btn-close"
-              (click)="closeInfoModal()" aria-label="Close">
+            <button type="button" class="close mb-1" (click)="closeInfoModal()" aria-label="Close">
+              <span aria-hidden="true">×</span>
             </button>
           </div>
           <div class="modal-body">
-            @for (value of field.enums; track value) {
-              <div
-                class="mb-4">
-                <h5>
-                  {{ value.label }}
-                </h5>
-                <div [innerHTML]="value.description" class="fw-light"></div>
-              </div>
-            }
+            <div *ngFor="let value of field.enums" class="mb-4">
+              <h5>{{ value.label }}</h5>
+              <div [innerHTML]="value.description" class="font-weight-light"></div>
+            </div>
           </div>
         </div>
       </ng-template>
-      @if (field.enums?.length > 5) {
-        <ds-select [disabled]="field.id === 'jurisdiction' && defaultJurisdiction !== undefined && defaultJurisdiction !== 'none'">
-          <ng-container class="selection" *ngVar="getSelectedOption(getSelectedCcLicense(), field) as option">
-            @if (option) {
-              <span>
-                {{ option.label }}
-              </span>
-            }
-            @if (!option) {
-              <span>
-                {{ 'submission.sections.ccLicense.option.select' | translate }}
-              </span>
-            }
-          </ng-container>
-          <ng-container class="menu">
-            <div class="options-select-menu overflow-auto">
-              @for (option of field.enums; track option) {
-                <button
-                  class="dropdown-item"
-                  (click)="selectOption(getSelectedCcLicense(), field, option)">
-                  {{ option.label }}
-                </button>
-              }
-            </div>
-          </ng-container>
-        </ds-select>
-      }
-      @if (field.enums?.length <= 5) {
-        @for (option of field.enums; track option) {
-          <div
-            class="d-flex flex-row m-1">
-            <div (click)="selectOption(getSelectedCcLicense(), field, option)">
-              <input type="radio"
-                title="{{ option.label }}"
-                class="me-1"
-                [checked]="isSelectedOption(getSelectedCcLicense(), field, option)">
-              <span>{{ option.label }}</span>
-            </div>
-          </div>
-        }
-      }
-    </div>
-  }
-}
 
-@if (ccLicenseLink$) {
-  @let licenseLink = (ccLicenseLink$ | async);
-  @if (licenseLink) {
-    <div
-      class="mt-2 p-4 bg-light text-dark">
-      <div>
-        {{ 'submission.sections.ccLicense.link' | translate }}
-      </div>
-      <a class="license-link" href="{{ licenseLink }}" target="_blank" rel="noopener noreferrer">
-        {{ licenseLink }}
-      </a>
-      <div class="m-2">
-        <div (click)="setAccepted(!accepted)">
-          <input type="checkbox"
-                 class="me-2"
-                 title="accepted"
-                 [checked]="accepted">
-          <span> {{ 'submission.sections.ccLicense.confirmation' | translate }}</span>
+      <ds-select *ngIf="field.enums && field.enums?.length > 5" [disabled]="field.id === 'jurisdiction' && defaultJurisdiction !== undefined && defaultJurisdiction !== 'none'">
+        <ng-container class="selection" *ngVar="getSelectedOption(getSelectedCcLicense(), field) as option">
+          <span *ngIf="option">{{ option.label }}</span>
+          <span *ngIf="!option">{{ 'submission.sections.ccLicense.option.select' | translate }}</span>
+        </ng-container>
+        <ng-container class="menu">
+          <div class="options-select-menu overflow-auto">
+            <button *ngFor="let option of field.enums" class="dropdown-item" (click)="selectOption(getSelectedCcLicense(), field, option)">
+              {{ option.label }}
+            </button>
+          </div>
+        </ng-container>
+      </ds-select>
+
+      <ng-container *ngIf="field.enums && field.enums?.length <= 5">
+        <div *ngFor="let option of field.enums" class="d-flex flex-row ml-3">
+          <div (click)="selectOption(getSelectedCcLicense(), field, option)">
+            <input type="radio" title="{{ option.label }}" class="mr-1" [checked]="isSelectedOption(getSelectedCcLicense(), field, option)">
+            <span>{{ option.label }}</span>
+          </div>
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="field.type && field.type === 'textarea'">
+        <div role="group" class="form-row" style="width: 100%;">
+          <div class="col-sm-12 d-flex flex-column justify-content-start">
+            <textarea [(ngModel)]="data.ccLicense.fields['dc_rights']" (blur)="updateInput(getSelectedCcLicense(), field)" class="form-control" cols="20"
+                      id="{{ field.id }}" name="{{ field.id }}" rows="2" spellcheck="true" wrap="undefined"></textarea>
+            <small class="text-muted ds-hint">{{ field.description }}</small>
+          </div>
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="field.type && field.type === 'input'">
+        <div role="group" class="form-row" style="width: 100%;">
+          <div class="col-sm-12 d-flex flex-column justify-content-start">
+            <input [(ngModel)]="data.ccLicense.fields['dc_rights_uri']" (blur)="updateInput(getSelectedCcLicense(), field)" class="form-control" id="{{ field.id }}"
+                   name="{{ field.id }}" spellcheck="false" type="text">
+            <small class="text-muted ds-hint ng-star-inserted">{{ field.description }}</small>
+          </div>
+        </div>
+      </ng-container>
+    </div>
+
+    <ng-container *ngVar="getCcLicenseLink$() | async as licenseLink">
+      <div class="mt-2 p-2 text-dark alert-info">
+        <div *ngIf="licenseLink && licenseLink!='All Rights Reserved' && licenseLink!='http://creativecommons.org/publicdomain/zero/1.0/'">
+          {{ 'submission.sections.ccLicense.selected' | translate }}
+          <a class="license-link" href="{{ licenseLink }}" target="_blank" rel="noopener noreferrer">{{ licenseMap[licenseLink] }}</a>.
+          <p>{{ 'submission.sections.ccLicense.link2' | translate }}</p>
+        </div>
+        <div *ngIf="licenseLink && licenseLink=='http://creativecommons.org/publicdomain/zero/1.0/'">
+          <p [dsMarkdown]="'submission.sections.ccLicense.publicdomain' | translate"></p>
+        </div>
+        <div class="m-2">
+          <div (click)="setAccepted(!accepted)">
+            <input type="checkbox" class="mr-2" title="accepted">
+            <span *ngIf="licenseLink=='All Rights Reserved'; else other_content">
+              {{ 'submission.sections.ccLicense.copyrighted' | translate }}
+            </span>
+            <ng-template #other_content>
+              <span *ngIf="licenseLink!='http://creativecommons.org/publicdomain/zero/1.0/'; else zero_content">
+                {{ 'submission.sections.ccLicense.confirmation' | translate }}
+              </span>
+            </ng-template>
+            <ng-template #zero_content>
+              <span>
+                {{ 'submission.sections.ccLicense.cczero' | translate }}
+              </span>
+            </ng-template>
+          </div>
         </div>
       </div>
-    </div>
-  } @else {
-    <ds-loading></ds-loading>
-  }
-}
+    </ng-container>
+  </div>
+</ng-container>
+
+<p class="small mb-0 mt-3">{{ 'submission.sections.ccLicense.attribution' | translate }}, <a href="http://creativecommons.org" target="_blank">creativecommons.org</a></p>

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.spec.ts
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.spec.ts
@@ -56,11 +56,13 @@ describe('SubmissionSectionCcLicensesComponent', () => {
             {
               id: 'test enum id 1a I',
               label: 'test enum label 1a I',
+              default: true,
               description: 'test enum description 1a I',
             },
             {
               id: 'test enum id 1a II',
               label: 'test enum label 1a II',
+              default: false,
               description: 'test enum description 1a II',
             },
           ],
@@ -73,11 +75,13 @@ describe('SubmissionSectionCcLicensesComponent', () => {
             {
               id: 'test enum id 1b I',
               label: 'test enum label 1b I',
+              default: true,
               description: 'test enum description 1b I',
             },
             {
               id: 'test enum id 1b II',
               label: 'test enum label 1b II',
+              default: false,
               description: 'test enum description 1b II',
             },
           ],
@@ -102,12 +106,14 @@ describe('SubmissionSectionCcLicensesComponent', () => {
             {
               id: 'test enum id 2a I',
               label: 'test enum label 2a I',
-              description: 'test enum description 2a I',
+              default: true,
+              description: 'test enum description 2a I'
             },
             {
               id: 'test enum id 2a II',
               label: 'test enum label 2a II',
-              description: 'test enum description 2a II',
+              default: false,
+              description: 'test enum description 2a II'
             },
           ],
         },
@@ -119,12 +125,14 @@ describe('SubmissionSectionCcLicensesComponent', () => {
             {
               id: 'test enum id 2b I',
               label: 'test enum label 2b I',
-              description: 'test enum description 2b I',
+              default: true,
+              description: 'test enum description 2b I'
             },
             {
               id: 'test enum id 2b II',
               label: 'test enum label 2b II',
-              description: 'test enum description 2b II',
+              default: false,
+              description: 'test enum description 2b II'
             },
           ],
         },

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.ts
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.ts
@@ -1,4 +1,8 @@
-import { AsyncPipe } from '@angular/common';
+import {
+  AsyncPipe,
+  NgForOf,
+  NgIf,
+} from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -41,7 +45,7 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import {
   BehaviorSubject,
   Observable,
-  of,
+  of as observableOf,
   Subscription,
 } from 'rxjs';
 import {
@@ -53,12 +57,13 @@ import {
 } from 'rxjs/operators';
 
 import { DsSelectComponent } from '../../../shared/ds-select/ds-select.component';
-import { ThemedLoadingComponent } from '../../../shared/loading/themed-loading.component';
 import { VarDirective } from '../../../shared/utils/var.directive';
 import { SectionModelComponent } from '../models/section.model';
 import { SectionDataObject } from '../models/section-data.model';
 import { SectionsService } from '../sections.service';
 import { renderSectionFor } from '../sections-decorator';
+import { TranslateService } from '@ngx-translate/core';
+import { MarkdownDirective } from '../../../shared/utils/markdown.directive';
 
 /**
  * This component represents the submission section to select the Creative Commons license.
@@ -68,15 +73,18 @@ import { renderSectionFor } from '../sections-decorator';
   templateUrl: './submission-section-cc-licenses.component.html',
   styleUrls: ['./submission-section-cc-licenses.component.scss'],
   imports: [
+    TranslateModule,
+    NgIf,
     AsyncPipe,
+    VarDirective,
+    NgForOf,
     DsSelectComponent,
+    NgbDropdownModule,
     FormsModule,
     InfiniteScrollModule,
-    NgbDropdownModule,
-    ThemedLoadingComponent,
-    TranslateModule,
-    VarDirective,
+    MarkdownDirective,
   ],
+  standalone: true,
 })
 @renderSectionFor(SectionsType.CcLicense)
 export class SubmissionSectionCcLicensesComponent extends SectionModelComponent implements OnChanges, OnInit {
@@ -108,6 +116,18 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
    * Cache of the available Creative Commons licenses.
    */
   submissionCcLicenses: SubmissionCcLicence[] = [];
+
+  /**
+   * Map of licence uris to names
+   */
+  public licenseMap: Record<string, string> = {
+    'http://creativecommons.org/licenses/by/4.0/'       : 'CC BY 4.0 (Attribution 4.0 International)',
+    'http://creativecommons.org/licenses/by-sa/4.0/'    : 'CC BY-SA 4.0 (Attribution-ShareAlike 4.0 International)',
+    'http://creativecommons.org/licenses/by-nc/4.0/'    : 'CC BY-NC 4.0 (Attribution-NonCommercial 4.0 International)',
+    'http://creativecommons.org/licenses/by-nc-sa/4.0/' : 'CC BY-NC-SA 4.0 (Attribution-NonCommercial-ShareAlike 4.0 International)',
+    'http://creativecommons.org/licenses/by-nd/4.0/'    : 'CC BY-ND 4.0 (Attribution-NoDerivatives 4.0 International)',
+    'http://creativecommons.org/licenses/by-nc-nd/4.0/' : 'CC BY-NC-ND 4.0 (Attribution-NonCommercial-NoDerivatives 4.0 International)'
+  };
 
   /**
    * Reference to NgbModal
@@ -170,6 +190,7 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
     protected operationsBuilder: JsonPatchOperationsBuilder,
     protected configService: ConfigurationDataService,
     protected ref: ChangeDetectorRef,
+    private translate: TranslateService,
     @Inject('collectionIdProvider') public injectedCollectionId: string,
     @Inject('sectionDataProvider') public injectedSectionData: SectionDataObject,
     @Inject('submissionIdProvider') public injectedSubmissionId: string,
@@ -212,10 +233,18 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
     }
     this.selectedCcLicense = ccLicense;
     this.setAccepted(false);
+
+    // Generate the defaults options for selected ccLicense
+    const defaults = {};
+    ccLicense.fields.forEach(field => {
+      const defaultEnumOption = field.enums.find(enumOption => enumOption.default);
+      if (defaultEnumOption) { defaults[field.id] = defaultEnumOption; }
+    });
+
     this.updateSectionData({
       ccLicense: {
         id: ccLicense.id,
-        fields: {},
+        fields: defaults
       },
       uri: undefined,
     });
@@ -255,6 +284,25 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
   }
 
   /**
+   * Update value for a given license field.
+   * @param ccLicense   the related Creative Commons license.
+   * @param field       the field for which to set a value.
+   */
+  updateInput(ccLicense: SubmissionCcLicence, field: Field) {
+     this.updateSectionData({
+      ccLicense: {
+        id: ccLicense.id,
+        fields: Object.assign({}, this.data.ccLicense.fields, {
+          [field.id]: this.data.ccLicense.fields[field.id]
+        }),
+      },
+      accepted: false,
+      uri: this.data.uri
+    });
+    this.ccLicenseLink$ = this.getCcLicenseLink$();
+  }
+
+  /**
    * Get the selected option for a given license field.
    * @param ccLicense   the related Creative Commons license.
    * @param field       the field for which to get the selected option value.
@@ -282,7 +330,7 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
   getCcLicenseLink$(): Observable<string> {
 
     if (this.storedCcLicenseLink) {
-      return of(this.storedCcLicenseLink);
+      return observableOf(this.storedCcLicenseLink);
     }
     if (!this.getSelectedCcLicense() || this.getSelectedCcLicense().fields.some(
       (field) => !this.getSelectedOption(this.getSelectedCcLicense(), field))) {
@@ -348,12 +396,18 @@ export class SubmissionSectionCcLicensesComponent extends SectionModelComponent 
         if (this.data.accepted !== data.accepted) {
           const path = this.pathCombiner.getPath('uri');
           if (data.accepted) {
-            this.getCcLicenseLink$().pipe(
-              take(1),
-            ).subscribe((link) => {
-              this.operationsBuilder.add(path, link.toString(), false, true);
-            });
-          } else if (this.data.uri) {
+            if (data.ccLicense.id === 'other') {
+              this.operationsBuilder.add(path, { 'uri': data.ccLicense.fields.dc_rights_uri, 'rights': data.ccLicense.fields.dc_rights }, false, true);
+            } else if (data.ccLicense.id === 'none') {
+              this.operationsBuilder.add(path, { 'uri': '', 'rights': this.translate.instant('submission.sections.ccLicense.copyrighted') }, false, true);
+            } else {
+              this.getCcLicenseLink$().pipe(
+                take(1),
+              ).subscribe((link) => {
+                this.operationsBuilder.add(path, link.toString(), false, true);
+              });
+            }
+          } else if (!!this.data.uri) {
             this.operationsBuilder.remove(path);
           }
         }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5812,19 +5812,33 @@
 
   "submission.sections.describe.relationship-lookup.name-variant.notification.decline": "Use only for this submission",
 
-  "submission.sections.ccLicense.type": "License Type",
+  "submission.sections.ccLicense.attribution": "The language in this tool is adapted from Creative Commons",
 
-  "submission.sections.ccLicense.select": "Select a license type…",
+  "submission.sections.ccLicense.change": "License selector…",
 
-  "submission.sections.ccLicense.change": "Change your license type…",
+  "submission.sections.ccLicense.confirmation": "I grant the license above",
 
-  "submission.sections.ccLicense.none": "No licenses available",
+  "submission.sections.ccLicense.copyrighted": "This work is protected by copyright unless stated otherwise.",
 
-  "submission.sections.ccLicense.option.select": "Select an option…",
+  "submission.sections.ccLicense.cczero": "I have read and understand the terms and intended legal effect of CC0 (Public domain). I hereby waive all copyright and related or neighboring rights together with all associated claims and causes of action with respect to this work to the extent possible under the law.",
+
+  "submission.sections.ccLicense.info": "Select license terms to limit how others may reuse your work. We recommend a CC BY-NC Creative Commons (CC) license. Learn more at <a href='https://creativecommons.org/share-your-work/cclicenses/' target='_blank'>About CC Licenses</a> or use the “Help me choose” option in the License Selector. Tip: If you save and then re-visit this submission form, your previous entries in this section will not be displayed. However, they will remain saved unless you make a new selection in this section.",
 
   "submission.sections.ccLicense.link": "You’ve selected the following license:",
 
-  "submission.sections.ccLicense.confirmation": "I grant the license above",
+  "submission.sections.ccLicense.link2": "All Creative Commons licenses require attribution, meaning that credit must be given to you, the creator.",
+
+  "submission.sections.ccLicense.none": "No licenses available",
+
+  "submission.sections.ccLicense.option.select": "Select…",
+
+  "submission.sections.ccLicense.publicdomain": "You have chosen to put your work into the public domain using the <a href='https://creativecommons.org/publicdomain/zero/1.0/' target='_blank' rel='noopener noreferrer'>CC0 Public Domain Dedication</a> deed.",
+
+  "submission.sections.ccLicense.select": "License selector…",
+
+  "submission.sections.ccLicense.selected": "You have selected",
+
+  "submission.sections.ccLicense.type": "License Type",
 
   "submission.sections.general.add-more": "Add more",
 
@@ -5874,7 +5888,7 @@
 
   "submission.sections.submit.progressbar.accessCondition": "Item access conditions",
 
-  "submission.sections.submit.progressbar.CClicense": "Creative commons license",
+  "submission.sections.submit.progressbar.CClicense": "Rights",
 
   "submission.sections.submit.progressbar.CustomUrlStep": "Custom Url",
 
@@ -5887,6 +5901,10 @@
   "submission.sections.submit.progressbar.describe.steptwo": "Describe",
 
   "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
+
+  "submission.sections.submit.progressbar.describe.rights": "Rights Statement",
+
+  "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
 
   "submission.sections.submit.progressbar.identifiers": "Identifiers",
 


### PR DESCRIPTION
This is a draft PR to assess interest in this work.
It is working well as-is and is in production at Indiana University on DSpace version 7.x. 
Tests will fail until it is determined that finishing this PR is worthwhile.

## References
* Fixes https://github.com/DSpace/DSpace/issues/11808
* Alternative to https://github.com/DSpace/DSpace/pull/12424
* Requires https://github.com/DSpace/DSpace/pull/12922 (an API PR is required to test this)

## Description
Replaces legacy CC API dependence with locally served resources.

## List of changes in this PR:
* Removes reliance on CC API, replaces with local logic and resources
* Adds new choices to CC License chooser to facilitate setting correct values for dc.rights and dc.rights.url: 

1. Help me choose (legacy style chooser)
2. I know my license (simple selection)
3. All rights reserved (protected by copyright)
4. Public Domain (apply cc0)
5. Other (manually enter values for dc.rights and dc.rights.uri)

* Each option in the chooser is configured via XML
* Chooser form logic now resides in DSpace
 
## Testing instructions

1. Merge this PR and the related DSpace backend PR
2. Turn on CC License Chooser by uncommenting  <step id="cclicense"/> in config/item-submission.xml
3. There are also a number of configuration settings to be applied in local.cfg:
```
###############################
#  Creative Commons settings  #
###############################

# The url to the web service API
cc.api.rooturl = ${dspace.server.url}/cc

# Metadata field to hold CC license URI of selected license
cc.license.uri = dc.rights.uri

# Metadata field to hold CC license name of selected license (if defined)
cc.license.name = dc.rights

# Metadata field to hold CC license rights of selected license (if defined)
cc.license.rights = dc.rights

# Assign license name during web submission
cc.submit.setname = false

# Assign license rights during web submission
cc.submit.setrights = true

# Store license bitstream (RDF license text) during web submission
cc.submit.addbitstream = true

# A list of license classes that should be included in the selection process
# class names - comma-separated list -  must exactly match what service returns.
cc.license.classes = standard,known,none,zero,other
```

4. Restart back end server, then restart front end
5. Add a new item in the UI and scroll down to the Rights section.
6. Explore the chooser options and make selections.
7. Finish adding the item and then check it's metadata to ensure expected values are in the dc.rights and dc.rights.uri fields.

## Screenshots
<img width="669" height="645" alt="Screenshot from 2026-07-29 14-46-21" src="https://github.com/user-attachments/assets/0b66ad53-a8bd-4189-a1a5-f2a1bcb87b5d" />
<img width="669" height="791" alt="Screenshot from 2026-07-29 14-44-01" src="https://github.com/user-attachments/assets/1b47fd83-bce3-4f9e-b698-9023c0dd0204" />
<img width="669" height="609" alt="Screenshot from 2026-07-29 14-44-28" src="https://github.com/user-attachments/assets/f111fc6b-33a3-4fcd-b77f-d406322d5943" />
<img width="669" height="435" alt="Screenshot from 2026-07-29 14-44-41" src="https://github.com/user-attachments/assets/8fe2574c-1ca3-4c6c-a737-907051484d03" />
<img width="669" height="551" alt="Screenshot from 2026-07-29 14-45-03" src="https://github.com/user-attachments/assets/2403d01a-62e9-41f8-b75a-82ee98f775c2" />
<img width="669" height="645" alt="Screenshot from 2026-07-29 14-45-15" src="https://github.com/user-attachments/assets/37f824f9-4e78-4f58-9dff-bb0cf930a872" />