### PR TITLE
Reject files above the upload size limit before sending any data

### DIFF
--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission.component.ts
@@ -120,6 +120,9 @@ export class MyDSpaceNewSubmissionComponent implements OnDestroy, OnInit {
    */
   public onUploadError(error: UploaderError) {
     let errorMessageKey = 'mydspace.upload.upload-failed';
+    if (hasValue(error.status) && error.status === 413) {
+      errorMessageKey = 'mydspace.upload.upload-failed-max-size';
+    }
     if (hasValue(error.status) && error.status === 422) {
       errorMessageKey = 'mydspace.upload.upload-failed-manyentries';
     }

--- a/src/app/shared/upload/uploader/uploader-options.model.ts
+++ b/src/app/shared/upload/uploader/uploader-options.model.ts
@@ -23,6 +23,12 @@ export class UploaderOptions {
   maxFileNumber: number;
 
   /**
+   * The largest file accepted, in bytes. Larger files are rejected before any data is sent.
+   * Undefined or zero means no client-side limit.
+   */
+  maxFileSize?: number;
+
+  /**
    * Impersonating user uuid
    */
   impersonatingID: string;

--- a/src/app/shared/upload/uploader/uploader.component.spec.ts
+++ b/src/app/shared/upload/uploader/uploader.component.spec.ts
@@ -10,6 +10,7 @@ import {
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { CookieService } from '@dspace/core/cookies/cookie.service';
 import { DragService } from '@dspace/core/drag.service';
 import { CookieServiceMock } from '@dspace/core/testing/cookie.service.mock';
@@ -67,6 +68,21 @@ describe('UploaderComponent', () => {
 
     expect(app).toBeDefined();
   }));
+
+  it('rejects a file larger than maxFileSize before any upload and reports it as a 413 error', () => {
+    testComp.uploadFilesOptions.autoUpload = false;
+    testComp.uploadFilesOptions.maxFileSize = 4;
+    testFixture.detectChanges();
+    const uploader: UploaderComponent = testFixture.debugElement.query(By.directive(UploaderComponent)).componentInstance;
+    spyOn(uploader.onUploadError, 'emit');
+
+    uploader.uploader.addToQueue([new File(['abcdef'], 'too-large.bin')]);
+    expect(uploader.uploader.queue.length).toBe(0);
+    expect(uploader.onUploadError.emit).toHaveBeenCalledWith(jasmine.objectContaining({ status: 413 }));
+
+    uploader.uploader.addToQueue([new File(['ab'], 'small.bin')]);
+    expect(uploader.uploader.queue.length).toBe(1);
+  });
 
 });
 

--- a/src/app/shared/upload/uploader/uploader.component.ts
+++ b/src/app/shared/upload/uploader/uploader.component.ts
@@ -28,6 +28,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import uniqueId from 'lodash/uniqueId';
 import {
   FileItem,
+  FileLikeObject,
   FileUploader,
   FileUploadModule,
 } from 'ng2-file-upload';
@@ -174,6 +175,8 @@ export class UploaderComponent implements OnInit, AfterViewInit {
       autoUpload: this.uploadFilesOptions.autoUpload,
       method: this.uploadFilesOptions.method,
       queueLimit: this.uploadFilesOptions.maxFileNumber,
+      // Evaluated when a file is added, so a limit that arrives after initialisation is honoured too
+      filters: [{ name: 'maxFileSize', fn: (item: FileLikeObject) => !this.exceedsMaxFileSize(item.size) }],
     });
 
     if (isUndefined(this.enableDragOverDocument)) {
@@ -191,6 +194,12 @@ export class UploaderComponent implements OnInit, AfterViewInit {
     this.uploader.onAfterAddingAll = ((items) => {
       this.onFileSelected.emit(items);
     });
+    this.uploader.onWhenAddingFileFailed = (item: FileLikeObject, filter: any) => {
+      if (filter.name === 'maxFileSize') {
+        // Nothing was sent: report it like the server's 413 so consumers handle both the same way
+        this.onUploadError.emit({ item: item, response: null, status: 413, headers: null });
+      }
+    };
     if (isUndefined(this.onBeforeUpload)) {
       this.onBeforeUpload = () => {return;};
     }
@@ -250,6 +259,15 @@ export class UploaderComponent implements OnInit, AfterViewInit {
       this.announceProgress(progress);
       this.onProgress();
     };
+  }
+
+  /**
+   * Whether a file is larger than the configured maximum upload size
+   * @param size the file size in bytes
+   */
+  private exceedsMaxFileSize(size: number): boolean {
+    const limit = this.uploadFilesOptions.maxFileSize;
+    return hasValue(limit) && limit > 0 && size > limit;
   }
 
   /**

--- a/src/app/submission/form/submission-form.component.spec.ts
+++ b/src/app/submission/form/submission-form.component.spec.ts
@@ -10,6 +10,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { AuthService } from '@dspace/core/auth/auth.service';
+import { SubmissionUploadsConfigDataService } from '@dspace/core/config/submission-uploads-config-data.service';
 import { HALEndpointService } from '@dspace/core/shared/hal-endpoint.service';
 import { Item } from '@dspace/core/shared/item.model';
 import { MetadataSecurityConfigurationService } from '@dspace/core/submission/metadatasecurityconfig-data.service';
@@ -61,6 +62,7 @@ describe('SubmissionFormComponent', () => {
 
   const submissionObject: any = mockSubmissionObject;
   const submissionServiceStub: SubmissionServiceStub = new SubmissionServiceStub();
+  let uploadsConfigService: any;
   const submissionId = mockSubmissionId;
   const collectionId = mockSubmissionCollectionId;
   const submissionObjectNew: any = mockSubmissionObjectNew;
@@ -74,6 +76,9 @@ describe('SubmissionFormComponent', () => {
     metadataSecurityConfigDataService = jasmine.createSpyObj('metadataSecurityConfigDataService', {
       findById: createSuccessfulRemoteDataObject$(submissionObject.metadataSecurityConfiguration),
     });
+    uploadsConfigService = jasmine.createSpyObj('uploadsConfigService', {
+      findByHref: createSuccessfulRemoteDataObject$({ maxSize: 1234 }),
+    });
     TestBed.configureTestingModule({
       imports: [
         SubmissionFormComponent,
@@ -85,6 +90,7 @@ describe('SubmissionFormComponent', () => {
         { provide: HALEndpointService, useValue: new HALEndpointServiceStub('workspaceitems') },
         { provide: SubmissionService, useValue: submissionServiceStub },
         { provide: MetadataSecurityConfigurationService, useValue: metadataSecurityConfigDataService },
+        { provide: SubmissionUploadsConfigDataService, useValue: uploadsConfigService },
         { provide: SectionsService, useValue:
           {
             isSectionTypeAvailable: () => of(true),
@@ -202,6 +208,36 @@ describe('SubmissionFormComponent', () => {
         null,
         undefined);
       expect(submissionServiceStub.startAutoSave).toHaveBeenCalled();
+      done();
+    });
+
+    it('should pass the upload section size limit to the uploader', (done) => {
+      comp.collectionId = collectionId;
+      comp.submissionId = submissionId;
+      comp.submissionDefinition = submissionDefinition;
+      comp.selfUrl = selfUrl;
+      comp.sections = sectionsData;
+      comp.submissionErrors = null;
+      comp.item = new Item();
+      comp.entityType = 'publication';
+      submissionServiceStub.getSubmissionObject.and.returnValue(of(submissionState));
+      submissionServiceStub.getSubmissionSections.and.returnValue(of([
+        { id: 'traditionalpageone', sectionType: 'submission-form', config: 'https://rest.api/config/submissionforms/one' },
+        { id: 'upload', sectionType: 'upload', config: 'https://rest.api/config/submissionuploads/upload' },
+      ]));
+      spyOn(authServiceStub, 'buildAuthHeader').and.returnValue('token');
+
+      scheduler.schedule(() => {
+        comp.ngOnChanges({
+          collectionId: new SimpleChange(null, collectionId, true),
+          submissionId: new SimpleChange(null, submissionId, true),
+        });
+        fixture.detectChanges();
+      });
+      scheduler.flush();
+
+      expect(uploadsConfigService.findByHref).toHaveBeenCalledWith('https://rest.api/config/submissionuploads/upload');
+      expect(comp.uploadFilesOptions.maxFileSize).toBe(1234);
       done();
     });
 

--- a/src/app/submission/form/submission-form.component.ts
+++ b/src/app/submission/form/submission-form.component.ts
@@ -9,6 +9,9 @@ import {
 } from '@angular/core';
 import { AuthService } from '@dspace/core/auth/auth.service';
 import { SubmissionDefinitionsModel } from '@dspace/core/config/models/config-submission-definitions.model';
+import { RemoteData } from '@dspace/core/data/remote-data';
+import { SubmissionUploadsModel } from '@dspace/core/config/models/config-submission-uploads.model';
+import { SubmissionUploadsConfigDataService } from '@dspace/core/config/submission-uploads-config-data.service';
 import { SubmissionSectionModel } from '@dspace/core/config/models/config-submission-section.model';
 import { Collection } from '@dspace/core/shared/collection.model';
 import { HALEndpointService } from '@dspace/core/shared/hal-endpoint.service';
@@ -186,7 +189,8 @@ export class SubmissionFormComponent implements OnChanges, OnDestroy {
     private halService: HALEndpointService,
     private submissionService: SubmissionService,
     private sectionsService: SectionsService,
-    private metadataSecurityConfigDataService: MetadataSecurityConfigurationService) {
+    private metadataSecurityConfigDataService: MetadataSecurityConfigurationService,
+    private uploadsConfigService: SubmissionUploadsConfigDataService) {
     this.isActive = true;
   }
 
@@ -226,6 +230,18 @@ export class SubmissionFormComponent implements OnChanges, OnDestroy {
         map((submission: SubmissionObjectEntry) => submission.isLoading),
         map((isLoading: boolean) => isLoading),
         distinctUntilChanged());
+
+      // Let the uploader reject files above the upload section's limit before any data is sent
+      this.subs.push(
+        this.submissionService.getSubmissionSections(this.submissionId).pipe(
+          map((sections: SectionDataObject[]) => sections.find((section) => section.sectionType === SectionsType.Upload)),
+          filter((section: SectionDataObject) => hasValue(section) && isNotEmpty(section.config)),
+          distinctUntilChanged((previous: SectionDataObject, current: SectionDataObject) => previous.config === current.config),
+          switchMap((section: SectionDataObject) => this.uploadsConfigService.findByHref(section.config).pipe(getFirstCompletedRemoteData())),
+        ).subscribe((rd: RemoteData<SubmissionUploadsModel>) => {
+          this.uploadFilesOptions.maxFileSize = rd.hasSucceeded && rd.payload.maxSize > 0 ? rd.payload.maxSize : undefined;
+        }),
+      );
 
       // init submission state
       this.subs.push(

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.html
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.html
@@ -6,5 +6,5 @@
     [onBeforeUpload]="onBeforeUpload"
     [uploadFilesOptions]="uploadFilesOptions"
     (onCompleteItem)="onCompleteItem($event)"
-  (onUploadError)="onUploadError()"></ds-uploader>
+  (onUploadError)="onUploadError($event)"></ds-uploader>
 }

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.spec.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.spec.ts
@@ -156,6 +156,23 @@ describe('SubmissionUploadFilesComponent Component', () => {
       expect(compAsAny.uploadEnabled).toBeObservable(expected);
     });
 
+    describe('on upload error', () => {
+      it('should name the size limit when the file was too large', () => {
+        const translate = TestBed.inject(TranslateService);
+        comp.uploadFilesOptions = Object.assign(new UploaderOptions(), { maxFileSize: 1024 });
+        comp.onUploadError({ status: 413 });
+        expect(translate.get).toHaveBeenCalledWith('submission.sections.upload.upload-failed-max-size', { size: '1 KB' });
+        expect(notificationsServiceStub.error).toHaveBeenCalled();
+      });
+
+      it('should show the generic message for other failures', () => {
+        const translate = TestBed.inject(TranslateService);
+        comp.onUploadError({ status: 500 });
+        expect(translate.get).toHaveBeenCalledWith('submission.sections.upload.upload-failed');
+        expect(notificationsServiceStub.error).toHaveBeenCalled();
+      });
+    });
+
     describe('on upload complete', () => {
       beforeEach(() => {
         sectionsServiceStub.isSectionType.and.callFake((_, sectionId, __) => of(sectionId === 'upload'));

--- a/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
+++ b/src/app/submission/form/submission-upload-files/submission-upload-files.component.ts
@@ -16,6 +16,7 @@ import {
   isNotEmpty,
 } from '@dspace/shared/utils/empty.util';
 import { TranslateService } from '@ngx-translate/core';
+import { filesize } from 'filesize';
 import {
   Observable,
   of,
@@ -27,6 +28,7 @@ import {
 } from 'rxjs/operators';
 
 import { UploaderComponent } from '../../../shared/upload/uploader/uploader.component';
+import { UploaderError } from '../../../shared/upload/uploader/uploader-error.model';
 import { UploaderOptions } from '../../../shared/upload/uploader/uploader-options.model';
 import { SectionsService } from '../../sections/sections.service';
 import { SubmissionService } from '../../submission.service';
@@ -173,9 +175,20 @@ export class SubmissionUploadFilesComponent implements OnChanges, OnDestroy {
   }
 
   /**
-   * Show error notification on upload fails
+   * Show an error notification when an upload fails, naming the size limit when the file was too large
+   * @param error the uploader error, when available
    */
-  public onUploadError() {
+  public onUploadError(error?: UploaderError) {
+    if (hasValue(error) && error.status === 413) {
+      const limit = this.uploadFilesOptions?.maxFileSize;
+      if (limit > 0) {
+        this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed-max-size',
+          { size: filesize(limit, { standard: 'jedec', round: 0 }) }));
+      } else {
+        this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed-max-size-unknown'));
+      }
+      return;
+    }
     this.notificationsService.error(null, this.translate.get('submission.sections.upload.upload-failed'));
   }
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2071,6 +2071,8 @@
 
   "error.validation.filerequired": "The file upload is mandatory",
 
