### PR TITLE
Allow users to unsubscribe via "Manage Subscription" modal

### DIFF
--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.html
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.html
@@ -37,9 +37,6 @@
         </fieldset>
       }
     </div>
-    @if ((showDeleteInfo$ | async)) {
-      <p class="text-muted">{{'subscriptions.modal.delete-info' | translate}}</p>
-    }
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-outline-secondary"

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.spec.ts
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.spec.ts
@@ -188,6 +188,31 @@ describe('SubscriptionModalComponent', () => {
       expect(component.subscriptionForm.controls).toBeTruthy();
     });
 
+    it('should delete an existing subscription when all frequencies are unchecked', () => {
+      subscriptionServiceStub.deleteSubscription = jasmine.createSpy('deleteSubscription').and.returnValue(createSuccessfulRemoteDataObject$({}));
+
+      component.subscriptionForm = new UntypedFormGroup({});
+      for (let t of testTypes) {
+        const formGroup = new UntypedFormGroup({
+          subscriptionId: new UntypedFormControl(testSubscriptionId),
+          frequencies: new UntypedFormGroup({
+            f: new UntypedFormControl(false),
+            g: new UntypedFormControl(false),
+          }),
+        });
+        component.subscriptionForm.addControl(t, formGroup);
+        component.subscriptionForm.get('test1').markAsDirty();
+        component.subscriptionForm.get('test1').markAsTouched();
+      }
+
+      fixture.detectChanges();
+      component.submit();
+
+      expect(subscriptionServiceStub.deleteSubscription).toHaveBeenCalled();
+      expect(subscriptionServiceStub.createSubscription).not.toHaveBeenCalled();
+      expect(subscriptionServiceStub.updateSubscription).not.toHaveBeenCalled();
+    });
+
   });
 
   describe('when no subscription is given', () => {

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
@@ -97,11 +97,6 @@ export class SubscriptionModalComponent implements OnInit {
   public processing$ = new BehaviorSubject<boolean>(false);
 
   /**
-   * If true, show a message explaining how to delete a subscription
-   */
-  public showDeleteInfo$ = new BehaviorSubject<boolean>(false);
-
-  /**
    * Reactive form group that will be used to add/edit subscriptions
    */
   subscriptionForm: UntypedFormGroup;
@@ -122,7 +117,7 @@ export class SubscriptionModalComponent implements OnInit {
   frequencyDefaultValues = ['D', 'W', 'M'];
 
   /**
-   * True if form status has changed and at least one frequency is checked
+    * True if form status has changed and submit action is valid
    */
   isValid = false;
   /**

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
@@ -170,7 +170,7 @@ export class SubscriptionModalComponent implements OnInit {
         anyFrequencySelected = anyFrequencySelected || newValue.content.frequencies[f];
       }
       const hasExistingSubscription = this.subscriptionDefaultTypes.some(
-        (t) => isNotEmpty(newValue[t]?.subscriptionId)
+        (t) => isNotEmpty(newValue[t]?.subscriptionId),
       );
       this.isValid = anyFrequencySelected || hasExistingSubscription;
     });

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
@@ -220,7 +220,6 @@ export class SubscriptionModalComponent implements OnInit {
     ).subscribe({
       next: (res: PaginatedList<Subscription>) => {
         if (res.pageInfo.totalElements > 0) {
-          //this.showDeleteInfo$.next(true);
           for (const subscription of res.page) {
             const type = subscription.subscriptionType;
             const subscriptionGroup: UntypedFormGroup = this.subscriptionForm.get(type) as UntypedFormGroup;

--- a/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
+++ b/src/app/shared/subscriptions/subscription-modal/subscription-modal.component.ts
@@ -169,7 +169,10 @@ export class SubscriptionModalComponent implements OnInit {
       for (const f of this.frequencyDefaultValues) {
         anyFrequencySelected = anyFrequencySelected || newValue.content.frequencies[f];
       }
-      this.isValid = anyFrequencySelected;
+      const hasExistingSubscription = this.subscriptionDefaultTypes.some(
+        (t) => isNotEmpty(newValue[t]?.subscriptionId)
+      );
+      this.isValid = anyFrequencySelected || hasExistingSubscription;
     });
   }
 
@@ -217,7 +220,7 @@ export class SubscriptionModalComponent implements OnInit {
     ).subscribe({
       next: (res: PaginatedList<Subscription>) => {
         if (res.pageInfo.totalElements > 0) {
-          this.showDeleteInfo$.next(true);
+          //this.showDeleteInfo$.next(true);
           for (const subscription of res.page) {
             const type = subscription.subscriptionType;
             const subscriptionGroup: UntypedFormGroup = this.subscriptionForm.get(type) as UntypedFormGroup;
@@ -245,6 +248,7 @@ export class SubscriptionModalComponent implements OnInit {
     const subscriptionTypes: string[] = Object.keys(this.subscriptionForm.controls);
     const subscriptionsToBeCreated = [];
     const subscriptionsToBeUpdated = [];
+    const subscriptionsToBeDeleted = [];
 
     subscriptionTypes.forEach((subscriptionType: string) => {
       const subscriptionGroup: UntypedFormGroup = this.subscriptionForm.controls[subscriptionType] as UntypedFormGroup;
@@ -254,9 +258,10 @@ export class SubscriptionModalComponent implements OnInit {
           subscriptionType,
           subscriptionGroup.controls.frequencies as UntypedFormGroup,
         );
-
-        if (isNotEmpty(body.id)) {
+        if (isNotEmpty(body.id) && isNotEmpty(body.subscriptionParameterList)) {
           subscriptionsToBeUpdated.push(body);
+        } else if (isNotEmpty(body.id) && !isNotEmpty(body.subscriptionParameterList)) {
+          subscriptionsToBeDeleted.push(body);
         } else if (isNotEmpty(body.subscriptionParameterList)) {
           subscriptionsToBeCreated.push(body);
         }
@@ -299,6 +304,23 @@ export class SubscriptionModalComponent implements OnInit {
             }
           } else {
             this.notificationsService.error(null, this.translate.instant('subscriptions.modal.update.error'));
+          }
+        }),
+      ));
+    }
+
+    if (isNotEmpty(subscriptionsToBeDeleted)) {
+      toBeProcessed.push(from(subscriptionsToBeDeleted).pipe(
+        mergeMap((subscriptionBody: any) => {
+          return this.subscriptionService.deleteSubscription(subscriptionBody.id).pipe(
+            getFirstCompletedRemoteData(),
+          );
+        }),
+        tap((res: any) => {
+          if (res.hasSucceeded) {
+            this.notificationsService.success(null, this.translate.instant('subscriptions.modal.delete.success'));
+          } else {
+            this.notificationsService.error(null, this.translate.instant('subscriptions.modal.delete.error'));
           }
         }),
       ));


### PR DESCRIPTION
## References

Fixes #5922

## Description
Allows users to unsubscribe from a Community or Collection directly from the "Manage Subscription" modal by submitting with all frequency checkboxes unchecked.

## Instructions for Reviewers
List of changes in this PR:

- Modified isValid logic to also enable the Submit button when an existing subscription is present, even if all frequencies are unchecked (indicating intent to delete)
- Added delete logic in submit(): when a subscription exists but all frequencies are unchecked, it calls deleteSubscription() instead of update
- Removed the helper text that redirected users to the /subscriptions page to unsubscribe, since it is no longer necessary

How to test:

1. Log in as administrator
2. Navigate to any Community or Collection
3. Click ⋮ → Subscribe, select at least one frequency, click Submit
4. Open the same dialog again (now "Manage subscription")
5. Uncheck all frequency checkboxes
6. Verify the Submit button remains enabled
7. Click Submit — subscription should be deleted and a success notification appears

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
