### PR TITLE
-Fix issue 1059, refactor html view to display in tabs insted of list

### DIFF
--- a/src/app/access-control/group-registry/group-form/group-form.component.html
+++ b/src/app/access-control/group-registry/group-form/group-form.component.html
@@ -35,37 +35,58 @@
         }
       }
 
-      <ds-form [formId]="formId"
-        [formModel]="formModel"
-        [formGroup]="formGroup"
-        [formLayout]="formLayout"
-        [displayCancel]="false"
-        (submitForm)="onSubmit()">
-        <div before class="btn-group">
-          <button (click)="onCancel()" type="button"
-            class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{messagePrefix + '.return' | translate}}</button>
-          </div>
-          @if ((canEdit$ | async) && !(activeGroup$ | async)?.permanent) {
-            <div after class="btn-group">
-              <button (click)="delete()" class="btn btn-danger delete-button" type="button">
-                <i class="fa fa-trash"></i> {{ messagePrefix + '.actions.delete' | translate}}
-              </button>
+      <ul ngbNav [destroyOnHide]="true" #tabs="ngbNav" class="nav-tabs" role="tablist">
+        <li [ngbNavItem]="'editGroupTab'" role="presentation" data-test="editGroupTab">
+          <a ngbNavLink>{{messagePrefix + '.tabs.edit' | translate}}</a>
+          <ng-template ngbNavContent>
+            <div class="mt-2">
+              <ds-form [formId]="formId"
+                [formModel]="formModel"
+                [formGroup]="formGroup"
+                [formLayout]="formLayout"
+                [displayCancel]="false"
+                (submitForm)="onSubmit()">
+                <div before class="btn-group">
+                  <button (click)="onCancel()" type="button"
+                    class="btn btn-outline-secondary"><i class="fas fa-arrow-left"></i> {{messagePrefix + '.return' | translate}}</button>
+                  </div>
+                  @if ((canEdit$ | async) && !(activeGroup$ | async)?.permanent) {
+                    <div after class="btn-group">
+                      <button (click)="delete()" class="btn btn-danger delete-button" type="button">
+                        <i class="fa fa-trash"></i> {{ messagePrefix + '.actions.delete' | translate}}
+                      </button>
+                    </div>
+                  }
+                </ds-form>
             </div>
-          }
-        </ds-form>
-
+          </ng-template>
+        </li>
         @if ((activeGroup$ | async); as groupBeingEdited) {
-          <div class="mb-5">
-            @if (groupBeingEdited !== undefined) {
-              <ds-members-list
-              [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
-            }
-          </div>
-          @if (groupBeingEdited !== undefined) {
-            <ds-subgroups-list
-            [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
-          }
+          <li [ngbNavItem]="'ePeopleTab'" role="presentation" data-test="ePeopleTab">
+            <a ngbNavLink>{{messagePrefix + '.tabs.ePeople' | translate}}</a>
+            <ng-template ngbNavContent>
+              <div class="mt-2">
+                @if (groupBeingEdited !== undefined) {
+                  <ds-members-list
+                    [messagePrefix]="messagePrefix + '.members-list'"></ds-members-list>
+                }
+              </div>
+            </ng-template>
+          </li>
+          <li [ngbNavItem]="'groupsTab'" role="presentation" data-test="groupsTab">
+            <a ngbNavLink>{{messagePrefix + '.tabs.groups' | translate}}</a>
+            <ng-template ngbNavContent>
+              <div class="mt-2">
+                @if (groupBeingEdited !== undefined) {
+                  <ds-subgroups-list
+                    [messagePrefix]="messagePrefix + '.subgroups-list'"></ds-subgroups-list>
+                }
+              </div>
+            </ng-template>
+          </li>
         }
-      </div>
+      </ul>
+      <div [ngbNavOutlet]="tabs"></div>
+    </div>
     </div>
   </div>

--- a/src/app/access-control/group-registry/group-form/group-form.component.ts
+++ b/src/app/access-control/group-registry/group-form/group-form.component.ts
@@ -42,7 +42,14 @@ import {
   hasValueOperator,
   isNotEmpty,
 } from '@dspace/shared/utils/empty.util';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import {
+  NgbModal,
+  NgbNav,
+  NgbNavContent,
+  NgbNavItem,
+  NgbNavLink,
+  NgbNavOutlet,
+} from '@ng-bootstrap/ng-bootstrap';
 import {
   DynamicFormControlModel,
   DynamicFormLayout,
@@ -93,6 +100,11 @@ import { ValidateGroupExists } from './validators/group-exists.validator';
     ContextHelpDirective,
     FormComponent,
     MembersListComponent,
+    NgbNav,
+    NgbNavContent,
+    NgbNavItem,
+    NgbNavLink,
+    NgbNavOutlet,
     SubgroupsListComponent,
     TranslateModule,
   ],

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -535,6 +535,12 @@
 
   "admin.access-control.groups.form.return": "Back",
 
+  "admin.access-control.groups.form.tabs.edit": "Edit Group",
+
+  "admin.access-control.groups.form.tabs.ePeople": "EPeople",
+
+  "admin.access-control.groups.form.tabs.groups": "Groups",
+
   "admin.quality-assurance.breadcrumbs": "Quality Assurance",
 
   "admin.notifications.event.breadcrumbs": "Quality Assurance Suggestions",


### PR DESCRIPTION
## References
Fixes #1059.

## Description
Adding a small change to Edit Group to display the forms in a Tab Group instead of a list.

## Instructions for Reviewers
To test it, we need to move to Edit Group, select an item for editing, and now in the forms, instead of scrolling down to display the list of forms, it'll be available in tab sections for Edit Group, EPeople y Groups (subgroups).

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
