### PR TITLE
Fix #5867: Clipped admin sidebar text macOS using firefox

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar.component.scss
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.scss
@@ -143,4 +143,11 @@
   .browser-firefox-windows {
     --ds-dark-scrollbar-width: 20px;
   }
+  .browser-firefox-macOS {
+    --ds-dark-scrollbar-width: 15px;
+  }
+  // Set default for firefox browser on all OSs
+  .browser-firefox {
+    --ds-dark-scrollbar-width: 15px;
+  }
 }

--- a/src/app/root/root.component.ts
+++ b/src/app/root/root.component.ts
@@ -157,6 +157,8 @@ export class RootComponent implements OnInit {
     const userAgent = this._window.nativeWindow.navigator?.userAgent;
     if (/Windows/.test(userAgent)) {
       return 'windows';
+    } else if (/Macintosh/.test(userAgent)) {
+      return 'macOS';
     }
     return undefined;
   }


### PR DESCRIPTION
## References
* Fixes #5867

## Description
For windows using Firefox, an estimated scrollbar width was already set for the admin-sidebar [here](https://github.com/DSpace/dspace-angular/blob/main/src/app/admin/admin-sidebar/admin-sidebar.component.scss#L143). This was not the case yet for macOS.
- Made sure macOS was recognized when setting the class .browser-{browser name}-{OS name}
- Added the appropriate width for macOS
- Added the same width as a default for other OSs, so this shouldn't be an issue anymore in the future.

## Instructions for Reviewers
- Open the admin sidebar (make sure to be logged in as an administrator)
- Verify the text is now displayed fully next to the icon, instead of partially hidden by the icon.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
