### PR TITLE
fix #6086 : resolve WCAG 1.4.10 reflow issues on mobile and 200% zoom

### DIFF
--- a/src/app/community-list-page/community-list/community-list.component.html
+++ b/src/app/community-list-page/community-list/community-list.component.html
@@ -3,7 +3,7 @@
 }
 <cdk-tree [dataSource]="dataSource" [treeControl]="treeControl" [trackBy]="trackBy">
   <!-- This is the tree node template for show more node -->
-  <cdk-tree-node *cdkTreeNodeDef="let node; when: isShowMore" cdkTreeNodePadding
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: isShowMore" cdkTreeNodePadding [cdkTreeNodePaddingIndent]="24"
     class="example-tree-node show-more-node">
     <div class="btn-group">
       <span aria-hidden="true" class="btn btn-default invisible" cdkTreeNodeToggle>
@@ -27,7 +27,7 @@
     </div>
   </cdk-tree-node>
   <!-- This is the tree node template for expandable nodes (coms and subcoms with children) -->
-  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding [cdkTreeNodePaddingIndent]="24"
     class="example-tree-node expandable-node">
     <div class="btn-group">
       @if (hasChild(null, node) | async) {
@@ -85,7 +85,7 @@
     }
   </cdk-tree-node>
   <!-- This is the tree node template for leaf nodes (collections and (sub)coms without children) -->
-  <cdk-tree-node *cdkTreeNodeDef="let node; when: !(hasChild && isShowMore)" cdkTreeNodePadding
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: !(hasChild && isShowMore)" cdkTreeNodePadding [cdkTreeNodePaddingIndent]="24"
     class="example-tree-node childless-node">
     <div class="btn-group">
       <span aria-hidden="true" class="btn btn-default invisible" cdkTreeNodeToggle>

--- a/src/app/community-list-page/community-list/community-list.component.scss
+++ b/src/app/community-list-page/community-list/community-list.component.scss
@@ -2,3 +2,33 @@
   display: block;
   width: 16px;
 }
+
+// Fix WCAG 1.4.10
+.example-tree-node {
+  .btn-group {
+    flex-wrap: nowrap;
+    align-items: flex-start;
+
+    .d-flex.flex-row {
+      min-width: 0;
+
+      span.d-flex {
+        min-width: 0;
+
+        a.lead {
+          white-space: normal;
+          word-break: break-word;
+          overflow-wrap: anywhere;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .example-tree-node {
+    &[style*="padding-left"] {
+      padding-left: 0.75rem !important;
+    }
+  }
+}

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -2,27 +2,26 @@
   header {
     background-color: var(--ds-header-bg);
   }
-
   .navbar-brand img {
     max-height: var(--ds-header-logo-height);
     max-width: 100%;
   }
-
+  .navbar-brand {
+    flex-shrink: 1;
+    min-width: 0;
+  }
   .navbar-toggler {
     border: none;
     color: var(--ds-header-icon-color);
-
     &:hover, &:focus {
       color: var(--ds-header-icon-color-hover);
     }
-
     .toggler-icon {
       width: 1.5em;
       height: 1.5em;
       line-height: 1.5;
     }
   }
-
   .navbar, div[role="toolbar"] {
     display: flex;
     gap: calc(var(--bs-spacer) / 3);

--- a/src/app/item-page/full/field-components/file-section/full-file-section.component.html
+++ b/src/app/item-page/full/field-components/file-section/full-file-section.component.html
@@ -13,7 +13,7 @@
           <div class="col-3">
             <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
           </div>
-          <div class="col-7">
+          <div class="col">
             <dl class="row dont-break-out">
               <dt class="col-md-4">
                 {{ "item.page.filesection.name" | translate }}
@@ -38,7 +38,7 @@
               }
             </dl>
           </div>
-          <div class="col-2">
+          <div class="col-auto">
             <ds-file-download-link [showIcon]="true" [bitstream]="file" [item]="item" cssClasses="btn btn-outline-primary btn-download">
                 <span class="d-none d-md-inline">
                   {{ "item.page.filesection.download" | translate }}
@@ -66,7 +66,7 @@
           <div class="col-3">
             <ds-thumbnail [thumbnail]="(file.thumbnail | async)?.payload"></ds-thumbnail>
           </div>
-          <div class="col-7">
+          <div class="col">
             <dl class="row">
               <dt class="col-md-4">
                 {{ "item.page.filesection.name" | translate }}
@@ -89,7 +89,7 @@
               </dd>
             </dl>
           </div>
-          <div class="col-2">
+          <div class="col-auto">
             <ds-file-download-link [showIcon]="true" [bitstream]="file" [item]="item" cssClasses="btn btn-outline-primary btn-download">
                 <span class="d-none d-md-inline">
                   {{ "item.page.filesection.download" | translate }}

--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.html
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.html
@@ -7,9 +7,9 @@
   </div>
 }
 @if ((moreThanOne$ | async)) {
-  <div class="add w-100" display="dynamic" placement="bottom-right"
-    ngbDropdown
-    >
+<div class="add w-100"
+  ngbDropdown
+  placement="bottom-end">
     <button class="btn btn-lg btn-primary mt-1 ms-2" id="dropdownSubmission" ngbDropdownToggle
       type="button"  [dsBtnDisabled]="(initialized$ | async) !== true"
       [attr.aria-label]="'mydspace.new-submission' | translate"

--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.scss
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.scss
@@ -1,11 +1,9 @@
 .parent {
   display: flex;
 }
-
 .upload {
   flex: auto;
 }
-
 .add {
   flex: initial;
 }
@@ -13,4 +11,10 @@
 #entityControlsDropdownMenu {
   min-width: 18rem;
   box-shadow: $btn-focus-box-shadow;
+  max-width: 100vw;
+
+  @media (max-width: 767px) {
+    min-width: 0;
+    max-width: calc(100vw - 5rem);
+  }
 }


### PR DESCRIPTION
## References
Fixes #6086

## Description
Resolves WCAG 1.4.10 and 1.4.4 reflow issues affecting mobile viewports and 200% zoom across multiple pages.
Issue 3 (footer) was skipped as it is already being addressed in #5503.

## Instructions for Reviewers
List of changes in this PR:
* Community list page: reduced cdkTreeNodePaddingIndent from 40px (default) to 24px and added CSS to allow text wrapping inside tree nodes, preventing cut-off of long community/collection names on mobile and at 200% zoom (WCAG 1.4.10)
* Header: added flex-shrink:1 and min-width:0 to .navbar-brand to allow the site logo to shrink on small viewports, preventing horizontal overflow when a large logo is used
* Item page (full view) file section: changed col-7/col-2 Bootstrap columns to col/col-auto so the download button always has enough space and is never clipped at 200% zoom
* MyDSpace new submission dropdown: changed ngbDropdown placement to bottom-end and added max-width constraint to prevent the entity dropdown from overflowing off-screen on mobile viewports

To test:
1. Go to /community-list, expand a node with a long name, reduce viewport to 375px or zoom to 200% — text should wrap without being cut off
2. Go to /home on a 375px viewport — header logo and nav items should all be visible
3. Go to any item full page (/items/xxx/full), zoom to 200% — download button should be fully visible
4. Log in, go to /mydspace on a 375px viewport, click the "+" button — dropdown should be fully visible without being clipped by the sidebar

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [ ] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
