### PR TITLE
[Port dspace-8_x] Add detailed warnings to SSR-related configs about impact on SEO.

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -27,8 +27,11 @@ ssr:
   # disabled (false) by default to boost server performance at the expense of loading smoothness.
   inlineCriticalCss: false
   # Patterns to be run as regexes against the path of the page to check if SSR is allowed.
-  # If the path match any of the regexes it will be served directly in CSR.
+  # If the path match any of the regexes it will be served directly in CSR (i.e. SSR will be disabled for this path).
   # By default, excludes community and collection browse, global browse, global search, community list, statistics and various administrative tools.
+  # [WARNING] changing these settings may impact your Search Engine Optimization (SEO). Any paths listed in "excludedPathPatterns"
+  # may NOT be indexable by search engine crawlers (like Google Scholar). For search engine crawlers to fully index your site,
+  # this "excludePathPatterns" should NEVER exclude SSR from the homepage, community/collection pages or item/entity pages.
   excludePathPatterns:
     - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
       flag: "i"

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -5,11 +5,17 @@ export const environment: Partial<BuildConfig> = {
 
   // Angular SSR (Server Side Rendering) settings
   ssr: {
+    // WARNING: Disabling SSR will block major search engine crawlers (like Google Scholar) from indexing your site.
+    // Therefore, we highly recommend keeping SSR enabled at all times. However, for better performance, you may choose
+    // to minimize the paths that undergo SSR via the "excludePathPatterns" setting below.
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
     transferState: true,
     replaceRestUrl: true,
+    // WARNING: changing these settings may impact your Search Engine Optimization (SEO). Any paths listed in "excludedPathPatterns"
+    // may NOT be indexable by search engine crawlers (like Google Scholar). For search engine crawlers to fully index your site,
+    // this "excludePathPatterns" should NEVER exclude SSR from the homepage, community/collection pages or item/entity pages.
     excludePathPatterns: [
       {
         pattern: '^/communities/[a-f0-9-]{36}/browse(/.*)?$',


### PR DESCRIPTION
Manual port of https://github.com/DSpace/dspace-angular/pull/6075 to `dspace-8_x`.

NOTE: This backport does NOT include the warning on the `baseUrl` setting, as that warning is only applicable if you are using Angular 20+ (and 8.x uses Angular 17.x)