### PR TITLE
[Port dspace-9_x] Fix Mirador build warnings on 9.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20746,6 +20746,25 @@
         "react-dom": "16.x"
       }
     },
+    "node_modules/mirador-share-plugin/node_modules/notistack": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.10.tgz",
+      "integrity": "sha512-z0y4jJaVtOoH3kc3GtNUlhNTY+5LE04QDeLVujX3VPhhzg67zw055mZjrBF+nzpv3V9aiPNph1EgRU4+t8kQTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/mirador/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -21250,44 +21269,6 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/notistack": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
-      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.0",
-        "goober": "^2.0.33"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/notistack"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/notistack/node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/notistack/node_modules/goober": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
-      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/nouislider": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
     "@nicky-lenaers/ngx-scroll-to": {
       "@angular/common": "^20.3.12",
       "@angular/core": "^20.3.12"
+    },
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "mirador-share-plugin": {
+      "notistack": "1.0.10"
     }
   },
   "dependencies": {


### PR DESCRIPTION

## Description
Partial port of #6171 to `dspace-9_x`

This PR only includes the commit which fixes the `ERESOLVE` warnings when running `npm install`.  Those same warnings appear in 9.x. (The other Mirador build issue does NOT exist in 9.x)
