### PR TITLE
Update DOMPurify by overriding version used by Mirador

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9891,6 +9891,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -13378,9 +13385,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw=="
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "react-dom": "16.14.0",
     "mirador-share-plugin": {
       "notistack": "1.0.10"
+    },
+    "mirador": {
+      "dompurify": "^3.4.15"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Description
Update the version of [`dompurify`](https://www.npmjs.com/package/dompurify) used by Mirador by overriding the value (in the `overrides` section of `package.json`). Bumps  `dompurify` from v2.5.8 to v3.4.15  

This major upgrade to v3 moves us to a version of `dompurify` that has much fewer vulnerability warnings (as v2 has a larger number of potential vulnerabilities).

However, from my testing, this major upgrade to `dompurify` is still compatible with Mirador v3 because `dompurify` is only used in a few places to sanitize the HTML in Mirador.

## Instructions for Reviewers
* Verify tests pass
* Optionally, verify no changes in behavior to Mirador viewer for [IIIF Integration ](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944973/IIIF+Configuration)
    * NOTE: I've verified locally that the Mirador viewer still works the same as before. I've not found any differences in behavior.