### PR TITLE
fix(accessibility): group search filters into single section landmark and remove individual facet landmarks (#5497)

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.html
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.html
@@ -1,6 +1,6 @@
 @if (active$ | async) {
   <div class="facet-filter d-block mb-3 p-3"
-    [id]="regionId" [attr.aria-labelledby]="toggleId" [ngClass]="{ 'focus': focusBox }" role="region">
+    [id]="regionId" [attr.aria-labelledby]="toggleId" [ngClass]="{ 'focus': focusBox }">
     <button (click)="toggle()" (focusin)="focusBox = true" (focusout)="focusBox = false"
       class="filter-name d-flex" [attr.aria-controls]="regionId" [id]="toggleId"
       [attr.aria-expanded]="(collapsed$ | async) !== true"

--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.spec.ts
@@ -97,7 +97,7 @@ describe('SearchFilterComponent', () => {
 
   it('should not expose individual facet filter as a region landmark', () => {
     const facetFilterElement = fixture.debugElement.query(By.css('.facet-filter'));
-    expect(facetFilterElement.attributes['role']).not.toBe('region');
+    expect(facetFilterElement.attributes.role).not.toBe('region');
   });
 
   describe('when the toggle method is triggered', () => {

--- a/src/app/shared/search/search-filters/search-filter/search-filter.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-filter.component.spec.ts
@@ -7,6 +7,7 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { AppliedFilter } from '@dspace/core/shared/search/models/applied-filter.model';
@@ -92,6 +93,11 @@ describe('SearchFilterComponent', () => {
     expect(sequenceService.next).toHaveBeenCalled();
     expect(comp.toggleId).toContain('17');
     expect(comp.regionId).toContain('17');
+  });
+
+  it('should not expose individual facet filter as a region landmark', () => {
+    const facetFilterElement = fixture.debugElement.query(By.css('.facet-filter'));
+    expect(facetFilterElement.attributes['role']).not.toBe('region');
   });
 
   describe('when the toggle method is triggered', () => {

--- a/src/app/shared/search/search-filters/search-filters.component.html
+++ b/src/app/shared/search/search-filters/search-filters.component.html
@@ -1,3 +1,5 @@
+<section [attr.aria-label]="filterLabel + '.filters.head' | translate">
+
 @if (inPlaceSearch) {
   <h3>{{filterLabel+'.filters.head' | translate}}</h3>
 } @else {
@@ -21,4 +23,4 @@
     <i class="fas fa-undo"></i> {{"search.filters.reset" | translate}}
   </button>
 }
-
+</section>

--- a/src/app/shared/search/search-filters/search-filters.component.spec.ts
+++ b/src/app/shared/search/search-filters/search-filters.component.spec.ts
@@ -7,6 +7,7 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { APP_CONFIG } from '@dspace/config/app-config.interface';
@@ -65,6 +66,14 @@ describe('SearchFiltersComponent', () => {
 
     it('should call getSearchLink on the searchService', () => {
       expect(searchService.getSearchLink).toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should render a section landmark with an accessible aria-label', () => {
+      const sectionElement = fixture.debugElement.query(By.css('section'));
+      expect(sectionElement).toBeTruthy();
+      expect(sectionElement.attributes['aria-label']).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## References
* Fixes #5497

## Description
This PR resolves accessibility landmark overload in the search filters by removing `role="region"` from individual facet filters and grouping the entire filter component under a single labeled `<section>` landmark.

## Instructions for Reviewers
List of changes in this PR:
* Removed `role="region"` from `SearchFilterComponent` (`search-filter.component.html`) so individual facets (e.g. Author, Subject, Date, Item Type) are no longer exposed as separate region landmarks.
* Wrapped `SearchFiltersComponent` (`search-filters.component.html`) in a semantic `<section [attr.aria-label]="filterLabel + '.filters.head' | translate">` landmark to provide a single labeled region for the entire search filters panel.
* Added accessibility unit tests in `search-filter.component.spec.ts` and `search-filters.component.spec.ts`.

### How to test:
1. Run the search filters unit tests:
   ```bash
   npm test -- --include="src/app/shared/search/search-filters/**/*.spec.ts"
   ```