### PR TITLE
Admin Sidebar: support optional icons for extendable submenu

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.scss
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.scss
@@ -56,6 +56,20 @@
         padding-bottom: var(--ds-admin-sidebar-item-padding);
       }
 
+      // Menu item layout to align the optional icon and text label
+      .ds-menu-item {
+        display: flex;
+        width: 100%;
+        align-items: center;
+        box-sizing: border-box;
+        gap: var(--ds-admin-sidebar-item-padding);
+
+        span {
+          flex: 1;
+          min-width: 0;
+        }
+      }
+
       // These classes handle the collapsing behavior
       .sidebar-section-wrapper {
 

--- a/src/app/shared/menu/menu-item/external-link-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/external-link-menu-item.component.html
@@ -5,4 +5,8 @@
    [href]="href"
    [title]="item.text | translate"
    (click)="$event.stopPropagation()"
->{{item.text | translate}}</a>
+>@if (item.icon) {
+    <i class="fas fa-{{item.icon}} fa-fw" aria-hidden="true"></i>
+  }
+  <span>{{item.text | translate}}</span>
+</a>

--- a/src/app/shared/menu/menu-item/link-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/link-menu-item.component.html
@@ -9,4 +9,8 @@
    (keydown.enter)="navigate($event)"
    href="javascript:void(0);"
    tabindex="0"
->{{item.text | translate}}</a>
+>@if (item.icon) {
+    <i class="fas fa-{{item.icon}} fa-fw" aria-hidden="true"></i>
+  }
+  <span>{{item.text | translate}}</span>
+</a>

--- a/src/app/shared/menu/menu-item/link-menu-item.component.spec.ts
+++ b/src/app/shared/menu/menu-item/link-menu-item.component.spec.ts
@@ -87,4 +87,29 @@ describe('LinkMenuItemComponent', () => {
     expect(routerParamsQuery.length).toBe(1);
     expect(routerParamsQuery[0].queryParams).toBe(queryParams);
   });
+
+  describe('icon rendering', () => {
+    beforeEach(() => {
+      component.item.icon = undefined;
+      fixture.detectChanges();
+    });
+
+    it('should render the icon when item.icon is provided', () => {
+      component.item.icon = 'cog';
+      fixture.detectChanges();
+
+      const icon = debugElement.query(By.css('i.fa-cog'));
+
+      expect(icon).toBeTruthy();
+      expect(icon.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should not render the icon when item.icon is not provided', () => {
+      fixture.detectChanges();
+
+      const icon = debugElement.query(By.css('i.fas'));
+
+      expect(icon).toBeFalsy();
+    });
+  });
 });

--- a/src/app/shared/menu/menu-item/models/external-link.model.ts
+++ b/src/app/shared/menu/menu-item/models/external-link.model.ts
@@ -9,4 +9,5 @@ export class ExternalLinkMenuItemModel implements MenuItemModel {
   disabled?: boolean;
   text: string;
   href: string;
+  icon?: string;
 }

--- a/src/app/shared/menu/menu-item/models/link.model.ts
+++ b/src/app/shared/menu/menu-item/models/link.model.ts
@@ -12,4 +12,5 @@ export class LinkMenuItemModel implements MenuItemModel {
   text: string;
   link: string;
   queryParams?: Params | null;
+  icon?: string;
 }

--- a/src/app/shared/menu/menu-item/models/menu-item.model.ts
+++ b/src/app/shared/menu/menu-item/models/menu-item.model.ts
@@ -6,4 +6,5 @@ import { MenuItemType } from '../../menu-item-type.model';
 export interface MenuItemModel {
   type: MenuItemType;
   disabled?: boolean;
+  icon?: string;
 }

--- a/src/app/shared/menu/menu-item/models/onclick.model.ts
+++ b/src/app/shared/menu/menu-item/models/onclick.model.ts
@@ -8,5 +8,6 @@ export class OnClickMenuItemModel implements MenuItemModel {
   type = MenuItemType.ONCLICK;
   disabled?: boolean;
   text: string;
+  icon?: string;
   function: () => void;
 }

--- a/src/app/shared/menu/menu-item/models/text.model.ts
+++ b/src/app/shared/menu/menu-item/models/text.model.ts
@@ -8,4 +8,5 @@ export class TextMenuItemModel implements MenuItemModel {
   type = MenuItemType.TEXT;
   disabled?: boolean;
   text: string;
+  icon?: string;
 }

--- a/src/app/shared/menu/menu-item/onclick-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/onclick-menu-item.component.html
@@ -8,8 +8,17 @@
     (keyup.space)="activate($event)"
     (keyup.enter)="activate($event)"
     [attr.data-test]="item.text"
-  >{{item.text | translate}}</a>
+  >@if (item.icon) {
+      <i class="fas fa-{{item.icon}} fa-fw" aria-hidden="true"></i>
+    }
+    <span>{{item.text | translate}}</span>
+  </a>
 }
 @if (item.disabled) {
-  <span [attr.data-test]="item.text" class="nav-item nav-link disabled">{{item.text | translate}}</span>
+  <span [attr.data-test]="item.text" class="ds-menu-item nav-item nav-link disabled">
+    @if (item.icon) {
+      <i class="fas fa-{{item.icon}} fa-fw" aria-hidden="true"></i>
+    }
+    <span>{{item.text | translate}}</span>
+  </span>
 }

