### PR TITLE
Allow scope selector to be hidden by config in tabbed entities search

### DIFF
--- a/src/app/item-page/simple/related-entities/related-entities-search/related-entities-search.component.html
+++ b/src/app/item-page/simple/related-entities/related-entities-search/related-entities-search.component.html
@@ -2,5 +2,6 @@
   [fixedFilterQuery]="fixedFilter"
   [configuration]="configuration"
   [searchEnabled]="searchEnabled"
-  [sideBarWidth]="sideBarWidth">
+  [sideBarWidth]="sideBarWidth"
+  [showScopeSelector]="showScopeSelector">
 </ds-configuration-search-page>

--- a/src/app/item-page/simple/related-entities/related-entities-search/related-entities-search.component.ts
+++ b/src/app/item-page/simple/related-entities/related-entities-search/related-entities-search.component.ts
@@ -42,6 +42,11 @@ export class RelatedEntitiesSearchComponent implements OnInit {
    */
   @Input() sideBarWidth = 4;
 
+  /**
+   * Defines whether or not to show the scope selector
+   */
+  @Input() showScopeSelector = true;
+
   fixedFilter: string;
 
   ngOnInit(): void {

--- a/src/app/item-page/simple/related-entities/tabbed-related-entities-search/tabbed-related-entities-search.component.html
+++ b/src/app/item-page/simple/related-entities/tabbed-related-entities-search/tabbed-related-entities-search.component.html
@@ -8,7 +8,8 @@
                                       [relationType]="relationType.filter"
                                       [configuration]="relationType.configuration"
                                       [searchEnabled]="searchEnabled"
-                                      [sideBarWidth]="sideBarWidth">
+                                      [sideBarWidth]="sideBarWidth"
+                                      [showScopeSelector]="showScopeSelector">
           </ds-related-entities-search>
         </div>
       </ng-template>
@@ -21,6 +22,7 @@
                               [relationType]="relationType.filter"
                               [configuration]="relationType.configuration"
                               [searchEnabled]="searchEnabled"
-                              [sideBarWidth]="sideBarWidth">
+                              [sideBarWidth]="sideBarWidth"
+                              [showScopeSelector]="showScopeSelector">
   </ds-related-entities-search>
 </div>

--- a/src/app/item-page/simple/related-entities/tabbed-related-entities-search/tabbed-related-entities-search.component.ts
+++ b/src/app/item-page/simple/related-entities/tabbed-related-entities-search/tabbed-related-entities-search.component.ts
@@ -42,6 +42,11 @@ export class TabbedRelatedEntitiesSearchComponent implements OnInit {
   @Input() sideBarWidth = 4;
 
   /**
+   * Defines whether or not to show the scope selector
+   */
+  @Input() showScopeSelector = true;
+
+  /**
    * The active tab
    */
   activeTab$: Observable<string>;


### PR DESCRIPTION
## Description
This PR makes the visibility of the search scope selector configurable for related entities searches on simple item pages.

## Instructions for Reviewers
The showScopeSelector input is exposed on:

- `RelatedEntitiesSearchComponent`
- `TabbedRelatedEntitiesSearchComponent`

and passed through to the underlying `ConfigurationSearchPageComponent`.

**How to test**

Set [showScopeSelector]="false" on a tabbed related entities search and verify the scope selector is hidden. 
Eg in `src/app/entity-groups/research-entities/item-pages/org-unit/org-unit.component.html` in `ds-tabbed-related-entities-search`
=> Verify on OrgUnit simple item page the search doesn't have selector, but on e.g. Person entity simple item page it does

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
