### PR TITLE
Minor dependabot rule updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -115,12 +115,14 @@ updates:
         - "actions/*"
         - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "github/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "docker/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   #####################
   ## dspace-10_x branch
   #####################
@@ -232,12 +234,14 @@ updates:
         - "actions/*"
         - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "github/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "docker/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   #####################
   ## dspace-9_x branch
   #####################
@@ -349,12 +353,14 @@ updates:
         - "actions/*"
         - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "github/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "docker/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   #####################
   ## dspace-8_x branch
   #####################
@@ -468,9 +474,11 @@ updates:
         - "actions/*"
         - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "github/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "docker/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]


### PR DESCRIPTION
## References
* Port of https://github.com/DSpace/DSpace/pull/12927 to `dspace-angular`

## Description

This PR just includes a minor Dependabot update:
* Add `docker/**` GitHub actions to the list of actions which we ignore minor/patch updates for. This is because we reference these actions by a major version tag which automatically uses the latest minor/patch version (e.g. "v5" references latest v5.x.x release)

This change was already added to `DSpace/DSpace` in https://github.com/DSpace/DSpace/pull/12927 , but I forgot to add it to the frontend repo.

## Instructions for Reviewers
* This can only be tested by merging as it's just updates to dependabot rules.