--- a/src/app/shared/menu/menu-item/onclick-menu-item.component.spec.ts
+++ b/src/app/shared/menu/menu-item/onclick-menu-item.component.spec.ts
@@ -38,6 +38,7 @@ describe('OnClickMenuItemComponent', () => {
     spyOn(item, 'function');
     fixture = TestBed.createComponent(OnClickMenuItemComponent);
     component = fixture.componentInstance;
+    component.item = item;
     debugElement = fixture.debugElement;
     fixture.detectChanges();
   });
@@ -54,5 +55,42 @@ describe('OnClickMenuItemComponent', () => {
   it('should call the function on the item when clicked', () => {
     debugElement.query(By.css('a.ds-menu-item')).triggerEventHandler('click', new Event(('click')));
     expect(item.function).toHaveBeenCalled();
+  });
+
+  describe('icon rendering', () => {
+    beforeEach(() => {
+      item.icon = undefined;
+      item.disabled = false;
+      fixture.detectChanges();
+    });
+
+    it('should render the icon when item.icon is provided and enabled', () => {
+      item.icon = 'users';
+      fixture.detectChanges();
+
+      const icon = debugElement.query(By.css('a.ds-menu-item i.fa-users'));
+
+      expect(icon).toBeTruthy();
+      expect(icon.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should render the icon when item.icon is provided and disabled', () => {
+      item.icon = 'users';
+      item.disabled = true;
+      fixture.detectChanges();
+
+      const icon = debugElement.query(By.css('span.ds-menu-item i.fa-users'));
+
+      expect(icon).toBeTruthy();
+      expect(icon.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should not render the icon when item.icon is not provided', () => {
+      fixture.detectChanges();
+
+      const icon = debugElement.query(By.css('i.fas'));
+
+      expect(icon).toBeFalsy();
+    });
   });
 });

--- a/src/app/shared/menu/menu-item/text-menu-item.component.html
+++ b/src/app/shared/menu/menu-item/text-menu-item.component.html
@@ -1,1 +1,9 @@
-<span class="ds-menu-item" [class.disabled]="item.disabled" tabindex="0" role="button">{{item.text | translate}}</span>
+<span class="ds-menu-item"
+      [class.disabled]="item.disabled"
+      tabindex="0"
+      role="button"
+>@if (item.icon) {
+    <i class="fas fa-{{item.icon}} fa-fw" aria-hidden="true"></i>
+  }
+  <span>{{item.text | translate}}</span>
+</span>


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/6117

## Description
This PR adds icon support to extendable submenu items in the admin sidebar.

**Please note this PR does not add any new icons!**

#### Example
<img width="564" height="685" alt="screenshot_20260821161212" src="https://github.com/user-attachments/assets/611f3faf-a746-402f-af28-3e5c9d429c62" />

## Instructions for Reviewers

**Changes in this PR:**
* Added optional `icon` property to extendable submenu item configuration for every instance of `MenuItemModel`
* Updated submenu rendering logic to display icons **when provided**
* Updated `MenuItemModel`s rendering logic to display icons **when provided**
  * Both `AltmetricMenuItemModel` and `SearchMenuItemModel` were **not updated** due to their specific use cases (they are not used in the extendable submenu anyway)
* Kept fallback behavior (existing menu items without icons still render correctly)
* Added tests (`LinkMenuItem` & `OnclickMenuItem`) to validate the icon rendering support

### How to Test

Please note DSpace does not have built-in validation to verify if a FontAwesome icon string actually exists. This PR does **not** change that.

During tests, please ensure that:
* Admin Sidebar still behaves the same (no new icons, no changes in sections, etc.)
* New icons appear correctly when added via the `icon` property (check the configuration example below)
* No regression in menu rendering for items without icons
* Rendering fits DSpace standards (gaps between icon/label, etc.)

To fully test this PR, you can add new icons in submenu: go to any inheritor of `AbstractExpandableMenuProvider` and inside a `model` define a value for `icon: '...'`.

#### Example

```typescript
// src/app/shared/menu/providers/new.menu.ts
// ...
return [
        {
          visible: isCommunityAdmin,
          model: {
            type: MenuItemType.ONCLICK,
            text: 'menu.section.new_community',
            icon: 'user-group', // <-------------- add an icon like this
            function: () => {
              this.modalService.open(ThemedCreateCommunityParentSelectorComponent);
            },
          },
        },
        // ...
]
```

## LLM Disclosure

Instructed local Qwen3.8:27B to write tests & test compliance with CODE_CONVENTIONS.md & check browser compatibility before submitting the PR. The rest is my own work (meaning pretty much copy-pasted from the existing DSpace components :wink:)

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [X] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [X] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [X] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [ ] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [X] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [X] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
