### PR TITLE
Fix: 5503, applying fixes for mobile/tablet screens

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   plugins: [
     require('postcss-import')(),
-    require('postcss-preset-env')()
+    require('postcss-preset-env')({
+      features: {
+        'has-pseudo-class': false
+      }
+    })
   ]
 };

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -22,6 +22,8 @@
     }
 
     .bottom-footer {
+      flex-wrap: wrap;
+
       .notify-enabled {
         position: relative;
         margin-top: 4px;
@@ -36,7 +38,7 @@
           margin-bottom: 8.5px;
         }
 
-        @media screen and (min-width: map-get($grid-breakpoints, md))  {
+        @media screen and (min-width: map-get($grid-breakpoints, xl))  {
           position: absolute;
           bottom: 4px;
           right: 0;
@@ -67,6 +69,24 @@
               border-right: 1px var(--bs-secondary) solid;
             }
 
+          }
+        }
+      }
+
+      @include media-breakpoint-down(md) {
+        ul {
+          flex-wrap: wrap;
+          column-gap: calc(var(--bs-spacer) / 2);
+          row-gap: calc(var(--bs-spacer) / 2);
+
+          li {
+            &::after {
+              display: none;
+            }
+
+            a, .btn-link {
+              white-space: nowrap;
+            }
           }
         }
       }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,6 +1,7 @@
 :host {
   header {
     background-color: var(--ds-header-bg);
+    position: relative;
   }
 
   .navbar-brand img {

--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -1,7 +1,7 @@
 <div (dsClickOutside)="collapse()">
   <div class="d-inline-block position-relative">
-    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" class="d-flex">
-      <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"
+    <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" [class.search-expanded]="searchExpanded || collapsing" class="d-flex">
+      <input #searchInput [@toggleAnimation]="isExpanded" (@toggleAnimation.done)="onAnimationDone()" [attr.aria-label]="('nav.search' | translate)" name="query"
              formControlName="query" type="text" placeholder="{{searchExpanded ? ('nav.search' | translate) : ''}}"
              autocomplete="off"
              class="d-inline-block bg-transparent position-absolute form-control dropdown-menu-end p1"

--- a/src/app/search-navbar/search-navbar.component.scss
+++ b/src/app/search-navbar/search-navbar.component.scss
@@ -22,10 +22,27 @@ input[type="text"] {
 }
 
 @media screen and (max-width: map-get($grid-breakpoints, md)) {
-  .query:focus {
-    max-width: 250px !important;
-    width: 40vw !important;
+  .d-inline-block.position-relative {
+    position: static !important;
   }
 
+  form.search-expanded {
+    input[type="text"] {
+      position: absolute !important;
+      top: calc(65% + var(--ds-header-navbar-border-bottom-height, 0px));
+      right: calc(var(--bs-gutter-x, 1.5rem) / 2);
+      left: auto;
+      width: 220px !important;
+      max-width: 220px;
+      margin-top: 0;
+      padding: 0.375rem 0.75rem;
+      border: 1px solid var(--ds-header-icon-color);
+      border-radius: 4px;
+      background-color: #fff !important;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      opacity: 1;
+      z-index: 1001;
+    }
+  }
 }
 

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ElementRef,
   ViewChild,
@@ -45,7 +46,12 @@ export class SearchNavbarComponent {
   // Whether the collapse animation is still running, keeps the dropdown visible until it finishes
   collapsing = false;
 
-  constructor(private formBuilder: UntypedFormBuilder, private router: Router, private searchService: SearchService) {
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private router: Router,
+    private searchService: SearchService,
+    private cdr: ChangeDetectorRef,
+  ) {
     this.searchForm = this.formBuilder.group(({
       query: '',
     }));
@@ -77,7 +83,15 @@ export class SearchNavbarComponent {
    * Called when the expand/collapse animation finishes
    */
   onAnimationDone(): void {
-    this.collapsing = false;
+    // The animation's "done" event can fire synchronously while Angular is still
+    // running change detection (e.g. in tests). Deferring the state change avoids
+    // ExpressionChangedAfterItHasBeenCheckedError. The component's OnPush ancestors
+    // are not notified when the flag is reset outside an event handler, so the view
+    // has to be marked for check explicitly.
+    setTimeout(() => {
+      this.collapsing = false;
+      this.cdr.markForCheck();
+    });
   }
 
   /**

--- a/src/app/search-navbar/search-navbar.component.ts
+++ b/src/app/search-navbar/search-navbar.component.ts
@@ -42,6 +42,8 @@ export class SearchNavbarComponent {
 
   // Search input field
   @ViewChild('searchInput') searchField: ElementRef;
+  // Whether the collapse animation is still running, keeps the dropdown visible until it finishes
+  collapsing = false;
 
   constructor(private formBuilder: UntypedFormBuilder, private router: Router, private searchService: SearchService) {
     this.searchForm = this.formBuilder.group(({
@@ -62,9 +64,20 @@ export class SearchNavbarComponent {
    * Collapses & blurs search bar by angular animation, see expandSearchInput
    */
   collapse() {
+    if (!this.searchExpanded) {
+      return;
+    }
     this.searchField.nativeElement.blur();
     this.searchExpanded = false;
     this.isExpanded = 'collapsed';
+    this.collapsing = true;
+  }
+
+  /**
+   * Called when the expand/collapse animation finishes
+   */
+  onAnimationDone(): void {
+    this.collapsing = false;
   }
 
   /**

--- a/src/app/shared/animations/slide.ts
+++ b/src/app/shared/animations/slide.ts
@@ -58,6 +58,10 @@ export const expandSearchInput = trigger('toggleAnimation', [
     width: '250px',
     opacity: '1',
   })),
+  transition('void => collapsed', style({
+    width: '0',
+    opacity: '0',
+  })),
   transition('* => collapsed', group([
     animate('300ms ease-in-out', style({
       width: '30px',

--- a/src/app/shared/sidebar/page-with-sidebar.component.scss
+++ b/src/app/shared/sidebar/page-with-sidebar.component.scss
@@ -20,6 +20,7 @@
 
   @include media-breakpoint-down(md) {
     position: relative;
+    left: 0 !important;
 
     &.row-offcanvas {
       position: relative;
@@ -39,7 +40,18 @@
       width: 100%;
       height: 100%;
       overflow: auto;
-      background-color: var(--bs-body-bg)
+      background-color: var(--bs-body-bg);
+
+      &.active {
+        position: relative;
+        left: 0;
+        height: auto;
+        overflow: visible;
+      }
+    }
+
+    .sidebar-content.active ~ .col-12:not(.sidebar-content) {
+      display: none;
     }
   }
 }

--- a/src/themes/dspace/app/header/header.component.scss
+++ b/src/themes/dspace/app/header/header.component.scss
@@ -10,6 +10,7 @@
 
     &-container {
       min-height: var(--ds-header-height);
+      position: relative;
     }
   }
 

--- a/src/themes/dspace/styles/_global-styles.scss
+++ b/src/themes/dspace/styles/_global-styles.scss
@@ -3,6 +3,12 @@
 // imports the base global style
 @import '../../../styles/_global-styles.scss';
 
+@media screen and (max-width: map-get($grid-breakpoints, md)) {
+  #main-site-header-container:has(form.search-expanded) {
+    margin-bottom: 25px;
+  }
+}
+
 .facet-filter, .setting-option, .advanced-search {
   background-color: var(--bs-light);
   border-radius: var(--bs-border-radius);


### PR DESCRIPTION
## References issue 
Fixes #5503

## Description
Applying fixes for mobile/table screens to fit properly on those screen sizes.

## Instructions for Reviewers
To test those scenarios please move to mobile/tablet screens and then follow the following instructions.

List of changes in this PR:
* Search input on Header, now on mobile the Search input is move to the botton to avoid overlaping with the icon on the header.
* Remove blank space on Search Items Screen, when you move through the Filter and Serch result the blank space between the filter and the footer has been removed to just keep the height needed to display it properly.
* Footer icon and links, now on mobile/tables screens the links on the footer are displayed inline without break it and then move to the next line to fit properly on the screen size.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
