### PR TITLE
Removed $min-contrast-ratio override to improve text contrast

### DIFF
--- a/src/styles/_bootstrap_variables.scss
+++ b/src/styles/_bootstrap_variables.scss
@@ -56,8 +56,6 @@ $navbar-light-color: rgba(black, .5) !default;
 $navbar-dark-toggler-icon-bg: url("data:image/svg+xml;charset=utf8,<svg+viewBox='0+0+30+30'+xmlns='http://www.w3.org/2000/svg'><path+stroke='#{$navbar-dark-color}'+stroke-width='2'+stroke-linecap='round'+stroke-miterlimit='10'+d='M4+7h22M4+15h22M4+23h22'/></svg>") !default;
 $navbar-light-toggler-icon-bg: url("data:image/svg+xml;charset=utf8,<svg+viewBox='0+0+30+30'+xmlns='http://www.w3.org/2000/svg'><path+stroke='#{$navbar-light-color}'+stroke-width='2'+stroke-linecap='round'+stroke-miterlimit='10'+d='M4+7h22M4+15h22M4+23h22'/></svg>") !default;
 
-$min-contrast-ratio: 2 !default;
-
 $link-decoration: none;
 $link-hover-decoration: underline;
 

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -60,8 +60,6 @@ $theme-custom-semantic-colors: (
 
 /*** OTHER BOOTSTRAP VARIABLES ***/
 
-$min-contrast-ratio: 2.06 !default;
-
 $body-color: #343a40;       // As Bootstrap $gray-800
 
 $link-color: #1e6f90;       // Blue green, as DSpace $info


### PR DESCRIPTION
## References
* Fixes #5606

## Description
Removed the `$min-contrast-ratio` bootstrap override to ensure that all themes that use a light primary color still have a high enough text contrast.

## Instructions for Reviewers

List of changes in this PR:
* Removed the `$min-contrast-ratio` override in `_bootstrap_variables.scss` & `src/themes/dspace/styles/_theme_sass_variable_overrides.scss`

**Include guidance for how to test or review your PR.**
- Override the primary color in your theme by setting this in `src/themes/{theme}/styles/_theme_sass_variable_overrides.scss`: `$primary: #43515f`
- Verify that without the fix the primary buttons have a failing contrast
  <img width="45%" height="493" alt="image" src="https://github.com/user-attachments/assets/cb566b40-9211-4fe0-a9d7-b843a8e27038" />
- Run it again on this branch and verify that the primary button's text color is now dark enough to pass the WCAG AA threshold

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
