### PR TITLE
[Docker] Update `dspace-10_x` branch to use the `dspace-10_x` Docker tags in all Docker Compose scripts

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -2,7 +2,7 @@
 # See https://github.com/DSpace/dspace-angular/tree/main/docker for usage details
 
 # Test build:
-# docker build -f Dockerfile.dist -t dspace/dspace-angular:latest-dist .
+# docker build -f Dockerfile.dist -t dspace/dspace-angular:dspace-10_x-dist .
 
 # Step 1 - Build code for production
 FROM docker.io/node:22-alpine AS build

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,14 +24,14 @@ This Dockerfile is used to build a *development* mode DSpace Angular UI image, p
 when local source code is modified.
 
 ```
-docker build -t dspace/dspace-angular:latest .
+docker build -t dspace/dspace-angular:dspace-10_x .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace-angular:latest
+docker push dspace/dspace-angular:dspace-10_x
 ```
 
 ### Dockerfile.dist
@@ -39,8 +39,8 @@ docker push dspace/dspace-angular:latest
 The `Dockerfile.dist` is used to build a *production* mode DSpace Angular UI image, published as 'dspace/dspace-angular' with a `*-dist` tag. Because it uses production mode, this image supports Server Side Rendering (SSR).
 
 ```bash
-# build the latest image
-docker build -f Dockerfile.dist -t dspace/dspace-angular:latest-dist .
+# build the 10.x image
+docker build -f Dockerfile.dist -t dspace/dspace-angular:dspace-10_x-dist .
 ```
 
 A default/demo version of this image is built *automatically*.

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -21,7 +21,7 @@ networks:
     external: true
 services:
   dspace-cli:
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-10_x}"
     container_name: dspace-cli
     environment:
       # Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -14,7 +14,7 @@
 # # Therefore, it should be kept in sync with that file
 services:
   dspacedb:
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-10_x}"
     environment:
       # This LOADSQL should be kept in sync with the URL in DSpace/DSpace
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -33,7 +33,7 @@ services:
       # This allows us to generate statistics in e2e tests so that statistics pages can be tested thoroughly.
       solr__D__statistics__P__autoCommit: ${solr__D__statistics__P__autoCommit:-false}
       LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-10_x-test}"
     depends_on:
     - dspacedb
     networks:
@@ -58,7 +58,7 @@ services:
   # NOTE: This is customized to use our loadsql image, so that we are using a database with existing test data
   dspacedb:
     container_name: dspacedb
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-10_x}"
     environment:
       # This LOADSQL should be kept in sync with the LOADSQL in
       # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
@@ -79,7 +79,7 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-10_x}"
     networks:
       - dspacenet
     ports:

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -29,7 +29,7 @@ services:
       DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
       # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
       DSPACE_REST_SSRBASEURL: ${DSPACE_REST_SSRBASEURL:-http://dspace:8080/server}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}-dist"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-10_x}-dist"
     build:
       context: ..
       dockerfile: Dockerfile.dist

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -48,7 +48,7 @@ services:
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: ${proxies__P__trusted__P__ipranges:-172.23.0}
       LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-10_x-test}"
     depends_on:
     - dspacedb
     networks:
@@ -91,7 +91,7 @@ services:
   # DSpace Solr container  
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-10_x}"
     networks:
       - dspacenet
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
       DSPACE_REST_PORT: ${DSPACE_REST_PORT:-8080}
       DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-10_x}"
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## References
* Fixes recent Docker build issues specific to the `dspace-10_x` branch.
* Ported to backend in https://github.com/DSpace/DSpace/pull/12947

## Description
As of today, we started seeing some random Docker build issues in our GitHub actions **only on the dspace-10_x branch** of code.  See for example the `docker-deploy` failures here: https://github.com/DSpace/dspace-angular/actions/runs/31034059861/job/92411790102

After investigating why these issues only happen on one branch, I discovered that the `dspace-10_x` branch is using the **wrong** Docker images...it's still trying to use the `latest` images (from `main`) instead of the `dspace-10_x` images.

This small PR corrects that misconfiguration in our Docker scripts so that the `dspace-10_x` branch will use that same version of Docker images.

This same PR needs to be applied to the `dspace-10_x` branch of `DSpace/DSpace` as it's also pointed at `latest` images instead of `dspace-10_x` images.

## Instructions for Reviewers
* If this passes all tests, then that is verification that it has fixed the current Docker build issues we are seeing on the `dspace-10_x` branch.  If so, I'll merge this immediately to fix the issues on our `dspace-10_x` branch.