### PR TITLE
Fix Mirador build issues on `main` and 10.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20718,6 +20718,25 @@
         "react-dom": "16.x"
       }
     },
+    "node_modules/mirador-share-plugin/node_modules/notistack": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
+      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/mirador/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -21224,44 +21243,6 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/notistack": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
-      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.0",
-        "goober": "^2.0.33"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/notistack"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/notistack/node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/notistack/node_modules/goober": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
-      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/nouislider": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
     "@nicky-lenaers/ngx-scroll-to": {
       "@angular/common": "^20.3.12",
       "@angular/core": "^20.3.12"
+    },
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "mirador-share-plugin": {
+      "notistack": "1.0.10"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean:prod": "npm run clean:dist && npm run clean:log && npm run clean:doc && npm run clean:coverage && npm run clean:json",
     "clean": "npm run clean:prod && npm run clean:dev:config && npm run clean:cli && npm run clean:decorator:registries && npm run clean:node",
     "sync-i18n": "ts-node -r tsconfig-paths/register --project ./tsconfig.ts-node.json scripts/sync-i18n-files.ts",
-    "build:mirador": "webpack --config webpack/webpack.mirador.config.ts",
+    "build:mirador": "cross-env TS_NODE_PROJECT=./tsconfig.ts-node.json webpack --config webpack/webpack.mirador.config.ts",
     "merge-i18n": "ts-node -r tsconfig-paths/register --project ./tsconfig.ts-node.json scripts/merge-i18n-files.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",


### PR DESCRIPTION
## Description
This PR fixes issues that have recently appeared on the `main` and `dspace-10_x` branch regarding install/build warnings related to Mirador inconsistencies/incompatibilities.

There's two main issues that are fixed here:

1. A regular `npm install` will show a number of `ERESOLVE` warnings that look like this. These warnings all relate to Mirador and the `mirador-share-plugin` 
   ```
   npm warn While resolving: notistack@3.0.2
   npm warn Found: react@16.14.0
   npm warn node_modules/react
   npm warn   peer react@"^16.8.0 || ^17.0.0" from @material-ui/core@4.12.4
   npm warn   node_modules/@material-ui/core
   npm warn     peer @material-ui/core@"^4.0.0" from @material-ui/icons@4.11.3
   npm warn     node_modules/@material-ui/icons
   npm warn     4 more (@material-ui/lab, mirador, mirador-dl-plugin, mirador-share-plugin)
   npm warn   33 more (@material-ui/icons, @material-ui/lab, ...)
   npm warn
   npm warn Could not resolve dependency:
   npm warn peer react@"^17.0.0 || ^18.0.0 || ^19.0.0" from notistack@3.0.2
   npm warn node_modules/notistack
   npm warn   notistack@"^3.0.1" from mirador-share-plugin@0.16.0
   npm warn   node_modules/mirador-share-plugin
   npm warn
   npm warn Conflicting peer dependency: react@19.2.8
   npm warn node_modules/react
   npm warn   peer react@"^17.0.0 || ^18.0.0 || ^19.0.0" from notistack@3.0.2
   npm warn   node_modules/notistack
   npm warn     notistack@"^3.0.1" from mirador-share-plugin@0.16.0
   npm warn     node_modules/mirador-share-plugin
   npm warn ERESOLVE overriding peer dependency
   npm warn While resolving: notistack@3.0.2
   npm warn Found: react-dom@16.14.0
   npm warn node_modules/react-dom
   npm warn   peer react-dom@"^16.8.0 || ^17.0.0" from @material-ui/core@4.12.4
   npm warn   node_modules/@material-ui/core
   npm warn     peer @material-ui/core@"^4.0.0" from @material-ui/icons@4.11.3
   npm warn     node_modules/@material-ui/icons
   npm warn     4 more (@material-ui/lab, mirador, mirador-dl-plugin, mirador-share-plugin)
   npm warn   21 more (@material-ui/icons, @material-ui/lab, ...)
   npm warn
   npm warn Could not resolve dependency:
   npm warn peer react-dom@"^17.0.0 || ^18.0.0 || ^19.0.0" from notistack@3.0.2
   npm warn node_modules/notistack
   npm warn   notistack@"^3.0.1" from mirador-share-plugin@0.16.0
   npm warn   node_modules/mirador-share-plugin
   npm warn
   npm warn Conflicting peer dependency: react-dom@19.2.8
   npm warn node_modules/react-dom
   npm warn   peer react-dom@"^17.0.0 || ^18.0.0 || ^19.0.0" from notistack@3.0.2
   npm warn   node_modules/notistack
   npm warn     notistack@"^3.0.1" from mirador-share-plugin@0.16.0
   npm warn     node_modules/mirador-share-plugin
   ```
2. Second, the Mirador build process (`npm run build:mirador`) doesn't work for Node 22.20+.  It will throw an immediate error that looks like this:
   ```
   [webpack-cli] Failed to load 'C:\dspace-angular\webpack\webpack.mirador.config.ts' config
   [webpack-cli] ReferenceError: require is not defined in ES module scope, you can use import instead
      at file:///C:/dspace-angular/webpack/webpack.mirador.config.ts:4:27
      at ModuleJobSync.runSync (node:internal/modules/esm/module_job:458:37)
      at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:435:47)
      at loadESMFromCJS (node:internal/modules/cjs/loader:1537:24)
      at Module._compile (node:internal/modules/cjs/loader:1688:5)
      at Module.m._compile (C:\dspace-angular\node_modules\ts-node\src\index.ts:858:23)
      at node:internal/modules/cjs/loader:1839:10
      at Object.require.extensions.<computed> [as .ts] (C:\dspace-angular\node_modules\ts-node\src\index.ts:861:12)
      at Module.load (node:internal/modules/cjs/loader:1441:32)
      at Function._load (node:internal/modules/cjs/loader:1263:12)
   ```

There's two fixes in this PR:
1. To fix the `npm install` issues, I've pinned `react` and `react-dom` to `16.14.0` and `notistack` to `1.0.10` in the `overrides` section of the `package.json`.
    * Pinning `react` and `react-dom` ensures that we are using the exact version of React that Mirador v3 is expecting
    * Pinning `notistack` is actually a *downgrade* of the `notistack` version used by `mirador-share-plugin`. But, this older version of `notistack` is compatible with React v16.  (*I've also tested it manually and verified this doesn't impact the `mirador-share-plugin` behavior...the share button still works fine from within Mirador*)
    * ALL of these pinned versions should be considered temporary until we upgrade to Mirador v4 (see #5443), but that seems like a larger effort.
2. To fix the `npm run build:mirador` error, I've updated that script in `package.json` to align with the `npm run build:prod` script by using `cross-env`.  That fixes the build error.

**NOTE: This needs to be minimally backported to 10.x.**  It is possible that the `npm install` fix may also need to be backported further (I haven't yet analyzed if 9.x sees these same warnings. I suspect it likely does since the warnings come from using Mirador v3 with more modern dependencies elsewhere and v9 dependencies are similar enough to 10.x and main).

**NOTE 2:** This PR also MIGHT solve `dependabot` issues we are seeing in recent PRs like #6161.  That's where this work all started...but the exact process that `dependabot` uses to create new PRs is a bit mysterious to me still.  So, it may not be a complete solution.

## Instructions for Reviewers
* Review code changes
* Try running `npm install`.  Verify you no longer see the above `ERESOLVE` warnings
* Try running `npm run build:mirador` (especially with Node v22.20+) and verify the build process now succeeds. Previously it failed immediately.
* Optionally deploy & test IIIF integration with Mirador.  (NOTE: I've already tested that the IIIF functionality still works with these changes in place, and the `mirador-share-plugin` still works to allow you to copy IIIF manifest information to share.)

## AI Disclosure

I used Claude Code to help determine the source of both issues.  Initially, I was trying to solve the first issue (`npm install` bug), and when I went to test the solution, I ran into the second issue.  While the AI initially gave some incomplete, inaccurate advice for the `ERESOLVE` errors, I was able to build the solution to the first issue (`npm install`) via these discussions.  The second issue was pinpointed directly by AI, but I fully tested the solution to ensure IIIF still functions properly.  

This PR description is fully written by me & all code fully reviewed & tested by me (including re-deploying and verifying that Mirador and IIIF integration work as expected). 