### PR TITLE
fix: avoid undefined community breadcrumb lookup

### DIFF
--- a/src/app/core/breadcrumbs/community-breadcrumb.resolver.spec.ts
+++ b/src/app/core/breadcrumbs/community-breadcrumb.resolver.spec.ts
@@ -1,0 +1,91 @@
+import { Community } from '../shared/community.model';
+import { createSuccessfulRemoteDataObject$ } from '../utilities/remote-data.utils';
+import { communityBreadcrumbResolver } from './community-breadcrumb.resolver';
+
+describe('communityBreadcrumbResolver', () => {
+  let breadcrumbService: any;
+  let communityDataService: any;
+  let community: Community;
+  let parentCommunity: Community;
+  let state: any;
+
+  beforeEach(() => {
+    community = Object.assign(new Community(), {
+      uuid: '1234-65487-12354-1235',
+      type: 'community',
+    });
+    parentCommunity = Object.assign(new Community(), {
+      uuid: '4321-76548-45321-5321',
+      type: 'community',
+    });
+    breadcrumbService = {};
+    state = {};
+    communityDataService = jasmine.createSpyObj('communityDataService', ['findById']);
+    communityDataService.findById.and.callFake((uuid: string) =>
+      createSuccessfulRemoteDataObject$(uuid === parentCommunity.uuid ? parentCommunity : community),
+    );
+  });
+
+  it('should resolve the community from the route id', () => {
+    const resolvedConfig = (communityBreadcrumbResolver as any)(
+      { data: {}, params: { id: community.uuid }, queryParams: {} } as any,
+      state,
+      breadcrumbService,
+      communityDataService,
+    );
+
+    let emitted = false;
+    resolvedConfig.subscribe((config) => {
+      emitted = true;
+      expect(config).toEqual({
+        provider: breadcrumbService,
+        key: community,
+        url: `/communities/${community.uuid}`,
+      });
+    });
+    expect(emitted).toBeTrue();
+    expect(communityDataService.findById.calls.mostRecent().args[0]).toEqual(community.uuid);
+  });
+
+  it('should resolve the parent community from the configured query parameter', () => {
+    const resolvedConfig = (communityBreadcrumbResolver as any)(
+      {
+        data: { breadcrumbQueryParam: 'parent' },
+        params: {},
+        queryParams: { parent: parentCommunity.uuid },
+      } as any,
+      state,
+      breadcrumbService,
+      communityDataService,
+    );
+
+    let emitted = false;
+    resolvedConfig.subscribe((config) => {
+      emitted = true;
+      expect(config).toEqual({
+        provider: breadcrumbService,
+        key: parentCommunity,
+        url: `/communities/${parentCommunity.uuid}`,
+      });
+    });
+    expect(emitted).toBeTrue();
+    expect(communityDataService.findById.calls.mostRecent().args[0]).toEqual(parentCommunity.uuid);
+  });
+
+  it('should not request a community when the configured query parameter is absent', () => {
+    const resolvedConfig = (communityBreadcrumbResolver as any)(
+      { data: { breadcrumbQueryParam: 'parent' }, params: {}, queryParams: {} } as any,
+      state,
+      breadcrumbService,
+      communityDataService,
+    );
+
+    let emitted = false;
+    resolvedConfig.subscribe((config) => {
+      emitted = true;
+      expect(config).toBeUndefined();
+    });
+    expect(emitted).toBeTrue();
+    expect(communityDataService.findById).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/breadcrumbs/community-breadcrumb.resolver.ts
+++ b/src/app/core/breadcrumbs/community-breadcrumb.resolver.ts
@@ -5,7 +5,10 @@ import {
   RouterStateSnapshot,
 } from '@angular/router';
 import { hasValue } from '@dspace/shared/utils/empty.util';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 
 import { CommunityDataService } from '../data/community-data.service';
 import {
@@ -31,11 +34,15 @@ export const communityBreadcrumbResolver: ResolveFn<BreadcrumbConfig<Community>>
   dataService: CommunityDataService = inject(CommunityDataService),
 ): Observable<BreadcrumbConfig<Community>> => {
   const linksToFollow: FollowLinkConfig<DSpaceObject>[] = COMMUNITY_PAGE_LINKS_TO_FOLLOW as FollowLinkConfig<DSpaceObject>[];
-  if (hasValue(route.data.breadcrumbQueryParam) && hasValue(route.queryParams[route.data.breadcrumbQueryParam])) {
+  if (hasValue(route.data.breadcrumbQueryParam)) {
+    const queryParam = route.queryParams[route.data.breadcrumbQueryParam];
+    if (!hasValue(queryParam)) {
+      return of(undefined);
+    }
     return DSOBreadcrumbResolverByUuid(
       route,
       state,
-      route.queryParams[route.data.breadcrumbQueryParam],
+      queryParam,
       breadcrumbService,
       dataService,
       ...linksToFollow,


### PR DESCRIPTION
## References

Fixes #6168

## Description

When opening the top-level community creation route, the community breadcrumb resolver is configured with `breadcrumbQueryParam: 'parent'`, but no `parent` query parameter is present. The resolver currently falls back to the route `id`, which is also absent on `/communities/create`, and requests the REST endpoint with `undefined`.

Return an empty breadcrumb result when the optional parent parameter is absent. Existing community routes and sub-community creation routes continue to resolve their breadcrumbs normally.

## Instructions for Reviewers

List of changes in this PR:
* Skip the community data lookup for top-level community creation.
* Add resolver coverage for normal routes, parent-community creation, and top-level creation.

To verify:
* Open **New → Community** as an administrator.
* Confirm that creating a top-level community does not issue a request to `/api/core/communities/undefined`.
* Confirm that creating a sub-community still loads the parent breadcrumb.

## Testing

* TypeScript semantic check for the resolver and regression spec.
* Resolver branch harness: baseline fails on the top-level route; the fix passes all three route cases.
* Prettier check for the changed files.
* `git diff --check`.

The full repository npm test suite was not run locally because the dependency tree is not installed in this environment; CI should run the repository's standard checks.
