### PR TITLE
src/styles: increase thumbnail maxwidth

### DIFF
--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -98,7 +98,7 @@
   --ds-edit-item-metadata-field-width: 190px;
   --ds-edit-item-language-field-width: 43px;
 
-  --ds-thumbnail-max-width: 125px;
+  --ds-thumbnail-max-width: 175px;
   --ds-thumbnail-placeholder-background: #{$gray-100};
   --ds-thumbnail-placeholder-border: 1px solid #{$gray-300};
   --ds-thumbnail-placeholder-color: #{lighten($gray-800, 7%)};


### PR DESCRIPTION
# References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/12004
* Requires https://github.com/DSpace/DSpace/pull/13046

# Description
Increase thumbnail maxwidth from 125px to 175px. Ideally the actual width of the thumbnail image itself is twice the size here so that it is scaled in CSS and looks more sharp.

<p align="center">
  <img width="750" src="https://github.com/user-attachments/assets/0d3b46c6-269f-4aa2-81c5-e1f587dc5f21" />
</p>

# Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, increase `--ds-thumbnail-max-width` from 125px to 175px.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You do not need to complete this checklist prior creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
