### PR TITLE
Fix <ds-search> rendering an empty page when the search configuration request fails

### DIFF
--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -41,6 +41,7 @@ import {
 } from '@dspace/core/shared/search/search-filters/search-config.model';
 import { SidebarServiceStub } from '@dspace/core/testing/sidebar-service.stub';
 import {
+  createFailedRemoteDataObject$,
   createSuccessfulRemoteDataObject,
   createSuccessfulRemoteDataObject$,
 } from '@dspace/core/utilities/remote-data.utils';
@@ -200,6 +201,7 @@ export function configureSearchComponentTestingModule(compType, additionalDeclar
     getConfigurationSortOptions: sortOptionsList,
     getConfig: filtersConfigRD$,
     getConfigurationSearchConfig: of(searchConfig),
+    getSearchConfigurationFor: createSuccessfulRemoteDataObject$(searchConfig),
     getCurrentConfiguration: of('default'),
     getCurrentScope: of('test-id'),
     getCurrentSort: of(sortOptionsList[0]),
@@ -450,6 +452,30 @@ describe('SearchComponent', () => {
         //Check that the last method from which the search depend upon is being called
         expect(searchManagerStub.search).toHaveBeenCalled();
       }));
+
+      describe('when the search configuration request fails', () => {
+        beforeEach(() => {
+          searchConfigurationServiceStub.getSearchConfigurationFor.and.returnValue(
+            createFailedRemoteDataObject$('Error fetching search configuration', 500),
+          );
+        });
+
+        it('should still initialize, so the search results error can be rendered', fakeAsync(() => {
+          comp.ngOnInit();
+          tick(100);
+
+          let initialized: boolean;
+          comp.initialized$.subscribe((res) => initialized = res);
+          expect(initialized).toBeTrue();
+        }));
+
+        it('should still request results, whose failure is what the user is shown', fakeAsync(() => {
+          comp.ngOnInit();
+          tick(100);
+
+          expect(searchManagerStub.search).toHaveBeenCalled();
+        }));
+      });
     });
   });
 });

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -38,7 +38,10 @@ import { DSpaceObject } from '@dspace/core/shared/dspace-object.model';
 import { followLink } from '@dspace/core/shared/follow-link-config.model';
 import { Item } from '@dspace/core/shared/item.model';
 import { ListableObject } from '@dspace/core/shared/object-collection/listable-object.model';
-import { getFirstCompletedRemoteData } from '@dspace/core/shared/operators';
+import {
+  getAllCompletedRemoteData,
+  getFirstCompletedRemoteData,
+} from '@dspace/core/shared/operators';
 import { PaginatedSearchOptions } from '@dspace/core/shared/search/models/paginated-search-options.model';
 import { SearchFilterConfig } from '@dspace/core/shared/search/models/search-filter-config.model';
 import { SearchObjects } from '@dspace/core/shared/search/models/search-objects.model';
