### PR TITLE
Applying changes to display properly the input warnings and submit form button

### DIFF
--- a/src/app/process-page/form/process-form.component.html
+++ b/src/app/process-page/form/process-form.component.html
@@ -5,10 +5,10 @@
     </h1>
     <div class="col-12 col-md-6 mb-2">
       <form #form="ngForm" (ngSubmit)="submitForm(form)">
-        <ds-scripts-select [script]="selectedScript" (select)="selectedScript = $event; parameters = undefined"></ds-scripts-select>
+        <ds-scripts-select [submitted]="submitted" [script]="selectedScript" (select)="selectedScript = $event; parameters = undefined"></ds-scripts-select>
         <ds-process-parameters [initialParams]="parameters" [script]="selectedScript" (updateParameters)="parameters = $event"></ds-process-parameters>
         <a [routerLink]="['/processes']" class="btn btn-danger float-start">{{ 'process.new.cancel' | translate }}</a>
-        <button type="submit" class="btn btn-primary float-end">{{ 'process.new.submit' | translate }}</button>
+        <button type="submit" class="btn btn-primary float-end" [disabled]="form.invalid || !isScriptSelected">{{ 'process.new.submit' | translate }}</button>
       </form>
     </div>
     <div class="col-12 col-md-6">

--- a/src/app/process-page/form/process-form.component.html
+++ b/src/app/process-page/form/process-form.component.html
@@ -8,7 +8,7 @@
         <ds-scripts-select [submitted]="submitted" [script]="selectedScript" (select)="selectedScript = $event; parameters = undefined"></ds-scripts-select>
         <ds-process-parameters [initialParams]="parameters" [script]="selectedScript" (updateParameters)="parameters = $event"></ds-process-parameters>
         <a [routerLink]="['/processes']" class="btn btn-danger float-start">{{ 'process.new.cancel' | translate }}</a>
-        <button type="submit" class="btn btn-primary float-end" [disabled]="form.invalid || !isScriptSelected">{{ 'process.new.submit' | translate }}</button>
+        <button type="submit" class="btn btn-primary float-end" [dsBtnDisabled]="form.invalid || !isScriptSelected">{{ 'process.new.submit' | translate }}</button>
       </form>
     </div>
     <div class="col-12 col-md-6">

--- a/src/app/process-page/form/process-form.component.spec.ts
+++ b/src/app/process-page/form/process-form.component.spec.ts
@@ -110,6 +110,31 @@ describe('ProcessFormComponent', () => {
     expect(scriptService.invoke).toHaveBeenCalled();
   });
 