+  "error.validation.filesize": "The file is larger than the maximum upload size.",
+
   "error.validation.required": "This field is required",
 
   "error.validation.NotValidEmail": "This is not a valid email",
@@ -3955,6 +3957,8 @@
   "mydspace.title": "MyDSpace",
 
   "mydspace.upload.upload-failed": "Error creating new workspace. Please verify the content uploaded before retry.",
+
+  "mydspace.upload.upload-failed-max-size": "The file is larger than the maximum upload size.",
 
   "mydspace.upload.upload-failed-manyentries": "Unprocessable file. Detected too many entries but allowed only one for file.",
 
@@ -6005,6 +6009,10 @@
   "submission.sections.upload.undo": "Cancel",
 
   "submission.sections.upload.upload-failed": "Upload failed",
+
+  "submission.sections.upload.upload-failed-max-size": "The file is larger than the maximum upload size of {{size}}.",
+
+  "submission.sections.upload.upload-failed-max-size-unknown": "The file is larger than the maximum upload size.",
 
   "submission.sections.upload.upload-successful": "Upload successful",
 


### PR DESCRIPTION
## References

* Fixes #2848
* Requires DSpace/DSpace#13107 for the reported `maxSize` to reflect the effective limit (without it the check only applies when `upload.max` or a `maxSize` is configured)
* Related to DSpace/DSpace#13106 (phase 0 of the generic upload proposal); builds on the approach @floriangantner explored in the issue