@@ -401,9 +404,21 @@ export class SearchComponent implements OnDestroy, OnInit {
     // Determinate PaginatedSearchOptions and listen to any update on it
     const configuration$: Observable<string> = this.searchConfigService
       .getCurrentConfiguration(this.configuration).pipe(distinctUntilChanged());
+    // A failed search-configuration request must not stall the whole component.
+    // getConfigurationSearchConfig() pipes through
+    // getAllSucceededRemoteDataPayload(), so on failure it never emits: the
+    // combineLatest below never fires, initialized$ stays false, and the entire
+    // template is skipped — leaving a blank page in which not even
+    // ds-search-results (which renders the error) is created. Treat a failed
+    // configuration as "no sort options" so the component still initializes and
+    // the search results error can surface.
     const searchSortOptions$: Observable<SortOptions[]> = combineLatest([configuration$, this.currentScope$]).pipe(
-      switchMap(([configuration, scope]: [string, string]) => this.searchConfigService.getConfigurationSearchConfig(configuration, scope)),
-      map((searchConfig: SearchConfig) => this.searchConfigService.getConfigurationSortOptions(searchConfig)),
+      switchMap(([configuration, scope]: [string, string]) => this.searchConfigService.getSearchConfigurationFor(scope, configuration).pipe(
+        getAllCompletedRemoteData(),
+        map((searchConfigRD: RemoteData<SearchConfig>) => searchConfigRD.hasSucceeded
+          ? this.searchConfigService.getConfigurationSortOptions(searchConfigRD.payload)
+          : []),
+      )),
       distinctUntilChanged(),
     );
     const sortOption$: Observable<SortOptions> = searchSortOptions$.pipe(


### PR DESCRIPTION
This PR was developed with the help of an LLM. I also relied on an LLM to write the description below.

---------------

## References

_No issue ticket — this was found while investigating #5936 and is filed on its own merits. 

* Related to #5936 (closed) — the investigation that surfaced this, but this PR does not depend on it and reproduces on unmodified `main`.

---

## Description

`<ds-search>` renders nothing at all — no search form, no results, no empty state and no error — when its **search-configuration** request fails. The page looks like an empty repository. This PR lets the component initialise so its existing error handling can run.

---

## Instructions for Reviewers

`getConfigurationSearchConfig()` pipes through `getAllSucceededRemoteDataPayload()`, so a failed configuration request never emits. `combineLatest` therefore never fires, `initialized$` stays `false`, and the whole `<ds-search>` template is skipped — including the `ds-error` block that `search-results.component` already has. The error handling is present; it is simply never constructed.

**List of changes in this PR:**
* `search.component.ts` — initialise the component when the search-configuration   request fails, falling back to empty sort options, so the existing error and   empty states can render.
* `search.component.spec.ts` — two specs covering error-versus-empty.

### How to test

**1. Unit specs — no backend, no configuration required.**

```
npm test
```

The two added specs in `search.component.spec.ts` cover the case directly.

**2. In a browser.** This reproduces on unmodified `main`; the patch is not needed to see the bug.

1. Log in to any DSpace instance.
2. Go to **`/mydspace`**.
   ⚠ **Not `/search`** — `/search` does not issue this request at all, because the    homepage has already cached the `default` configuration. `/mydspace` uses    `workspace`, which has not been cached. `/access-control/bulk-access` also    reproduces it.
3. DevTools → Network → tick **Enable request blocking**, add the pattern:
   `*discover/search?configuration=*`
   ⚠ Use exactly that pattern. `*/discover/search*` also blocks the HAL
   endpoint-discovery request, which produces a different failure that
   demonstrates nothing.
4. Reload.

**Before this PR:** the content area is empty — no search form, no results, no
empty state, no error. Only the submission drag-and-drop zone remains, because that sits outside `<ds-search>`. The Network panel shows **no
`discover/search/objects` request at all**: the component never gets far enough to ask for results.

**After this PR:** the page renders and is usable — though with an empty sort
dropdown, and results in the fallback `dc.title,ASC` order rather than the
configured `lastModified,DESC`, because only the configuration request was blocked and the results request still succeeds.

**To see the error state**, add a second blocking pattern
`*discover/search/objects*`. You then get **"Error fetching search results"**
instead of a blank page.

### Known limitation, and a question for reviewers

Some installations report a `400` on this endpoint when the search fires before
authentication is attached (*"An anonymous user cannot perform a workspace or workflow search"*). Upstream already treats that as "no results" via `showError()`'s `statusCode !== 400` exemption, and this PR leaves that exemption intact. Our stack does not reproduce that 400, so we have shown that this change does not *introduce* a spurious error state — not that it handles that case correctly.

Separately: when only the configuration request fails, this PR substitutes defaults **silently** — the sort order changes and the sort dropdown is empty, with nothing saying so. It may be better to render the error *alongside* the results rather than
degrading quietly. I do not have a settled view and would welcome yours.

---

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** — 44 insertions, 3 deletions, across 2 files.
- [ ] My PR **follows all coding best practices** based on the Code Conventions Guide. 
- [x] My PR **passes ESLint** validation using `npm run lint` — full-repo clean.
- [x] My PR **doesn't introduce circular dependencies** — verified via `npm run check-circ-deps`.
- [ ] My PR **includes TypeDoc comments** for all new or modified public methods and classes. _
- [x] My PR **passes all specs/tests and includes new/updated specs** — 40/40 plus 2 new specs.
- [ ] My PR **aligns with Accessibility guidelines**. _
- [x] My PR **uses i18n keys** instead of hardcoded English text — no new key; reuses the existing `ds-error` component and message.
- [x] My PR **includes details on how to test it** — see above.
- [x] My PR does not include **new libraries/dependencies**.
- [x] My PR does not include **new features or configurations**.
- [ ] My PR **links an issue ticket** — none exists; see References.
