### PR TITLE
Use the current JWT before each file upload

### DIFF
--- a/src/app/shared/upload/uploader/uploader.component.spec.ts
+++ b/src/app/shared/upload/uploader/uploader.component.spec.ts
@@ -10,6 +10,8 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AuthService } from '@dspace/core/auth/auth.service';
 import { CookieService } from '@dspace/core/cookies/cookie.service';
 import { DragService } from '@dspace/core/drag.service';
 import { CookieServiceMock } from '@dspace/core/testing/cookie.service.mock';
@@ -28,9 +30,12 @@ describe('UploaderComponent', () => {
   let testComp: TestComponent;
   let testFixture: ComponentFixture<TestComponent>;
   let html;
+  let authService: jasmine.SpyObj<AuthService>;
 
   // waitForAsync beforeEach
   beforeEach(waitForAsync(() => {
+    authService = jasmine.createSpyObj('AuthService', ['buildAuthHeader']);
+    authService.buildAuthHeader.and.returnValue('Bearer initial-jwt');
 
     TestBed.configureTestingModule({
       imports: [
@@ -43,6 +48,7 @@ describe('UploaderComponent', () => {
         ChangeDetectorRef,
         UploaderComponent,
         DragService,
+        { provide: AuthService, useValue: authService },
         { provide: HttpXsrfTokenExtractor, useValue: new HttpXsrfTokenExtractorMock('mock-token') },
         { provide: CookieService, useValue: new CookieServiceMock() },
         { provide: LiveRegionService, useValue: getLiveRegionServiceStub() },
@@ -67,6 +73,47 @@ describe('UploaderComponent', () => {
 
     expect(app).toBeDefined();
   }));
+
+  it('should send only the current JWT when uploading again after token refresh', () => {
+    const component: UploaderComponent = testFixture.debugElement.query(By.directive(UploaderComponent)).componentInstance;
+    component.uploader.options.autoUpload = false;
+    const requests: any[] = [];
+    spyOn(window, 'XMLHttpRequest').and.callFake(function () {
+      const xhr = jasmine.createSpyObj('XMLHttpRequest', ['open', 'setRequestHeader', 'send', 'getAllResponseHeaders']);
+      xhr.upload = {};
+      xhr.status = 200;
+      xhr.response = '{}';
+      xhr.getAllResponseHeaders.and.returnValue('');
+      requests.push(xhr);
+      return xhr;
+    });
+
+    component.uploader.addToQueue([new File(['first'], 'first.txt')]);
+    component.uploader.uploadAll();
+    expect(requests.length).withContext('first upload').toBe(1);
+    expect(requests[0].setRequestHeader.calls.allArgs().filter(([name]) => name === 'Authorization'))
+      .toEqual([['Authorization', 'Bearer initial-jwt']]);
+    requests[0].onload();
+
+    authService.buildAuthHeader.and.returnValue('Bearer refreshed-jwt');
+    component.uploader.addToQueue([new File(['second'], 'second.txt')]);
+    component.uploader.uploadAll();
+    expect(requests.length).withContext('second upload').toBe(2);
+    expect(requests[1].setRequestHeader.calls.allArgs().filter(([name]) => name === 'Authorization'))
+      .toEqual([['Authorization', 'Bearer refreshed-jwt']]);
+    expect(requests[1].setRequestHeader).toHaveBeenCalledWith('X-XSRF-TOKEN', 'mock-token');
+    requests[1].onload();
+  });
+
+  it('should clear the cached JWT when authentication is no longer available', () => {
+    const component: UploaderComponent = testFixture.debugElement.query(By.directive(UploaderComponent)).componentInstance;
+    component.uploader.authToken = 'Bearer expired-jwt';
+    authService.buildAuthHeader.and.returnValue('');
+
+    component.uploader.onBeforeUploadItem({ url: component.uploader.options.url } as any);
+
+    expect(component.uploader.authToken).toBe('');
+  });
 
 });
 

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -12,6 +12,7 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
+import { AuthService } from '@dspace/core/auth/auth.service';
 import { CookieService } from '@dspace/core/cookies/cookie.service';
 import { DragService } from '@dspace/core/drag.service';
 import {
@@ -156,6 +157,7 @@ export class UploaderComponent implements OnInit, AfterViewInit {
     private tokenExtractor: HttpXsrfTokenExtractor,
     private cookieService: CookieService,
     private liveRegionService: LiveRegionService,
+    private authService: AuthService,
   ) {
   }
 
@@ -187,6 +189,9 @@ export class UploaderComponent implements OnInit, AfterViewInit {
     }
   }
 
+  /**
+   * Configure upload callbacks, refreshing authentication headers before each file is sent.
+   */
   ngAfterViewInit(): void {
     this.uploader.onAfterAddingAll = ((items) => {
       this.onFileSelected.emit(items);
@@ -195,6 +200,8 @@ export class UploaderComponent implements OnInit, AfterViewInit {
       this.onBeforeUpload = () => {return;};
     }
     this.uploader.onBeforeUploadItem = (item) => {
+      // ng2-file-upload caches authToken and bypasses the Angular authentication interceptor.
+      this.uploader.authToken = this.authService.buildAuthHeader();
       if (item.url !== this.uploader.options.url) {
         item.url = this.uploader.options.url;
       }


### PR DESCRIPTION
## References

Fixes #3979

## Description

File uploads now use the current JWT immediately before each file is sent. Previously, ng2-file-upload retained the Authorization value captured when the uploader was initialized, so later uploads on an open submission form could fail after token renewal.

The existing upload callback now updates the library's `authToken` field using `AuthService.buildAuthHeader()`. This avoids adding a second Authorization header. The CSRF handling remains independent.

## Instructions for Reviewers

1. Log in and open a submission with a file-upload section.
2. Upload a file, then keep the form open until the UI renews the JWT (or use a shorter login-token lifetime in a test installation).
3. Upload another file without reloading the form. Inspect its request: it should contain exactly one Authorization value using the renewed JWT, and the upload should succeed.

This fixes stale credentials on subsequent uploads. It does not change the token attached to a request already in flight or address expiry during a single long SAF upload.

Validation: all 13 focused tests pass (uploader, submission upload, and bitstream replacement). The uploader regression tests verify the actual library's outgoing headers across token renewal and clear cached credentials when authentication disappears. Full ESLint validation passes with warnings only. `npm run check-circ-deps` passes on the clean source tree, after `npm run clean:decorator:registries` removes build-generated registries, matching CI's pre-build check.

## Checklist

- [x] Created against `main`; small change with no new dependencies.
- [x] Includes regression tests and reviewer instructions.
- [x] Modified lifecycle method has TypeDoc.
- [x] No user-interface or translation changes.