## Description

Files larger than the upload section's `maxSize` are now refused by the uploader when they are added, before any data is sent, and reported with the limit in the notification. Previously the whole file was transferred and the failure surfaced afterwards as a generic error.

## Instructions for Reviewers

List of changes in this PR:

* `UploaderOptions.maxFileSize` (bytes, optional). `UploaderComponent` registers a size filter that reads the option when a file is added, so a limit that arrives after initialisation is honoured, and reports a rejected file through `onUploadError` with `status: 413`, the same shape as the server's own rejection.
* `SubmissionFormComponent` reads the upload section's configuration (`/api/config/submissionuploads/<id>`) and passes its `maxSize` to the uploader.
* `SubmissionUploadFilesComponent.onUploadError` names the limit for a 413 (`submission.sections.upload.upload-failed-max-size`), or uses a generic too-large message when no limit is known; other failures keep the existing message.
* `MyDSpaceNewSubmissionComponent` recognises a server-side 413 (`mydspace.upload.upload-failed-max-size`). No client-side limit is applied there because the collection, and therefore the upload configuration, is not known before the file is dropped; that open question from #2848 stays open.
* New i18n keys, including `error.validation.filesize` for the section error the backend now returns.
* Specs for the uploader filter, the form wiring and the notifications.

How to test:

1. Set `upload.max = 1048576` in the backend `local.cfg` (or use DSpace/DSpace#13107, which reports the multipart limit by default). Open a submission's upload section and drop a 2 MB file: it is refused immediately with "The file is larger than the maximum upload size of 1 MB" and no request is sent.
2. Drop a smaller file: it uploads as before.
3. Without DSpace/DSpace#13107 and without `upload.max`, behaviour is unchanged.

Validation: `npm run lint` (0 errors), `npm run check-circ-deps`, and the specs for `uploader.component`, `submission-form.component` and `submission-upload-files.component` pass.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (No new dependencies.)
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

https://claude.ai/code/session_01HtPYmqfFzg7fmZgovGWP5A
