### PR TITLE
Add detailed warnings to SSR-related configs about impact on SEO.

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -8,8 +8,10 @@ ui:
   ssl: false
   host: localhost
   port: 4000
-  # Specify the public URL that this user interface responds to. This corresponds to the "dspace.ui.url" property in your backend's local.cfg.
-  # SSR is only enabled when the client's "Host" HTTP header matches this baseUrl. The baseUrl is also used for redirects and SEO links (in robots.txt).
+  # Specify the public baseURL that this user interface responds to. This corresponds to the "dspace.ui.url" property in your backend's local.cfg.
+  # [WARNING] SSR is only enabled when the client's "Host" HTTP header matches this baseUrl. The baseUrl is also used for redirects and SEO links (in robots.txt).
+  # If the baseUrl is invalid/incorrrect, then search engine crawlers (like Google Scholar) will not be able to index your site.
+  # The baseUrl is required by Angular to protect against SSRF attacks like those described in CVE-2026-27739.
   baseUrl: http://localhost:4000
   # NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
   nameSpace: /
@@ -30,8 +32,11 @@ ssr:
   # disabled (false) by default to boost server performance at the expense of loading smoothness.
   inlineCriticalCss: false
   # Patterns to be run as regexes against the path of the page to check if SSR is allowed.
-  # If the path match any of the regexes it will be served directly in CSR.
+  # If the path match any of the regexes it will be served directly in CSR (i.e. SSR will be disabled for this path).
   # By default, excludes community and collection browse, global browse, global search, community list, statistics and various administrative tools.
+  # [WARNING] changing these settings may impact your Search Engine Optimization (SEO). Any paths listed in "excludedPathPatterns"
+  # may NOT be indexable by search engine crawlers (like Google Scholar). For search engine crawlers to fully index your site,
+  # this "excludePathPatterns" should NEVER exclude SSR from the homepage, community/collection pages or item/entity pages.
   excludePathPatterns:
     - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
       flag: "i"

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -5,11 +5,17 @@ export const environment: Partial<BuildConfig> = {
 
   // Angular SSR (Server Side Rendering) settings
   ssr: {
+    // WARNING: Disabling SSR will block major search engine crawlers (like Google Scholar) from indexing your site.
+    // Therefore, we highly recommend keeping SSR enabled at all times. However, for better performance, you may choose
+    // to minimize the paths that undergo SSR via the "excludePathPatterns" setting below.
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
     transferState: true,
     replaceRestUrl: true,
+    // WARNING: changing these settings may impact your Search Engine Optimization (SEO). Any paths listed in "excludedPathPatterns"
+    // may NOT be indexable by search engine crawlers (like Google Scholar). For search engine crawlers to fully index your site,
+    // this "excludePathPatterns" should NEVER exclude SSR from the homepage, community/collection pages or item/entity pages.
     excludePathPatterns: [
       {
         pattern: '^/communities/[a-f0-9-]{36}/browse(/.*)?$',


### PR DESCRIPTION
## Description
This PR is coming out of a discussion I had with the Google Scholar team today.  Google Scholar is still noticing a large number of DSpace sites that are either disabling SSR entirely, or accidentally disabling it on pages that require indexing.  

This PR therefore adds inline comments next to the key SSR-related configurations which warn sites about the risk of SEO impacts if they modify the current settings in Production scenarios.  This is just an attempt to ensure these warnings are documented at the place(s) where sites might be modifying their configurations...to ensure they don't overlook them.


## Instructions for Reviewers
* PR only adds inline comments.  No actual code added.
* Therefore, just review the comments and determine whether they are clearly written or need any updates.