+  it('should mark the form as submitted when submit is attempted', () => {
+    expect(component.submitted).toBeFalse();
+    component.submitForm({ controls: {} } as any);
+    expect(component.submitted).toBeTrue();
+  });
+
+  describe('when no script is selected', () => {
+    beforeEach(() => {
+      component.selectedScript = undefined;
+    });
+
+    it('should not invoke the script on submit', () => {
+      component.submitForm({ controls: {} } as any);
+      expect(scriptService.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should report that a script is not selected', () => {
+      expect(component.isScriptSelected).toBeFalse();
+    });
+  });
+
+  it('should report that a script is selected', () => {
+    expect(component.isScriptSelected).toBeTrue();
+  });
+
   describe('when undefined parameters are provided', () => {
     beforeEach(() => {
       component.parameters = undefined;

--- a/src/app/process-page/form/process-form.component.ts
+++ b/src/app/process-page/form/process-form.component.ts
@@ -30,6 +30,7 @@ import {
   TranslateService,
 } from '@ngx-translate/core';
 
+import { BtnDisabledDirective } from '../../shared/btn-disabled.directive';
 import { getProcessListRoute } from '../process-page-routing.paths';
 import { ProcessParametersComponent } from './process-parameters/process-parameters.component';
 import { ScriptHelpComponent } from './script-help/script-help.component';
@@ -43,6 +44,7 @@ import { ScriptsSelectComponent } from './scripts-select/scripts-select.componen
   templateUrl: './process-form.component.html',
   styleUrls: ['./process-form.component.scss'],
   imports: [
+    BtnDisabledDirective,
     FormsModule,
     ProcessParametersComponent,
     RouterLink,

--- a/src/app/process-page/form/process-form.component.ts
+++ b/src/app/process-page/form/process-form.component.ts
@@ -21,7 +21,10 @@ import { ProcessParameter } from '@dspace/core/processes/process-parameter.model
 import { getFirstCompletedRemoteData } from '@dspace/core/shared/operators';
 import { Script } from '@dspace/core/shared/scripts/script.model';
 import { ScriptParameter } from '@dspace/core/shared/scripts/script-parameter.model';
-import { isEmpty } from '@dspace/shared/utils/empty.util';
+import {
+  hasValue,
+  isEmpty,
+} from '@dspace/shared/utils/empty.util';
 import {
   TranslateModule,
   TranslateService,
@@ -79,6 +82,19 @@ export class ProcessFormComponent implements OnInit {
    */
   public missingParameters = [];
 
+  /**
+   * Indicates whether the form has been submitted
+   * Used to surface validation errors on an interrupted submission
+   */
+  public submitted = false;
+
+  /**
+   * Indicates whether a script has been selected
+   */
+  get isScriptSelected(): boolean {
+    return hasValue(this.selectedScript);
+  }
+
   constructor(
     private scriptService: ScriptDataService,
     private notificationsService: NotificationsService,
@@ -95,10 +111,11 @@ export class ProcessFormComponent implements OnInit {
    * @param form
    */
   submitForm(form: NgForm) {
+    this.submitted = true;
     if (isEmpty(this.parameters)) {
       this.parameters = [];
     }
-    if (!this.validateForm(form) || this.isRequiredMissing()) {
+    if (!this.isScriptSelected || !this.validateForm(form) || this.isRequiredMissing()) {
       return;
     }
 
@@ -157,6 +174,9 @@ export class ProcessFormComponent implements OnInit {
 
   private isRequiredMissing() {
     this.missingParameters = [];
+    if (!this.isScriptSelected || isEmpty(this.selectedScript.parameters)) {
+      return false;
+    }
     const setParams: string[] = this.parameters
       .map((param) => param.name);
     const requiredParams: ScriptParameter[] = this.selectedScript.parameters.filter((param) => param.mandatory);

--- a/src/app/process-page/form/scripts-select/scripts-select.component.html
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.html
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div>
-    @if (script.invalid && (script.dirty || script.touched)) {
+    @if (script.invalid && (script.dirty || script.touched || submitted)) {
       <div
         class="alert alert-danger validation-error">
         @if (script.errors.required) {

--- a/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
@@ -121,6 +121,13 @@ describe('ScriptsSelectComponent', () => {
 
   it('should not show a validation error if the form was submitted but the input was not left empty', fakeAsync(() => {
     (component as any)._selectedScript.id = 'testValue';
+    fixture.detectChanges();
+    tick();
+
+    const select = fixture.debugElement.query(By.css('#process-script'));
+    select.triggerEventHandler('blur', null);
+    fixture.detectChanges();
+
     component.submitted = true;
     fixture.detectChanges();
     tick();

--- a/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.spec.ts
@@ -110,6 +110,25 @@ describe('ScriptsSelectComponent', () => {
     expect(validationError).toBeFalsy();
   }));
 
+  it('should show a validation error if the form was submitted but the input was left empty', fakeAsync(() => {
+    component.submitted = true;
+    fixture.detectChanges();
+    tick();
+
+    const validationError = fixture.debugElement.query(By.css('.validation-error'));
+    expect(validationError).toBeTruthy();
+  }));
+
+  it('should not show a validation error if the form was submitted but the input was not left empty', fakeAsync(() => {
+    (component as any)._selectedScript.id = 'testValue';
+    component.submitted = true;
+    fixture.detectChanges();
+    tick();
+
+    const validationError = fixture.debugElement.query(By.css('.validation-error'));
+    expect(validationError).toBeFalsy();
+  }));
+
   it('should load more scripts when scrolled to the bottom', fakeAsync(() => {
     spyOn(component, 'loadScripts');
     const event = {

--- a/src/app/process-page/form/scripts-select/scripts-select.component.ts
+++ b/src/app/process-page/form/scripts-select/scripts-select.component.ts
@@ -68,6 +68,11 @@ export class ScriptsSelectComponent implements OnInit, OnDestroy {
    */
   @Output() select: EventEmitter<Script> = new EventEmitter<Script>();
   /**
+   * Indicates whether the parent form has been submitted
+   * Used to surface validation errors for an empty selection
+   */
+  @Input() submitted = false;
+  /**
    * All available scripts
    */
   scripts: Script[] = [];


### PR DESCRIPTION

## References
Fixes #6166

## Description

The validation for the process creation form has been corrected to prevent submission unless a script has been selected. Previously, it was possible to click "Submit" without selecting a script, which caused errors. Now, the button is automatically disabled until a script is selected and the form is valid. Additionally, validation errors in the script selector are displayed immediately upon attempting to submit, even if the field had not been interacted with previously.

## Instructions for Reviewers
Applying changes to fix and display the input warnings on new process creation and the submit form button.

To reproduce

1. Log in as admin
2. Navigate to /processes/new
3. Enter a process name that does not exist/not enter a value
4. Click the 'Save' button won't be enabled until the form is valid.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [ ] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
